### PR TITLE
start sync when a new node join instead of waiting for consensus

### DIFF
--- a/api/service/syncing/downloader/client.go
+++ b/api/service/syncing/downloader/client.go
@@ -110,7 +110,7 @@ func (client *Client) PushNewBlock(selfPeerHash [20]byte, blockHash []byte, time
 
 // GetBlockChainHeight gets the blockheight from peer
 func (client *Client) GetBlockChainHeight() *pb.DownloaderResponse {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	request := &pb.DownloaderRequest{Type: pb.DownloaderRequest_BLOCKHEIGHT}
 	response, err := client.dlClient.Query(ctx, request)

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -67,9 +67,6 @@ SyncingLoop:
 	for {
 		select {
 		case <-ticker.C:
-			if willJoinConsensus {
-				<-node.Consensus.ConsensusIDLowChan
-			}
 			if node.stateSync == nil {
 				node.stateSync = syncing.CreateStateSync(node.SelfPeer.IP, node.SelfPeer.Port, node.GetSyncID())
 			}
@@ -97,6 +94,9 @@ SyncingLoop:
 			node.stateMutex.Lock()
 			node.State = NodeReadyForConsensus
 			node.stateMutex.Unlock()
+			if willJoinConsensus {
+				<-node.Consensus.ConsensusIDLowChan
+			}
 		}
 	}
 }

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -78,7 +78,7 @@ SyncingLoop:
 					continue SyncingLoop
 				}
 			}
-			if node.stateSync.IsOutOfSync() {
+			if node.stateSync.IsOutOfSync(bc) {
 				utils.GetLogInstance().Debug("[SYNC] out of sync, doing syncing")
 				node.stateMutex.Lock()
 				node.State = NodeNotInSync


### PR DESCRIPTION
A new node will begin state syncing as soon as its join network now.