### PR TITLE
only use logging singleton

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -10,7 +10,6 @@ import (
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/sign/schnorr"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/harmony-one/harmony/core/state"
@@ -101,8 +100,6 @@ type Consensus struct {
 	ConsensusBlock chan *types.Block
 	// verified block to state sync broadcast
 	VerifiedNewBlock chan *types.Block
-
-	Log log.Logger
 
 	uniqueIDInstance *utils.UniqueValidatorID
 
@@ -197,7 +194,6 @@ func New(host p2p.Host, ShardID string, peers []p2p.Peer, leader p2p.Peer) *Cons
 		}()
 	}
 
-	consensus.Log = log.New()
 	consensus.uniqueIDInstance = utils.GetUniqueValidatorIDInstance()
 	consensus.OfflinePeerList = make([]p2p.Peer, 0)
 
@@ -285,7 +281,7 @@ func (consensus *Consensus) AddPeers(peers []*p2p.Peer) int {
 			consensus.pubKeyLock.Lock()
 			consensus.PublicKeys = append(consensus.PublicKeys, peer.PubKey)
 			consensus.pubKeyLock.Unlock()
-			consensus.Log.Debug("[SYNC] new peer added", "pubKey", peer.PubKey, "ip", peer.IP, "port", peer.Port)
+			utils.GetLogInstance().Debug("[SYNC] new peer added", "pubKey", peer.PubKey, "ip", peer.IP, "port", peer.Port)
 		}
 		count++
 	}
