### PR TITLE
fix format in node.md

### DIFF
--- a/node/node.md
+++ b/node/node.md
@@ -49,11 +49,11 @@ Service Manager is very handy to transform a node role from validator to leader 
 We have enabled libp2p based gossiping using pubsub. Nodes no longer send messages to individual nodes.
 All message communication is via SendMessageToGroups function.
 
-* Beacon chain nodes need to subscribe to TWO topics
-** one is beacon chain topic itself: GroupIDBeacon
-** another one is beacon client topic: GroupIDBeaconClient. Only Beacon Chain leader needs to send to this topic.
+* Beacon chain nodes need to subscribe to _TWO_ topics
+  * one is beacon chain topic itself: **GroupIDBeacon**
+  * another one is beacon client topic: **GroupIDBeaconClient**. Only Beacon Chain leader needs to send to this topic.
 
-* Every new node other than beacon chain nodes needs to subscribe to THREE topic. This also include txgen program.
-** one is beacon chain client topic => It is used to send staking transaction, and receive beacon chain blocks to determine the sharding info and randomness
-** one is shard consensus itself => It is used for within shard consensus, pingpong messages
-** one is client of the shard => It is used to receive tx from client, and send block back to client like txgen. Only shard Leader needs to send to this topic.
+* Every new node other than beacon chain nodes needs to subscribe to _THREE_ topic. This also include txgen program or wallet.
+  * one is beacon chain client topic => It is used to send staking transaction, and receive beacon chain blocks to determine the sharding info and randomness
+  * one is shard consensus itself => It is used for within shard consensus, pingpong messages
+  * one is client of the shard => It is used to receive tx from client, and send block back to client like txgen. Only shard Leader needs to send to this topic.


### PR DESCRIPTION
Signed-off-by: Leo Chen <leo@harmony.one>

Fixed the markdown format of the node.md with the content I added about libp2p integration with node structure.