### PR TITLE
[log] disable huge debug log in leader

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1741,14 +1741,14 @@ func (bc *BlockChain) StoreNewShardState(block *types.Block, stakeInfo *map[comm
 		number := block.NumberU64()
 		rawdb.WriteShardState(bc.db, hash, number, shardState)
 		utils.GetLogInstance().Debug("[Resharding] Saved new shard state successfully", "epoch", GetEpochFromBlockNumber(block.NumberU64()))
-		for _, shard := range shardState {
-			output := shard.Leader.BlsPublicKey.Hex()
-			output = output + " \n"
-			for _, node := range shard.NodeList {
-				output = output + node.BlsPublicKey.Hex() + " \n"
-			}
-			utils.GetLogInstance().Debug(fmt.Sprintf("[Resharding][shard: %d] Leader: %s", shard.ShardID, output))
-		}
+		//		for _, shard := range shardState {
+		//			output := shard.Leader.BlsAddress
+		//			output = output + " \n"
+		//			for _, node := range shard.NodeList {
+		//				output = output + node.BlsAddress + " \n"
+		//			}
+		//			utils.GetLogInstance().Debug(fmt.Sprintf("[Resharding][shard: %d] Leader: %s", shard.ShardID, output))
+		//		}
 	}
 	return shardState
 }

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -89,9 +89,9 @@ func (node *Node) addNewShardStateHash(block *types.Block) {
 	if shardState != nil {
 		shardHash := shardState.Hash()
 		utils.GetLogInstance().Debug("[resharding] adding new shard state", "shardHash", shardHash)
-		for _, c := range shardState {
-			utils.GetLogInstance().Debug("new shard information", "shardID", c.ShardID, "NodeList", c.NodeList)
-		}
+		//		for _, c := range shardState {
+		//			utils.GetLogInstance().Debug("new shard information", "shardID", c.ShardID, "NodeList", c.NodeList)
+		//		}
 		block.AddShardStateHash(shardHash)
 	}
 }


### PR DESCRIPTION
the excessive logs have caused leader node out of space only after 8k
consensuses.

Signed-off-by: Leo Chen <leo@harmony.one>

## Issue

<!-- link to the issue number or description of the issue -->

## Test

#### Test Coverage Data

<!-- run 'go test -cover' in the directory you made change -->

* Before
* After

#### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## TODO
