### PR TITLE
be verbose in travis checker

### DIFF
--- a/scripts/travis_checker.sh
+++ b/scripts/travis_checker.sh
@@ -37,7 +37,7 @@ go_dirs="${tmpdir}/go_dirs.txt"
 dirnames < "${go_files}" | sort -u -t/ > "${go_dirs}"
 
 echo "Running go test..."
-if go test ./...
+if go test -v -count=1 ./...
 then
 	echo "go test succeeded."
 else


### PR DESCRIPTION
use -count=1 to disable test cache. This is useful, especially in the local test.

Signed-off-by: Leo Chen <leo@harmony.one>