### PR TITLE
Version-peg tools (#600)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ install:
   - cd ../harmony
   - go get -v ./...
   - go get gopkg.in/check.v1
-  - go get github.com/golang/mock/mockgen
   - go get github.com/golang/protobuf/protoc-gen-go
   - scripts/install_build_tools.sh
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ install:
   - make
   - cd ../harmony
   - go get -v ./...
-  - go get -u golang.org/x/lint/golint
   - go get -u golang.org/x/tools/cmd/goimports
   - go get gopkg.in/check.v1
   - go get github.com/harmony-ek/gencodec

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ install:
   - cd ../harmony
   - go get -v ./...
   - go get gopkg.in/check.v1
-  - go get github.com/golang/protobuf/protoc-gen-go
   - scripts/install_build_tools.sh
 script:
   - go build -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ install:
   - make
   - cd ../harmony
   - go get -v ./...
-  - go get gopkg.in/check.v1
   - scripts/install_build_tools.sh
 script:
   - go build -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ install:
   - make
   - cd ../harmony
   - go get -v ./...
-  - go get -u golang.org/x/tools/cmd/goimports
   - go get gopkg.in/check.v1
   - go get github.com/harmony-ek/gencodec
   - go get github.com/golang/mock/mockgen

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ install:
   - cd ../harmony
   - go get -v ./...
   - go get gopkg.in/check.v1
-  - go get github.com/harmony-ek/gencodec
   - go get github.com/golang/mock/mockgen
   - go get github.com/golang/protobuf/protoc-gen-go
   - scripts/install_build_tools.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - go get github.com/harmony-ek/gencodec
   - go get github.com/golang/mock/mockgen
   - go get github.com/golang/protobuf/protoc-gen-go
-  - ./scripts/install_protoc.sh -V 3.6.1
+  - scripts/install_build_tools.sh
 script:
   - go build -v ./...
   - ./scripts/travis_checker.sh

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/golang/mock v1.2.0
 	github.com/golang/protobuf v1.3.0
+	github.com/golangci/golangci-lint v1.15.0
 	github.com/gorilla/handlers v1.4.0
 	github.com/gorilla/mux v1.7.0
 	github.com/harmony-ek/gencodec v0.0.0-20190215044613-e6740dbdd846
@@ -41,7 +42,6 @@ require (
 	github.com/rjeczalik/notify v0.9.2 // indirect
 	github.com/rs/cors v1.6.0 // indirect
 	github.com/shirou/gopsutil v2.18.12+incompatible
-	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect
 	github.com/stretchr/testify v1.3.0
 	github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3
+	golang.org/x/tools v0.0.0-20190320160634-b6b7807791df
 	google.golang.org/grpc v1.19.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/stretchr/testify v1.3.0
 	github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
+	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3
 	google.golang.org/grpc v1.19.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,17 +12,20 @@ require (
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/ethereum/go-ethereum v1.8.23
 	github.com/fjl/memsize v0.0.0-20180929194037-2a09253e352a // indirect
+	github.com/garslo/gogen v0.0.0-20170307003452-d6ebae628c7c // indirect
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/golang/mock v1.2.0
 	github.com/golang/protobuf v1.3.0
 	github.com/gorilla/handlers v1.4.0
 	github.com/gorilla/mux v1.7.0
+	github.com/harmony-ek/gencodec v0.0.0-20190215044613-e6740dbdd846
 	github.com/harmony-one/bls v0.0.1
 	github.com/hashicorp/golang-lru v0.5.1
 	github.com/ipfs/go-datastore v0.0.1
 	github.com/ipfs/go-log v0.0.1
 	github.com/karalabe/hid v0.0.0-20181128192157-d815e0c1a2e2 // indirect
+	github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 // indirect
 	github.com/libp2p/go-libp2p v0.0.2
 	github.com/libp2p/go-libp2p-crypto v0.0.1
 	github.com/libp2p/go-libp2p-discovery v0.0.1

--- a/scripts/add_build_tool_package.sh
+++ b/scripts/add_build_tool_package.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+
+set -eu
+
+unset -v progname progdir
+progname="${0##*/}"
+case "${0}" in
+*/*) progdir="${0%/*}";;
+*) progdir=".";;
+esac
+
+msg() { case $# in [1-9]*) echo "${progname}: $*" >&2;; esac; }
+
+print_usage() {
+	cat <<- ENDEND
+		usage: ${progname} [-h] pkg ...
+
+		Register the given tool package(s) in tools/tools.go and go.mod.
+
+		pkg is a tool to install, ex: github.com/golangci/golangci-lint/cmd/golangci-lint@v1.15.0
+		omitting the @version suffix installs the latest.
+
+		options:
+		-h	print this help
+		ENDEND
+}
+
+usage() {
+	msg "$@"
+	print_usage >&2
+	exit 64
+}
+
+unset -v opt
+OPTIND=1
+while getopts :h opt
+do
+	case "${opt}" in
+	"?") usage "unrecognized option -${OPTARG}";;
+	":") usage "missing argument for -${OPTARG}";;
+	h) print_usage; exit 0;;
+	esac
+done
+shift $((${OPTIND} - 1))
+
+cd "${progdir}/.."
+
+if git status --short go.mod tools/tools.go | grep -q .
+then
+	msg "go.mod or tools/tools.go contains local change;" \
+		"commit or stash them first." >&2
+	exit 69
+fi
+
+go mod tidy
+if git status --short go.mod | grep -q .
+then
+	git commit -m 'go mod tidy' go.mod
+fi
+
+doit() {
+	local pkg pkg_name
+	pkg="${1-}"
+	shift 1 || return $?
+	pkg_name="${pkg%%@*}"
+	msg "adding ${pkg} to tools/tools.go"
+	sed -i.orig '/^import ($/a\
+	_ "'"${pkg_name}"'"
+' tools/tools.go
+	rm -f tools/tools.go.orig
+	goimports -w tools/tools.go
+	if git diff --exit-code tools/tools.go
+	then
+		msg "${pkg_name} already seems to be in tools/tools.go"
+		return 0
+	fi
+	msg "adding ${pkg} to go.mod"
+	go get "${pkg}"
+	go mod tidy
+	if git diff --exit-code go.mod
+	then
+		msg "${pkg} already seems to be in go.mod" \
+			"(maybe it is already required as a build dependency)"
+	fi
+	git commit -m "Add ${pkg} as a build tool" tools/tools.go go.mod
+}
+
+unset -v pkg ok
+ok=true
+for pkg
+do
+	doit "${pkg}" || ok=false
+done
+exec "${ok}"

--- a/scripts/goget.sh
+++ b/scripts/goget.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+set -eu
+
+unset -v progname progdir
+progname="${0##*/}"
+case "${0}" in
+*/*) progdir="${0%/*}";;
+*) progdir=.;;
+esac
+
+unset -v tmpdir
+sigs="0 1 2 15"  # EXIT HUP INT TERM
+trapfunc() {
+	case "${tmpdir-}" in ?*) rm -rf "${tmpdir}";; esac
+	trap -- ${sigs}
+	case "${1}" in 0|EXIT) ;; *) kill "-${1}" "$$";; esac
+}
+unset -v sig; for sig in ${sigs}; do trap "trapfunc ${sig}" "${sig}"; done
+tmpdir=$(mktemp -d)
+
+unset -v jq
+jq=$(which jq) || { echo "${progname}: jq not found" >&2; exit 69; }
+
+cd "${progdir}"
+while [ ! -f go.mod ]
+do
+	case "$(pwd)" in
+	/) echo "${progname}: go.mod not found" >&2; exit 69;;
+	esac
+	cd ..
+done
+
+go mod edit -json | \
+	"${jq}" -r '.Require[] | .Path + "@" + .Version' \
+	> "${tmpdir}/gomod.txt"
+
+ok=true
+unset -v pkg
+for pkg
+do
+	unset -v best_path best_version path version
+	while IFS=@ read -r path version
+	do
+		# Is requested package at or under this path?  Skip if not.
+		case "${pkg}" in
+		"${path}"|"${path}"/*) ;;
+		*) continue;;
+		esac
+		: ${best_path="${path}"}
+		: ${best_version="${version}"}
+		# Is this path more specific than the current best?
+		case "${path}" in
+		"${best_path}"/*)
+			best_path="${path}"
+			best_version="${version}"
+		esac
+	done < "${tmpdir}/gomod.txt"
+	case "${best_path-}" in
+	"")
+		echo "${progname}: no module provides package ${pkg}" >&2
+		ok=false
+		continue
+		;;
+	esac
+	echo "${progname}: ${pkg} is provided by ${best_path}@${best_version}"
+	go get "${pkg}@${best_version}"
+done
+"${ok}" && exit 0 || exit 1

--- a/scripts/install_build_tools.sh
+++ b/scripts/install_build_tools.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -eu
+
+unset -v progdir
+case "${0}" in
+/*) progdir="/";;
+*/*) progdir="${0%/*}";;
+*) progdir=".";
+esac
+
+sed -n 's/^	_ "\([^"]*\)"$/\1/p' "${progdir}/../tools/tools.go" | \
+	xargs "${progdir}/goget.sh"
+
+"${progdir}/install_protoc.sh" -V 3.6.1

