### PR TITLE
update balance output

### DIFF
--- a/cmd/client/wallet/main.go
+++ b/cmd/client/wallet/main.go
@@ -267,7 +267,8 @@ func processBalancesCommand() {
 
 	if *balanceAddressPtr == "" {
 		for i, address := range ReadAddresses() {
-			fmt.Printf("Account %d: %s:\n", i, address.Hex())
+			fmt.Printf("Account %d:\n", i)
+			fmt.Printf("    Address: %s\n", address.Hex())
 			for shardID, balanceNonce := range FetchBalance(address) {
 				fmt.Printf("    Balance in Shard %d:  %s, nonce: %v \n", shardID, convertBalanceIntoReadableFormat(balanceNonce.balance), balanceNonce.nonce)
 			}


### PR DESCRIPTION
Minor update:
Currently the `balances` command shows output like this:
```
Account 0: 0x50118d7E7106b038489804e63999eCb3bd1C6f1a:
    Balance in Shard 0:  10.0000, nonce: 0 
```
When copying the address, the `:` is always included. Not desirable.