### PR TITLE
Vendor Kyber at pre-modularization

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "vendor/github.com/golang/protobuf"]
 	path = vendor/github.com/golang/protobuf
 	url = https://github.com/golang/protobuf
+[submodule "vendor/github.com/dedis/kyber"]
+	path = vendor/github.com/dedis/kyber
+	url = https://github.com/dedis/kyber


### PR DESCRIPTION
Kyber is going through version 3 release process, in which they are
switching to being a full module and requiring the import path to be
go.dedis.ch/kyber. This breaks fresh installs and likely CI builds too.
Peg at the version right before the modularization so that our code (yet
to be adjusted for the new import path) continues to build.

This is a temporary bandaid.  We will be getting rid of Kyber soon in
favor of https://github.com/herumi/bls.