### PR TITLE
#540 filter out private IP

### DIFF
--- a/api/service/networkinfo/service.go
+++ b/api/service/networkinfo/service.go
@@ -113,7 +113,7 @@ func (s *Service) Run() {
 
 // DoService does network info.
 func (s *Service) DoService() {
-	_, ipv4Net, err := net.ParseCIDR("100.64.0.0/10")
+	_, cgnPrefix, err := net.ParseCIDR("100.64.0.0/10")
 	if err != nil {
 		utils.GetLogInstance().Error("can't parse CIDR", "error", err)
 		return
@@ -137,7 +137,7 @@ func (s *Service) DoService() {
 						continue
 					}
 					nip := netaddr.(*net.TCPAddr).IP
-					if nip.IsGlobalUnicast() || ipv4Net.Contains(nip) {
+					if (nip.IsGlobalUnicast() && !utils.IsPrivateIP(nip)) || cgnPrefix.Contains(nip) {
 						ip = nip.String()
 						port = fmt.Sprintf("%d", netaddr.(*net.TCPAddr).Port)
 						break

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bytes"
 	"encoding/hex"
+	"net"
 	"os"
 	"testing"
 
@@ -156,4 +157,39 @@ func TestSaveLoadKeyFile(t *testing.T) {
 
 	os.Remove(filename)
 	os.Remove(nonexist)
+}
+
+func TestIsPrivateIP(t *testing.T) {
+	addr := []struct {
+		ip        net.IP
+		isPrivate bool
+	}{
+		{
+			net.IPv4(127, 0, 0, 1),
+			true,
+		},
+		{
+			net.IPv4(172, 31, 82, 23),
+			true,
+		},
+		{
+			net.IPv4(192, 168, 82, 23),
+			true,
+		},
+		{
+			net.IPv4(54, 172, 99, 189),
+			false,
+		},
+		{
+			net.IPv4(10, 1, 0, 1),
+			true,
+		},
+	}
+
+	for _, a := range addr {
+		r := IsPrivateIP(a.ip)
+		if r != a.isPrivate {
+			t.Errorf("IP: %v, IsPrivate: %v, Expected: %v", a.ip, r, a.isPrivate)
+		}
+	}
 }


### PR DESCRIPTION
Signed-off-by: Leo Chen <leo@harmony.one>

## Issue

Private IP wasn't filter out by net.IsGlobalUnicast function

```
IsGlobalUnicast reports whether ip is a global unicast address.

The identification of global unicast addresses uses address type identification as defined in RFC 1122, RFC 4632 and RFC 4291 with the exception of IPv4 directed broadcast addresses. It returns true even if ip is in IPv4 private address space or local IPv6 unicast address space.
```

## Test

Add a TestIsPrivateIP function as well.

#### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## TODO
