### PR TITLE
Enable libp2p peer discovery and test

### DIFF
--- a/scripts/go_executable_build.sh
+++ b/scripts/go_executable_build.sh
@@ -83,12 +83,13 @@ function build_only
 
    for bin in "${!SRC[@]}"; do
       if [[ -z "$build" || "$bin" == "$build" ]]; then
+         rm -f $BINDIR/$bin
          echo "building ${SRC[$bin]}"
          env GOOS=$GOOS GOARCH=$GOARCH go build -ldflags="-X main.version=v${VERSION} -X main.commit=${COMMIT} -X main.builtAt=${BUILTAT} -X main.builtBy=${BUILTBY}" -o $BINDIR/$bin $RACE ${SRC[$bin]}
          if [ "$(uname -s)" == "Linux" ]; then
             $BINDIR/$bin -version
          fi
-         if [ "$(uname -s)" == "Darwin" -a "$GOOS" == "darwin" ]; then
+         if [ "$(uname -s)" == "Darwin" -a "$GOOS" == "darwin" -a -e $BINDIR/$bin ]; then
             $BINDIR/$bin -version
          fi
       fi

--- a/test/deploy.sh
+++ b/test/deploy.sh
@@ -19,7 +19,7 @@ function check_result() {
 }
 
 function cleanup() {
-   for pid in `/bin/ps -fu $USER| grep "harmony\|txgen\|soldier\|commander\|profiler\|beacon" | grep -v "grep" | grep -v "vi" | awk '{print $2}'`;
+   for pid in `/bin/ps -fu $USER| grep "harmony\|txgen\|soldier\|commander\|profiler\|beacon\|bootnode" | grep -v "grep" | grep -v "vi" | awk '{print $2}'`;
    do
        echo 'Killed process: '$pid
        $DRYRUN kill -9 $pid 2> /dev/null
@@ -57,6 +57,7 @@ USAGE: $ME [OPTIONS] config_file_name
    -k nodeport    kill the node with specified port number (default: $KILLPORT)
    -n             dryrun mode (default: $DRYRUN)
    -S             enable sync test (default: $SYNC)
+   -P             enable libp2p peer discovery test (default: $P2P)
 
 This script will build all the binaries and start harmony and txgen based on the configuration file.
 
@@ -77,8 +78,9 @@ SHARDS=2
 KILLPORT=9004
 SYNC=false
 DRYRUN=
+P2P=false
 
-while getopts "hdtD:m:s:k:nS" option; do
+while getopts "hdtD:m:s:k:nSP" option; do
    case $option in
       h) usage ;;
       d) DB='-db_supported' ;;
@@ -89,6 +91,7 @@ while getopts "hdtD:m:s:k:nS" option; do
       k) KILLPORT=$OPTARG ;;
       n) DRYRUN=echo ;;
       S) SYNC=true ;;
+      P) P2P=true ;;
    esac
 done
 
@@ -117,6 +120,7 @@ echo "compiling ..."
 go build -o bin/harmony cmd/harmony.go
 go build -o bin/txgen cmd/client/txgen/main.go
 go build -o bin/beacon cmd/beaconchain/main.go
+go build -o bin/bootnode cmd/bootnode/main.go
 popd
 
 # Create a tmp folder for logs
@@ -129,10 +133,25 @@ LOG_FILE=$log_folder/r.log
 echo "launching beacon chain ..."
 $DRYRUN $ROOT/bin/beacon -numShards $SHARDS > $log_folder/beacon.log 2>&1 | tee -a $LOG_FILE &
 sleep 1 #waiting for beaconchain
-MA=$(grep "Beacon Chain Started" $log_folder/beacon.log | awk -F: ' { print $2 } ')
+BC_MA=$(grep "Beacon Chain Started" $log_folder/beacon.log | awk -F: ' { print $2 } ')
 
-if [ -n "$MA" ]; then
-   HMY_OPT="-bc_addr $MA"
+echo "launching boot node ..."
+$DRYRUN $ROOT/bin/bootnode > $log_folder/bootnode.log 2>&1 | tee -a $LOG_FILE &
+sleep 1
+BN_MA=$(grep "BN_MA" $log_folder/bootnode.log | awk -F\= ' { print $2 } ')
+
+HMY_OPT=
+HMY_OPT2=
+if [ -n "$BC_MA" ]; then
+   HMY_OPT=" -bc_addr $BC_MA"
+fi
+
+if [ -n "$BN_MA" ]; then
+   HMY_OPT2=" -bootnodes $BN_MA"
+fi
+
+if [ "$P2P" == "true" ]; then
+   HMY_OPT2+=" -libp2p_pd"
 fi
 
 NUM_NN=0
@@ -141,12 +160,12 @@ NUM_NN=0
 while IFS='' read -r line || [[ -n "$line" ]]; do
   IFS=' ' read ip port mode shardID <<< $line
   if [[ "$mode" == "leader" || "$mode" == "validator" ]]; then
-     $DRYRUN $ROOT/bin/harmony -ip $ip -port $port -log_folder $log_folder $DB -min_peers $MIN $HMY_OPT 2>&1 | tee -a $LOG_FILE &
+     $DRYRUN $ROOT/bin/harmony -ip $ip -port $port -log_folder $log_folder $DB -min_peers $MIN $HMY_OPT $HMY_OPT2 -key /tmp/$ip-$port.key 2>&1 | tee -a $LOG_FILE &
      sleep 0.5
   fi
   if [[ "$mode" == "newnode" && "$SYNC" == "true" ]]; then
      (( NUM_NN += 35 ))
-     (sleep $NUM_NN; $DRYRUN $ROOT/bin/harmony -ip $ip -port $port -log_folder $log_folder $DB -min_peers $MIN $HMY_OPT 2>&1 | tee -a $LOG_FILE ) &
+     (sleep $NUM_NN; $DRYRUN $ROOT/bin/harmony -ip $ip -port $port -log_folder $log_folder $DB -min_peers $MIN $HMY_OPT $HMY_OPT2 -key /tmp/$ip-$port.key 2>&1 | tee -a $LOG_FILE ) &
   fi
 done < $config
 


### PR DESCRIPTION
## Issue

#373 

## Test

#### Test Coverage Data

#### Test/Run Logs

the original test/deploy.sh works fine.  I just added a new parameter "-P" to enable libp2p peer discovery test.
Also, for harmony.go, I added a parameter -libp2p_pd for testing as well.

## TODO

- [ ] integrate 2nd stage peer discovery
- [ ] integrate leader and all pubkeys support