### PR TITLE
Fix stream leak

### DIFF
--- a/p2p/host/hostv2/hostv2.go
+++ b/p2p/host/hostv2/hostv2.go
@@ -222,6 +222,11 @@ func (host *HostV2) SendMessage(p p2p.Peer, message []byte) error {
 			"protocolID", ProtocolID, "error", err)
 		return p2p.ErrNewStream
 	}
+	defer func() {
+		if err := s.Close(); err != nil {
+			logger.Warn("cannot close stream", "error", err)
+		}
+	}()
 	if nw, err := s.Write(message); err != nil {
 		logger.Error("Write() failed", "peerID", p.PeerID,
 			"protocolID", ProtocolID, "error", err)


### PR DESCRIPTION
Since streams were multiplexed over connections, this wouldn't have caused file descriptor/socket leaks; however, it would have definitely caused memory leak (for the stream data structures).