### PR TITLE
Fix go generate step of travis_checker.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
   - go get -u golang.org/x/tools/cmd/goimports
   - go get gopkg.in/check.v1
   - go get github.com/harmony-ek/gencodec
+  - go get github.com/golang/mock/mockgen
   - go get github.com/golang/protobuf/protoc-gen-go
   - ./scripts/install_protoc.sh -V 3.6.1
   - ./scripts/travis_checker.sh

--- a/p2p/host/hostv2/mock/hostv2_mock.go
+++ b/p2p/host/hostv2/mock/hostv2_mock.go
@@ -36,6 +36,7 @@ func (m *Mockpubsub) EXPECT() *MockpubsubMockRecorder {
 
 // Publish mocks base method
 func (m *Mockpubsub) Publish(topic string, data []byte) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Publish", topic, data)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -43,11 +44,13 @@ func (m *Mockpubsub) Publish(topic string, data []byte) error {
 
 // Publish indicates an expected call of Publish
 func (mr *MockpubsubMockRecorder) Publish(topic, data interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Publish", reflect.TypeOf((*Mockpubsub)(nil).Publish), topic, data)
 }
 
 // Subscribe mocks base method
 func (m *Mockpubsub) Subscribe(topic string, opts ...go_libp2p_pubsub.SubOpt) (*go_libp2p_pubsub.Subscription, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{topic}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -60,6 +63,7 @@ func (m *Mockpubsub) Subscribe(topic string, opts ...go_libp2p_pubsub.SubOpt) (*
 
 // Subscribe indicates an expected call of Subscribe
 func (mr *MockpubsubMockRecorder) Subscribe(topic interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{topic}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*Mockpubsub)(nil).Subscribe), varargs...)
 }
