### PR TITLE
Add beacon peer for every node

### DIFF
--- a/api/service/discovery/discovery_test.go
+++ b/api/service/discovery/discovery_test.go
@@ -26,7 +26,7 @@ func TestDiscoveryService(t *testing.T) {
 
 	config := service.NodeConfig{}
 
-	dService = New(host, config, nil)
+	dService = New(host, config, nil, nil)
 
 	if dService == nil {
 		t.Fatalf("unable to create new discovery service")

--- a/api/service/networkinfo/service.go
+++ b/api/service/networkinfo/service.go
@@ -112,7 +112,7 @@ func (s *Service) DoService() {
 		select {
 		case peer := <-s.peerInfo:
 			if peer.ID != s.Host.GetP2PHost().ID() && len(peer.ID) > 0 {
-				utils.GetLogInstance().Info("Found Peer", "peer", peer.ID, "addr", peer.Addrs, "my ID", s.Host.GetP2PHost().ID())
+				//				utils.GetLogInstance().Info("Found Peer", "peer", peer.ID, "addr", peer.Addrs, "my ID", s.Host.GetP2PHost().ID())
 				if err := s.Host.GetP2PHost().Connect(s.ctx, peer); err != nil {
 					utils.GetLogInstance().Warn("can't connect to peer node", "error", err)
 				} else {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -110,6 +110,53 @@ func TestAddPeers(t *testing.T) {
 	}
 }
 
+func TestAddBeaconPeer(t *testing.T) {
+	_, pubKey1 := utils.GenKey("127.0.0.1", "2000")
+	_, pubKey2 := utils.GenKey("127.0.0.1", "8000")
+
+	peers1 := []*p2p.Peer{
+		&p2p.Peer{
+			IP:          "127.0.0.1",
+			Port:        "8888",
+			PubKey:      pubKey1,
+			ValidatorID: 1,
+			PeerID:      "1234",
+		},
+		&p2p.Peer{
+			IP:          "127.0.0.1",
+			Port:        "9999",
+			PubKey:      pubKey2,
+			ValidatorID: 2,
+			PeerID:      "4567",
+		},
+	}
+	_, pubKey := utils.GenKey("1", "2")
+	leader := p2p.Peer{IP: "127.0.0.1", Port: "8982", PubKey: pubKey}
+	validator := p2p.Peer{IP: "127.0.0.1", Port: "8985"}
+	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "9902")
+	host, err := p2pimpl.NewHost(&leader, priKey)
+	if err != nil {
+		t.Fatalf("newhost failure: %v", err)
+	}
+	consensus := consensus.New(host, "0", []p2p.Peer{leader, validator}, leader)
+	dRand := drand.New(host, "0", []p2p.Peer{leader, validator}, leader, nil, true)
+
+	node := New(host, consensus, nil)
+	node.DRand = dRand
+	for _, p := range peers1 {
+		ret := node.AddBeaconPeer(p)
+		if ret {
+			t.Errorf("AddBeaconPeer Failed, expecting false, got %v, peer %v", ret, p)
+		}
+	}
+	for _, p := range peers1 {
+		ret := node.AddBeaconPeer(p)
+		if !ret {
+			t.Errorf("AddBeaconPeer Failed, expecting true, got %v, peer %v", ret, p)
+		}
+	}
+}
+
 func sendPingMessage(node *Node, leader p2p.Peer) {
 	pubKey1 := pki.GetBLSPrivateKeyFromInt(333).GetPublicKey()
 

--- a/node/service_setup.go
+++ b/node/service_setup.go
@@ -25,7 +25,7 @@ func (node *Node) setupForShardLeader() {
 	nodeConfig, chanPeer := node.initNodeConfiguration()
 
 	// Register peer discovery service. No need to do staking for beacon chain node.
-	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer))
+	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, node.AddBeaconPeer))
 	// Register networkinfo service. "0" is the beacon shard ID
 	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, p2p.GroupIDBeacon, chanPeer))
 
@@ -45,7 +45,7 @@ func (node *Node) setupForShardValidator() {
 	nodeConfig, chanPeer := node.initNodeConfiguration()
 
 	// Register peer discovery service. "0" is the beacon shard ID. No need to do staking for beacon chain node.
-	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer))
+	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, node.AddBeaconPeer))
 	// Register networkinfo service. "0" is the beacon shard ID
 	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, p2p.GroupIDBeacon, chanPeer))
 }
@@ -54,7 +54,7 @@ func (node *Node) setupForBeaconLeader() {
 	nodeConfig, chanPeer := node.initBeaconNodeConfiguration()
 
 	// Register peer discovery service. No need to do staking for beacon chain node.
-	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer))
+	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, nil))
 	// Register networkinfo service.
 	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, p2p.GroupIDBeacon, chanPeer))
 	// Register consensus service.
@@ -71,7 +71,7 @@ func (node *Node) setupForBeaconValidator() {
 	nodeConfig, chanPeer := node.initBeaconNodeConfiguration()
 
 	// Register peer discovery service. No need to do staking for beacon chain node.
-	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer))
+	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, nil))
 	// Register networkinfo service.
 	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, p2p.GroupIDBeacon, chanPeer))
 }
@@ -82,7 +82,7 @@ func (node *Node) setupForNewNode() {
 	// Register staking service.
 	node.serviceManager.RegisterService(service.Staking, staking.New(node.host, node.AccountKey, 0, node.beaconChain))
 	// Register peer discovery service. "0" is the beacon shard ID
-	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer))
+	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, node.AddBeaconPeer))
 	// Register networkinfo service. "0" is the beacon shard ID
 	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, p2p.GroupIDBeacon, chanPeer))
 
@@ -93,7 +93,7 @@ func (node *Node) setupForClientNode() {
 	nodeConfig, chanPeer := node.initNodeConfiguration()
 
 	// Register peer discovery service.
-	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer))
+	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, nil))
 	// Register networkinfo service. "0" is the beacon shard ID
 	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, p2p.GroupIDBeacon, chanPeer))
 }


### PR DESCRIPTION
## Issue

The new node needs to get a list of beacon peers for state syncing on beacon chain blockchain.
<!-- link to the issue number or description of the issue -->

## Test

#### Test Coverage Data

<!-- run 'go test -cover' in the directory you made change -->

Added test program for the AddBeaconPeer function.

#### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->
+ results='1 shards, 166 consensus, 269 total TPS, 10 nodes, 11 total nodes, 8 total signatures
127.0.0.1, 166, 269.298

## TODO
