### PR TITLE
Fix and tidy go mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gorilla/mux v1.7.0
 	github.com/harmony-one/bls v0.0.0-20190309234102-1bd75ac96c09
 	github.com/hashicorp/golang-lru v0.5.1
-	github.com/ipfs/go-datastore v3.2.0+incompatible
+	github.com/ipfs/go-datastore v0.0.1
 	github.com/libp2p/go-libp2p v0.0.2
 	github.com/libp2p/go-libp2p-crypto v0.0.1
 	github.com/libp2p/go-libp2p-discovery v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,16 @@ module github.com/harmony-one/harmony
 go 1.12
 
 require (
+	github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705 // indirect
 	github.com/Workiva/go-datastructures v1.0.50
 	github.com/allegro/bigcache v1.2.0 // indirect
 	github.com/aristanetworks/goarista v0.0.0-20190308231643-e9fb69a13f45 // indirect
+	github.com/cespare/cp v1.1.1 // indirect
 	github.com/deckarep/golang-set v1.7.1 // indirect
+	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/ethereum/go-ethereum v1.8.23
+	github.com/fjl/memsize v0.0.0-20180929194037-2a09253e352a // indirect
+	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/golang/mock v1.2.0
 	github.com/golang/protobuf v1.3.0
@@ -15,6 +20,8 @@ require (
 	github.com/harmony-one/bls v0.0.0-20190309234102-1bd75ac96c09
 	github.com/hashicorp/golang-lru v0.5.1
 	github.com/ipfs/go-datastore v0.0.1
+	github.com/ipfs/go-log v0.0.1
+	github.com/karalabe/hid v0.0.0-20181128192157-d815e0c1a2e2 // indirect
 	github.com/libp2p/go-libp2p v0.0.2
 	github.com/libp2p/go-libp2p-crypto v0.0.1
 	github.com/libp2p/go-libp2p-discovery v0.0.1
@@ -28,8 +35,14 @@ require (
 	github.com/multiformats/go-multiaddr-net v0.0.1
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/rjeczalik/notify v0.9.2 // indirect
+	github.com/rs/cors v1.6.0 // indirect
 	github.com/shirou/gopsutil v2.18.12+incompatible
+	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect
+	github.com/stretchr/testify v1.3.0
+	github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	google.golang.org/grpc v1.19.0
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
+	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
+	gopkg.in/urfave/cli.v1 v1.20.0 // indirect
 )


### PR DESCRIPTION
## Issue

go-datastore, like other IPFS/libp2p projects already did, switched to module-style versioning, and old tags (v3.y.z) are now prefixed with gx/ and not available for Go module imports.

While we are here, run `go mod tidy` to populate test and other dependencies not normally captured via simple builds.  It also marks check.v1 as a direct dependency, which it is.

## Test

#### Test Coverage Data

No code change; test coverage shouldn't be different.

#### Test/Run Logs

Awaiting PR builds.