### PR TITLE
Vendor github.com/golang/protobuf

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = vendor/github.com/ethereum/go-ethereum
 	url = https://github.com/harmony-one/go-ethereum
 	branch = master
+[submodule "vendor/github.com/golang/protobuf"]
+	path = vendor/github.com/golang/protobuf
+	url = https://github.com/golang/protobuf


### PR DESCRIPTION
Peg at commit 8d0c54c1246661d9a51ca0ba455d22116d485eaa in order to avoid
https://github.com/golang/protobuf/issues/763.