### PR TITLE
Add libp2p peer discovery to txgen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ vendor
 
 # node_modules
 node_modules/
+
+# txgen node keystore
+.txgenkey

--- a/cmd/harmony.go
+++ b/cmd/harmony.go
@@ -99,7 +99,7 @@ func main() {
 	minPeers := flag.Int("min_peers", 100, "Minimal number of Peers in shard")
 
 	// Key file to store the private key
-	keyFile := flag.String("key", "./.hmykey", "the private key file of the bootnode")
+	keyFile := flag.String("key", "./.hmykey", "the private key file of the harmony node")
 	flag.Var(&utils.BootNodes, "bootnodes", "a list of bootnode multiaddress")
 
 	// LibP2P peer discovery integration test


### PR DESCRIPTION
## Issue

support libp2p peer discovery in txgen

#373 
## Test

#### Test Coverage Data


#### Test/Run Logs

local build, travis_checker passed.

I also tested using bootnode/beacon node, the txgen can connect to boot node.

## TODO
