### PR TITLE
Bounded, backgrounded retry

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -128,15 +128,16 @@ func send(ip, port string, message []byte) {
 
 	backoff := NewExpBackoff(250*time.Millisecond, 10*time.Second, 2)
 
-	for {
+	for trial := 0; trial < 10; trial++ {
 		err := sendWithSocketClient(ip, port, message)
 		if err == nil {
-			break
+			return
 		}
 		log.Info("sleeping before trying to send again",
 			"duration", backoff.Cur, "addr", net.JoinHostPort(ip, port))
 		backoff.Sleep()
 	}
+	log.Error("gave up sending a message", "addr", net.JoinHostPort(ip, port))
 }
 
 func DialWithSocketClient(ip, port string) (conn net.Conn, err error) {


### PR DESCRIPTION
Current broadcast code waits until all breakout goroutines finish (one goroutine per peer).  If some peer hangs or otherwise refuses to receive a message, its goroutine will continue to run; if the peer never comes back, e.g. it crashed, the goroutine may as well not terminate at all, blocking the broadcaster's progress.  Do not wait until all deliveries are complete, and return immediately instead.  If enough quorum members receive the message and reply back to the leader, the consensus should proceed without waiting for a few outliers lagging behind.

Also, try to send each message only up to 10 times.  This is to eliminate goroutine leakage for dead peers.