### PR TITLE
shorten timeout for consensus

### DIFF
--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -11,6 +11,7 @@ import (
 const (
 	DefaultThreshold   = 1
 	FirstTimeThreshold = 2
+	ConsensusTimeOut   = 10
 )
 
 // WaitForConsensusReady listen for the readiness signal from consensus and generate new block for consensus.
@@ -30,10 +31,10 @@ func (node *Node) WaitForConsensusReady(readySignal chan struct{}, stopChan chan
 			select {
 			case <-readySignal:
 				time.Sleep(100 * time.Millisecond) // Delay a bit so validator is catched up (test-only).
-			case <-time.After(300 * time.Second):
+			case <-time.After(ConsensusTimeOut * time.Second):
 				node.Consensus.ResetState()
 				timeoutCount++
-				utils.GetLogInstance().Debug("Consensus timeout, retry!", "count", timeoutCount, "node", node)
+				utils.GetLogInstance().Debug("Consensus timeout, retry!", "count", timeoutCount)
 				// FIXME: retry is not working, there is no retry logic here. It will only wait for new transaction.
 			case <-stopChan:
 				return


### PR DESCRIPTION
Signed-off-by: Leo Chen <leo@harmony.one>

## Issue

We reach only 30 consensuses on AWS devnet deployment test. One consensus got the time out in 300 seconds. This patch shortens the timeout. In a normal case, a consensus can be reached in 3-5 seconds.
<!-- link to the issue number or description of the issue -->

## Test

#### Test Coverage Data

<!-- run 'go test -cover' in the directory you made change -->

* Before
* After

#### Test/Run Logs

http://jenkins.harmony.one/view/Benchmark/job/branch_build_test/20/console

1 shards, 60 consensus, 33 total TPS, 165 nodes

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## TODO
