### PR TITLE
enable consensus service in service manager

### DIFF
--- a/cmd/harmony.go
+++ b/cmd/harmony.go
@@ -212,8 +212,6 @@ func main() {
 
 	if consensus.IsLeader {
 		currentNode.State = node.NodeLeader
-		// Let consensus run
-		consensus.WaitForNewBlock(currentNode.BlockChannel, nil, nil)
 		// Node waiting for consensus readiness to create new block
 		go func() {
 			currentNode.WaitForConsensusReady(consensus.ReadySignal)

--- a/node/node.go
+++ b/node/node.go
@@ -34,6 +34,7 @@ import (
 	"github.com/harmony-one/harmony/core/vm"
 	"github.com/harmony-one/harmony/crypto/pki"
 	"github.com/harmony-one/harmony/internal/utils"
+	"github.com/harmony-one/harmony/node/service"
 	"github.com/harmony-one/harmony/node/worker"
 	"github.com/harmony-one/harmony/p2p"
 )
@@ -649,8 +650,8 @@ func (node *Node) AddAndRunServices() {
 		node.RegisterService(SupportExplorer, explorer.New(&node.SelfPeer))
 		node.actionChannel <- &Action{action: Start, serviceType: SupportExplorer}
 
-		// node.RegisterService(Consensus, service.NewConsensusService(node.BlockChannel, node.Consensus))
-		// node.actionChannel <- &Action{action: Start, serviceType: Consensus}
+		node.RegisterService(Consensus, service.NewConsensusService(node.BlockChannel, node.Consensus))
+		node.actionChannel <- &Action{action: Start, serviceType: Consensus}
 
 		// node.RegisterService(SupportClient, service.NewSupportClient(node.blockchain.State, node.CallFaucetContract, node.SelfPeer.IP, node.SelfPeer.Port))
 		// node.actionChannel <- &Action{action: Start, serviceType: SupportClient}


### PR DESCRIPTION
## Issue

enable consensus service in service manager

## Test

====== RESULTS ======
++ ./test/../test/cal_tps.sh tmp_log/log-20190130-160304/all-leaders.txt tmp_log/log-20190130-160304/all-validators.txt
+ results='2 shards, 128 consensus, 386 total TPS, 11 nodes
127.0.0.1, 64, 195.656'
+ echo 2 shards, 128 consensus, 386 total TPS, 11 nodes 127.0.0.1, 64, 195.656
+ tee -a tmp_log/log-20190130-160304/r.log
2 shards, 128 consensus, 386 total TPS, 11 nodes 127.0.0.1, 64, 195.656
+ echo 2 shards, 128 consensus, 386 total TPS, 11 nodes 127.0.0.1, 64, 195.656

#### Test Coverage Data

Not applied.

* Before
* After

#### Test/Run Logs

https://gist.github.com/mikedoan/3e84bf02c2af713b17f060cf0a6156f3

## TODO
NA