### PR TITLE
Fetch and use (“gimme”) stable Go, not master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - master
+  - stable
 install:
   - export GOPATH=$HOME/gopath
   - export CGO_CPPFLAGS="-I$GOPATH/src/github.com/harmony-one/bls/include -I$GOPATH/src/github.com/harmony-one/mcl/include"


### PR DESCRIPTION
The Go installation (gimme) step of Travis-CI is super slow (~3m),
because we use master version of Go, which gimme needs to
download/compile/install out of the Git repository.

Use stable instead of master, which lets gimme to download/install the
binary version (if available), of the latest stable release, and fall
back to source only if that fails.