### PR TITLE
HAR-84: golint fix on ida

### DIFF
--- a/p2p/ida/errors.go
+++ b/p2p/ida/errors.go
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Package errors provides common error types used throughout leveldb.
+// Package ida errors provides common error types used throughout leveldb.
 package ida
 
 import (


### PR DESCRIPTION
golint ida still has a warning and I don't have a good solution yet.

will leave it to Eugene/Chao.

ida.go:10:6: type name will be used as ida.IDAImp by other packages, and that stutters; consider calling this Imp

Signed-off-by: Leo Chen <leo@harmony.one>