### PR TITLE
propose using *Peer instead of Peer

### DIFF
--- a/api/service/discovery/service.go
+++ b/api/service/discovery/service.go
@@ -11,15 +11,15 @@ import (
 type Service struct {
 	host        p2p.Host
 	Rendezvous  string
-	peerChan    chan p2p.Peer
-	stakingChan chan p2p.Peer
+	peerChan    chan *p2p.Peer
+	stakingChan chan *p2p.Peer
 	stopChan    chan struct{}
 }
 
 // New returns discovery service.
 // h is the p2p host
 // r is the rendezvous string, we use shardID to start (TODO: leo, build two overlays of network)
-func New(h p2p.Host, r string, peerChan chan p2p.Peer, stakingChan chan p2p.Peer) *Service {
+func New(h p2p.Host, r string, peerChan chan *p2p.Peer, stakingChan chan *p2p.Peer) *Service {
 	return &Service{
 		host:        h,
 		Rendezvous:  r,
@@ -56,7 +56,7 @@ func (s *Service) contactP2pPeers() {
 				log.Debug("end of info", "peer", peer.PeerID)
 				return
 			}
-			s.host.AddPeer(&peer)
+			s.host.AddPeer(peer)
 			// Add to outgoing peer list
 			s.host.AddOutgoingPeer(peer)
 			log.Debug("[DISCOVERY]", "add outgoing peer", peer)
@@ -74,7 +74,7 @@ func (s *Service) Init() {
 	log.Info("Init discovery service")
 }
 
-func (s *Service) pingPeer(peer p2p.Peer) {
+func (s *Service) pingPeer(peer *p2p.Peer) {
 	ping := proto_discovery.NewPingMessage(s.host.GetSelfPeer())
 	buffer := ping.ConstructPingMessage()
 	content := host.ConstructP2pMessage(byte(0), buffer)

--- a/api/service/networkinfo/service.go
+++ b/api/service/networkinfo/service.go
@@ -25,14 +25,14 @@ type Service struct {
 	cancel      context.CancelFunc
 	stopChan    chan struct{}
 	stoppedChan chan struct{}
-	peerChan    chan p2p.Peer
+	peerChan    chan *p2p.Peer
 	peerInfo    <-chan peerstore.PeerInfo
 	discovery   *libp2pdis.RoutingDiscovery
 	lock        sync.Mutex
 }
 
 // New returns role conversion service.
-func New(h p2p.Host, rendezvous string, peerChan chan p2p.Peer) *Service {
+func New(h p2p.Host, rendezvous string, peerChan chan *p2p.Peer) *Service {
 	timeout := 30 * time.Minute
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	dht, err := libp2pdht.New(ctx, h.GetP2PHost())
@@ -139,7 +139,7 @@ func (s *Service) DoService() {
 						break
 					}
 				}
-				p := p2p.Peer{IP: ip, Port: port, PeerID: peer.ID, Addrs: peer.Addrs}
+				p := &p2p.Peer{IP: ip, Port: port, PeerID: peer.ID, Addrs: peer.Addrs}
 				utils.GetLogInstance().Info("Notify peerChan", "peer", p)
 				s.peerChan <- p
 			}

--- a/api/service/staking/service.go
+++ b/api/service/staking/service.go
@@ -22,13 +22,13 @@ import (
 type Service struct {
 	stopChan      chan struct{}
 	stoppedChan   chan struct{}
-	peerChan      <-chan p2p.Peer
+	peerChan      <-chan *p2p.Peer
 	accountKey    *ecdsa.PrivateKey
 	stakingAmount int64
 }
 
 // New returns staking service.
-func New(accountKey *ecdsa.PrivateKey, stakingAmount int64, peerChan <-chan p2p.Peer) *Service {
+func New(accountKey *ecdsa.PrivateKey, stakingAmount int64, peerChan <-chan *p2p.Peer) *Service {
 	return &Service{
 		stopChan:      make(chan struct{}),
 		stoppedChan:   make(chan struct{}),
@@ -68,20 +68,20 @@ func (s *Service) Run() {
 }
 
 // DoService does staking.
-func (s *Service) DoService(peer p2p.Peer) {
+func (s *Service) DoService(peer *p2p.Peer) {
 	utils.GetLogInstance().Info("Staking with Peer")
 
 	// TODO(minhdoan): How to use the p2p or pubsub to send Staking Message to beacon chain.
 	// See below of how to create a staking message.
 }
 
-func (s *Service) getStakingInfo(beaconPeer p2p.Peer) *proto.StakingContractInfoResponse {
+func (s *Service) getStakingInfo(beaconPeer *p2p.Peer) *proto.StakingContractInfoResponse {
 	client := client.NewClient(beaconPeer.IP, beaconPeer.Port)
 	defer client.Close()
 	return client.GetStakingContractInfo(crypto.PubkeyToAddress(s.accountKey.PublicKey))
 }
 
-func (s *Service) createStakingMessage(beaconPeer p2p.Peer) *message.Message {
+func (s *Service) createStakingMessage(beaconPeer *p2p.Peer) *message.Message {
 	stakingInfo := s.getStakingInfo(beaconPeer)
 	toAddress := common.HexToAddress(stakingInfo.ContractAddress)
 	tx := types.NewTransaction(

--- a/node/node.go
+++ b/node/node.go
@@ -679,7 +679,7 @@ func (node *Node) setupForShardValidator() {
 }
 
 func (node *Node) setupForBeaconLeader() {
-	chanPeer := make(chan p2p.Peer)
+	chanPeer := make(chan *p2p.Peer)
 
 	var err error
 	node.groupReceiver, err = node.host.GroupReceiver(p2p.GroupIDBeacon)
@@ -702,7 +702,7 @@ func (node *Node) setupForBeaconLeader() {
 }
 
 func (node *Node) setupForBeaconValidator() {
-	chanPeer := make(chan p2p.Peer)
+	chanPeer := make(chan *p2p.Peer)
 
 	var err error
 	node.groupReceiver, err = node.host.GroupReceiver(p2p.GroupIDBeacon)
@@ -718,8 +718,8 @@ func (node *Node) setupForBeaconValidator() {
 }
 
 func (node *Node) setupForNewNode() {
-	chanPeer := make(chan p2p.Peer)
-	stakingPeer := make(chan p2p.Peer)
+	chanPeer := make(chan *p2p.Peer)
+	stakingPeer := make(chan *p2p.Peer)
 
 	var err error
 	node.groupReceiver, err = node.host.GroupReceiver(p2p.GroupIDBeacon)

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -286,8 +286,8 @@ func (node *Node) pingMessageHandler(msgPayload []byte) int {
 	utils.GetLogInstance().Debug("[pingMessageHandler]", "incoming peer", peer)
 
 	// add to incoming peer list
-	node.host.AddIncomingPeer(*peer)
-	node.host.ConnectHostPeer(*peer)
+	node.host.AddIncomingPeer(peer)
+	node.host.ConnectHostPeer(peer)
 
 	if ping.Node.Role == proto_node.ClientRole {
 		utils.GetLogInstance().Info("Add Client Peer to Node", "Node", node.Consensus.GetNodeID(), "Client", peer)

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -17,9 +17,9 @@ type Host interface {
 	GetID() peer.ID
 	GetP2PHost() p2p_host.Host
 
-	AddIncomingPeer(Peer)
-	AddOutgoingPeer(Peer)
-	ConnectHostPeer(Peer)
+	AddIncomingPeer(*Peer)
+	AddOutgoingPeer(*Peer)
+	ConnectHostPeer(*Peer)
 
 	// SendMessageToGroups sends a message to one or more multicast groups.
 	SendMessageToGroups(groups []GroupID, msg []byte) error

--- a/p2p/host/hostv2/hostv2.go
+++ b/p2p/host/hostv2/hostv2.go
@@ -47,8 +47,8 @@ type HostV2 struct {
 	priKey p2p_crypto.PrivKey
 	lock   sync.Mutex
 
-	incomingPeers []p2p.Peer // list of incoming Peers. TODO: fixed number incoming
-	outgoingPeers []p2p.Peer // list of outgoing Peers. TODO: fixed number of outgoing
+	incomingPeers []*p2p.Peer // list of incoming Peers. TODO: fixed number incoming
+	outgoingPeers []*p2p.Peer // list of outgoing Peers. TODO: fixed number of outgoing
 }
 
 // SendMessageToGroups sends a message to one or more multicast groups.
@@ -135,12 +135,12 @@ func (host *HostV2) AddPeer(p *p2p.Peer) error {
 }
 
 // AddIncomingPeer add peer to incoming peer list
-func (host *HostV2) AddIncomingPeer(peer p2p.Peer) {
+func (host *HostV2) AddIncomingPeer(peer *p2p.Peer) {
 	host.incomingPeers = append(host.incomingPeers, peer)
 }
 
 // AddOutgoingPeer add peer to outgoing peer list
-func (host *HostV2) AddOutgoingPeer(peer p2p.Peer) {
+func (host *HostV2) AddOutgoingPeer(peer *p2p.Peer) {
 	host.outgoingPeers = append(host.outgoingPeers, peer)
 }
 
@@ -233,7 +233,7 @@ func (host *HostV2) GetP2PHost() p2p_host.Host {
 }
 
 // ConnectHostPeer connects to peer host
-func (host *HostV2) ConnectHostPeer(peer p2p.Peer) {
+func (host *HostV2) ConnectHostPeer(peer *p2p.Peer) {
 	ctx := context.Background()
 	addr := fmt.Sprintf("/ip4/%s/tcp/%s/ipfs/%s", peer.IP, peer.Port, peer.PeerID.Pretty())
 	peerAddr, err := ma.NewMultiaddr(addr)

--- a/p2p/host/mock/host_mock.go
+++ b/p2p/host/mock/host_mock.go
@@ -144,7 +144,7 @@ func (mr *MockHostMockRecorder) GroupReceiver(arg0 interface{}) *gomock.Call {
 }
 
 // AddIncomingPeer mocks base method
-func (m *MockHost) AddIncomingPeer(peer p2p.Peer) {
+func (m *MockHost) AddIncomingPeer(peer *p2p.Peer) {
 	m.ctrl.Call(m, "AddIncomingPeer", peer)
 }
 
@@ -154,7 +154,7 @@ func (mr *MockHostMockRecorder) AddIncomingPeer(groups, msg interface{}) *gomock
 }
 
 // AddOutgoingPeer mocks base method
-func (m *MockHost) AddOutgoingPeer(peer p2p.Peer) {
+func (m *MockHost) AddOutgoingPeer(peer *p2p.Peer) {
 	m.ctrl.Call(m, "AddOutgoingPeer", peer)
 }
 
@@ -164,7 +164,7 @@ func (mr *MockHostMockRecorder) AddOutgoingPeer(groups, msg interface{}) *gomock
 }
 
 // ConnectHostPeer mocks base method
-func (m *MockHost) ConnectHostPeer(peer p2p.Peer) {
+func (m *MockHost) ConnectHostPeer(peer *p2p.Peer) {
 	m.ctrl.Call(m, "ConnectHostPeer", peer)
 }
 


### PR DESCRIPTION
## Issue

Replace p2p.Peer by *p2p.Peer

## Problem

1/ Avoid allocation of Peer.
2/ There is no consistency among different places. at some place, we used *Peer, and some we used Peer

## TODO
