### PR TITLE
Seperate the notion of shardId=0 from a beacon node

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -218,6 +218,7 @@ func setUpConsensusAndNode(nodeConfig *nodeconfig.ConfigType) (*consensus.Consen
 	if *isGenesis {
 		// TODO: need change config file and use switch instead of complicated "if else" condition
 		if nodeConfig.ShardID == 0 { // Beacon chain
+			nodeConfig.SetIsBeacon(true)
 			if nodeConfig.StringRole == "leader" {
 				currentNode.NodeConfig.SetRole(nodeconfig.BeaconLeader)
 				currentNode.NodeConfig.SetIsLeader(true)

--- a/internal/configs/node/config.go
+++ b/internal/configs/node/config.go
@@ -66,6 +66,7 @@ type ConfigType struct {
 	client   p2p.GroupID // the client group ID of the shard
 	isClient bool        // whether this node is a client node, such as wallet/txgen
 	isLeader bool        // whether this node is a leader or not
+	isBeacon bool        // whether this node is beacon node doing consensus or not
 	ShardID  uint32      // ShardID of this node
 	role     Role        // Role of the node
 
@@ -146,6 +147,11 @@ func (conf *ConfigType) SetIsLeader(b bool) {
 	conf.isLeader = b
 }
 
+// SetIsBeacon sets the isBeacon configuration
+func (conf *ConfigType) SetIsBeacon(b bool) {
+	conf.isBeacon = b
+}
+
 // SetShardID set the ShardID
 func (conf *ConfigType) SetShardID(s uint32) {
 	conf.ShardID = s
@@ -178,7 +184,7 @@ func (conf *ConfigType) IsClient() bool {
 
 // IsBeacon returns the isBeacon configuration
 func (conf *ConfigType) IsBeacon() bool {
-	return conf.ShardID == 0
+	return conf.isBeacon
 }
 
 // IsLeader returns the isLeader configuration

--- a/internal/configs/node/config_test.go
+++ b/internal/configs/node/config_test.go
@@ -45,8 +45,14 @@ func TestNodeConfigMultiple(t *testing.T) {
 		t.Errorf("expecting nil, got: %v", f)
 	}
 
+	if c.IsBeacon() != false {
+		t.Errorf("expecting the node to not be beacon yet, got: %v", c.IsBeacon())
+	}
+
+	c.SetIsBeacon(true)
+
 	if c.IsBeacon() != true {
-		t.Errorf("expecting true, got: %v", c.IsBeacon())
+		t.Errorf("expecting the node to be beacon, got: %v", c.IsBeacon())
 	}
 
 	d.SetShardGroupID("abcd")


### PR DESCRIPTION
## Issue

Currently if a node is asked whether its a beacon node, it responds `true` if its shardID is zero. If it is a beaconnode [it won't add peers ](https://github.com/harmony-one/harmony/blob/72dd417202ab02b08437ad221d65a67436040ce6/api/service/discovery/service.go#L90 )
However we want light nodes/client nodes to join shardID=0, have peers, so that they can state-sync and possibly send transactions to this shard. This change makes the distinction (without a difference) between `shardID=0` and being a beaconnode.
