### PR TITLE
reduce wait to join shard

### DIFF
--- a/cmd/client/txgen/main.go
+++ b/cmd/client/txgen/main.go
@@ -165,14 +165,14 @@ func main() {
 		log.Debug("Client Join Shard", "leader", leader)
 		clientNode.GetHost().AddPeer(&leader)
 		go clientNode.JoinShard(leader)
-		// wait for 3 seconds for client to send ping message to leader
-		time.Sleep(3 * time.Second)
-		clientNode.StopPing <- struct{}{}
-		clientNode.State = node.NodeJoinedShard
 	}
+	// wait for 1 seconds for client to send ping message to leader
+	time.Sleep(time.Second)
+	clientNode.StopPing <- struct{}{}
+	clientNode.State = node.NodeJoinedShard
 
 	// Transaction generation process
-	time.Sleep(5 * time.Second) // wait for nodes to be ready
+	time.Sleep(2 * time.Second) // wait for nodes to be ready
 	start := time.Now()
 	totalTime := float64(*duration)
 


### PR DESCRIPTION
My recent test had got consensus on 3 shards testing on AWS.

```
3 shards, 1535 consensus, 610 total TPS, 165 nodes
3.90.6.34, 530, 221.398
34.219.212.230, 509, 201.104
34.240.197.109, 496, 188.317
```

Signed-off-by: Leo Chen <leo@harmony.one>