### PR TITLE
[HAR-5] populate the public keys to all nodes

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -47,7 +47,7 @@ type Consensus struct {
 	// Leader
 	leader p2p.Peer
 	// Public keys of the committee including leader and validators
-	publicKeys []kyber.Point
+	PublicKeys []kyber.Point
 
 	// private/public keys of current node
 	priKey kyber.Scalar
@@ -137,7 +137,7 @@ func NewConsensus(ip, port, ShardID string, peers []p2p.Peer, leader p2p.Peer) *
 	if err != nil {
 		panic("Failed to create final mask")
 	}
-	consensus.publicKeys = allPublicKeys
+	consensus.PublicKeys = allPublicKeys
 	consensus.bitmap = mask
 	consensus.finalBitmap = finalMask
 
@@ -208,8 +208,8 @@ func (consensus *Consensus) ResetState() {
 	consensus.responses = &map[uint16]kyber.Scalar{}
 	consensus.finalResponses = &map[uint16]kyber.Scalar{}
 
-	mask, _ := crypto.NewMask(crypto.Ed25519Curve, consensus.publicKeys, consensus.leader.PubKey)
-	finalMask, _ := crypto.NewMask(crypto.Ed25519Curve, consensus.publicKeys, consensus.leader.PubKey)
+	mask, _ := crypto.NewMask(crypto.Ed25519Curve, consensus.PublicKeys, consensus.leader.PubKey)
+	finalMask, _ := crypto.NewMask(crypto.Ed25519Curve, consensus.PublicKeys, consensus.leader.PubKey)
 	consensus.bitmap = mask
 	consensus.finalBitmap = finalMask
 	consensus.bitmap.SetMask([]byte{})
@@ -236,6 +236,7 @@ func (consensus *Consensus) String() string {
 // and add the public keys
 func (consensus *Consensus) AddPeers(peers []p2p.Peer) int {
 	count := 0
+
 	for _, peer := range peers {
 		_, ok := consensus.validators.Load(utils.GetUniqueIdFromPeer(peer))
 		if !ok {
@@ -243,41 +244,28 @@ func (consensus *Consensus) AddPeers(peers []p2p.Peer) int {
 				peer.ValidatorID = int(consensus.uniqueIdInstance.GetUniqueId())
 			}
 			consensus.validators.Store(utils.GetUniqueIdFromPeer(peer), peer)
-			consensus.publicKeys = append(consensus.publicKeys, peer.PubKey)
-			count++
+			consensus.PublicKeys = append(consensus.PublicKeys, peer.PubKey)
 		}
-	}
-	if count > 0 {
-		// regenerate bitmaps
-		mask, err := crypto.NewMask(crypto.Ed25519Curve, consensus.publicKeys, consensus.leader.PubKey)
-		if err != nil {
-			panic("Failed to create mask")
-		}
-		finalMask, err := crypto.NewMask(crypto.Ed25519Curve, consensus.publicKeys, consensus.leader.PubKey)
-		if err != nil {
-			panic("Failed to create final mask")
-		}
-		consensus.bitmap = mask
-		consensus.finalBitmap = finalMask
+		count++
 	}
 	return count
 }
 
-// RemovePeers will remove the peers from the validator list and publicKeys
+// RemovePeers will remove the peers from the validator list and PublicKeys
 // It will be called when leader/node lost connection to peers
 func (consensus *Consensus) RemovePeers(peers []p2p.Peer) int {
 	// TODO (lc) we need to have a corresponding RemovePeers function
 	return 0
 }
 
-// DebugPrintPublicKeys print all the publicKeys in string format in Consensus
+// DebugPrintPublicKeys print all the PublicKeys in string format in Consensus
 func (consensus *Consensus) DebugPrintPublicKeys() {
-	for _, k := range consensus.publicKeys {
+	for _, k := range consensus.PublicKeys {
 		str := fmt.Sprintf("%s", k)
 		consensus.Log.Debug("pk:", "string", str)
 	}
 
-	consensus.Log.Debug("PublicKeys:", "#", len(consensus.publicKeys))
+	consensus.Log.Debug("PublicKeys:", "#", len(consensus.PublicKeys))
 }
 
 // DebugPrintValidators print all validator ip/port/key in string format in Consensus

--- a/consensus/consensus_validator.go
+++ b/consensus/consensus_validator.go
@@ -338,7 +338,7 @@ func (consensus *Consensus) processCollectiveSigMessage(payload []byte) {
 	}
 
 	// Verify collective signature
-	err := crypto.Verify(crypto.Ed25519Curve, consensus.publicKeys, payload[:36], append(collectiveSig, bitmap...), crypto.NewThresholdPolicy((2*len(consensus.publicKeys)/3)+1))
+	err := crypto.Verify(crypto.Ed25519Curve, consensus.PublicKeys, payload[:36], append(collectiveSig, bitmap...), crypto.NewThresholdPolicy((2*len(consensus.PublicKeys)/3)+1))
 	if err != nil {
 		consensus.Log.Warn("Failed to verify the collective sig message", "consensusID", consensusID, "err", err)
 		return

--- a/node/node.go
+++ b/node/node.go
@@ -316,8 +316,7 @@ func (node *Node) AddPeers(peers []p2p.Peer) int {
 	}
 
 	if count > 0 {
-		c := node.Consensus.AddPeers(peers)
-		node.log.Info("Node.AddPeers", "#", c)
+		node.Consensus.AddPeers(peers)
 	}
 	return count
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -130,7 +130,7 @@ func sendPongMessage(leader p2p.Peer) {
 		PubKey: pubKey2,
 	}
 
-	pong1 := proto_node.NewPongMessage([]p2p.Peer{p1, p2})
+	pong1 := proto_node.NewPongMessage([]p2p.Peer{p1, p2}, nil)
 	buf1 := pong1.ConstructPongMessage()
 
 	fmt.Println("waiting for 10 seconds ...")

--- a/proto/node/pingpong_test.go
+++ b/proto/node/pingpong_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dedis/kyber"
 	"github.com/harmony-one/harmony/crypto"
 	"github.com/harmony-one/harmony/crypto/pki"
 	"github.com/harmony-one/harmony/p2p"
@@ -43,6 +44,8 @@ var (
 	}
 	e2 = "pong:1=>length:2"
 
+	pubKeys = []kyber.Point{pubKey1, pubKey2}
+
 	buf1 []byte
 	buf2 []byte
 )
@@ -57,7 +60,7 @@ func TestString(test *testing.T) {
 		fmt.Println(r1)
 	}
 
-	pong1 := NewPongMessage(p2)
+	pong1 := NewPongMessage(p2, pubKeys)
 	r2 := fmt.Sprintf("%v", *pong1)
 
 	if !strings.HasPrefix(r2, e2) {
@@ -72,7 +75,7 @@ func TestSerialize(test *testing.T) {
 	buf1 = ping1.ConstructPingMessage()
 	fmt.Printf("buf ping: %v\n", buf1)
 
-	pong1 := NewPongMessage(p2)
+	pong1 := NewPongMessage(p2, pubKeys)
 	buf2 = pong1.ConstructPongMessage()
 	fmt.Printf("buf pong: %v\n", buf2)
 }


### PR DESCRIPTION
All validators should have the identical list of public keys as the
leader. Otherwise, the CoSi will failure to verify.

consensus.publicKeys => consensus.PublicKeys, make it visiable to external modules.

Signed-off-by: Leo Chen <leo@harmony.one>