### PR TITLE
[build] disable noisy -v -x in build

### DIFF
--- a/scripts/go_executable_build.sh
+++ b/scripts/go_executable_build.sh
@@ -87,7 +87,7 @@ function build_only
       if [[ -z "$build" || "$bin" == "$build" ]]; then
          rm -f $BINDIR/$bin
          echo "building ${SRC[$bin]}"
-         env GOOS=$GOOS GOARCH=$GOARCH go build -v -x -ldflags="-X main.version=v${VERSION} -X main.commit=${COMMIT} -X main.builtAt=${BUILTAT} -X main.builtBy=${BUILTBY}" -o $BINDIR/$bin $RACE ${SRC[$bin]}
+         env GOOS=$GOOS GOARCH=$GOARCH go build -ldflags="-X main.version=v${VERSION} -X main.commit=${COMMIT} -X main.builtAt=${BUILTAT} -X main.builtBy=${BUILTBY}" -o $BINDIR/$bin $RACE ${SRC[$bin]}
          if [ "$(uname -s)" == "Linux" ]; then
             $BINDIR/$bin -version
          fi


### PR DESCRIPTION
otherwise, it is very hard to find the build errors

Signed-off-by: Leo Chen <leo@harmony.one>
