### PR TITLE
[build] fix jenkins build issue

### DIFF
--- a/scripts/setup_bls_build_flags.sh
+++ b/scripts/setup_bls_build_flags.sh
@@ -1,8 +1,18 @@
 # no shebang; to be sourced from other scripts
 
+unset -v progdir
+case "${0}" in
+*/*) progdir="${0%/*}";;
+*) progdir=.;;
+esac
+
 unset -v gopath
 gopath=$(go env GOPATH)
+# HMY_PATH is the common root directory of all harmony repos
 HMY_PATH="${gopath%%:*}/src/github.com/harmony-one"
+if [ ! -d $HMY_PATH ]; then
+   HMY_PATH=$(realpath $progdir/../..)
+fi
 : ${OPENSSL_DIR="/usr/local/opt/openssl"}
 : ${MCL_DIR="${HMY_PATH}/mcl"}
 : ${BLS_DIR="${HMY_PATH}/bls"}


### PR DESCRIPTION
This will fix the Jenkins build issue after the removal of $GOPATH in Jenkins configuration.

This is needed for go_executable_build.sh script to locate the MCL and BLS libraries.

Signed-off-by: Leo Chen <leo@harmony.one>
