### PR TITLE
Abort QueryStakeInfo on early errors

### DIFF
--- a/node/contract.go
+++ b/node/contract.go
@@ -61,10 +61,12 @@ func (node *Node) QueryStakeInfo() *structs.StakeInfoReturnValue {
 	abi, err := abi.JSON(strings.NewReader(contracts.StakeLockContractABI))
 	if err != nil {
 		utils.GetLogInstance().Error("Failed to generate staking contract's ABI", "error", err)
+		return nil
 	}
 	bytesData, err := abi.Pack("listLockedAddresses")
 	if err != nil {
 		utils.GetLogInstance().Error("Failed to generate ABI function bytes data", "error", err)
+		return nil
 	}
 
 	priKey := contract_constants.GenesisBeaconAccountPriKey


### PR DESCRIPTION
Previously, JSON-to-ABI conversion failure or `listLockedAddresses` argument packing failure would result in calling the contract with empty data.  The proper thing to do is to log error (already being done) *and* early terminate the function and return an error indication.
