### PR TITLE
Add peer discovery service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,9 @@ db/
 
 # bootnode keystore
 .bnkey
+
+# harmony node keystore
+.hmykey
+
+# vendor directory
+vendor

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "vendor/github.com/golang/protobuf"]
 	path = vendor/github.com/golang/protobuf
 	url = https://github.com/golang/protobuf
+[submodule "vendor/github.com/libp2p/go-libp2p-kad-dht"]
+	path = vendor/github.com/libp2p/go-libp2p-kad-dht
+	url = https://github.com/libp2p/go-libp2p-kad-dht

--- a/api/service/discovery/discovery_test.go
+++ b/api/service/discovery/discovery_test.go
@@ -1,0 +1,31 @@
+package discovery
+
+import (
+	"testing"
+
+	"github.com/harmony-one/harmony/internal/utils"
+	"github.com/harmony-one/harmony/p2p"
+	"github.com/harmony-one/harmony/p2p/p2pimpl"
+)
+
+var (
+	ip      = "127.0.0.1"
+	port    = "7099"
+	service *Service
+)
+
+func TestDiscoveryService(t *testing.T) {
+	selfPeer := p2p.Peer{IP: ip, Port: port}
+	priKey, _, err := utils.GenKeyP2P(ip, port)
+
+	host, err := p2pimpl.NewHost(&selfPeer, priKey)
+	if err != nil {
+		t.Fatalf("unable to new host in harmony: %v", err)
+	}
+
+	service = New(host, "rendezvous")
+
+	if service == nil {
+		t.Fatalf("unable to create new discovery service")
+	}
+}

--- a/api/service/discovery/errors.go
+++ b/api/service/discovery/errors.go
@@ -1,0 +1,12 @@
+package discovery
+
+import "errors"
+
+// Errors of peer discovery
+var (
+	ErrGetPeers       = errors.New("[DISCOVERY]: get peer list failed")
+	ErrConnectionFull = errors.New("[DISCOVERY]: node's incoming connection full")
+	ErrPing           = errors.New("[DISCOVERY]: ping peer failed")
+	ErrPong           = errors.New("[DISCOVERY]: pong peer failed")
+	ErrDHTBootstrap   = errors.New("[DISCOVERY]: DHT bootstrap failed")
+)

--- a/api/service/discovery/service.go
+++ b/api/service/discovery/service.go
@@ -1,0 +1,118 @@
+package discovery
+
+import (
+	"context"
+	"io"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/harmony-one/harmony/internal/utils"
+	"github.com/harmony-one/harmony/p2p"
+
+	peerstore "github.com/libp2p/go-libp2p-peerstore"
+
+	libp2pdis "github.com/libp2p/go-libp2p-discovery"
+	libp2pdht "github.com/libp2p/go-libp2p-kad-dht"
+)
+
+// Constants for discovery service.
+const (
+	numIncoming = 128
+	numOutgoing = 16
+)
+
+// Service is the struct for discovery service.
+type Service struct {
+	Host       p2p.Host
+	DHT        *libp2pdht.IpfsDHT
+	Rendezvous string
+	reader     io.Reader
+	writer     io.Writer
+	ctx        context.Context
+}
+
+// New returns discovery service.
+// h is the p2p host
+// r is the rendezvous string, we use shardID to start (TODO: leo, build two overlays of network)
+func New(h p2p.Host, r string) *Service {
+	ctx := context.Background()
+	dht, err := libp2pdht.New(ctx, h.GetP2PHost())
+	if err != nil {
+		panic(err)
+	}
+
+	return &Service{
+		Host:       h,
+		DHT:        dht,
+		Rendezvous: r,
+		ctx:        ctx,
+	}
+}
+
+// StartService starts discovery service.
+func (s *Service) StartService() {
+	log.Info("Starting discovery service.")
+	err := s.Init()
+	if err != nil {
+		log.Error("StartService Aborted", "Error", err)
+		return
+	}
+
+	// We use a rendezvous point "shardID" to announce our location.
+	log.Info("Announcing ourselves...")
+	routingDiscovery := libp2pdis.NewRoutingDiscovery(s.DHT)
+	libp2pdis.Advertise(s.ctx, routingDiscovery, s.Rendezvous)
+	log.Debug("Successfully announced!")
+
+	log.Debug("Searching for other peers...")
+	peerChan, err := routingDiscovery.FindPeers(s.ctx, s.Rendezvous)
+	if err != nil {
+		log.Error("FindPeers", "error", err)
+	}
+
+	for peer := range peerChan {
+		// skip myself
+		if peer.ID == s.Host.GetP2PHost().ID() {
+			continue
+		}
+		log.Debug("Found peer", "adding peer", peer)
+		p := p2p.Peer{PeerID: peer.ID, Addrs: peer.Addrs}
+		s.Host.AddPeer(&p)
+	}
+
+	select {}
+}
+
+// StopService shutdowns discovery service.
+func (s *Service) StopService() {
+	log.Info("Shutting down discovery service.")
+}
+
+// Init is to initialize for discoveryService.
+func (s *Service) Init() error {
+	log.Info("Init discovery service")
+
+	// Bootstrap the DHT. In the default configuration, this spawns a Background
+	// thread that will refresh the peer table every five minutes.
+	log.Debug("Bootstrapping the DHT")
+	if err := s.DHT.Bootstrap(s.ctx); err != nil {
+		return ErrDHTBootstrap
+	}
+
+	var wg sync.WaitGroup
+	for _, peerAddr := range utils.BootNodes {
+		peerinfo, _ := peerstore.InfoFromP2pAddr(peerAddr)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := s.Host.GetP2PHost().Connect(s.ctx, *peerinfo); err != nil {
+				log.Warn("can't connect to bootnode", "error", err)
+			} else {
+				log.Info("connected to bootnode", "node", *peerinfo)
+			}
+		}()
+	}
+	wg.Wait()
+
+	return nil
+}