@@ -348,10 +344,10 @@ func (consensus *Consensus) RemovePeers(peers []p2p.Peer) int {
 func (consensus *Consensus) DebugPrintPublicKeys() {
 	for _, k := range consensus.PublicKeys {
 		str := fmt.Sprintf("%s", k)
-		consensus.Log.Debug("pk:", "string", str)
+		utils.GetLogInstance().Debug("pk:", "string", str)
 	}
 
-	consensus.Log.Debug("PublicKeys:", "#", len(consensus.PublicKeys))
+	utils.GetLogInstance().Debug("PublicKeys:", "#", len(consensus.PublicKeys))
 }
 
 // DebugPrintValidators print all validator ip/port/key in string format in Consensus
@@ -360,13 +356,13 @@ func (consensus *Consensus) DebugPrintValidators() {
 	consensus.validators.Range(func(k, v interface{}) bool {
 		if p, ok := v.(p2p.Peer); ok {
 			str2 := fmt.Sprintf("%s", p.PubKey)
-			consensus.Log.Debug("validator:", "IP", p.IP, "Port", p.Port, "VID", p.ValidatorID, "Key", str2)
+			utils.GetLogInstance().Debug("validator:", "IP", p.IP, "Port", p.Port, "VID", p.ValidatorID, "Key", str2)
 			count++
 			return true
 		}
 		return false
 	})
-	consensus.Log.Debug("Validators", "#", count)
+	utils.GetLogInstance().Debug("Validators", "#", count)
 }
 
 // UpdatePublicKeys updates the PublicKeys variable, protected by a mutex

--- a/consensus/consensus_leader_msg.go
+++ b/consensus/consensus_leader_msg.go
@@ -9,6 +9,7 @@ import (
 	consensus_proto "github.com/harmony-one/harmony/api/consensus"
 	"github.com/harmony-one/harmony/api/proto"
 	"github.com/harmony-one/harmony/crypto"
+	"github.com/harmony-one/harmony/internal/utils"
 )
 
 // Constructs the announce message
@@ -30,7 +31,7 @@ func (consensus *Consensus) constructAnnounceMessage() []byte {
 
 	marshaledMessage, err := protobuf.Marshal(&message)
 	if err != nil {
-		consensus.Log.Debug("Failed to marshal Announce message", "error", err)
+		utils.GetLogInstance().Debug("Failed to marshal Announce message", "error", err)
 	}
 	// 64 byte of signature on previous data
 	signature := consensus.signMessage(marshaledMessage)
@@ -38,9 +39,9 @@ func (consensus *Consensus) constructAnnounceMessage() []byte {
 
 	marshaledMessage, err = protobuf.Marshal(&message)
 	if err != nil {
-		consensus.Log.Debug("Failed to marshal Announce message", "error", err)
+		utils.GetLogInstance().Debug("Failed to marshal Announce message", "error", err)
 	}
-	consensus.Log.Info("New Announce", "NodeID", consensus.nodeID, "bitmap", consensus.bitmap)
+	utils.GetLogInstance().Info("New Announce", "NodeID", consensus.nodeID, "bitmap", consensus.bitmap)
 	return proto.ConstructConsensusMessage(marshaledMessage)
 }
 
@@ -92,7 +93,7 @@ func (consensus *Consensus) constructChallengeMessage(msgType consensus_proto.Me
 
 	marshaledMessage, err := protobuf.Marshal(&message)
 	if err != nil {
-		consensus.Log.Debug("Failed to marshal Challenge message", "error", err)
+		utils.GetLogInstance().Debug("Failed to marshal Challenge message", "error", err)
 	}
 	// 64 byte of signature on previous data
 	signature := consensus.signMessage(marshaledMessage)
@@ -100,9 +101,9 @@ func (consensus *Consensus) constructChallengeMessage(msgType consensus_proto.Me
 
 	marshaledMessage, err = protobuf.Marshal(&message)
 	if err != nil {
-		consensus.Log.Debug("Failed to marshal Challenge message", "error", err)
+		utils.GetLogInstance().Debug("Failed to marshal Challenge message", "error", err)
 	}
-	consensus.Log.Info("New Challenge", "NodeID", consensus.nodeID, "bitmap", consensus.bitmap)
+	utils.GetLogInstance().Info("New Challenge", "NodeID", consensus.nodeID, "bitmap", consensus.bitmap)
 	return proto.ConstructConsensusMessage(marshaledMessage), challengeScalar, aggCommitment
 }
 
@@ -134,7 +135,7 @@ func (consensus *Consensus) constructCollectiveSigMessage(collectiveSig [64]byte
 
 	marshaledMessage, err := protobuf.Marshal(&message)
 	if err != nil {
-		consensus.Log.Debug("Failed to marshal Challenge message", "error", err)
+		utils.GetLogInstance().Debug("Failed to marshal Challenge message", "error", err)
 	}
 	// 64 byte of signature on previous data
 	signature := consensus.signMessage(marshaledMessage)
@@ -142,9 +143,9 @@ func (consensus *Consensus) constructCollectiveSigMessage(collectiveSig [64]byte
 
 	marshaledMessage, err = protobuf.Marshal(&message)
 	if err != nil {
-		consensus.Log.Debug("Failed to marshal Challenge message", "error", err)
+		utils.GetLogInstance().Debug("Failed to marshal Challenge message", "error", err)
 	}
-	consensus.Log.Info("New CollectiveSig", "NodeID", consensus.nodeID, "bitmap", consensus.bitmap)
+	utils.GetLogInstance().Info("New CollectiveSig", "NodeID", consensus.nodeID, "bitmap", consensus.bitmap)
 	return proto.ConstructConsensusMessage(marshaledMessage)
 }
 

--- a/consensus/consensus_validator_msg.go
+++ b/consensus/consensus_validator_msg.go
@@ -6,6 +6,7 @@ import (
 	consensus_proto "github.com/harmony-one/harmony/api/consensus"
 	"github.com/harmony-one/harmony/api/proto"
 	"github.com/harmony-one/harmony/crypto"
+	"github.com/harmony-one/harmony/internal/utils"
 )
 
 // Construct the commit message to send to leader (assumption the consensus data is already verified)
@@ -26,13 +27,13 @@ func (consensus *Consensus) constructCommitMessage(msgType consensus_proto.Messa
 	secret, commitment := crypto.Commit(crypto.Ed25519Curve)
 	bytes, err := commitment.MarshalBinary()
 	if err != nil {
-		consensus.Log.Debug("Failed to marshal commit", "error", err)
+		utils.GetLogInstance().Debug("Failed to marshal commit", "error", err)
 	}
 	message.Payload = bytes
 
 	marshaledMessage, err := protobuf.Marshal(&message)
 	if err != nil {
-		consensus.Log.Debug("Failed to marshal Announce message", "error", err)
+		utils.GetLogInstance().Debug("Failed to marshal Announce message", "error", err)
 	}
 	// 64 byte of signature on previous data
 	signature := consensus.signMessage(marshaledMessage)
@@ -40,7 +41,7 @@ func (consensus *Consensus) constructCommitMessage(msgType consensus_proto.Messa
 
 	marshaledMessage, err = protobuf.Marshal(&message)
 	if err != nil {
-		consensus.Log.Debug("Failed to marshal Announce message", "error", err)
+		utils.GetLogInstance().Debug("Failed to marshal Announce message", "error", err)
 	}
 
 	return secret, proto.ConstructConsensusMessage(marshaledMessage)
@@ -62,13 +63,13 @@ func (consensus *Consensus) constructResponseMessage(msgType consensus_proto.Mes
 
 	bytes, err := response.MarshalBinary()
 	if err != nil {
-		consensus.Log.Debug("Failed to marshal response", "error", err)
+		utils.GetLogInstance().Debug("Failed to marshal response", "error", err)
 	}
 	message.Payload = bytes
 
 	marshaledMessage, err := protobuf.Marshal(&message)
 	if err != nil {
-		consensus.Log.Debug("Failed to marshal Announce message", "error", err)
+		utils.GetLogInstance().Debug("Failed to marshal Announce message", "error", err)
 	}
 	// 64 byte of signature on previous data
 	signature := consensus.signMessage(marshaledMessage)
@@ -76,7 +77,7 @@ func (consensus *Consensus) constructResponseMessage(msgType consensus_proto.Mes
 
 	marshaledMessage, err = protobuf.Marshal(&message)
 	if err != nil {
-		consensus.Log.Debug("Failed to marshal Announce message", "error", err)
+		utils.GetLogInstance().Debug("Failed to marshal Announce message", "error", err)
 	}
 	return proto.ConstructConsensusMessage(marshaledMessage)
 }

--- a/internal/beaconchain/libs/beaconchain_handler.go
+++ b/internal/beaconchain/libs/beaconchain_handler.go
@@ -3,6 +3,7 @@ package beaconchain
 import (
 	"github.com/harmony-one/harmony/api/proto"
 	proto_identity "github.com/harmony-one/harmony/api/proto/identity"
+	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 )
 
@@ -10,27 +11,27 @@ import (
 func (bc *BeaconChain) BeaconChainHandler(s p2p.Stream) {
 	content, err := p2p.ReadMessageContent(s)
 	if err != nil {
-		bc.log.Error("Read p2p data failed")
+		utils.GetLogInstance().Error("Read p2p data failed")
 		return
 	}
 	msgCategory, err := proto.GetMessageCategory(content)
 	if err != nil {
-		bc.log.Error("Read message category failed", "err", err)
+		utils.GetLogInstance().Error("Read message category failed", "err", err)
 		return
 	}
 	msgType, err := proto.GetMessageType(content)
 	if err != nil {
-		bc.log.Error("Read action type failed")
+		utils.GetLogInstance().Error("Read action type failed")
 		return
 	}
 	msgPayload, err := proto.GetMessagePayload(content)
 	if err != nil {
-		bc.log.Error("Read message payload failed")
+		utils.GetLogInstance().Error("Read message payload failed")
 		return
 	}
 	identityMsgPayload, err := proto_identity.GetIdentityMessagePayload(msgPayload)
 	if err != nil {
-		bc.log.Error("Read message payload failed")
+		utils.GetLogInstance().Error("Read message payload failed")
 		return
 	}
 	switch msgCategory {
@@ -38,20 +39,20 @@ func (bc *BeaconChain) BeaconChainHandler(s p2p.Stream) {
 		actionType := proto_identity.IDMessageType(msgType)
 		switch actionType {
 		case proto_identity.Identity:
-			bc.log.Info("Message category is of the type identity protocol, which is correct!")
+			utils.GetLogInstance().Info("Message category is of the type identity protocol, which is correct!")
 			idMsgType, err := proto_identity.GetIdentityMessageType(msgPayload)
 			if err != nil {
-				bc.log.Error("Error finding the identity message type")
+				utils.GetLogInstance().Error("Error finding the identity message type")
 			}
 			switch idMsgType {
 			case proto_identity.Register:
-				bc.log.Info("Identity Message Type is of the type Register")
+				utils.GetLogInstance().Info("Identity Message Type is of the type Register")
 				bc.AcceptConnections(identityMsgPayload)
 			default:
-				bc.log.Error("Unrecognized identity message type", "type", idMsgType)
+				utils.GetLogInstance().Error("Unrecognized identity message type", "type", idMsgType)
 			}
 		default:
-			bc.log.Error("Unrecognized message category", "actionType", actionType)
+			utils.GetLogInstance().Error("Unrecognized message category", "actionType", actionType)
 		}
 
 	}

--- a/internal/utils/singleton.go
+++ b/internal/utils/singleton.go
@@ -16,6 +16,7 @@ var (
 )
 
 // SetPortAndIP used to print out loggings of node with Port and IP.
+// Every instance (node, txgen, etc..) needs to set this for logging.
 func SetPortAndIP(port, ip string) {
 	Port = port
 	IP = ip

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/harmony-one/harmony/core/types"
 	hmy_crypto "github.com/harmony-one/harmony/crypto"
 	"github.com/harmony-one/harmony/crypto/pki"
+	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/p2p/host"
 )
@@ -41,7 +42,7 @@ func (node *Node) StreamHandler(s p2p.Stream) {
 	content, err := p2p.ReadMessageContent(s)
 
 	if err != nil {
-		node.log.Error("Read p2p data failed", "err", err, "node", node)
+		utils.GetLogInstance().Error("Read p2p data failed", "err", err, "node", node)
 		return
 	}
 	node.MaybeBroadcastAsValidator(content)
@@ -50,19 +51,19 @@ func (node *Node) StreamHandler(s p2p.Stream) {
 
 	msgCategory, err := proto.GetMessageCategory(content)
 	if err != nil {
-		node.log.Error("Read node type failed", "err", err, "node", node)
+		utils.GetLogInstance().Error("Read node type failed", "err", err, "node", node)
 		return
 	}
 
 	msgType, err := proto.GetMessageType(content)
 	if err != nil {
-		node.log.Error("Read action type failed", "err", err, "node", node)
+		utils.GetLogInstance().Error("Read action type failed", "err", err, "node", node)
 		return
 	}
 
 	msgPayload, err := proto.GetMessagePayload(content)
 	if err != nil {
-		node.log.Error("Read message payload failed", "err", err, "node", node)
+		utils.GetLogInstance().Error("Read message payload failed", "err", err, "node", node)
 		return
 	}
 
@@ -75,18 +76,18 @@ func (node *Node) StreamHandler(s p2p.Stream) {
 			switch messageType {
 			case proto_identity.Register:
 				fmt.Println("received a identity message")
-				node.log.Info("NET: received message: IDENTITY/REGISTER")
+				utils.GetLogInstance().Info("NET: received message: IDENTITY/REGISTER")
 			default:
-				node.log.Error("Announce message should be sent to IdentityChain")
+				utils.GetLogInstance().Error("Announce message should be sent to IdentityChain")
 			}
 		}
 	case proto.Consensus:
 		msgPayload, _ := proto.GetConsensusMessagePayload(content)
 		if consensusObj.IsLeader {
-			node.log.Info("NET: Leader received message:", "messageCategory", msgCategory, "messageType", msgType)
+			utils.GetLogInstance().Info("NET: Leader received message:", "messageCategory", msgCategory, "messageType", msgType)
 			consensusObj.ProcessMessageLeader(msgPayload)
 		} else {
-			node.log.Info("NET: Validator received message:", "messageCategory", msgCategory, "messageType", msgType)
+			utils.GetLogInstance().Info("NET: Validator received message:", "messageCategory", msgCategory, "messageType", msgType)
 			consensusObj.ProcessMessageValidator(msgPayload)
 			// TODO(minhdoan): add logic to check if the current blockchain is not sync with other consensus
 			// we should switch to other state rather than DoingConsensus.
@@ -95,17 +96,17 @@ func (node *Node) StreamHandler(s p2p.Stream) {
 		actionType := proto_node.MessageType(msgType)
 		switch actionType {
 		case proto_node.Transaction:
-			node.log.Info("NET: received message: Node/Transaction")
+			utils.GetLogInstance().Info("NET: received message: Node/Transaction")
 			node.transactionMessageHandler(msgPayload)
 		case proto_node.Block:
-			node.log.Info("NET: received message: Node/Block")
+			utils.GetLogInstance().Info("NET: received message: Node/Block")
 			blockMsgType := proto_node.BlockMessageType(msgPayload[0])
 			switch blockMsgType {
 			case proto_node.Sync:
 				var blocks []*types.Block
 				err := rlp.DecodeBytes(msgPayload[1:], &blocks) // skip the Sync messge type
 				if err != nil {
-					node.log.Error("block sync", "error", err)
+					utils.GetLogInstance().Error("block sync", "error", err)
 				} else {
 					if node.Client != nil && node.Client.UpdateBlocks != nil && blocks != nil {
 						node.Client.UpdateBlocks(blocks)
@@ -113,10 +114,10 @@ func (node *Node) StreamHandler(s p2p.Stream) {
 				}
 			}
 		case proto_node.Control:
-			node.log.Info("NET: received message: Node/Control")
+			utils.GetLogInstance().Info("NET: received message: Node/Control")
 			controlType := msgPayload[0]
 			if proto_node.ControlMessageType(controlType) == proto_node.STOP {
-				node.log.Debug("Stopping Node", "node", node, "numBlocks", node.blockchain.CurrentBlock().NumberU64(), "numTxsProcessed", node.countNumTransactionsInBlockchain())
+				utils.GetLogInstance().Debug("Stopping Node", "node", node, "numBlocks", node.blockchain.CurrentBlock().NumberU64(), "numTxsProcessed", node.countNumTransactionsInBlockchain())
 
 				var avgBlockSizeInBytes common.StorageSize
 				txCount := 0
@@ -136,7 +137,7 @@ func (node *Node) StreamHandler(s p2p.Stream) {
 					avgTxSize = avgTxSize / txCount
 				}
 
-				node.log.Debug("Blockchain Report", "totalNumBlocks", blockCount, "avgBlockSizeInCurrentEpoch", avgBlockSizeInBytes, "totalNumTxs", txCount, "avgTxSzieInCurrentEpoch", avgTxSize)
+				utils.GetLogInstance().Debug("Blockchain Report", "totalNumBlocks", blockCount, "avgBlockSizeInCurrentEpoch", avgBlockSizeInBytes, "totalNumTxs", txCount, "avgTxSzieInCurrentEpoch", avgTxSize)
 
 				os.Exit(0)
 			}
@@ -146,7 +147,7 @@ func (node *Node) StreamHandler(s p2p.Stream) {
 			node.pongMessageHandler(msgPayload)
 		}
 	default:
-		node.log.Error("Unknown", "MsgCategory", msgCategory)
+		utils.GetLogInstance().Error("Unknown", "MsgCategory", msgCategory)
 	}
 }
 
@@ -158,7 +159,7 @@ func (node *Node) transactionMessageHandler(msgPayload []byte) {
 		txs := types.Transactions{}
 		err := rlp.Decode(bytes.NewReader(msgPayload[1:]), &txs) // skip the Send messge type
 		if err != nil {
-			node.log.Error("Failed to deserialize transaction list", "error", err)
+			utils.GetLogInstance().Error("Failed to deserialize transaction list", "error", err)
 		}
 		node.addPendingTransactions(txs)
 
@@ -188,7 +189,7 @@ func (node *Node) transactionMessageHandler(msgPayload []byte) {
 
 // WaitForConsensusReady listen for the readiness signal from consensus and generate new block for consensus.
 func (node *Node) WaitForConsensusReady(readySignal chan struct{}) {
-	node.log.Debug("Waiting for Consensus ready", "node", node)
+	utils.GetLogInstance().Debug("Waiting for Consensus ready", "node", node)
 	time.Sleep(15 * time.Second) // Wait for other nodes to be ready (test-only)
 
 	firstTime := true
@@ -202,7 +203,7 @@ func (node *Node) WaitForConsensusReady(readySignal chan struct{}) {
 		case <-time.After(200 * time.Second):
 			node.Consensus.ResetState()
 			timeoutCount++
-			node.log.Debug("Consensus timeout, retry!", "count", timeoutCount, "node", node)
+			utils.GetLogInstance().Debug("Consensus timeout, retry!", "count", timeoutCount, "node", node)
 		}
 
 		for {
@@ -212,7 +213,7 @@ func (node *Node) WaitForConsensusReady(readySignal chan struct{}) {
 				threshold = 2
 				firstTime = false
 			}
-			node.log.Debug("STARTING BLOCK", "threshold", threshold, "pendingTransactions", len(node.pendingTransactions))
+			utils.GetLogInstance().Debug("STARTING BLOCK", "threshold", threshold, "pendingTransactions", len(node.pendingTransactions))
 			if len(node.pendingTransactions) >= threshold {
 				// Normal tx block consensus
 				selectedTxs := node.getTransactionsForNewBlock(MaxNumberOfTransactionsPerBlock)
@@ -220,7 +221,7 @@ func (node *Node) WaitForConsensusReady(readySignal chan struct{}) {
 					node.Worker.CommitTransactions(selectedTxs)
 					block, err := node.Worker.Commit()
 					if err != nil {
-						node.log.Debug("Failed commiting new block", "Error", err)
+						utils.GetLogInstance().Debug("Failed commiting new block", "Error", err)
 					} else {
 						newBlock = block
 						break
@@ -243,7 +244,7 @@ func (node *Node) WaitForConsensusReady(readySignal chan struct{}) {
 // TODO (lc): broadcast the new blocks to new nodes doing state sync
 func (node *Node) BroadcastNewBlock(newBlock *types.Block) {
 	if node.ClientPeer != nil {
-		node.log.Debug("Sending new block to client", "client", node.ClientPeer)
+		utils.GetLogInstance().Debug("Sending new block to client", "client", node.ClientPeer)
 		node.SendMessage(*node.ClientPeer, proto_node.ConstructBlocksSyncMessage([]*types.Block{newBlock}))
 	}
 }
@@ -252,13 +253,13 @@ func (node *Node) BroadcastNewBlock(newBlock *types.Block) {
 func (node *Node) VerifyNewBlock(newBlock *types.Block) bool {
 	err := node.blockchain.ValidateNewBlock(newBlock, pki.GetAddressFromPublicKey(node.SelfPeer.PubKey))
 	if err != nil {
-		node.log.Debug("Failed verifying new block", "Error", err, "tx", newBlock.Transactions()[0])
+		utils.GetLogInstance().Debug("Failed verifying new block", "Error", err, "tx", newBlock.Transactions()[0])
 
 		// send consensus block to state syncing
 		select {
 		case node.Consensus.ConsensusBlock <- newBlock:
 		default:
-			node.log.Warn("consensus block unable to sent to state sync", "height", newBlock.NumberU64(), "blockHash", newBlock.Hash().Hex())
+			utils.GetLogInstance().Warn("consensus block unable to sent to state sync", "height", newBlock.NumberU64(), "blockHash", newBlock.Hash().Hex())
 		}
 
 		return false
@@ -282,19 +283,19 @@ func (node *Node) PostConsensusProcessing(newBlock *types.Block) {
 func (node *Node) AddNewBlock(newBlock *types.Block) {
 	blockNum, err := node.blockchain.InsertChain([]*types.Block{newBlock})
 	if err != nil {
-		node.log.Debug("Error adding new block to blockchain", "blockNum", blockNum, "Error", err)
+		utils.GetLogInstance().Debug("Error adding new block to blockchain", "blockNum", blockNum, "Error", err)
 	} else {
-		node.log.Info("adding new block to blockchain", "blockNum", blockNum)
+		utils.GetLogInstance().Info("adding new block to blockchain", "blockNum", blockNum)
 	}
 }
 
 func (node *Node) pingMessageHandler(msgPayload []byte) int {
 	ping, err := proto_node.GetPingMessage(msgPayload)
 	if err != nil {
-		node.log.Error("Can't get Ping Message")
+		utils.GetLogInstance().Error("Can't get Ping Message")
 		return -1
 	}
-	//	node.log.Info("Ping", "Msg", ping)
+	//	utils.GetLogInstance().Info("Ping", "Msg", ping)
 
 	peer := new(p2p.Peer)
 	peer.IP = ping.Node.IP
@@ -305,12 +306,12 @@ func (node *Node) pingMessageHandler(msgPayload []byte) int {
 	peer.PubKey = hmy_crypto.Ed25519Curve.Point()
 	err = peer.PubKey.UnmarshalBinary(ping.Node.PubKey[:])
 	if err != nil {
-		node.log.Error("UnmarshalBinary Failed", "error", err)
+		utils.GetLogInstance().Error("UnmarshalBinary Failed", "error", err)
 		return -1
 	}
 
 	if ping.Node.Role == proto_node.ClientRole {
-		node.log.Info("Add Client Peer to Node", "Node", node.Consensus.GetNodeID(), "Client", peer)
+		utils.GetLogInstance().Info("Add Client Peer to Node", "Node", node.Consensus.GetNodeID(), "Client", peer)
 		node.ClientPeer = peer
 		return 0
 	}
@@ -342,11 +343,11 @@ func (node *Node) pingMessageHandler(msgPayload []byte) int {
 func (node *Node) pongMessageHandler(msgPayload []byte) int {
 	pong, err := proto_node.GetPongMessage(msgPayload)
 	if err != nil {
-		node.log.Error("Can't get Pong Message")
+		utils.GetLogInstance().Error("Can't get Pong Message")
 		return -1
 	}
 
-	//	node.log.Debug("pongMessageHandler", "pong", pong, "nodeID", node.Consensus.GetNodeID())
+	//	utils.GetLogInstance().Debug("pongMessageHandler", "pong", pong, "nodeID", node.Consensus.GetNodeID())
 
 	peers := make([]*p2p.Peer, 0)
 
@@ -360,7 +361,7 @@ func (node *Node) pongMessageHandler(msgPayload []byte) int {
 		peer.PubKey = hmy_crypto.Ed25519Curve.Point()
 		err = peer.PubKey.UnmarshalBinary(p.PubKey[:])
 		if err != nil {
-			node.log.Error("UnmarshalBinary Failed", "error", err)
+			utils.GetLogInstance().Error("UnmarshalBinary Failed", "error", err)
 			continue
 		}
 		peers = append(peers, peer)
@@ -380,7 +381,7 @@ func (node *Node) pongMessageHandler(msgPayload []byte) int {
 		key := hmy_crypto.Ed25519Curve.Point()
 		err = key.UnmarshalBinary(k[:])
 		if err != nil {
-			node.log.Error("UnmarshalBinary Failed PubKeys", "error", err)
+			utils.GetLogInstance().Error("UnmarshalBinary Failed PubKeys", "error", err)
 			continue
 		}
 		publicKeys = append(publicKeys, key)


### PR DESCRIPTION
Currently we use different log object everywhere. Replace them by a logging singleton.

Good thing about this log - it gives information about the which node (ip and port) is logging. it helps debugging easier.