### PR TITLE
use different port for bootnode in local test

### DIFF
--- a/test/deploy.sh
+++ b/test/deploy.sh
@@ -141,7 +141,7 @@ if [ "$P2P" == "false" ]; then
    HMY_OPT=" -bc_addr $BC_MA"
 else
    echo "launching boot node ..."
-   $DRYRUN $ROOT/bin/bootnode > $log_folder/bootnode.log 2>&1 | tee -a $LOG_FILE &
+   $DRYRUN $ROOT/bin/bootnode -port 19876 > $log_folder/bootnode.log 2>&1 | tee -a $LOG_FILE &
    sleep 1
    BN_MA=$(grep "BN_MA" $log_folder/bootnode.log | awk -F\= ' { print $2 } ')
    HMY_OPT2=" -bootnodes $BN_MA"


### PR DESCRIPTION
Signed-off-by: Leo Chen <leo@harmony.one>

## Issue

Jenkins test on Jenkins server has a conflicting port with bootnode already running there.

## Test

#### Test Coverage Data

<!-- run 'go test -cover' in the directory you made change -->

* Before
* After

#### Test/Run Logs

Local test passed.

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## TODO
