### PR TITLE
HAR-65: fix can't bind address issue on AWS

### DIFF
--- a/p2p/host/hostv1/hostv1.go
+++ b/p2p/host/hostv1/hostv1.go
@@ -34,7 +34,7 @@ func (host *HostV1) GetSelfPeer() p2p.Peer {
 // BindHandlerAndServe Version 0 p2p. Going to be deprecated.
 func (host *HostV1) BindHandlerAndServe(handler p2p.StreamHandler) {
 	port := host.self.Port
-	addr := net.JoinHostPort(host.self.IP, port)
+	addr := net.JoinHostPort("", port)
 	var err error
 	host.listener, err = net.Listen("tcp4", addr)
 	if err != nil {


### PR DESCRIPTION
on AWS EC2 instances, we can't bind the IP address, has to use no IP to
join host.

Signed-off-by: Leo Chen <leo@harmony.one>