### PR TITLE
Add addrlist in utils for bootnode

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -76,7 +76,7 @@ func main() {
 		panic(err)
 	}
 
-	log.Info("bootnode", "BN_MA", fmt.Sprintf("/ipv/%s/tcp/%s/p2p/%s", *ip, *port, host.GetID().Pretty()))
+	log.Info("bootnode", "BN_MA", fmt.Sprintf("/ip4/%s/tcp/%s/p2p/%s", *ip, *port, host.GetID().Pretty()))
 
 	dataStore := dsync.MutexWrap(ds.NewMapDatastore())
 	dht := kaddht.NewDHT(context.Background(), host.GetP2PHost(), dataStore)

--- a/internal/utils/flags.go
+++ b/internal/utils/flags.go
@@ -1,0 +1,52 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+// AddrList is a list of multiaddress
+type AddrList []ma.Multiaddr
+
+// String is a function to print a string representation of the AddrList
+func (al *AddrList) String() string {
+	strs := make([]string, len(*al))
+	for i, addr := range *al {
+		strs[i] = addr.String()
+	}
+	return strings.Join(strs, ",")
+}
+
+// Set is a function to set the value of AddrList based on a string
+func (al *AddrList) Set(value string) error {
+	if len(*al) > 0 {
+		return fmt.Errorf("AddrList is already set")
+	}
+	for _, a := range strings.Split(value, ",") {
+		addr, err := ma.NewMultiaddr(a)
+		if err != nil {
+			return err
+		}
+		*al = append(*al, addr)
+	}
+	return nil
+}
+
+// StringsToAddrs convert a list of strings to a list of multiaddresses
+func StringsToAddrs(addrStrings []string) (maddrs []ma.Multiaddr, err error) {
+	for _, addrString := range addrStrings {
+		addr, err := ma.NewMultiaddr(addrString)
+		if err != nil {
+			return maddrs, err
+		}
+		maddrs = append(maddrs, addr)
+	}
+	return
+}
+
+// DefaultBootNodeAddrStrings is a list of Harmony bootnodes. Used to find other peers in the network.
+var DefaultBootNodeAddrStrings = []string{
+	"/ip4/127.0.0.1/tcp/9876/p2p/QmayB8NwxmfGE4Usb4H61M8uwbfc7LRbmXb3ChseJgbVuf",
+}

--- a/internal/utils/flags_test.go
+++ b/internal/utils/flags_test.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestStringsToAddrs(t *testing.T) {
+	bn, err := StringsToAddrs(DefaultBootNodeAddrStrings)
+	if err != nil {
+		t.Fatalf("unable to convert string to addresses: %v", err)
+	}
+	if len(bn) == 0 {
+		t.Fatalf("should have more than one multiaddress returned")
+	}
+}
+
+func TestAddrListFunc(t *testing.T) {
+	addr := new(AddrList)
+	err := addr.Set("/ip4/127.0.0.1/tcp/9999/p2p/QmayB8NwxmfGE4Usb4H61M8uwbfc7LRbmXb3ChseJgbVuf,/ip4/127.0.0.1/tcp/9877/p2p/QmS374uzJ9yEEoWcEQ6JcbSUaVUj29SKakcmVvr3HVAjKP")
+	if err != nil || len(*addr) < 2 {
+		t.Fatalf("unable to set addr list")
+	}
+	s := fmt.Sprintf("addr: %s\n", addr)
+	if len(s) == 0 {
+		t.Fatalf("unable to print AddrList")
+	}
+}


### PR DESCRIPTION
## test coverage before
$ go test -cover
2019/01/29 20:16:16 No priviate key can be loaded from filekeyfile/tmp/please_ignore_the_non-exist_file
2019/01/29 20:16:16 Using random private key
PASS
coverage: 74.8% of statements
ok      github.com/harmony-one/harmony/internal/utils   1.057s
[20:16] ec2-user @ leo-cloud: ~/go/src/github.com/harmony-one/harmony/internal/utils [bootnode]: Added
$ mv /tmp/flags* .
[20:16] ec2-user @ leo-cloud: ~/go/src/github.com/harmony-one/harmony/internal/utils [bootnode]: Added

## tets coverage after
$ go test -cover
2019/01/29 20:16:27 No priviate key can be loaded from filekeyfile/tmp/please_ignore_the_non-exist_file
2019/01/29 20:16:27 Using random private key
PASS
coverage: 76.0% of statements
ok      github.com/harmony-one/harmony/internal/utils   1.459s