### PR TITLE
[sync] fix getNeighborPeers return 0

### DIFF
--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -38,20 +38,15 @@ func GetSyncingPort(nodePort string) string {
 // getNeighborPeers is a helper function to return list of peers
 // based on different neightbor map
 func (node *Node) getNeighborPeers(neighbor *sync.Map) []p2p.Peer {
-	res := []p2p.Peer{}
 	tmp := []p2p.Peer{}
 	neighbor.Range(func(k, v interface{}) bool {
-		tmp = append(tmp, v.(p2p.Peer))
+		p := v.(p2p.Peer)
+		t := p.Port
+		p.Port = GetSyncingPort(t)
+		tmp = append(tmp, p)
 		return true
 	})
-	for _, peer := range tmp {
-		port := GetSyncingPort(peer.Port)
-		if peer.Port != node.SelfPeer.Port && port != "" {
-			peer.Port = port
-			res = append(res, peer)
-		}
-	}
-	return res
+	return tmp
 }
 
 // GetBeaconSyncingPeers returns a list of peers for beaconchain syncing


### PR DESCRIPTION
On AWS launch, every node is using the same port number.
The original function filtered out all the peer with the same port and
got 0 peer on AWS test.

Signed-off-by: Leo Chen <leo@harmony.one>
