### PR TITLE
roll back. the recent PR broke the consensus as the passing interface…

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -296,7 +296,7 @@ func New(host p2p.Host, consensus *bft.Consensus, db ethdb.Database) *Node {
 
 	if consensus != nil && consensus.IsLeader {
 		node.State = NodeLeader
-		go node.ReceiveGroupMessage(node.clientReceiver)
+		go node.ReceiveClientGroupMessage()
 	} else {
 		node.State = NodeInit
 	}
@@ -309,7 +309,7 @@ func New(host p2p.Host, consensus *bft.Consensus, db ethdb.Database) *Node {
 	go node.RemovePeersHandler()
 
 	// start the goroutine to receive group message
-	go node.ReceiveGroupMessage(node.groupReceiver)
+	go node.ReceiveGroupMessage()
 
 	node.duplicatedPing = make(map[string]bool)
 

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -53,14 +53,32 @@ func (node *Node) StreamHandler(s p2p.Stream) {
 }
 
 // ReceiveGroupMessage use libp2p pubsub mechanism to receive broadcast messages
-func (node *Node) ReceiveGroupMessage(receiver p2p.GroupReceiver) {
+func (node *Node) ReceiveGroupMessage() {
 	ctx := context.Background()
 	for {
-		if receiver == nil {
+		if node.groupReceiver == nil {
 			time.Sleep(100 * time.Millisecond)
 			continue
 		}
-		msg, sender, err := receiver.Receive(ctx)
+		msg, sender, err := node.groupReceiver.Receive(ctx)
+		if sender != node.host.GetID() {
+			if err == nil {
+				// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
+				node.messageHandler(msg[5:], string(sender))
+			}
+		}
+	}
+}
+
+// ReceiveClientGroupMessage use libp2p pubsub mechanism to receive broadcast messages from client.
+func (node *Node) ReceiveClientGroupMessage() {
+	ctx := context.Background()
+	for {
+		if node.clientReceiver == nil {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		msg, sender, err := node.clientReceiver.Receive(ctx)
 		if sender != node.host.GetID() {
 			if err == nil {
 				// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size


### PR DESCRIPTION
Roll back https://github.com/harmony-one/harmony/pull/492

## Issue

<!-- link to the issue number or description of the issue -->

## Test
Ran with 100 seconds and got the following results.
++ ./test/../test/cal_tps.sh tmp_log/log-20190222-144651/all-leaders.txt tmp_log/log-20190222-144651/all-validators.txt
+ results='1 shards, 29 consensus, 94 total TPS, 10 nodes, 11 total nodes, 8 total signatures
127.0.0.1, 29, 93.648
peerID: 9002, numOfConsensus: 29
peerID: 9003, numOfConsensus: 29
peerID: 9001, numOfConsensus: 29
peerID: 9010, numOfConsensus: 29
peerID: 9004, numOfConsensus: 29
peerID: 9005, numOfConsensus: 8
peerID: 9007, numOfConsensus: 29
peerID: 9006, numOfConsensus: 29
peerID: 9008, numOfConsensus: 29
peerID: 9009, numOfConsensus: 29'
+ echo 1 shards, 29 consensus, 94 total TPS, 10 nodes, 11 total nodes, 8 total signatures 127.0.0.1, 29, 93.648 peerID: 9002, numOfConsensus: 29 peerID: 9003, numOfConsensus: 29 peerID: 9001, numOfConsensus: 29 peerID: 9010, numOfConsensus: 29 peerID: 9004, numOfConsensus: 29 peerID: 9005, numOfConsensus: 8 peerID: 9007, numOfConsensus: 29 peerID: 9006, numOfConsensus: 29 peerID: 9008, numOfConsensus: 29 peerID: 9009, numOfConsensus: 29
+ tee -a tmp_log/log-20190222-144651/r.log
1 shards, 29 consensus, 94 total TPS, 10 nodes, 11 total nodes, 8 total signatures 127.0.0.1, 29, 93.648 peerID: 9002, numOfConsensus: 29 peerID: 9003, numOfConsensus: 29 peerID: 9001, numOfConsensus: 29 peerID: 9010, numOfConsensus: 29 peerID: 9004, numOfConsensus: 29 peerID: 9005, numOfConsensus: 8 peerID: 9007, numOfConsensus: 29 peerID: 9006, numOfConsensus: 29 peerID: 9008, numOfConsensus: 29 peerID: 9009, numOfConsensus: 29
+ echo 1 shards, 29 consensus, 94 total TPS, 10 nodes, 11 total nodes, 8 total signatures 127.0.0.1, 29, 93.648 peerID: 9002, numOfConsensus: 29 peerID: 9003, numOfConsensus: 29 peerID: 9001, numOfConsensus: 29 peerID: 9010, numOfConsensus: 29 peerID: 9004, numOfConsensus: 29 peerID: 9005, numOfConsensus: 8 peerID: 9007, numOfConsensus: 29 peerID: 9006, numOfConsensus: 29 peerID: 9008, numOfConsensus: 29 peerID: 9009, numOfConsensus: 29
