### PR TITLE
Log block rewards

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 
@@ -199,6 +200,8 @@ func setUpConsensusAndNode(nodeConfig *nodeconfig.ConfigType) (*consensus.Consen
 	currentNode.NodeConfig.SetRole(nodeconfig.NewNode)
 	currentNode.AccountKey = nodeConfig.StakingPriKey
 	consensus.SetStakeInfoFinder(currentNode)
+	utils.GetLogInstance().Info("node account set",
+		"address", crypto.PubkeyToAddress(currentNode.AccountKey.PublicKey).Hex())
 
 	// TODO: refactor the creation of blockchain out of node.New()
 	consensus.ChainReader = currentNode.Blockchain()

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -671,6 +671,11 @@ func (consensus *Consensus) accumulateRewards(
 		}
 		numAccounts += len(stakeInfos)
 		for _, stakeInfo := range stakeInfos {
+			utils.GetLogInstance().Info("accumulateRewards: rewarding",
+				"block", header.Hash().Hex(),
+				"account", stakeInfo.Address.Hex(),
+				"node", hex.EncodeToString(stakeInfo.BlsAddress[:]),
+				"amount", BlockReward)
 			state.AddBalance(stakeInfo.Address, BlockReward)
 			totalAmount = new(big.Int).Add(totalAmount, BlockReward)
 		}

--- a/node/node.go
+++ b/node/node.go
@@ -145,7 +145,6 @@ type Node struct {
 
 	//Node Account
 	AccountKey *ecdsa.PrivateKey
-	Address    common.Address
 
 	// For test only
 	TestBankKeys        []*ecdsa.PrivateKey


### PR DESCRIPTION
## Issue

SSIA.  To use this:

```sh
logfile=... # change this
acct=$(head -100 "$logfile" | jq -r 'select(.msg == "node account set") | .address')
tail -fc+0 "$logfile" | jq --arg acct "${acct}" 'select(.msg == "accumulateRewards: rewarding" and .account == $acct)'
```

Sample output (`amount` is in Wei; 1000000000000000 Wei = 0.001 token):

```json
{
  "account": "0xE2bD4413172C98d5094B94de1A8AC6a383d68b84",
  "amount": "1000000000000000",
  "block": "0x021f2fe4c387de859b8c341099e116bb37cf5e1729a590d0a0aee58d8b63e6ad",
  "ip": "127.0.0.1",
  "lvl": "info",
  "msg": "accumulateRewards: rewarding",
  "node": "ac286808e6ce0e56559d08b99a3e0e71af1f6dec",
  "port": "9000",
  "t": "2019-04-01T19:24:26.856624-07:00"
}
```

## Test

### Test Coverage Data

Logging-only PR.  No coverage change.

### Test/Run Logs

Local test passes.