### PR TITLE
use struct{} which is size 0, good practice for many go programmers

### DIFF
--- a/client/txgen/main.go
+++ b/client/txgen/main.go
@@ -175,7 +175,7 @@ func main() {
 		go clientNode.JoinShard(leader)
 		// wait for 3 seconds for client to send ping message to leader
 		time.Sleep(3 * time.Second)
-		clientNode.StopPing <- 1
+		clientNode.StopPing <- struct{}{}
 		clientNode.State = node.NodeJoinedShard
 	}
 

--- a/node/node.go
+++ b/node/node.go
@@ -109,7 +109,7 @@ type Node struct {
 	host host.Host
 
 	// Channel to stop sending ping message
-	StopPing chan int
+	StopPing chan struct{}
 }
 
 // Add new crossTx and proofs to the list of crossTx that needs to be sent back to client
@@ -301,7 +301,7 @@ func New(host host.Host, consensus *bft.Consensus, db *hdb.LDBDatabase) *Node {
 
 	// Setup initial state of syncing.
 	node.syncingState = NotDoingSyncing
-	node.StopPing = make(chan int)
+	node.StopPing = make(chan struct{})
 
 	return &node
 }

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -617,7 +617,7 @@ func (node *Node) pongMessageHandler(msgPayload []byte) int {
 
 	node.State = NodeJoinedShard
 	// Notify JoinShard to stop sending Ping messages
-	node.StopPing <- 1
+	node.StopPing <- struct{}{}
 
 	return node.Consensus.UpdatePublicKeys(publicKeys)
 }


### PR DESCRIPTION
tested with deploy.sh with and without -p

See: https://blog.golang.org/pipelines
https://www.programming-books.io/essential/go/f5daa999f5134b9ba9f2d69916df292a-signaling-channel-with-chan-struct