### PR TITLE
Use a rough equivalent of realpath

### DIFF
--- a/scripts/setup_bls_build_flags.sh
+++ b/scripts/setup_bls_build_flags.sh
@@ -11,7 +11,9 @@ gopath=$(go env GOPATH)
 # HMY_PATH is the common root directory of all harmony repos
 HMY_PATH="${gopath%%:*}/src/github.com/harmony-one"
 if [ ! -d $HMY_PATH ]; then
-   HMY_PATH=$(realpath $progdir/../..)
+   # "env pwd" uses external pwd(1) implementation and not the Bash built-in,
+   # which does not fully dereference symlinks.
+   HMY_PATH=$(cd $progdir/../.. && env pwd)
 fi
 : ${OPENSSL_DIR="/usr/local/opt/openssl"}
 : ${MCL_DIR="${HMY_PATH}/mcl"}


### PR DESCRIPTION
realpath(1) is not available on macOS.

(Funny, because realpath(3) originated in FreeBSD, so it came to macOS before Linux adopted it, but Linux beat macOS to realpath(1).)