### PR TITLE
call a request to beacon to get nonce & create staking transaction

### DIFF
--- a/api/service/staking/service.go
+++ b/api/service/staking/service.go
@@ -4,6 +4,8 @@ import (
 	"crypto/ecdsa"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/params"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -81,15 +83,13 @@ func (s *Service) getAccountState(beaconPeer p2p.Peer) *proto.FetchAccountStateR
 func (s *Service) createStakingMessage(beaconPeer p2p.Peer) *message.Message {
 	accountState := s.getAccountState(beaconPeer)
 	toAddress := common.HexToAddress("0x4592d8f8d7b001e72cb26a73e4fa1806a51ac79d")
-	gasLimit := uint64(0)
-	gasPrice := big.NewInt(0)
 	tx := types.NewTransaction(
 		accountState.Nonce,
 		toAddress,
 		0, // beacon chain.
 		new(big.Int).SetBytes(accountState.Balance),
-		gasLimit,
-		gasPrice,
+		params.CallValueTransferGas*2,           // hard-code
+		big.NewInt(int64(params.Sha256BaseGas)), // pick some predefined gas price.
 		nil)
 
 	if signedTx, err := types.SignTx(tx, types.HomesteadSigner{}, s.accountKey); err == nil {

--- a/api/service/staking/service.go
+++ b/api/service/staking/service.go
@@ -21,19 +21,21 @@ import (
 // Service requires private key here which is not a right design.
 // In stead in the right design, the end-user who runs mining needs to provide signed tx to this service.
 type Service struct {
-	stopChan    chan struct{}
-	stoppedChan chan struct{}
-	peerChan    <-chan p2p.Peer
-	accountKey  *ecdsa.PrivateKey
+	stopChan      chan struct{}
+	stoppedChan   chan struct{}
+	peerChan      <-chan p2p.Peer
+	accountKey    *ecdsa.PrivateKey
+	stakingAmount int64
 }
 
 // New returns staking service.
-func New(accountKey *ecdsa.PrivateKey, peerChan <-chan p2p.Peer) *Service {
+func New(accountKey *ecdsa.PrivateKey, stakingAmount int64, peerChan <-chan p2p.Peer) *Service {
 	return &Service{
-		stopChan:    make(chan struct{}),
-		stoppedChan: make(chan struct{}),
-		peerChan:    peerChan,
-		accountKey:  accountKey,
+		stopChan:      make(chan struct{}),
+		stoppedChan:   make(chan struct{}),
+		peerChan:      peerChan,
+		accountKey:    accountKey,
+		stakingAmount: stakingAmount,
 	}
 }
 
@@ -87,7 +89,7 @@ func (s *Service) createStakingMessage(beaconPeer p2p.Peer) *message.Message {
 		accountState.Nonce,
 		toAddress,
 		0, // beacon chain.
-		new(big.Int).SetBytes(accountState.Balance),
+		big.NewInt(s.stakingAmount),
 		params.CallValueTransferGas*2,           // hard-code
 		big.NewInt(int64(params.Sha256BaseGas)), // pick some predefined gas price.
 		nil)

--- a/node/contract.go
+++ b/node/contract.go
@@ -40,22 +40,6 @@ func (node *Node) AddStakingContractToPendingTransactions() {
 	node.addPendingTransactions(types.Transactions{mycontracttx})
 }
 
-// CreateStakingDepositTransaction creates a new deposit staking transaction
-func (node *Node) CreateStakingDepositTransaction(stake int) (*types.Transaction, error) {
-	//These should be read from somewhere.
-	DepositContractPriKey, _ := ecdsa.GenerateKey(crypto.S256(), strings.NewReader("Deposit Smart Contract Key")) //DepositContractPriKey is pk for contract
-	DepositContractAddress := crypto.PubkeyToAddress(DepositContractPriKey.PublicKey)                             //DepositContractAddress is the address for the contract
-	state, err := node.blockchain.State()
-	if err != nil {
-		log.Error("Failed to get chain state", "Error", err)
-	}
-	nonce := state.GetNonce(crypto.PubkeyToAddress(DepositContractPriKey.PublicKey))
-	callingFunction := "0xd0e30db0"
-	dataEnc := common.FromHex(callingFunction) //Deposit Does not take a argument, stake is transferred via amount.
-	tx, err := types.SignTx(types.NewTransaction(nonce, DepositContractAddress, node.Consensus.ShardID, big.NewInt(int64(stake)), params.TxGasContractCreation*10, nil, dataEnc), types.HomesteadSigner{}, node.AccountKey)
-	return tx, err
-}
-
 //CreateStakingWithdrawTransaction creates a new withdraw stake transaction
 func (node *Node) CreateStakingWithdrawTransaction(stake int) (*types.Transaction, error) {
 	//These should be read from somewhere.

--- a/node/node.go
+++ b/node/node.go
@@ -632,7 +632,7 @@ func (node *Node) setupForNewNode() {
 	stakingPeer := make(chan p2p.Peer)
 
 	// Register staking service.
-	node.serviceManager.RegisterService(service_manager.Staking, staking.New(node.AccountKey, stakingPeer))
+	node.serviceManager.RegisterService(service_manager.Staking, staking.New(node.AccountKey, 0, stakingPeer))
 	// Register peer discovery service. "0" is the beacon shard ID
 	node.serviceManager.RegisterService(service_manager.PeerDiscovery, discovery.New(node.host, "0", chanPeer, stakingPeer))
 	// Register networkinfo service. "0" is the beacon shard ID

--- a/node/node.go
+++ b/node/node.go
@@ -632,7 +632,7 @@ func (node *Node) setupForNewNode() {
 	stakingPeer := make(chan p2p.Peer)
 
 	// Register staking service.
-	node.serviceManager.RegisterService(service_manager.Staking, staking.New(stakingPeer))
+	node.serviceManager.RegisterService(service_manager.Staking, staking.New(crypto.PubkeyToAddress(node.AccountKey.PublicKey), stakingPeer))
 	// Register peer discovery service. "0" is the beacon shard ID
 	node.serviceManager.RegisterService(service_manager.PeerDiscovery, discovery.New(node.host, "0", chanPeer, stakingPeer))
 	// Register networkinfo service. "0" is the beacon shard ID

--- a/node/node.go
+++ b/node/node.go
@@ -632,7 +632,7 @@ func (node *Node) setupForNewNode() {
 	stakingPeer := make(chan p2p.Peer)
 
 	// Register staking service.
-	node.serviceManager.RegisterService(service_manager.Staking, staking.New(crypto.PubkeyToAddress(node.AccountKey.PublicKey), stakingPeer))
+	node.serviceManager.RegisterService(service_manager.Staking, staking.New(node.AccountKey, stakingPeer))
 	// Register peer discovery service. "0" is the beacon shard ID
 	node.serviceManager.RegisterService(service_manager.PeerDiscovery, discovery.New(node.host, "0", chanPeer, stakingPeer))
 	// Register networkinfo service. "0" is the beacon shard ID


### PR DESCRIPTION
## Issue

call a request to beacon to get nonce & create staking transaction

## Test

#### Test Coverage Data

NA 

#### Test/Run Logs
     14968 Done                    | tee -a $LOG_FILE
+ rm -rf ./db/harmony_127.0.0.1_9000 ./db/harmony_127.0.0.1_9001 ./db/harmony_127.0.0.1_9002 ./db/harmony_127.0.0.1_9003 ./db/harmony_127.0.0.1_9004 ./db/harmony_127.0.0.1_9005 ./db/harmony_127.0.0.1_9006 ./db/harmony_127.0.0.1_9007 ./db/harmony_127.0.0.1_9008 ./db/harmony_127.0.0.1_9009 ./db/harmony_127.0.0.1_9010 ./db/harmony_127.0.0.1_9011 ./db/harmony_127.0.0.1_9012
./test/deploy.sh: line 21: 14970 Killed: 9               $DRYRUN $ROOT/bin/harmony -ip $ip -port $port -log_folder $log_folder $DB -min_peers $MIN $HMY_OPT $HMY_OPT2 -key /tmp/$ip-$port.key 2>&1
     14971 Done                    | tee -a $LOG_FILE
+ check_result
+ find tmp_log/log-20190208-230443 -name 'leader-*.log'
+ find tmp_log/log-20190208-230443 -name 'validator-*.log'
+ echo ====== RESULTS ======
====== RESULTS ======
++ ./test/../test/cal_tps.sh tmp_log/log-20190208-230443/all-leaders.txt tmp_log/log-20190208-230443/all-validators.txt
+ results='2 shards, 118 consensus, 359 total TPS, 11 nodes
127.0.0.1, 59, 181.308'
+ echo 2 shards, 118 consensus, 359 total TPS, 11 nodes 127.0.0.1, 59, 181.308
+ tee -a tmp_log/log-20190208-230443/r.log
2 shards, 118 consensus, 359 total TPS, 11 nodes 127.0.0.1, 59, 181.308
+ echo 2 shards, 118 consensus, 359 total TPS, 11 nodes 127.0.0.1, 59, 181.308

## TODO
