### PR TITLE
add bootnode parameter in networkinfo service

### DIFF
--- a/api/service/networkinfo/service_test.go
+++ b/api/service/networkinfo/service_test.go
@@ -1,0 +1,33 @@
+package networkinfo
+
+import (
+	"testing"
+	"time"
+
+	"github.com/harmony-one/harmony/internal/utils"
+	"github.com/harmony-one/harmony/p2p"
+	"github.com/harmony-one/harmony/p2p/p2pimpl"
+)
+
+func TestService(t *testing.T) {
+	nodePriKey, _, err := utils.LoadKeyFromFile("/tmp/127.0.0.1.12345.key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	peerPriKey, peerPubKey := utils.GenKey("127.0.0.1", "12345")
+	if peerPriKey == nil || peerPubKey == nil {
+		t.Fatal("generate key error")
+	}
+	selfPeer := p2p.Peer{IP: "127.0.0.1", Port: "12345", ValidatorID: -1, PubKey: peerPubKey}
+
+	host, err := p2pimpl.NewHost(&selfPeer, nodePriKey)
+	if err != nil {
+		t.Fatal("unable to new host in harmony")
+	}
+
+	s := New(host, "teststring", nil, nil)
+	s.StartService()
+
+	time.Sleep(2 * time.Second)
+	s.StopService()
+}

--- a/node/service_setup.go
+++ b/node/service_setup.go
@@ -28,7 +28,7 @@ func (node *Node) setupForShardLeader() {
 	// Register peer discovery service. No need to do staking for beacon chain node.
 	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, node.AddBeaconPeer))
 	// Register networkinfo service. "0" is the beacon shard ID
-	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, p2p.GroupIDBeacon, chanPeer))
+	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, p2p.GroupIDBeacon, chanPeer, nil))
 
 	// Register explorer service.
 	node.serviceManager.RegisterService(service.SupportExplorer, explorer.New(&node.SelfPeer))
@@ -48,7 +48,7 @@ func (node *Node) setupForShardValidator() {
 	// Register peer discovery service. "0" is the beacon shard ID. No need to do staking for beacon chain node.
 	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, node.AddBeaconPeer))
 	// Register networkinfo service. "0" is the beacon shard ID
-	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, p2p.GroupIDBeacon, chanPeer))
+	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, p2p.GroupIDBeacon, chanPeer, nil))
 }
 
 func (node *Node) setupForBeaconLeader() {
@@ -57,7 +57,7 @@ func (node *Node) setupForBeaconLeader() {
 	// Register peer discovery service. No need to do staking for beacon chain node.
 	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, nil))
 	// Register networkinfo service.
-	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, p2p.GroupIDBeacon, chanPeer))
+	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, p2p.GroupIDBeacon, chanPeer, nil))
 	// Register consensus service.
 	node.serviceManager.RegisterService(service.Consensus, consensus.New(node.BlockChannel, node.Consensus, node.startConsensus))
 	// Register new block service.
@@ -74,7 +74,7 @@ func (node *Node) setupForBeaconValidator() {
 	// Register peer discovery service. No need to do staking for beacon chain node.
 	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, nil))
 	// Register networkinfo service.
-	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, p2p.GroupIDBeacon, chanPeer))
+	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, p2p.GroupIDBeacon, chanPeer, nil))
 }
 
 func (node *Node) setupForNewNode() {
@@ -85,7 +85,7 @@ func (node *Node) setupForNewNode() {
 	// Register peer discovery service. "0" is the beacon shard ID
 	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, node.AddBeaconPeer))
 	// Register networkinfo service. "0" is the beacon shard ID
-	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, p2p.GroupIDBeacon, chanPeer))
+	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, p2p.GroupIDBeacon, chanPeer, nil))
 
 	// TODO: how to restart networkinfo and discovery service after receiving shard id info from beacon chain?
 }
@@ -96,7 +96,7 @@ func (node *Node) setupForClientNode() {
 	// Register peer discovery service.
 	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, nil))
 	// Register networkinfo service. "0" is the beacon shard ID
-	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, p2p.GroupIDBeacon, chanPeer))
+	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, p2p.GroupIDBeacon, chanPeer, nil))
 }
 
 // AddBeaconChainDatabase adds database support for beaconchain blocks on normal sharding nodes (not BeaconChain node)


### PR DESCRIPTION
instead of always using global bootnode, networkinfo now support a list
of new bootnodes.  This is to enable 2nd stage peer discovery, which can
use existing beacon peers as the bootnode to discover shard peers.

Signed-off-by: Leo Chen <leo@harmony.one>

## Issue

The bootnode was fixed in networkinfo service before.  Now it supports a new list of bootnodes.

## Test

#### Test Coverage Data

<!-- run 'go test -cover' in the directory you made change -->

* Before
api/service/networkinfo 0%

* After
coverage: 53.1% of statements

#### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## TODO
