### PR TITLE
[FIX] integer divide by zero error

### DIFF
--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -135,7 +135,7 @@ func (node *Node) messageHandler(content []byte) {
 					blockCount++
 				}
 
-				if blockCount != 0 {
+				if blockCount != 0 && txCount != 0 {
 					avgBlockSizeInBytes = avgBlockSizeInBytes / common.StorageSize(blockCount)
 					avgTxSize = avgTxSize / txCount
 				}


### PR DESCRIPTION
Signed-off-by: Leo Chen <leo@harmony.one>

## Issue

Jenkins test reported a crash on integer divide by zero.

17:18:45 panic: runtime error: integer divide by zero
17:18:45 
17:18:45 goroutine 3843 [running]:
17:18:45 github.com/harmony-one/harmony/node.(*Node).messageHandler(0xc0014b8200, 0xc0011d8d9c, 0x3, 0x3)
17:18:45 	/mnt/jenkins/workspace/auto-benchmark/node/node_handler.go:161 +0x1884
17:18:45 github.com/harmony-one/harmony/node.(*Node).StreamHandler(0xc0014b8200, 0x7fe7b0499170, 0xc0021c8ee0)

## Test

#### Test Coverage Data

<!-- run 'go test -cover' in the directory you made change -->

* Before
* After

#### Test/Run Logs

local build passed

## TODO