--- a/api/service/manager.go
+++ b/api/service/manager.go
@@ -26,6 +26,7 @@ const (
 	SupportExplorer
 	Consensus
 	BlockProposal
+	PeerDiscovery
 	Test
 	Done
 )
@@ -42,6 +43,8 @@ func (t Type) String() string {
 		return "Consensus"
 	case BlockProposal:
 		return "BlockProposal"
+	case PeerDiscovery:
+		return "PeerDiscovery"
 	case Test:
 		return "Test"
 	case Done:

--- a/internal/utils/flags.go
+++ b/internal/utils/flags.go
@@ -46,7 +46,10 @@ func StringsToAddrs(addrStrings []string) (maddrs []ma.Multiaddr, err error) {
 	return
 }
 
-// DefaultBootNodeAddrStrings is a list of Harmony bootnodes. Used to find other peers in the network.
+// DefaultBootNodeAddrStrings is a list of Harmony bootnodes address. Used to find other peers in the network.
 var DefaultBootNodeAddrStrings = []string{
 	"/ip4/127.0.0.1/tcp/9876/p2p/QmayB8NwxmfGE4Usb4H61M8uwbfc7LRbmXb3ChseJgbVuf",
 }
+
+// BootNodes is a list of boot nodes. It is populated either from default or from user CLI input.
+var BootNodes AddrList

--- a/p2p/host/hostv2/hostv2.go
+++ b/p2p/host/hostv2/hostv2.go
@@ -13,6 +13,7 @@ import (
 	net "github.com/libp2p/go-libp2p-net"
 	peer "github.com/libp2p/go-libp2p-peer"
 	peerstore "github.com/libp2p/go-libp2p-peerstore"
+	protocol "github.com/libp2p/go-libp2p-protocol"
 	p2p_config "github.com/libp2p/go-libp2p/config"
 	ma "github.com/multiformats/go-multiaddr"
 )
@@ -103,7 +104,7 @@ func (host *HostV2) GetSelfPeer() p2p.Peer {
 
 // BindHandlerAndServe bind a streamHandler to the harmony protocol.
 func (host *HostV2) BindHandlerAndServe(handler p2p.StreamHandler) {
-	host.h.SetStreamHandler(ProtocolID, func(s net.Stream) {
+	host.h.SetStreamHandler(protocol.ID(ProtocolID), func(s net.Stream) {
 		handler(s)
 	})
 	// Hang forever
@@ -113,7 +114,8 @@ func (host *HostV2) BindHandlerAndServe(handler p2p.StreamHandler) {
 // SendMessage a p2p message sending function with signature compatible to p2pv1.
 func (host *HostV2) SendMessage(p p2p.Peer, message []byte) error {
 	logger := log.New("from", host.self, "to", p, "PeerID", p.PeerID)
-	s, err := host.h.NewStream(context.Background(), p.PeerID, ProtocolID)
+	host.Peerstore().AddProtocols(p.PeerID, ProtocolID)
+	s, err := host.h.NewStream(context.Background(), p.PeerID, protocol.ID(ProtocolID))
 	if err != nil {
 		logger.Error("NewStream() failed", "peerID", p.PeerID,
 			"protocolID", ProtocolID, "error", err)


### PR DESCRIPTION
## Issue

https://github.com/harmony-one/harmony/issues/373

This is the first step to add the discovery service in the new service framework. The discovery service is not enabled yet.

## Test

#### Test Coverage Data

<!-- run 'go test -cover' in the directory you made change -->

* Before
n/a

* After
```
$ go test -cover
PASS
coverage: 9.8% of statements
ok      github.com/harmony-one/harmony/api/service/discovery    0.240s
```

#### Test/Run Logs

Passed local travis_checker.go.  Haven't enabled the peer discovery service in harmony.go.

## TODO
Enable and integrate peer discovery service into harmony.go.
