### PR TITLE
send a ping message before the timer tick

### DIFF
--- a/api/service/discovery/discovery_test.go
+++ b/api/service/discovery/discovery_test.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"testing"
+	"time"
 
 	"github.com/harmony-one/harmony/api/service"
 	"github.com/harmony-one/harmony/internal/utils"
@@ -16,10 +17,17 @@ var (
 )
 
 func TestDiscoveryService(t *testing.T) {
-	selfPeer := p2p.Peer{IP: ip, Port: port}
-	priKey, _, err := utils.GenKeyP2P(ip, port)
+	nodePriKey, _, err := utils.LoadKeyFromFile("/tmp/127.0.0.1.12345.key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	peerPriKey, peerPubKey := utils.GenKey("127.0.0.1", "12345")
+	if peerPriKey == nil || peerPubKey == nil {
+		t.Fatal("generate key error")
+	}
+	selfPeer := p2p.Peer{IP: "127.0.0.1", Port: "12345", ValidatorID: -1, PubKey: peerPubKey}
 
-	host, err := p2pimpl.NewHost(&selfPeer, priKey)
+	host, err := p2pimpl.NewHost(&selfPeer, nodePriKey)
 	if err != nil {
 		t.Fatalf("unable to new host in harmony: %v", err)
 	}
@@ -31,4 +39,10 @@ func TestDiscoveryService(t *testing.T) {
 	if dService == nil {
 		t.Fatalf("unable to create new discovery service")
 	}
+
+	dService.StartService()
+
+	time.Sleep(3 * time.Second)
+
+	dService.StopService()
 }

--- a/api/service/discovery/service.go
+++ b/api/service/discovery/service.go
@@ -149,8 +149,8 @@ func (s *Service) sentPingMessage(g p2p.GroupID, regMsgBuf, clientMsgBuf []byte)
 	}
 	if err != nil {
 		utils.GetLogInstance().Error("Failed to send ping message", "group", g)
-	} else {
-		utils.GetLogInstance().Info("[DISCOVERY]", "Sent Ping Message", g)
+		//	} else {
+		//		utils.GetLogInstance().Info("[DISCOVERY]", "Sent Ping Message", g)
 	}
 
 }

--- a/consensus/consensus_leader.go
+++ b/consensus/consensus_leader.go
@@ -58,11 +58,6 @@ func (consensus *Consensus) WaitForNewBlock(blockChannel chan *types.Block, stop
 					utils.GetLogInstance().Debug("WaitForNewBlock", "removed peers", c)
 				}
 
-				for !consensus.HasEnoughValidators() {
-					utils.GetLogInstance().Debug("Not enough validators", "# Validators", len(consensus.PublicKeys))
-					time.Sleep(waitForEnoughValidators * time.Millisecond)
-				}
-
 				if core.IsEpochBlock(newBlock) {
 					// Receive pRnd from DRG protocol
 					utils.GetLogInstance().Debug("[DRG] Waiting for pRnd")
@@ -364,15 +359,4 @@ func (consensus *Consensus) reportMetrics(block types.Block) {
 		"blockLatency":    int(timeElapsed / time.Millisecond),
 	}
 	profiler.LogMetrics(metrics)
-}
-
-// HasEnoughValidators checks the number of publicKeys to determine
-// if the shard has enough validators
-// FIXME (HAR-82): we need epoch support or a better way to determine
-// when to initiate the consensus
-func (consensus *Consensus) HasEnoughValidators() bool {
-	if len(consensus.PublicKeys) < consensus.MinPeers {
-		return false
-	}
-	return true
 }


### PR DESCRIPTION
this shall speed up the bootstrap process by sending a ping message
immediately entering the goroutine

Signed-off-by: Leo Chen <leo@harmony.one>

## Issue

The original service sends the 1st ping message after the timer tick (5sec).
This patch speeds up the process by sending one ping message immediately.

## Test

#### Test/Run Logs

+ results='1 shards, 30 consensus, 62 total TPS, 10 nodes, 11 total nodes, 8 total signatures
127.0.0.1, 30, 62.2404


<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## TODO
