### PR TITLE
Pay data gases

### DIFF
--- a/cmd/client/wallet/main.go
+++ b/cmd/client/wallet/main.go
@@ -345,7 +345,18 @@ func processTransferCommand() {
 
 	amountBigInt := big.NewInt(int64(amount * params.GWei))
 	amountBigInt = amountBigInt.Mul(amountBigInt, big.NewInt(params.GWei))
-	tx, _ := types.SignTx(types.NewTransaction(state.nonce, receiverAddress, uint32(shardID), amountBigInt, params.TxGas, nil, inputData), types.HomesteadSigner{}, senderPriKey)
+	gas := params.TxGas
+	for b := range inputData {
+		if b != 0 {
+			gas += params.TxDataNonZeroGas
+		} else {
+			gas += params.TxDataZeroGas
+		}
+	}
+	tx := types.NewTransaction(
+		state.nonce, receiverAddress, uint32(shardID), amountBigInt,
+		gas, nil, inputData)
+	tx, _ = types.SignTx(tx, types.HomesteadSigner{}, senderPriKey)
 	submitTransaction(tx, walletNode, uint32(shardID))
 }
 


### PR DESCRIPTION
SSIA.  This fixes harmony-one/harmony#633.

# Test

Balances before are 10.00/0.00:
```
quelthalas 13:02:22 bin (pay_gas_for_data) $ 80 wallet balances
Account 0: 0x2139c763215a801aA4FdE2520dB84c11a6Cd3061:
    Balance in Shard 0:  10.0000, nonce: 0 
Account 1: 0xDf6C34F754f028fcAF77a5260581bBccc0e45D3F:
    Balance in Shard 0:  0.0000, nonce: 0 
Account 2: 0x6F3FE5De8A32401f91Da946aa4397b621528Cc17:
    Balance in Shard 0:  0.0000, nonce: 0 
Account 3: 0x32ecba42e6Bc099C5eb19BE9147aA226DaB2FF68:
    Balance in Shard 0:  0.0000, nonce: 0 
Account 4: 0x93714353dEc28C9ba95171A70B2eB8DBf7949E3E:
    Balance in Shard 0:  0.0000, nonce: 0 
```
Transfer 0.01 with non-empty input data:
```
quelthalas 13:04:07 bin (pay_gas_for_data) $ 82 wallet transfer --from=0x2139c763215a801aA4FdE2520dB84c11a6Cd3061 --to=0xDf6C34F754f028fcAF77a5260581bBccc0e45D3F --amount=0.01 --inputData=AAAA
Transaction Id for shard 0: 0xe6c06a7269f3ef620f8b61681253fc7ca2c7c512d070ebe25ba640f39772c413
```
Balances after are 9.99/0.01
```
quelthalas 13:04:44 bin (pay_gas_for_data) $ 83 wallet balances
Account 0: 0x2139c763215a801aA4FdE2520dB84c11a6Cd3061:
    Balance in Shard 0:  9.99, nonce: 1 
Account 1: 0xDf6C34F754f028fcAF77a5260581bBccc0e45D3F:
    Balance in Shard 0:  0.01, nonce: 0 
Account 2: 0x6F3FE5De8A32401f91Da946aa4397b621528Cc17:
    Balance in Shard 0:  0.0000, nonce: 0 
Account 3: 0x32ecba42e6Bc099C5eb19BE9147aA226DaB2FF68:
    Balance in Shard 0:  0.0000, nonce: 0 
Account 4: 0x93714353dEc28C9ba95171A70B2eB8DBf7949E3E:
    Balance in Shard 0:  0.0000, nonce: 0 
