### PR TITLE
[log] adding log to debug #680

### DIFF
--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -38,6 +38,7 @@ func (node *Node) WaitForConsensusReady(readySignal chan struct{}, stopChan chan
 				utils.GetLogInstance().Debug("Consensus timeout, retry!", "count", timeoutCount)
 				// FIXME: retry is not working, there is no retry logic here. It will only wait for new transaction.
 			case <-stopChan:
+				utils.GetLogInstance().Debug("Consensus propose new block: STOPPED!")
 				return
 			}
 
@@ -74,7 +75,9 @@ func (node *Node) WaitForConsensusReady(readySignal chan struct{}, stopChan chan
 			}
 			// Send the new block to Consensus so it can be confirmed.
 			if newBlock != nil {
+				utils.GetLogInstance().Debug("Consensus sending new block to block channel")
 				node.BlockChannel <- newBlock
+				utils.GetLogInstance().Debug("Consensus sent new block to block channel")
 			}
 		}
 	}()


### PR DESCRIPTION
I suspect the new block proposing service is stopped in testnet. That's why leader still receive transaction but never propose new block on banjo testnet.

Add a few debug log to isolate the issue.

Signed-off-by: Leo Chen <leo@harmony.one>