--- a/scripts/protobuf_setup.md
+++ b/scripts/protobuf_setup.md
@@ -1,6 +1,0 @@
-# Setup
-
-You need to install protoc (protobuf compiler) and protoc-gen-go.
-
-- For protoc-gen-go just simple install by `go get -u github.com/golang/protobuf/protoc-gen-go`
-- For protoc, you install from the release https://github.com/protocolbuffers/protobuf/releases.

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -11,6 +11,7 @@ package tools
 // scripts/install_build_tools.sh parses these imports to install them.
 import (
 	_ "github.com/golang/mock/mockgen"
+	_ "github.com/golang/protobuf/protoc-gen-go"
 	_ "github.com/harmony-ek/gencodec"
 	_ "golang.org/x/lint/golint"
 	_ "golang.org/x/tools/cmd/goimports"

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -12,6 +12,7 @@ package tools
 import (
 	_ "github.com/golang/mock/mockgen"
 	_ "github.com/golang/protobuf/protoc-gen-go"
+	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/harmony-ek/gencodec"
 	_ "golang.org/x/lint/golint"
 	_ "golang.org/x/tools/cmd/goimports"

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -10,4 +10,5 @@ package tools
 // Put only installable tools into this list.
 // scripts/install_build_tools.sh parses these imports to install them.
 import (
+	_ "golang.org/x/lint/golint"
 )

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,0 +1,13 @@
+// Do not remove the following build tag line: It exempts this file from normal
+// builds, which would fail because the imports are programs – package main –
+// and not really importable packages.
+//
+// +build tools
+
+// Package tools provides build tools necessary for Harmony.
+package tools
+
+// Put only installable tools into this list.
+// scripts/install_build_tools.sh parses these imports to install them.
+import (
+)

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -10,6 +10,7 @@ package tools
 // Put only installable tools into this list.
 // scripts/install_build_tools.sh parses these imports to install them.
 import (
+	_ "github.com/golang/mock/mockgen"
 	_ "github.com/harmony-ek/gencodec"
 	_ "golang.org/x/lint/golint"
 	_ "golang.org/x/tools/cmd/goimports"

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -10,6 +10,7 @@ package tools
 // Put only installable tools into this list.
 // scripts/install_build_tools.sh parses these imports to install them.
 import (
+	_ "github.com/harmony-ek/gencodec"
 	_ "golang.org/x/lint/golint"
 	_ "golang.org/x/tools/cmd/goimports"
 )

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -11,4 +11,5 @@ package tools
 // scripts/install_build_tools.sh parses these imports to install them.
 import (
 	_ "golang.org/x/lint/golint"
+	_ "golang.org/x/tools/cmd/goimports"
 )


### PR DESCRIPTION
## Issue

Our builds do not fully specify versions of tools, especially code generators.  As a result, the builds are not fully reproducible, and what passed yesterday may fail now and vice versa, because the same `go get` command for the same tool package may fetch and install different versions of the package over time as the package gets updated.

To fix this, this PR introduces the following mechanisms, in line with [the officially recommended approach](https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module):

* `tools/tools.go` (new) has a list of `go get`-able build tools such as `golint` and `goimports`.
    * `go.mod` contains the specific pegged versions of the `go get`-able build tools.
* `scripts/goget.sh` (new) installs—that is, `go get`-s—given import paths using the versions specified in `go.mod`.
* `scripts/install_build_tools.sh` (new) reads a list of build tools from `tools/tools.go`, and uses `goget.sh` to install the specific version pegged in `go.mod` of each tool.
    * It also installs `protoc`.  As its name suggests, it is supposed to install all build tools required by the project.
    * `.travis.yml` now uses this script.
* `scripts/add_build_tool_package.sh` is a convenience helper scripts for adding a new build tool.

Going forward, the rules/steps for adding a new build tool are:

1. If the tool is installed by `go get`:

    1. Run `scripts/add_build_tool_package.sh` with the tool package name, preferably `@`-qualified with the desired version.  Example for installing version 1.15.0 of [`golangci-lint`](https://github.com/golangci/golangci-lint)—a modern replacement of [now-deprecated `gometalinter`](https://github.com/alecthomas/gometalinter):

           scripts/add_build_tool_package.sh github.com/golangci/golangci-lint/cmd/golangci-lint@v1.15.0

       This script introduces one or more commits, each introducing the given tool.

    2. Send a PR with the commits as usual.

2. If the tool is not installed by `go get`:

    1. Introduce a script to install the tool into the `scripts/` subdirectory.
        * Make it possible to install a specific pegged version of the tool.
        * See `scripts/install_protoc.sh` and its `-V` option handling for example.
    2. Make `scripts/install_build_tools.sh` run the new installation script, with a specific version.

## Test

### Test Coverage Data

N/A

### Test/Run Logs

[Jenkins](http://jenkins.harmony.one/blue/organizations/jenkins/build_test_on_ek_push/detail/build_test_on_ek_push/83/pipeline) | [Travis CI](https://travis-ci.org/harmony-ek/harmony/builds/513616613)