### PR TITLE
[wallet] support rpc server using environment variable

### DIFF
--- a/cmd/client/wallet/main.go
+++ b/cmd/client/wallet/main.go
@@ -81,19 +81,27 @@ var (
 	addrStrings = []string{"/ip4/100.26.90.187/tcp/9876/p2p/QmZJJx6AdaoEkGLrYG4JeLCKeCKDjnFz2wfHNHxAqFSGA9", "/ip4/54.213.43.194/tcp/9876/p2p/QmQayinFSgMMw5cSpDUiD9pQ2WeP6WNmGxpZ6ou3mdVFJX"}
 
 	// list of rpc servers
-	// TODO; (leo) take build time parameters or environment parameters to add rpcServers
-	// Then this can be automated
-	rpcServers = []struct {
-		IP   string
-		Port string
-	}{
-		{"52.39.144.88", "14555"},
-		{"100.27.48.137", "14555"},
-		{"18.236.238.59", "14555"},
-		{"34.216.169.242", "14555"},
-		{"52.39.189.88", "14555"},
-		{"3.92.19.244", "14555"},
-		{"35.171.228.165", "14555"},
+	rpcServers = []p2p.Peer{
+		p2p.Peer{
+			IP:   "52.39.144.88",
+			Port: "14555",
+		},
+		p2p.Peer{
+			IP:   "100.27.48.137",
+			Port: "14555",
+		},
+		p2p.Peer{
+			IP:   "18.236.238.59",
+			Port: "14555",
+		},
+		p2p.Peer{
+			IP:   "52.39.189.88",
+			Port: "14555",
+		},
+		p2p.Peer{
+			IP:   "3.92.19.244",
+			Port: "14555",
+		},
 	}
 )
 
@@ -134,10 +142,29 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Enable log if the last parameter is -verbose
-	if os.Args[len(os.Args)-1] == "--verbose" {
-		setupLog()
-		os.Args = os.Args[:len(os.Args)-1]
+ARG:
+	for {
+		lastArg := os.Args[len(os.Args)-1]
+		switch lastArg {
+		case "--verbose":
+			setupLog()
+			os.Args = os.Args[:len(os.Args)-1]
+		case "--devnet":
+			// the multiaddress of bootnodes for devnet
+			addrStrings = []string{"/ip4/100.26.90.187/tcp/9871/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv", "/ip4/54.213.43.194/tcp/9871/p2p/QmRVbTpEYup8dSaURZfF6ByrMTSKa4UyUzJhSjahFzRqNj"}
+			os.Args = os.Args[:len(os.Args)-1]
+		default:
+			break ARG
+		}
+	}
+
+	if len(os.Getenv("RpcNodes")) > 0 {
+		rpcServers = utils.StringsToPeers(os.Getenv("RpcNodes"))
+	}
+	if len(rpcServers) == 0 {
+		fmt.Println("Error: please set environment variable RpcNodes")
+		fmt.Println("Example: export RpcNodes=127.0.0.1:8000,192.168.0.1:9999")
+		os.Exit(0)
 	}
 
 	// Switch on the subcommand

--- a/internal/utils/flags.go
+++ b/internal/utils/flags.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	p2p "github.com/harmony-one/harmony/p2p"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
@@ -44,6 +45,23 @@ func StringsToAddrs(addrStrings []string) (maddrs []ma.Multiaddr, err error) {
 		maddrs = append(maddrs, addr)
 	}
 	return
+}
+
+// StringsToPeers converts a string to a list of Peers
+// addr is a string of format "ip:port,ip:port"
+func StringsToPeers(input string) []p2p.Peer {
+	addrs := strings.Split(input, ",")
+	peers := make([]p2p.Peer, 0)
+	for _, addr := range addrs {
+		data := strings.Split(addr, ":")
+		if len(data) >= 2 {
+			peer := p2p.Peer{}
+			peer.IP = data[0]
+			peer.Port = data[1]
+			peers = append(peers, peer)
+		}
+	}
+	return peers
 }
 
 // DefaultBootNodeAddrStrings is a list of Harmony bootnodes address. Used to find other peers in the network.

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -3,8 +3,10 @@ package utils
 import (
 	"net"
 	"os"
+	"reflect"
 	"testing"
 
+	p2p "github.com/harmony-one/harmony/p2p"
 	crypto "github.com/libp2p/go-libp2p-crypto"
 	"github.com/stretchr/testify/assert"
 )
@@ -163,6 +165,42 @@ func TestIsPrivateIP(t *testing.T) {
 		r := IsPrivateIP(a.ip)
 		if r != a.isPrivate {
 			t.Errorf("IP: %v, IsPrivate: %v, Expected: %v", a.ip, r, a.isPrivate)
+		}
+	}
+}
+
+func TestStringsToPeers(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []p2p.Peer
+	}{
+		{
+			"127.0.0.1:9000,192.168.192.1:8888,54.32.12.3:9898",
+			[]p2p.Peer{
+				p2p.Peer{IP: "127.0.0.1", Port: "9000"},
+				p2p.Peer{IP: "192.168.192.1", Port: "8888"},
+				p2p.Peer{IP: "54.32.12.3", Port: "9898"},
+			},
+		},
+		{
+			"a:b,xx:XX,hello:world",
+			[]p2p.Peer{
+				p2p.Peer{IP: "a", Port: "b"},
+				p2p.Peer{IP: "xx", Port: "XX"},
+				p2p.Peer{IP: "hello", Port: "world"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		peers := StringsToPeers(test.input)
+		if len(peers) != 3 {
+			t.Errorf("StringsToPeers failure")
+		}
+		for i, p := range peers {
+			if !reflect.DeepEqual(p, test.expected[i]) {
+				t.Errorf("StringToPeers: expected: %v, got: %v", test.expected[i], p)
+			}
 		}
 	}
 }


### PR DESCRIPTION
use an external environment variable to specify the rpc servers
of the wallet. this will greatly simplify the testing.

example of the environment variable:

export RpcNodes="127.0.0.1:8989,192.168.129.1:5555"

Signed-off-by: Leo Chen <leo@harmony.one>
