### PR TITLE
Pay data gas redux

### DIFF
--- a/cmd/client/wallet/main.go
+++ b/cmd/client/wallet/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	crypto2 "github.com/ethereum/go-ethereum/crypto"
+	"github.com/harmony-one/harmony/core"
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -345,13 +346,10 @@ func processTransferCommand() {
 
 	amountBigInt := big.NewInt(int64(amount * params.GWei))
 	amountBigInt = amountBigInt.Mul(amountBigInt, big.NewInt(params.GWei))
-	gas := params.TxGas
-	for _, b := range inputData {
-		if b != 0 {
-			gas += params.TxDataNonZeroGas
-		} else {
-			gas += params.TxDataZeroGas
-		}
+	gas, err := core.IntrinsicGas(inputData, false, true)
+	if err != nil {
+		fmt.Printf("cannot calculate required gas: %v\n", err)
+		return
 	}
 	tx := types.NewTransaction(
 		state.nonce, receiverAddress, uint32(shardID), amountBigInt,

--- a/cmd/client/wallet/main.go
+++ b/cmd/client/wallet/main.go
@@ -346,7 +346,7 @@ func processTransferCommand() {
 	amountBigInt := big.NewInt(int64(amount * params.GWei))
 	amountBigInt = amountBigInt.Mul(amountBigInt, big.NewInt(params.GWei))
 	gas := params.TxGas
-	for b := range inputData {
+	for _, b := range inputData {
 		if b != 0 {
 			gas += params.TxDataNonZeroGas
 		} else {


### PR DESCRIPTION
The previous fix for #633 was botched: It incorrectly used byte indices (`b := range inputData`) instead of byte values (`_, b := range inputData`).  The incorrectly calculated gas was enough for input data containing at least one NUL byte, a condition which all my test cases met—`AAAA` (which is 3 NUL bytes) as well as 10KiB data read from `/dev/urandom` (which was highly likely to contain at least one NUL byte).  However, it failed test cases such as `$(echo 1234 | base64)`, where none of the 4 characters are `NUL`.

I could've used the correct `_, b := range inputData` but here I use `core.IntrinsicGas()` which is the same gas calculation used on the server side.  Less logic duplication for DRY (and in turn future-proofing).