@@ -89,6 +93,7 @@ func (m *Mocksubscription) EXPECT() *MocksubscriptionMockRecorder {
 
 // Next mocks base method
 func (m *Mocksubscription) Next(ctx context.Context) (*go_libp2p_pubsub.Message, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Next", ctx)
 	ret0, _ := ret[0].(*go_libp2p_pubsub.Message)
 	ret1, _ := ret[1].(error)
@@ -97,15 +102,18 @@ func (m *Mocksubscription) Next(ctx context.Context) (*go_libp2p_pubsub.Message,
 
 // Next indicates an expected call of Next
 func (mr *MocksubscriptionMockRecorder) Next(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Next", reflect.TypeOf((*Mocksubscription)(nil).Next), ctx)
 }
 
 // Cancel mocks base method
 func (m *Mocksubscription) Cancel() {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Cancel")
 }
 
 // Cancel indicates an expected call of Cancel
 func (mr *MocksubscriptionMockRecorder) Cancel() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cancel", reflect.TypeOf((*Mocksubscription)(nil).Cancel))
 }

--- a/p2p/host/mock/host_mock.go
+++ b/p2p/host/mock/host_mock.go
@@ -37,6 +37,7 @@ func (m *MockHost) EXPECT() *MockHostMockRecorder {
 
 // GetSelfPeer mocks base method
 func (m *MockHost) GetSelfPeer() p2p.Peer {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSelfPeer")
 	ret0, _ := ret[0].(p2p.Peer)
 	return ret0
@@ -44,11 +45,13 @@ func (m *MockHost) GetSelfPeer() p2p.Peer {
 
 // GetSelfPeer indicates an expected call of GetSelfPeer
 func (mr *MockHostMockRecorder) GetSelfPeer() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSelfPeer", reflect.TypeOf((*MockHost)(nil).GetSelfPeer))
 }
 
 // Close mocks base method
 func (m *MockHost) Close() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -56,11 +59,13 @@ func (m *MockHost) Close() error {
 
 // Close indicates an expected call of Close
 func (mr *MockHostMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockHost)(nil).Close))
 }
 
 // AddPeer mocks base method
 func (m *MockHost) AddPeer(arg0 *p2p.Peer) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddPeer", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -68,11 +73,13 @@ func (m *MockHost) AddPeer(arg0 *p2p.Peer) error {
 
 // AddPeer indicates an expected call of AddPeer
 func (mr *MockHostMockRecorder) AddPeer(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPeer", reflect.TypeOf((*MockHost)(nil).AddPeer), arg0)
 }
 
 // GetID mocks base method
 func (m *MockHost) GetID() go_libp2p_peer.ID {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetID")
 	ret0, _ := ret[0].(go_libp2p_peer.ID)
 	return ret0
@@ -80,11 +87,13 @@ func (m *MockHost) GetID() go_libp2p_peer.ID {
 
 // GetID indicates an expected call of GetID
 func (mr *MockHostMockRecorder) GetID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetID", reflect.TypeOf((*MockHost)(nil).GetID))
 }
 
 // GetP2PHost mocks base method
 func (m *MockHost) GetP2PHost() go_libp2p_host.Host {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetP2PHost")
 	ret0, _ := ret[0].(go_libp2p_host.Host)
 	return ret0
@@ -92,21 +101,25 @@ func (m *MockHost) GetP2PHost() go_libp2p_host.Host {
 
 // GetP2PHost indicates an expected call of GetP2PHost
 func (mr *MockHostMockRecorder) GetP2PHost() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetP2PHost", reflect.TypeOf((*MockHost)(nil).GetP2PHost))
 }
 
 // ConnectHostPeer mocks base method
 func (m *MockHost) ConnectHostPeer(arg0 p2p.Peer) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ConnectHostPeer", arg0)
 }
 
 // ConnectHostPeer indicates an expected call of ConnectHostPeer
 func (mr *MockHostMockRecorder) ConnectHostPeer(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectHostPeer", reflect.TypeOf((*MockHost)(nil).ConnectHostPeer), arg0)
 }
 
 // SendMessageToGroups mocks base method
 func (m *MockHost) SendMessageToGroups(groups []p2p.GroupID, msg []byte) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendMessageToGroups", groups, msg)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -114,11 +127,13 @@ func (m *MockHost) SendMessageToGroups(groups []p2p.GroupID, msg []byte) error {
 
 // SendMessageToGroups indicates an expected call of SendMessageToGroups
 func (mr *MockHostMockRecorder) SendMessageToGroups(groups, msg interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMessageToGroups", reflect.TypeOf((*MockHost)(nil).SendMessageToGroups), groups, msg)
 }
 
 // GroupReceiver mocks base method
 func (m *MockHost) GroupReceiver(arg0 p2p.GroupID) (p2p.GroupReceiver, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GroupReceiver", arg0)
 	ret0, _ := ret[0].(p2p.GroupReceiver)
 	ret1, _ := ret[1].(error)
@@ -127,5 +142,6 @@ func (m *MockHost) GroupReceiver(arg0 p2p.GroupID) (p2p.GroupReceiver, error) {
 
 // GroupReceiver indicates an expected call of GroupReceiver
 func (mr *MockHostMockRecorder) GroupReceiver(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GroupReceiver", reflect.TypeOf((*MockHost)(nil).GroupReceiver), arg0)
 }

--- a/p2p/mock_stream.go
+++ b/p2p/mock_stream.go
@@ -35,6 +35,7 @@ func (m *MockStream) EXPECT() *MockStreamMockRecorder {
 
 // Read mocks base method
 func (m *MockStream) Read(arg0 []byte) (int, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Read", arg0)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
@@ -43,11 +44,13 @@ func (m *MockStream) Read(arg0 []byte) (int, error) {
 
 // Read indicates an expected call of Read
 func (mr *MockStreamMockRecorder) Read(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockStream)(nil).Read), arg0)
 }
 
 // Write mocks base method
 func (m *MockStream) Write(arg0 []byte) (int, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Write", arg0)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
@@ -56,11 +59,13 @@ func (m *MockStream) Write(arg0 []byte) (int, error) {
 
 // Write indicates an expected call of Write
 func (mr *MockStreamMockRecorder) Write(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockStream)(nil).Write), arg0)
 }
 
 // Close mocks base method
 func (m *MockStream) Close() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -68,11 +73,13 @@ func (m *MockStream) Close() error {
 
 // Close indicates an expected call of Close
 func (mr *MockStreamMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockStream)(nil).Close))
 }
 
 // SetReadDeadline mocks base method
 func (m *MockStream) SetReadDeadline(arg0 time.Time) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetReadDeadline", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -80,5 +87,6 @@ func (m *MockStream) SetReadDeadline(arg0 time.Time) error {
 
 // SetReadDeadline indicates an expected call of SetReadDeadline
 func (mr *MockStreamMockRecorder) SetReadDeadline(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReadDeadline", reflect.TypeOf((*MockStream)(nil).SetReadDeadline), arg0)
 }


### PR DESCRIPTION
# Issue

This is an offshoot of #516, where I found out `mockgen` was not installed so `go generate` was failing, yet `travis_checker.sh` didn't catch that.  Things done here:

* Ensure mockgen is installed (`go get -t -v ./...` is not enough for that)
* Catch and fail if `gogenerate.sh` fails.
    * Skip file change detection step if `gogenerate.sh` fails, because the failure would mean some/all of the files were not brought up to date and their working copy remained the same, essentially a false positive.

# Tests

Working branch builds on [Travis](https://travis-ci.org/harmony-ek/harmony/branches):

* [#51](https://travis-ci.org/harmony-ek/harmony/builds/500506700) – after the second commit: `go generate` is functioning again, and it detected out-of-date mocks (in this case, mockgen itself was updated, so format of the generated files changed).
* [#52](https://travis-ci.org/harmony-ek/harmony/builds/500510957) – mocks regenerated after updating gomock; check passed.