### PR TITLE
Fix README.md to reference scripts correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Tx Generator:
 go build -o bin/txgen cmd/client/txgen/main.go
 ```
 
-You can also run the script `./script/go_executable_build.sh` to build all the executables.
+You can also run the script `./scripts/go_executable_build.sh` to build all the executables.
 
 Some of our scripts require bash 4.x support, please [install bash 4.x](http://tldrdevnotes.com/bash-upgrade-3-4-macos) on MacOS X.
 


### PR DESCRIPTION
Fixing a small typo so that the correct scripts directory is referenced when building.