### PR TITLE
add isBeacon flag to specify the node is a beacon chain node

### DIFF
--- a/api/service/discovery/service.go
+++ b/api/service/discovery/service.go
@@ -85,5 +85,7 @@ func (s *Service) pingPeer(peer p2p.Peer) {
 	content := host.ConstructP2pMessage(byte(0), buffer)
 	s.Host.SendMessage(peer, content)
 	log.Debug("Sent Ping Message to", "peer", peer)
-	s.stakingChan <- peer
+	if s.stakingChan != nil {
+		s.stakingChan <- peer
+	}
 }

--- a/cmd/harmony.go
+++ b/cmd/harmony.go
@@ -105,6 +105,9 @@ func main() {
 	// LibP2P peer discovery integration test
 	libp2pPD := flag.Bool("libp2p_pd", false, "enable libp2p based peer discovery")
 
+	// isBeacon indicates this node is a beacon chain node
+	isBeacon := flag.Bool("is_beacon", false, "true means this node is a beacon chain node")
+
 	flag.Parse()
 
 	if *versionFlag {
@@ -214,9 +217,17 @@ func main() {
 	currentNode := node.New(host, consensus, ldb)
 	currentNode.Consensus.OfflinePeers = currentNode.OfflinePeers
 	if role == "leader" {
-		currentNode.Role = node.ShardLeader
+		if *isBeacon {
+			currentNode.Role = node.BeaconLeader
+		} else {
+			currentNode.Role = node.ShardLeader
+		}
 	} else {
-		currentNode.Role = node.ShardValidator
+		if *isBeacon {
+			currentNode.Role = node.BeaconValidator
+		} else {
+			currentNode.Role = node.ShardValidator
+		}
 	}
 
 	// If there is a client configured in the node list.

--- a/node/node.go
+++ b/node/node.go
@@ -646,6 +646,13 @@ func (node *Node) setupForShardValidator() {
 }
 
 func (node *Node) setupForBeaconLeader() {
+	chanPeer := make(chan p2p.Peer)
+
+	// Register peer discovery service. "0" is the beacon shard ID. No need to do staking for beacon chain node.
+	node.serviceManager.RegisterService(service_manager.PeerDiscovery, discovery.New(node.host, "0", chanPeer, nil))
+	// Register networkinfo service. "0" is the beacon shard ID
+	node.serviceManager.RegisterService(service_manager.NetworkInfo, networkinfo.New(node.host, "0", chanPeer))
+
 	// Register consensus service.
 	node.serviceManager.RegisterService(service_manager.Consensus, consensus_service.New(node.BlockChannel, node.Consensus))
 	// Register new block service.
@@ -655,6 +662,12 @@ func (node *Node) setupForBeaconLeader() {
 }
 
 func (node *Node) setupForBeaconValidator() {
+	chanPeer := make(chan p2p.Peer)
+
+	// Register peer discovery service. "0" is the beacon shard ID. No need to do staking for beacon chain node.
+	node.serviceManager.RegisterService(service_manager.PeerDiscovery, discovery.New(node.host, "0", chanPeer, nil))
+	// Register networkinfo service. "0" is the beacon shard ID
+	node.serviceManager.RegisterService(service_manager.NetworkInfo, networkinfo.New(node.host, "0", chanPeer))
 }
 
 func (node *Node) setupForNewNode() {
@@ -663,11 +676,12 @@ func (node *Node) setupForNewNode() {
 
 	// Register staking service.
 	node.serviceManager.RegisterService(service_manager.Staking, staking.New(stakingPeer))
-	// Register peer discovery service.
-	node.serviceManager.RegisterService(service_manager.PeerDiscovery, discovery.New(node.host, fmt.Sprintf("%v", node.Consensus.ShardID), chanPeer, stakingPeer))
-	// Register networkinfo service.
-	node.serviceManager.RegisterService(service_manager.NetworkInfo, networkinfo.New(node.host, fmt.Sprintf("%v", node.Consensus.ShardID), chanPeer))
+	// Register peer discovery service. "0" is the beacon shard ID
+	node.serviceManager.RegisterService(service_manager.PeerDiscovery, discovery.New(node.host, "0", chanPeer, stakingPeer))
+	// Register networkinfo service. "0" is the beacon shard ID
+	node.serviceManager.RegisterService(service_manager.NetworkInfo, networkinfo.New(node.host, "0", chanPeer))
 
+	// TODO: how to restart networkinfo and discovery service after receiving shard id info from beacon chain?
 }
 
 // ServiceManagerSetup setups service store.


### PR DESCRIPTION
add networkinfo/discovery service to beacon chain roles

Signed-off-by: Leo Chen <leo@harmony.one>

## Issue

During the bootstrap process, we need to indicate the node is a beacon chain node.
Thus, we introduce a flag as an indicator.

## Test

#### Test Coverage Data

#### Test/Run Logs

local travis_checker, build, and test passed.

## TODO
