### PR TITLE
Skip ping for validator

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -207,10 +207,13 @@ func setUpConsensusAndNode(nodeConfig *nodeconfig.ConfigType) (*consensus.Consen
 	if *isBeacon {
 		if nodeConfig.StringRole == "leader" {
 			currentNode.NodeConfig.SetRole(nodeconfig.BeaconLeader)
+			currentNode.NodeConfig.SetIsLeader(true)
 		} else {
 			currentNode.NodeConfig.SetRole(nodeconfig.BeaconValidator)
+			currentNode.NodeConfig.SetIsLeader(false)
 		}
 		currentNode.NodeConfig.SetShardGroupID(p2p.GroupIDBeacon)
+		currentNode.NodeConfig.SetIsBeacon(true)
 	} else {
 		currentNode.AddBeaconChainDatabase(nodeConfig.BeaconDB)
 
@@ -218,10 +221,13 @@ func setUpConsensusAndNode(nodeConfig *nodeconfig.ConfigType) (*consensus.Consen
 			currentNode.NodeConfig.SetRole(nodeconfig.NewNode)
 		} else if nodeConfig.StringRole == "leader" {
 			currentNode.NodeConfig.SetRole(nodeconfig.ShardLeader)
+			currentNode.NodeConfig.SetIsLeader(true)
 		} else {
 			currentNode.NodeConfig.SetRole(nodeconfig.ShardValidator)
+			currentNode.NodeConfig.SetIsLeader(false)
 		}
 		currentNode.NodeConfig.SetShardGroupID(p2p.GroupIDUnknown)
+		currentNode.NodeConfig.SetIsBeacon(false)
 	}
 
 	// Add randomness protocol

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -388,9 +388,10 @@ func (node *Node) pingMessageHandler(msgPayload []byte, sender string) int {
 		return 0
 	}
 
-	// Add to Node's peer list anyway
-	utils.GetLogInstance().Info("Add Peer to Node", "Node", node.Consensus.GetNodeID(), "Pear", peer)
-	node.AddPeers([]*p2p.Peer{peer})
+	if node.NodeConfig.IsLeader() {
+		utils.GetLogInstance().Info("Add Peer to Node", "Node", node.Consensus.GetNodeID(), "Pear", peer)
+		node.AddPeers([]*p2p.Peer{peer})
+	}
 
 	return 1
 }


### PR DESCRIPTION
validators reported, "Failed to validate multi-signature". It is because of the item/order of the public key was updated when the ping message received from the new node.

The original logic was intended for the leader to receive the ping message only. Since we moved to gossip, the validators are actually receiving and handling the ping message as well.  We now skip the validator in addPeer function.