### PR TITLE
move proto/pingping to discovery module

### DIFF
--- a/api/proto/common.go
+++ b/api/proto/common.go
@@ -34,11 +34,14 @@ const (
 	// TODO: add more types
 )
 
-// MessageCategoryBytes is the number of bytes message category takes
-const MessageCategoryBytes = 1
-
-// MessageTypeBytes is the number of bytes message type takes
-const MessageTypeBytes = 1
+const (
+	// ProtocolVersion is a constant defined as the version of the Harmony protocol
+	ProtocolVersion = 1
+	// MessageCategoryBytes is the number of bytes message category takes
+	MessageCategoryBytes = 1
+	// MessageTypeBytes is the number of bytes message type takes
+	MessageTypeBytes = 1
+)
 
 // GetMessageCategory gets the message category from the p2p message content
 func GetMessageCategory(message []byte) (MessageCategory, error) {

--- a/api/proto/discovery/pingpong_test.go
+++ b/api/proto/discovery/pingpong_test.go
@@ -1,4 +1,4 @@
-package node
+package discovery
 
 import (
 	"fmt"
@@ -8,6 +8,7 @@ import (
 
 	"github.com/harmony-one/bls/ffi/go/bls"
 	"github.com/harmony-one/harmony/api/proto"
+	"github.com/harmony-one/harmony/api/proto/node"
 	"github.com/harmony-one/harmony/crypto/pki"
 	"github.com/harmony-one/harmony/p2p"
 )
@@ -55,7 +56,7 @@ func TestString(test *testing.T) {
 		test.Errorf("expect: %v, got: %v", e1, r1)
 	}
 
-	ping1.Node.Role = ClientRole
+	ping1.Node.Role = node.ClientRole
 
 	r3 := fmt.Sprintf("%v", *ping1)
 	if strings.Compare(r3, e3) != 0 {

--- a/api/proto/node/node.go
+++ b/api/proto/node/node.go
@@ -3,6 +3,7 @@ package node
 import (
 	"bytes"
 	"encoding/gob"
+	"fmt"
 	"log"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -10,15 +11,11 @@ import (
 	"github.com/harmony-one/harmony/core/types"
 
 	"github.com/harmony-one/harmony/api/proto"
+	peer "github.com/libp2p/go-libp2p-peer"
 )
 
 // MessageType is to indicate the specific type of message under Node category
 type MessageType byte
-
-// ProtocolVersion is a constant defined as the version of the Harmony protocol
-const (
-	ProtocolVersion = 1
-)
 
 // Constant of the top level Message Type exchanged among nodes
 const (
@@ -56,6 +53,41 @@ const (
 	Request
 	Unlock
 )
+
+// RoleType defines the role of the node
+type RoleType int
+
+// Type of roles of a node
+const (
+	ValidatorRole RoleType = iota
+	ClientRole
+)
+
+func (r RoleType) String() string {
+	switch r {
+	case ValidatorRole:
+		return "Validator"
+	case ClientRole:
+		return "Client"
+	}
+	return "Unknown"
+}
+
+// Info refers to Peer struct in p2p/peer.go
+// this is basically a simplified version of Peer
+// for network transportation
+type Info struct {
+	IP          string
+	Port        string
+	PubKey      []byte
+	ValidatorID int
+	Role        RoleType
+	PeerID      peer.ID // Peerstore ID
+}
+
+func (info Info) String() string {
+	return fmt.Sprintf("Info:%v/%v=>%v/%v", info.IP, info.Port, info.ValidatorID, info.PeerID)
+}
 
 // BlockMessageType represents the type of messages used for Node/Block
 type BlockMessageType int

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -26,7 +26,7 @@ import (
 	"github.com/harmony-one/harmony/p2p/host"
 	"golang.org/x/crypto/sha3"
 
-	proto_node "github.com/harmony-one/harmony/api/proto/node"
+	proto_discovery "github.com/harmony-one/harmony/api/proto/discovery"
 )
 
 // Consensus is the main struct with all states and data related to consensus process.
@@ -412,7 +412,7 @@ func (consensus *Consensus) RemovePeers(peers []p2p.Peer) int {
 		// Or the shard won't be able to reach consensus if public keys are mismatch
 
 		validators := consensus.GetValidatorPeers()
-		pong := proto_node.NewPongMessage(validators, consensus.PublicKeys)
+		pong := proto_discovery.NewPongMessage(validators, consensus.PublicKeys)
 		buffer := pong.ConstructPongMessage()
 
 		host.BroadcastMessageFromLeader(consensus.host, validators, buffer, consensus.OfflinePeers)

--- a/node/node.go
+++ b/node/node.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/harmony-one/harmony/api/client"
 	clientService "github.com/harmony-one/harmony/api/client/service"
+	proto_discovery "github.com/harmony-one/harmony/api/proto/discovery"
 	proto_node "github.com/harmony-one/harmony/api/proto/node"
 	"github.com/harmony-one/harmony/api/services/explorer"
 	"github.com/harmony-one/harmony/api/services/syncing"
@@ -432,7 +433,7 @@ func (node *Node) JoinShard(leader p2p.Peer) {
 	for {
 		select {
 		case <-tick.C:
-			ping := proto_node.NewPingMessage(node.SelfPeer)
+			ping := proto_discovery.NewPingMessage(node.SelfPeer)
 			if node.Client != nil { // assume this is the client node
 				ping.Node.Role = proto_node.ClientRole
 			}

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/harmony-one/bls/ffi/go/bls"
 	"github.com/harmony-one/harmony/api/proto"
+	proto_discovery "github.com/harmony-one/harmony/api/proto/discovery"
 	proto_identity "github.com/harmony-one/harmony/api/proto/identity"
 	proto_node "github.com/harmony-one/harmony/api/proto/node"
 	"github.com/harmony-one/harmony/core/types"
@@ -288,7 +289,7 @@ func (node *Node) AddNewBlock(newBlock *types.Block) {
 }
 
 func (node *Node) pingMessageHandler(msgPayload []byte) int {
-	ping, err := proto_node.GetPingMessage(msgPayload)
+	ping, err := proto_discovery.GetPingMessage(msgPayload)
 	if err != nil {
 		utils.GetLogInstance().Error("Can't get Ping Message")
 		return -1
@@ -318,7 +319,7 @@ func (node *Node) pingMessageHandler(msgPayload []byte) int {
 	node.AddPeers([]*p2p.Peer{peer})
 
 	peers := node.Consensus.GetValidatorPeers()
-	pong := proto_node.NewPongMessage(peers, node.Consensus.PublicKeys)
+	pong := proto_discovery.NewPongMessage(peers, node.Consensus.PublicKeys)
 	buffer := pong.ConstructPongMessage()
 
 	// Send a Pong message directly to the sender
@@ -339,7 +340,7 @@ func (node *Node) pingMessageHandler(msgPayload []byte) int {
 }
 
 func (node *Node) pongMessageHandler(msgPayload []byte) int {
-	pong, err := proto_node.GetPongMessage(msgPayload)
+	pong, err := proto_discovery.GetPongMessage(msgPayload)
 	if err != nil {
 		utils.GetLogInstance().Error("Can't get Pong Message")
 		return -1

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	proto_node "github.com/harmony-one/harmony/api/proto/node"
+	proto_discovery "github.com/harmony-one/harmony/api/proto/discovery"
 	"github.com/harmony-one/harmony/consensus"
 	"github.com/harmony-one/harmony/crypto/pki"
 	"github.com/harmony-one/harmony/internal/utils"
@@ -114,7 +114,7 @@ func sendPingMessage(node *Node, leader p2p.Peer) {
 		PubKey: pubKey1,
 	}
 
-	ping1 := proto_node.NewPingMessage(p1)
+	ping1 := proto_discovery.NewPingMessage(p1)
 	buf1 := ping1.ConstructPingMessage()
 
 	fmt.Println("waiting for 5 seconds ...")
@@ -138,7 +138,7 @@ func sendPongMessage(node *Node, leader p2p.Peer) {
 		PubKey: pubKey2,
 	}
 
-	pong1 := proto_node.NewPongMessage([]p2p.Peer{p1, p2}, nil)
+	pong1 := proto_discovery.NewPongMessage([]p2p.Peer{p1, p2}, nil)
 	buf1 := pong1.ConstructPongMessage()
 
 	fmt.Println("waiting for 10 seconds ...")


### PR DESCRIPTION
This is needed for the new peer discovery enabled by libp2p

Signed-off-by: Leo Chen <leo@harmony.one>

## Issue

I am adding new peerdiscovery service and will use pingpong messages

## Test

#### Test Coverage Data

```
$ go test -cover
PASS
coverage: 87.5% of statements
ok      github.com/harmony-one/harmony/api/proto/discovery      0.066s
```

#### Test/Run Logs

run "./test/deploy.sh test/configs/local_config1.txt" locally and got the consensus working fine.

====== RESULTS ======
++ ./test/../test/cal_tps.sh tmp_log/log-20190130-224854/all-leaders.txt tmp_log/log-20190130-224854/all-validators.txt
+ results='2 shards, 45 consensus, 105 total TPS, 11 nodes
127.0.0.1, 23, 51.8767'
+ echo 2 shards, 45 consensus, 5 total TPS, 11 nodes 127.0.0.1, 23, 51.8767
+ tee -a tmp_log/log-20190130-224854/r.log
2 shards, 45 consensus, 105 total TPS, 11 nodes 127.0.0.1, 23, 51.8767

## TODO
n/a