### PR TITLE
set module version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,104 @@
 module github.com/harmony-one/harmony
+
+require (
+	github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705 // indirect
+	github.com/Workiva/go-datastructures v1.0.50
+	github.com/allegro/bigcache v1.2.0 // indirect
+	github.com/aristanetworks/goarista v0.0.0-20190213205509-c1e4b3741877 // indirect
+	github.com/btcsuite/btcd v0.0.0-20190213025234-306aecffea32 // indirect
+	github.com/coreos/go-semver v0.2.0 // indirect
+	github.com/deckarep/golang-set v1.7.1 // indirect
+	github.com/dedis/fixbuf v1.0.2
+	github.com/edsrzf/mmap-go v1.0.0 // indirect
+	github.com/ethereum/go-ethereum v1.8.23
+	github.com/fd/go-nat v1.0.0 // indirect
+	github.com/go-check/check v0.0.0-20180628173108-788fd7840127 // indirect
+	github.com/go-ole/go-ole v1.2.2 // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/gogo/protobuf v1.2.1 // indirect
+	github.com/golang/mock v1.2.0
+	github.com/golang/protobuf v1.2.1-0.20181127190454-8d0c54c12466
+	github.com/google/uuid v1.1.0 // indirect
+	github.com/gorilla/mux v1.7.0
+	github.com/gorilla/websocket v1.4.0 // indirect
+	github.com/gxed/hashland v0.0.1
+	github.com/harmony-one/bls v0.0.0-20190220064443-3c0ae384f04f
+	github.com/hashicorp/golang-lru v0.5.0
+	github.com/ipfs/go-cid v0.9.0 // indirect
+	github.com/ipfs/go-datastore v3.2.0+incompatible
+	github.com/ipfs/go-detect-race v1.0.1 // indirect
+	github.com/ipfs/go-ipfs-util v1.2.8 // indirect
+	github.com/ipfs/go-log v1.5.7
+	github.com/ipfs/go-todocounter v1.0.1 // indirect
+	github.com/jbenet/go-cienv v0.0.0-20150120210510-1bb1476777ec // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/jbenet/go-randbuf v0.0.0-20160322125720-674640a50e6a // indirect
+	github.com/jbenet/go-temp-err-catcher v0.0.0-20150120210811-aac704a3f4f2 // indirect
+	github.com/jbenet/goprocess v0.0.0-20160826012719-b497e2f366b8 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
+	github.com/libp2p/go-addr-util v2.0.7+incompatible // indirect
+	github.com/libp2p/go-buffer-pool v0.1.3 // indirect
+	github.com/libp2p/go-conn-security v0.1.15 // indirect
+	github.com/libp2p/go-conn-security-multistream v0.1.15 // indirect
+	github.com/libp2p/go-flow-metrics v0.2.0 // indirect
+	github.com/libp2p/go-libp2p v6.0.29+incompatible
+	github.com/libp2p/go-libp2p-autonat v0.0.0-20190218185411-842b9c4919f5 // indirect
+	github.com/libp2p/go-libp2p-blankhost v0.3.15 // indirect
+	github.com/libp2p/go-libp2p-circuit v2.3.2+incompatible // indirect
+	github.com/libp2p/go-libp2p-crypto v2.0.5+incompatible
+	github.com/libp2p/go-libp2p-discovery v0.0.0-20190221041540-5e0d40c7c880
+	github.com/libp2p/go-libp2p-host v3.0.15+incompatible
+	github.com/libp2p/go-libp2p-interface-connmgr v0.0.21 // indirect
+	github.com/libp2p/go-libp2p-interface-pnet v3.0.0+incompatible // indirect
+	github.com/libp2p/go-libp2p-kad-dht v4.4.13-0.20190122223835-838d43da02fc+incompatible
+	github.com/libp2p/go-libp2p-kbucket v2.2.12+incompatible // indirect
+	github.com/libp2p/go-libp2p-loggables v1.1.24 // indirect
+	github.com/libp2p/go-libp2p-metrics v2.1.7+incompatible // indirect
+	github.com/libp2p/go-libp2p-nat v0.8.8 // indirect
+	github.com/libp2p/go-libp2p-net v3.0.15+incompatible
+	github.com/libp2p/go-libp2p-netutil v0.4.12 // indirect
+	github.com/libp2p/go-libp2p-peer v2.4.0+incompatible
+	github.com/libp2p/go-libp2p-peerstore v2.0.6+incompatible
+	github.com/libp2p/go-libp2p-protocol v1.0.0
+	github.com/libp2p/go-libp2p-pubsub v0.11.10
+	github.com/libp2p/go-libp2p-record v4.1.7+incompatible // indirect
+	github.com/libp2p/go-libp2p-routing v2.7.1+incompatible // indirect
+	github.com/libp2p/go-libp2p-secio v2.0.17+incompatible // indirect
+	github.com/libp2p/go-libp2p-swarm v3.0.22+incompatible // indirect
+	github.com/libp2p/go-libp2p-transport v3.0.15+incompatible // indirect
+	github.com/libp2p/go-libp2p-transport-upgrader v0.1.16 // indirect
+	github.com/libp2p/go-maddr-filter v1.1.10 // indirect
+	github.com/libp2p/go-mplex v0.2.30 // indirect
+	github.com/libp2p/go-msgio v0.0.6 // indirect
+	github.com/libp2p/go-reuseport-transport v0.2.0 // indirect
+	github.com/libp2p/go-stream-muxer v3.0.1+incompatible // indirect
+	github.com/libp2p/go-tcp-transport v2.0.16+incompatible // indirect
+	github.com/libp2p/go-testutil v1.2.10 // indirect
+	github.com/libp2p/go-ws-transport v2.0.15+incompatible // indirect
+	github.com/mattn/go-colorable v0.1.0 // indirect
+	github.com/multiformats/go-multiaddr v1.4.0
+	github.com/multiformats/go-multiaddr-net v1.7.1
+	github.com/multiformats/go-multibase v0.3.0 // indirect
+	github.com/multiformats/go-multihash v1.0.10 // indirect
+	github.com/multiformats/go-multistream v0.3.9 // indirect
+	github.com/rs/cors v1.6.0 // indirect
+	github.com/shirou/gopsutil v2.18.12+incompatible
+	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect
+	github.com/stretchr/testify v1.2.2
+	github.com/syndtr/goleveldb v0.0.0-20190203031304-2f17a3356c66 // indirect
+	github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc // indirect
+	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 // indirect
+	github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc
+	github.com/whyrusleeping/go-notifier v0.0.0-20170827234753-097c5d47330f // indirect
+	github.com/whyrusleeping/go-smux-multiplex v3.0.16+incompatible // indirect
+	github.com/whyrusleeping/go-smux-multistream v2.0.2+incompatible // indirect
+	github.com/whyrusleeping/go-smux-yamux v2.0.8+incompatible // indirect
+	github.com/whyrusleeping/mafmt v1.2.8 // indirect
+	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 // indirect
+	github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee // indirect
+	github.com/whyrusleeping/yamux v1.1.5 // indirect
+	golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2
+	google.golang.org/grpc v1.18.0
+	gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
+	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
+)

--- a/scripts/go_executable_build.sh
+++ b/scripts/go_executable_build.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+export GO111MODULE=on
+
 declare -A SRC
 SRC[harmony]=cmd/harmony.go
 SRC[txgen]=cmd/client/txgen/main.go


### PR DESCRIPTION
this shall fix the ambiguous import issue

Signed-off-by: Leo Chen <leo@harmony.one>

## Issue

we have to deal with build errors when modules changed version.

## Test

#### Test/Run Logs

tested on both mac and linux. needs golang v1.11 to build.

## TODO
