### PR TITLE
process each message using a goroutine

### DIFF
--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -65,7 +65,7 @@ func (node *Node) ReceiveGroupMessage() {
 			//			utils.GetLogInstance().Info("[PUBSUB]", "received group msg", len(msg), "sender", sender)
 			if err == nil {
 				// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
-				node.messageHandler(msg[5:], string(sender))
+				go node.messageHandler(msg[5:], string(sender))
 			}
 		}
 	}
@@ -85,7 +85,7 @@ func (node *Node) ReceiveClientGroupMessage() {
 			utils.GetLogInstance().Info("[CLIENT]", "received group msg", len(msg), "sender", sender)
 			if err == nil {
 				// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
-				node.messageHandler(msg[5:], string(sender))
+				go node.messageHandler(msg[5:], string(sender))
 			}
 		}
 	}


### PR DESCRIPTION
this will parallel the processing of messages.

Signed-off-by: Leo Chen <leo@harmony.one>

## Issue

When we launch deploy test on AWS, more than 45 nodes in one shard, the consensus will get stuck after only two consensuses.  It turns out the leader wasn't able to process the commit messages from validators fast enough.
<!-- link to the issue number or description of the issue -->

## Test

#### Test/Run Logs

Run deployment on AWS, 45 nodes reached 107 consensuses with 300s run of txgen.
---
Tue Feb 26 00:28:16 UTC 2019 : deinit took 0 minutes and 2 seconds
1 shards, 107 consensus, 96 total TPS, 45 nodes
54.212.107.133, 107, 96.0816

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## TODO

- [ ] test consensus on 200 nodes in one shard
- [ ] clean up more log messages to speed up the processing