### PR TITLE
Honor HMY_PATH if set

### DIFF
--- a/scripts/setup_bls_build_flags.sh
+++ b/scripts/setup_bls_build_flags.sh
@@ -6,15 +6,19 @@ case "${0}" in
 *) progdir=.;;
 esac
 
-unset -v gopath
-gopath=$(go env GOPATH)
-# HMY_PATH is the common root directory of all harmony repos
-HMY_PATH="${gopath%%:*}/src/github.com/harmony-one"
-if [ ! -d $HMY_PATH ]; then
-   # "env pwd" uses external pwd(1) implementation and not the Bash built-in,
-   # which does not fully dereference symlinks.
-   HMY_PATH=$(cd $progdir/../.. && env pwd)
-fi
+case "${HMY_PATH+set}" in
+"")
+   unset -v gopath
+   gopath=$(go env GOPATH)
+   # HMY_PATH is the common root directory of all harmony repos
+   HMY_PATH="${gopath%%:*}/src/github.com/harmony-one"
+   if [ ! -d $HMY_PATH ]; then
+      # "env pwd" uses external pwd(1) implementation and not the Bash built-in,
+      # which does not fully dereference symlinks.
+      HMY_PATH=$(cd $progdir/../.. && env pwd)
+   fi
+   ;;
+esac
 : ${OPENSSL_DIR="/usr/local/opt/openssl"}
 : ${MCL_DIR="${HMY_PATH}/mcl"}
 : ${BLS_DIR="${HMY_PATH}/bls"}


### PR DESCRIPTION
Modules-based workflow makes it possible to put the harmony repo and friends outside `${GOPATH[0]}/src`, and without using the full import path.  That is, `~/h/harmony`, or even `~/harmony` should be usable.  This can be done by setting `HMY_PATH="${HOME}/h"`, or `HMY_PATH="${HOME}"`.  In order for this to work without modifying `setup_bls_build_flags.sh`, however, `HMY_PATH` set in the environment should be honored.