### PR TITLE
Remove deprecated ready field

### DIFF
--- a/api/proto/node/pingpong_test.go
+++ b/api/proto/node/pingpong_test.go
@@ -30,14 +30,12 @@ var (
 			IP:          "127.0.0.1",
 			Port:        "8888",
 			PubKey:      pubKey1,
-			Ready:       true,
 			ValidatorID: -1,
 		},
 		{
 			IP:          "127.0.0.1",
 			Port:        "9999",
 			PubKey:      pubKey2,
-			Ready:       false,
 			ValidatorID: -2,
 		},
 	}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -73,14 +73,12 @@ func TestAddPeers(t *testing.T) {
 			IP:          "127.0.0.1",
 			Port:        "8888",
 			PubKey:      pubKey1,
-			Ready:       true,
 			ValidatorID: 1,
 		},
 		&p2p.Peer{
 			IP:          "127.0.0.1",
 			Port:        "9999",
 			PubKey:      pubKey2,
-			Ready:       false,
 			ValidatorID: 2,
 		},
 	}

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -17,7 +17,6 @@ type Peer struct {
 	IP          string                // IP address of the peer
 	Port        string                // Port number of the peer
 	PubKey      *bls.PublicKey        // Public key of the peer, used for consensus signing
-	Ready       bool                  // Ready is true if the peer is ready to join consensus. (FIXME: deprecated)
 	ValidatorID int                   // -1 is the default value, means not assigned any validator ID in the shard
 	Addrs       []multiaddr.Multiaddr // MultiAddress of the peer
 	PeerID      peer.ID               // PeerID, the pubkey for communication


### PR DESCRIPTION
Originally #320, which can't go through 'cause it somehow doesn't trigger Travis-CI builds anymore.