### PR TITLE
Make Travis-CI use the canonical import path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
   - stable
+go_import_path: github.com/harmony-one/harmony
 install:
   - export GOPATH=$HOME/gopath
   - export CGO_CPPFLAGS="-I$GOPATH/src/github.com/harmony-one/bls/include -I$GOPATH/src/github.com/harmony-one/mcl/include"


### PR DESCRIPTION
Currently we get an import problem for forks, for example “someone-else/harmony”.  Travis-CI job set up for such a fork will check out the repo under GOPATH/src/github.com/someone-else/harmony, importable as `"github.com/someone-else/harmony"` and not as the intended `"github.com/harmony-one/harmony"`.

Recording the canonical import path (go_import_path) in .travis.yml lets Travis-CI check out the repo under GOPATH/src always using the canonical import path, resolving build issues for forks.