### PR TITLE
[debug] remove excessive logging on receiving messages

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -308,7 +308,6 @@ func verifyMessageSig(signerPubKey *bls.PublicKey, message *msg_pb.Message) erro
 		return err
 	}
 	msgHash := sha256.Sum256(messageBytes)
-	utils.GetLogInstance().Debug("verifyMessageSig")
 	if !msgSig.VerifyHash(signerPubKey, msgHash[:]) {
 		return errors.New("failed to verify the signature")
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -174,7 +174,7 @@ type Node struct {
 	clientReceiver p2p.GroupReceiver
 
 	// Duplicated Ping Message Received
-	duplicatedPing map[string]bool
+	duplicatedPing sync.Map
 
 	// Channel to notify consensus service to really start consensus
 	startConsensus chan struct{}
@@ -290,8 +290,6 @@ func New(host p2p.Host, consensusObj *consensus.Consensus, db ethdb.Database) *N
 
 	// start the goroutine to receive group message
 	go node.ReceiveGroupMessage()
-
-	node.duplicatedPing = make(map[string]bool)
 
 	if utils.UseLibP2P {
 		node.startConsensus = make(chan struct{})

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -132,10 +132,10 @@ func (node *Node) messageHandler(content []byte, sender string) {
 	case proto.Consensus:
 		msgPayload, _ := proto.GetConsensusMessagePayload(content)
 		if consensusObj.IsLeader {
-			utils.GetLogInstance().Info("NET: Leader received consensus message")
+			//			utils.GetLogInstance().Info("NET: Leader received consensus message")
 			consensusObj.ProcessMessageLeader(msgPayload)
 		} else {
-			utils.GetLogInstance().Info("NET: Validator received consensus message")
+			//			utils.GetLogInstance().Info("NET: Validator received consensus message")
 			consensusObj.ProcessMessageValidator(msgPayload)
 			// TODO(minhdoan): add logic to check if the current blockchain is not sync with other consensus
 			// we should switch to other state rather than DoingConsensus.
@@ -144,10 +144,10 @@ func (node *Node) messageHandler(content []byte, sender string) {
 		msgPayload, _ := proto.GetDRandMessagePayload(content)
 		if node.DRand != nil {
 			if node.DRand.IsLeader {
-				utils.GetLogInstance().Info("NET: DRand Leader received message")
+				//				utils.GetLogInstance().Info("NET: DRand Leader received message")
 				node.DRand.ProcessMessageLeader(msgPayload)
 			} else {
-				utils.GetLogInstance().Info("NET: DRand Validator received message")
+				//				utils.GetLogInstance().Info("NET: DRand Validator received message")
 				node.DRand.ProcessMessageValidator(msgPayload)
 			}
 		}

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -343,9 +343,9 @@ func (node *Node) AddNewBlock(newBlock *types.Block) {
 
 func (node *Node) pingMessageHandler(msgPayload []byte, sender string) int {
 	if sender != "" {
-		_, ok := node.duplicatedPing[sender]
+		_, ok := node.duplicatedPing.Load(sender)
 		if !ok {
-			node.duplicatedPing[sender] = true
+			node.duplicatedPing.Store(sender, true)
 		} else {
 			// duplicated ping message return
 			return 0


### PR DESCRIPTION
Signed-off-by: Leo Chen <leo@harmony.one>

## Issue

reduce the number of log messages on leader/validators when receiving consensus messages.

## Test

#### Test Coverage Data

<!-- run 'go test -cover' in the directory you made change -->

* Before
* After

#### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## TODO
