### PR TITLE
Do not try to add self key to mask

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -647,7 +647,7 @@ func (consensus *Consensus) accumulateRewards(
 			"parentHash", header.ParentHash.Hex(),
 		)
 	}
-	mask, err := bls_cosi.NewMask(consensus.PublicKeys, consensus.PubKey)
+	mask, err := bls_cosi.NewMask(consensus.PublicKeys, nil)
 	if err != nil {
 		return ctxerror.New("cannot create group sig mask").WithCause(err)
 	}


### PR DESCRIPTION
This may fail the newnode case because the new node may still be trying to sync up before joining the consensus, hence its key is not in `consensus.PublicKeys` yet.

When this happens, the new node will not be able to sync blocks and won't join consensus.
