### PR TITLE
adding more services: staking, networkinfo and wired-up logic

### DIFF
--- a/api/service/manager.go
+++ b/api/service/manager.go
@@ -152,3 +152,14 @@ func (m *Manager) StartServiceManager() chan *Action {
 	}()
 	return ch
 }
+
+// RunServices run registered services.
+func (m *Manager) RunServices() {
+	for serviceType := range m.services {
+		action := &Action{
+			Action:      Start,
+			ServiceType: serviceType,
+		}
+		m.TakeAction(action)
+	}
+}

--- a/api/service/manager.go
+++ b/api/service/manager.go
@@ -26,6 +26,7 @@ const (
 	SupportExplorer
 	Consensus
 	BlockProposal
+	NetworkInfo
 	PeerDiscovery
 	Staking
 	Test
@@ -44,6 +45,8 @@ func (t Type) String() string {
 		return "Consensus"
 	case BlockProposal:
 		return "BlockProposal"
+	case NetworkInfo:
+		return "NetworkInfo"
 	case PeerDiscovery:
 		return "PeerDiscovery"
 	case Staking:

--- a/api/service/manager.go
+++ b/api/service/manager.go
@@ -47,10 +47,10 @@ func (t Type) String() string {
 		return "BlockProposal"
 	case NetworkInfo:
 		return "NetworkInfo"
-	case PeerDiscovery:
-		return "PeerDiscovery"
 	case Staking:
 		return "Staking"
+	case PeerDiscovery:
+		return "PeerDiscovery"
 	case Test:
 		return "Test"
 	case Done:

--- a/api/service/networkinfo/service.go
+++ b/api/service/networkinfo/service.go
@@ -1,0 +1,63 @@
+package networkinfo
+
+import (
+	"github.com/harmony-one/harmony/internal/utils"
+	"github.com/harmony-one/harmony/p2p"
+)
+
+// Service is the role conversion service.
+type Service struct {
+	stopChan    chan struct{}
+	stoppedChan chan struct{}
+	peerChan    chan *p2p.Peer
+}
+
+// NewService returns role conversion service.
+func NewService(peerChan chan *p2p.Peer) *Service {
+	return &Service{
+		stopChan:    make(chan struct{}),
+		stoppedChan: make(chan struct{}),
+		peerChan:    peerChan,
+	}
+}
+
+// StartService starts role conversion service.
+func (s *Service) StartService() {
+	s.Init()
+	s.Run()
+}
+
+// Init initializes role conversion service.
+func (s *Service) Init() {
+}
+
+// Run runs role conversion.
+func (s *Service) Run() {
+	go func() {
+		defer close(s.stoppedChan)
+		for {
+			select {
+			default:
+				utils.GetLogInstance().Info("Running role conversion")
+				// TODO: Write some logic here.
+				s.DoService()
+			case <-s.stopChan:
+				return
+			}
+		}
+	}()
+}
+
+// DoService does role conversion.
+func (s *Service) DoService() {
+	// At the end, send Peer info to peer channel
+	s.peerChan <- &p2p.Peer{}
+}
+
+// StopService stops role conversion service.
+func (s *Service) StopService() {
+	utils.GetLogInstance().Info("Stopping role conversion service.")
+	s.stopChan <- struct{}{}
+	<-s.stoppedChan
+	utils.GetLogInstance().Info("Role conversion stopped.")
+}

--- a/api/service/staking/service.go
+++ b/api/service/staking/service.go
@@ -5,21 +5,59 @@ import (
 	"github.com/harmony-one/harmony/p2p"
 )
 
-// Service is the struct for staking service.
+// Service is the role conversion service.
 type Service struct {
-	Host p2p.Host
+	stopChan    chan struct{}
+	stoppedChan chan struct{}
+	peerChan    chan *p2p.Peer
 }
 
-//StartService starts the staking service.
+// NewService returns role conversion service.
+func NewService(peerChan chan *p2p.Peer) *Service {
+	return &Service{
+		stopChan:    make(chan struct{}),
+		stoppedChan: make(chan struct{}),
+		peerChan:    peerChan,
+	}
+}
+
+// StartService starts role conversion service.
 func (s *Service) StartService() {
-	utils.GetLogInstance().Info("Starting staking service.")
+	s.Init()
+	s.Run()
 }
 
-func (s *Service) createStakingTransaction() {
-	//creates staking transaction.
+// Init initializes role conversion service.
+func (s *Service) Init() {
 }
 
-// StopService shutdowns staking service.
+// Run runs role conversion.
+func (s *Service) Run() {
+	// Wait until peer info of beacon chain is ready.
+	peer := <-s.peerChan
+	go func() {
+		defer close(s.stoppedChan)
+		for {
+			select {
+			default:
+				utils.GetLogInstance().Info("Running role conversion")
+				// TODO: Write some logic here.
+				s.DoService(peer)
+			case <-s.stopChan:
+				return
+			}
+		}
+	}()
+}
+
+// DoService does role conversion.
+func (s *Service) DoService(peer *p2p.Peer) {
+}
+
+// StopService stops role conversion service.
 func (s *Service) StopService() {
-	utils.GetLogInstance().Info("Shutting down staking service.")
+	utils.GetLogInstance().Info("Stopping role conversion service.")
+	s.stopChan <- struct{}{}
+	<-s.stoppedChan
+	utils.GetLogInstance().Info("Role conversion stopped.")
 }

--- a/node/node.go
+++ b/node/node.go
@@ -30,6 +30,7 @@ import (
 	consensus_service "github.com/harmony-one/harmony/api/service/consensus"
 	"github.com/harmony-one/harmony/api/service/explorer"
 	"github.com/harmony-one/harmony/api/service/networkinfo"
+	"github.com/harmony-one/harmony/api/service/staking"
 	"github.com/harmony-one/harmony/api/service/syncing"
 	"github.com/harmony-one/harmony/api/service/syncing/downloader"
 	downloader_pb "github.com/harmony-one/harmony/api/service/syncing/downloader/proto"
@@ -692,7 +693,10 @@ func (node *Node) setupForBeaconValidator() {
 
 func (node *Node) setupForNewNode() {
 	chanPeer := make(chan *p2p.Peer)
+	// Add network info serivce.
 	node.serviceManager.RegisterService(service_manager.NetworkInfo, networkinfo.NewService(chanPeer))
+	// Add staking service.
+	node.serviceManager.RegisterService(service_manager.Staking, staking.NewService(chanPeer))
 }
 
 // ServiceManagerSetup setups service store.

--- a/node/node.go
+++ b/node/node.go
@@ -29,6 +29,7 @@ import (
 	"github.com/harmony-one/harmony/api/service/clientsupport"
 	consensus_service "github.com/harmony-one/harmony/api/service/consensus"
 	"github.com/harmony-one/harmony/api/service/explorer"
+	"github.com/harmony-one/harmony/api/service/networkinfo"
 	"github.com/harmony-one/harmony/api/service/syncing"
 	"github.com/harmony-one/harmony/api/service/syncing/downloader"
 	downloader_pb "github.com/harmony-one/harmony/api/service/syncing/downloader/proto"
@@ -690,12 +691,8 @@ func (node *Node) setupForBeaconValidator() {
 }
 
 func (node *Node) setupForNewNode() {
-	// Register consensus service.
-	node.serviceManager.RegisterService(service_manager.Consensus, consensus_service.NewService(node.BlockChannel, node.Consensus))
-	// Register new block service.
-	node.serviceManager.RegisterService(service_manager.BlockProposal, blockproposal.NewService(node.Consensus.ReadySignal, node.WaitForConsensusReady))
-	// Register client support service.
-	node.serviceManager.RegisterService(service_manager.ClientSupport, clientsupport.NewService(node.blockchain.State, node.CallFaucetContract, node.SelfPeer.IP, node.SelfPeer.Port))
+	chanPeer := make(chan *p2p.Peer)
+	node.serviceManager.RegisterService(service_manager.NetworkInfo, networkinfo.NewService(chanPeer))
 }
 
 // ServiceManagerSetup setups service store.

--- a/node/node.go
+++ b/node/node.go
@@ -678,12 +678,24 @@ func (node *Node) setupForShardValidator() {
 }
 
 func (node *Node) setupForBeaconLeader() {
+	// Register consensus service.
+	node.serviceManager.RegisterService(service_manager.Consensus, consensus_service.NewService(node.BlockChannel, node.Consensus))
+	// Register new block service.
+	node.serviceManager.RegisterService(service_manager.BlockProposal, blockproposal.NewService(node.Consensus.ReadySignal, node.WaitForConsensusReady))
+	// Register client support service.
+	node.serviceManager.RegisterService(service_manager.ClientSupport, clientsupport.NewService(node.blockchain.State, node.CallFaucetContract, node.SelfPeer.IP, node.SelfPeer.Port))
 }
 
 func (node *Node) setupForBeaconValidator() {
 }
 
 func (node *Node) setupForNewNode() {
+	// Register consensus service.
+	node.serviceManager.RegisterService(service_manager.Consensus, consensus_service.NewService(node.BlockChannel, node.Consensus))
+	// Register new block service.
+	node.serviceManager.RegisterService(service_manager.BlockProposal, blockproposal.NewService(node.Consensus.ReadySignal, node.WaitForConsensusReady))
+	// Register client support service.
+	node.serviceManager.RegisterService(service_manager.ClientSupport, clientsupport.NewService(node.blockchain.State, node.CallFaucetContract, node.SelfPeer.IP, node.SelfPeer.Port))
 }
 
 // ServiceManagerSetup setups service store.

--- a/node/node.go
+++ b/node/node.go
@@ -709,11 +709,5 @@ func (node *Node) RunServices() {
 		utils.GetLogInstance().Info("Service manager is not set up yet.")
 		return
 	}
-	for serviceType := range node.serviceManager.GetServices() {
-		action := &service_manager.Action{
-			Action:      service_manager.Start,
-			ServiceType: serviceType,
-		}
-		node.serviceManager.TakeAction(action)
-	}
+	node.serviceManager.RunServices()
 }


### PR DESCRIPTION
## Issue

https://github.com/harmony-one/harmony/issues/368

## Test

#### Test Coverage Data

NA

#### Test/Run Logs

++ ./test/../test/cal_tps.sh tmp_log/log-20190204-141654/all-leaders.txt tmp_log/log-20190204-141654/all-validators.txt
+ results='2 shards, 96 consensus, 503 total TPS, 11 nodes
127.0.0.1, 73, 293.412'
+ echo 2 shards, 96 consensus, 503 total TPS, 11 nodes 127.0.0.1, 73, 293.412
+ tee -a tmp_log/log-20190204-141654/r.log
2 shards, 96 consensus, 503 total TPS, 11 nodes 127.0.0.1, 73, 293.412
+ echo 2 shards, 96 consensus, 503 total TPS, 11 nodes 127.0.0.1, 73, 293.412

## TODO
