### PR TITLE
DYLD_LIBRARY_PATH → DYLD_FALLBACK_LIBRARY_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ export CGO_CFLAGS="-I$GOPATH/src/github.com/harmony-one/bls/include -I$GOPATH/sr
 export CGO_LDFLAGS="-L$GOPATH/src/github.com/harmony-one/bls/lib -L/usr/local/opt/openssl/lib"
 export LD_LIBRARY_PATH=$GOPATH/src/github.com/harmony-one/bls/lib:$GOPATH/src/github.com/harmony-one/mcl/lib:/usr/local/opt/openssl/lib
 export LIBRARY_PATH=$LD_LIBRARY_PATH
-export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH
+export DYLD_FALLBACK_LIBRARY_PATH=$LD_LIBRARY_PATH
 
 mkdir -p $HOME/<path_of_your_choice>/src/github.com/harmony-one
 

--- a/scripts/setup_bls_build_flags.sh
+++ b/scripts/setup_bls_build_flags.sh
@@ -16,6 +16,6 @@ case $OS in
       export CGO_CFLAGS="-I${BLS_DIR}/include -I${MCL_DIR}/include -I${OPENSSL_DIR}/include"
       export CGO_LDFLAGS="-L${BLS_DIR}/lib -L${OPENSSL_DIR}/lib"
       export LD_LIBRARY_PATH=${BLS_DIR}/lib:${MCL_DIR}/lib:${OPENSSL_DIR}/lib
-      export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH
+      export DYLD_FALLBACK_LIBRARY_PATH=$LD_LIBRARY_PATH
       ;;
 esac


### PR DESCRIPTION
## Issue

`DYLD_LIBRARY_PATH` has a “look here first before usual places” semantics, in order to let users use an alternative version of a shared library.  On the other side, `DYLD_FALLBACK_LIBRARY_PATH` has a “look here if not found in usual places” semantics, in order to let users specify additional locations where a shared library is found.

In our case, if a binary refers to a common shared library found in usual places, we want to use it; we simply want to specify additional locations where BLS/MCL/OpenSSL libraries are found.  So it is more appropriate to use `DYLD_FALLBACK_LIBRARY_PATH`.

This also fixes a nasty symbol table mismatch, which is the main reason for this change: Certain commonly used shared libraries - such as `libJPEG.dylib`, co-located within the ImageIO framework and expected by the main ImageIO library – are often also found in Homebrew or MacPorts root (`/opt/local/lib` for MacPort).  If `DYLD_LIBRARY_PATH` included `/opt/local/lib` for OpenSSL, many system programs linked against ImageIO will erroneously pick up `libJPEG.dylib` in `/opt/local/lib`, which lacks certain internal symbols that the framework version has.  Using `DYLD_FALLBACK_LIBRARY_PATH` makes `dyld` honor the full path to the framework version of `libJPEG`, which is hardcoded in the main ImageIO framework library.

## Test

Build succeeds on my MacPorts-based installation.  Prior to this change it would fail with the libJPEG errors.

