### PR TITLE
[cleanup] remove peers variable from consensus New function

### DIFF
--- a/cmd/client/txgen/main.go
+++ b/cmd/client/txgen/main.go
@@ -124,7 +124,7 @@ func main() {
 	}
 
 	// Client/txgenerator server node setup
-	consensusObj, err := consensus.New(host, 0, nil, p2p.Peer{}, nil)
+	consensusObj, err := consensus.New(host, 0, p2p.Peer{}, nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error :%v \n", err)
 		os.Exit(1)

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -199,7 +199,7 @@ func setUpConsensusAndNode(nodeConfig *nodeconfig.ConfigType) (*consensus.Consen
 	// Consensus object.
 	// TODO: consensus object shouldn't start here
 	// TODO(minhdoan): During refactoring, found out that the peers list is actually empty. Need to clean up the logic of consensus later.
-	consensus, err := consensus.New(nodeConfig.Host, nodeConfig.ShardID, []p2p.Peer{}, nodeConfig.Leader, nodeConfig.ConsensusPriKey)
+	consensus, err := consensus.New(nodeConfig.Host, nodeConfig.ShardID, nodeConfig.Leader, nodeConfig.ConsensusPriKey)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error :%v \n", err)
 		os.Exit(1)

--- a/consensus/consensus_leader_msg_test.go
+++ b/consensus/consensus_leader_msg_test.go
@@ -17,13 +17,12 @@ import (
 
 func TestConstructAnnounceMessage(test *testing.T) {
 	leader := p2p.Peer{IP: "127.0.0.1", Port: "19999"}
-	validator := p2p.Peer{IP: "127.0.0.1", Port: "55555"}
 	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "9902")
 	host, err := p2pimpl.NewHost(&leader, priKey)
 	if err != nil {
 		test.Fatalf("newhost failure: %v", err)
 	}
-	consensus, err := New(host, 0, []p2p.Peer{leader, validator}, leader, bls.RandPrivateKey())
+	consensus, err := New(host, 0, leader, bls.RandPrivateKey())
 	if err != nil {
 		test.Fatalf("Cannot craeate consensus: %v", err)
 	}
@@ -48,13 +47,12 @@ func TestConstructPreparedMessage(test *testing.T) {
 
 	validatorPriKey := bls.RandPrivateKey()
 	validatorPubKey := leaderPriKey.GetPublicKey()
-	validator := p2p.Peer{IP: "127.0.0.1", Port: "5555", ConsensusPubKey: validatorPubKey}
 	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "9902")
 	host, err := p2pimpl.NewHost(&leader, priKey)
 	if err != nil {
 		test.Fatalf("newhost failure: %v", err)
 	}
-	consensus, err := New(host, 0, []p2p.Peer{leader, validator}, leader, bls.RandPrivateKey())
+	consensus, err := New(host, 0, leader, bls.RandPrivateKey())
 	if err != nil {
 		test.Fatalf("Cannot craeate consensus: %v", err)
 	}

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -16,13 +16,12 @@ import (
 
 func TestNew(test *testing.T) {
 	leader := p2p.Peer{IP: "127.0.0.1", Port: "9902"}
-	validator := p2p.Peer{IP: "127.0.0.1", Port: "9905"}
 	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "9902")
 	host, err := p2pimpl.NewHost(&leader, priKey)
 	if err != nil {
 		test.Fatalf("newhost failure: %v", err)
 	}
-	consensus, err := New(host, 0, []p2p.Peer{leader, validator}, leader, bls.RandPrivateKey())
+	consensus, err := New(host, 0, leader, bls.RandPrivateKey())
 	if err != nil {
 		test.Fatalf("Cannot craeate consensus: %v", err)
 	}
@@ -39,78 +38,35 @@ func TestNew(test *testing.T) {
 	}
 }
 
-func TestRemovePeers(t *testing.T) {
-	pk1 := bls.RandPrivateKey().GetPublicKey()
-	pk2 := bls.RandPrivateKey().GetPublicKey()
-	pk3 := bls.RandPrivateKey().GetPublicKey()
-	pk4 := bls.RandPrivateKey().GetPublicKey()
-	pk5 := bls.RandPrivateKey().GetPublicKey()
-
-	p1 := p2p.Peer{IP: "127.0.0.1", Port: "19901", ConsensusPubKey: pk1}
-	p2 := p2p.Peer{IP: "127.0.0.1", Port: "19902", ConsensusPubKey: pk2}
-	p3 := p2p.Peer{IP: "127.0.0.1", Port: "19903", ConsensusPubKey: pk3}
-	p4 := p2p.Peer{IP: "127.0.0.1", Port: "19904", ConsensusPubKey: pk4}
-
-	peers := []p2p.Peer{p1, p2, p3, p4}
-
-	peerRemove := []p2p.Peer{p1, p2}
-
-	leader := p2p.Peer{IP: "127.0.0.1", Port: "9000", ConsensusPubKey: pk5}
-	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "9902")
-	host, err := p2pimpl.NewHost(&leader, priKey)
-	if err != nil {
-		t.Fatalf("newhost failure: %v", err)
-	}
-	consensus, err := New(host, 0, peers, leader, nil)
-	if err != nil {
-		t.Fatalf("Cannot craeate consensus: %v", err)
-	}
-
-	//	consensus.DebugPrintPublicKeys()
-	f := consensus.RemovePeers(peerRemove)
-	if f == 0 {
-		t.Errorf("consensus.RemovePeers return false")
-		consensus.DebugPrintPublicKeys()
-	}
-}
-
 func TestGetPeerFromID(t *testing.T) {
 	leaderPriKey := bls.RandPrivateKey()
 	leaderPubKey := leaderPriKey.GetPublicKey()
-	validatorPubKey := bls.RandPrivateKey().GetPublicKey()
 	leader := p2p.Peer{IP: "127.0.0.1", Port: "9902", ConsensusPubKey: leaderPubKey}
-	validator := p2p.Peer{IP: "127.0.0.1", Port: "9905", ConsensusPubKey: validatorPubKey}
 	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "9902")
 	host, err := p2pimpl.NewHost(&leader, priKey)
 	if err != nil {
 		t.Fatalf("newhost failure: %v", err)
 	}
-	consensus, err := New(host, 0, []p2p.Peer{leader, validator}, leader, leaderPriKey)
+	consensus, err := New(host, 0, leader, leaderPriKey)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
 	leaderAddress := utils.GetAddressFromBlsPubKey(leader.ConsensusPubKey)
-	validatorAddress := utils.GetAddressFromBlsPubKey(validator.ConsensusPubKey)
 	l := consensus.GetPeerByAddress(leaderAddress.Hex())
-	v := consensus.GetPeerByAddress(validatorAddress.Hex())
 	if l.IP != leader.IP || l.Port != leader.Port {
 		t.Errorf("leader IP not equal")
-	}
-	if v.IP != validator.IP || v.Port != validator.Port {
-		t.Errorf("validator IP not equal")
 	}
 }
 
 func TestPopulateMessageFields(t *testing.T) {
 	leader := p2p.Peer{IP: "127.0.0.1", Port: "9902"}
-	validator := p2p.Peer{IP: "127.0.0.1", Port: "9905"}
 	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "9902")
 	host, err := p2pimpl.NewHost(&leader, priKey)
 	if err != nil {
 		t.Fatalf("newhost failure: %v", err)
 	}
 	blsPriKey := bls.RandPrivateKey()
-	consensus, err := New(host, 0, []p2p.Peer{leader, validator}, leader, blsPriKey)
+	consensus, err := New(host, 0, leader, blsPriKey)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
@@ -138,13 +94,12 @@ func TestPopulateMessageFields(t *testing.T) {
 
 func TestSignAndMarshalConsensusMessage(t *testing.T) {
 	leader := p2p.Peer{IP: "127.0.0.1", Port: "9902"}
-	validator := p2p.Peer{IP: "127.0.0.1", Port: "9905"}
 	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "9902")
 	host, err := p2pimpl.NewHost(&leader, priKey)
 	if err != nil {
 		t.Fatalf("newhost failure: %v", err)
 	}
-	consensus, err := New(host, 0, []p2p.Peer{leader, validator}, leader, bls.RandPrivateKey())
+	consensus, err := New(host, 0, leader, bls.RandPrivateKey())
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}

--- a/consensus/consensus_validator_msg_test.go
+++ b/consensus/consensus_validator_msg_test.go
@@ -15,13 +15,12 @@ import (
 
 func TestConstructPrepareMessage(test *testing.T) {
 	leader := p2p.Peer{IP: "127.0.0.1", Port: "9992"}
-	validator := p2p.Peer{IP: "127.0.0.1", Port: "9995"}
 	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "9902")
 	host, err := p2pimpl.NewHost(&leader, priKey)
 	if err != nil {
 		test.Fatalf("newhost failure: %v", err)
 	}
-	consensus, err := New(host, 0, []p2p.Peer{leader, validator}, leader, bls.RandPrivateKey())
+	consensus, err := New(host, 0, leader, bls.RandPrivateKey())
 	if err != nil {
 		test.Fatalf("Cannot craeate consensus: %v", err)
 	}
@@ -44,13 +43,12 @@ func TestConstructPrepareMessage(test *testing.T) {
 
 func TestConstructCommitMessage(test *testing.T) {
 	leader := p2p.Peer{IP: "127.0.0.1", Port: "9902"}
-	validator := p2p.Peer{IP: "127.0.0.1", Port: "9905"}
 	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "9902")
 	host, err := p2pimpl.NewHost(&leader, priKey)
 	if err != nil {
 		test.Fatalf("newhost failure: %v", err)
 	}
-	consensus, err := New(host, 0, []p2p.Peer{leader, validator}, leader, bls.RandPrivateKey())
+	consensus, err := New(host, 0, leader, bls.RandPrivateKey())
 	if err != nil {
 		test.Fatalf("Cannot craeate consensus: %v", err)
 	}

--- a/consensus/consensus_validator_test.go
+++ b/consensus/consensus_validator_test.go
@@ -74,7 +74,7 @@ func TestProcessMessageValidatorAnnounce(test *testing.T) {
 	if err != nil {
 		test.Fatalf("newhost failure: %v", err)
 	}
-	consensusLeader, err := New(host, 0, []p2p.Peer{validator1, validator2, validator3}, leader, leaderPriKey)
+	consensusLeader, err := New(host, 0, leader, leaderPriKey)
 	if err != nil {
 		test.Fatalf("Cannot craeate consensus: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestProcessMessageValidatorAnnounce(test *testing.T) {
 		test.Errorf("Failed to unmarshal message payload")
 	}
 
-	consensusValidator1, err := New(m, 0, []p2p.Peer{validator1, validator2, validator3}, leader, bls_cosi.RandPrivateKey())
+	consensusValidator1, err := New(m, 0, leader, bls_cosi.RandPrivateKey())
 	if err != nil {
 		test.Fatalf("Cannot craeate consensus: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestProcessMessageValidatorPrepared(test *testing.T) {
 	if err != nil {
 		test.Fatalf("newhost failure: %v", err)
 	}
-	consensusLeader, err := New(host, 0, []p2p.Peer{validator1, validator2, validator3}, leader, leaderPriKey)
+	consensusLeader, err := New(host, 0, leader, leaderPriKey)
 	if err != nil {
 		test.Fatalf("Cannot craeate consensus: %v", err)
 	}
@@ -162,7 +162,7 @@ func TestProcessMessageValidatorPrepared(test *testing.T) {
 
 	preparedMsg, _ := consensusLeader.constructPreparedMessage()
 
-	consensusValidator1, err := New(m, 0, []p2p.Peer{validator1, validator2, validator3}, leader, bls_cosi.RandPrivateKey())
+	consensusValidator1, err := New(m, 0, leader, bls_cosi.RandPrivateKey())
 	if err != nil {
 		test.Fatalf("Cannot craeate consensus: %v", err)
 	}
@@ -223,7 +223,7 @@ func TestProcessMessageValidatorCommitted(test *testing.T) {
 		test.Fatalf("newhost failure: %v", err)
 	}
 	message := &msg_pb.Message{}
-	consensusLeader, err := New(host, 0, []p2p.Peer{validator1, validator2, validator3}, leader, leaderPriKey)
+	consensusLeader, err := New(host, 0, leader, leaderPriKey)
 	if err != nil {
 		test.Fatalf("Cannot craeate consensus: %v", err)
 	}
@@ -263,7 +263,7 @@ func TestProcessMessageValidatorCommitted(test *testing.T) {
 		test.Errorf("Failed to get consensus message")
 	}
 
-	consensusValidator1, err := New(m, 0, []p2p.Peer{validator1, validator2, validator3}, leader, bls_cosi.RandPrivateKey())
+	consensusValidator1, err := New(m, 0, leader, bls_cosi.RandPrivateKey())
 	if err != nil {
 		test.Fatalf("Cannot craeate consensus: %v", err)
 	}

--- a/node/contract_test.go
+++ b/node/contract_test.go
@@ -14,13 +14,12 @@ import (
 func prepareNode(t *testing.T) *Node {
 	pubKey := bls.RandPrivateKey().GetPublicKey()
 	leader := p2p.Peer{IP: "127.0.0.1", Port: "8882", ConsensusPubKey: pubKey}
-	validator := p2p.Peer{IP: "127.0.0.1", Port: "8885"}
 	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "9902")
 	host, err := p2pimpl.NewHost(&leader, priKey)
 	if err != nil {
 		t.Fatalf("newhost failure: %v", err)
 	}
-	consensus, err := consensus.New(host, 0, []p2p.Peer{leader, validator}, leader, nil)
+	consensus, err := consensus.New(host, 0, leader, nil)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}

--- a/node/node_handler_test.go
+++ b/node/node_handler_test.go
@@ -14,13 +14,12 @@ import (
 func TestAddNewBlock(t *testing.T) {
 	pubKey := bls.RandPrivateKey().GetPublicKey()
 	leader := p2p.Peer{IP: "127.0.0.1", Port: "9882", ConsensusPubKey: pubKey}
-	validator := p2p.Peer{IP: "127.0.0.1", Port: "9885"}
 	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "9902")
 	host, err := p2pimpl.NewHost(&leader, priKey)
 	if err != nil {
 		t.Fatalf("newhost failure: %v", err)
 	}
-	consensus, err := consensus.New(host, 0, []p2p.Peer{leader, validator}, leader, nil)
+	consensus, err := consensus.New(host, 0, leader, nil)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
@@ -40,13 +39,12 @@ func TestAddNewBlock(t *testing.T) {
 func TestVerifyNewBlock(t *testing.T) {
 	pubKey := bls.RandPrivateKey().GetPublicKey()
 	leader := p2p.Peer{IP: "127.0.0.1", Port: "8882", ConsensusPubKey: pubKey}
-	validator := p2p.Peer{IP: "127.0.0.1", Port: "8885"}
 	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "9902")
 	host, err := p2pimpl.NewHost(&leader, priKey)
 	if err != nil {
 		t.Fatalf("newhost failure: %v", err)
 	}
-	consensus, err := consensus.New(host, 0, []p2p.Peer{leader, validator}, leader, nil)
+	consensus, err := consensus.New(host, 0, leader, nil)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -22,13 +22,12 @@ import (
 func TestNewNode(t *testing.T) {
 	pubKey := bls2.RandPrivateKey().GetPublicKey()
 	leader := p2p.Peer{IP: "127.0.0.1", Port: "8882", ConsensusPubKey: pubKey}
-	validator := p2p.Peer{IP: "127.0.0.1", Port: "8885"}
 	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "9902")
 	host, err := p2pimpl.NewHost(&leader, priKey)
 	if err != nil {
 		t.Fatalf("newhost failure: %v", err)
 	}
-	consensus, err := consensus.New(host, 0, []p2p.Peer{leader, validator}, leader, nil)
+	consensus, err := consensus.New(host, 0, leader, nil)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
@@ -49,14 +48,13 @@ func TestNewNode(t *testing.T) {
 func TestGetSyncingPeers(t *testing.T) {
 	pubKey := bls2.RandPrivateKey().GetPublicKey()
 	leader := p2p.Peer{IP: "127.0.0.1", Port: "8882", ConsensusPubKey: pubKey}
-	validator := p2p.Peer{IP: "127.0.0.1", Port: "8885"}
 	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "9902")
 	host, err := p2pimpl.NewHost(&leader, priKey)
 	if err != nil {
 		t.Fatalf("newhost failure: %v", err)
 	}
 
-	consensus, err := consensus.New(host, 0, []p2p.Peer{leader, validator}, leader, nil)
+	consensus, err := consensus.New(host, 0, leader, nil)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
@@ -98,7 +96,7 @@ func TestAddPeers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newhost failure: %v", err)
 	}
-	consensus, err := consensus.New(host, 0, []p2p.Peer{leader, validator}, leader, nil)
+	consensus, err := consensus.New(host, 0, leader, nil)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
@@ -144,7 +142,7 @@ func TestAddBeaconPeer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newhost failure: %v", err)
 	}
-	consensus, err := consensus.New(host, 0, []p2p.Peer{leader, validator}, leader, nil)
+	consensus, err := consensus.New(host, 0, leader, nil)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
@@ -218,7 +216,7 @@ func TestPingPongHandler(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newhost failure: %v", err)
 	}
-	consensus, err := consensus.New(host, 0, []p2p.Peer{leader}, leader, nil)
+	consensus, err := consensus.New(host, 0, leader, nil)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}

--- a/node/staking_test.go
+++ b/node/staking_test.go
@@ -28,13 +28,12 @@ var (
 func TestUpdateStakingList(t *testing.T) {
 	pubKey := bls.RandPrivateKey().GetPublicKey()
 	leader := p2p.Peer{IP: "127.0.0.1", Port: "9882", ConsensusPubKey: pubKey}
-	validator := p2p.Peer{IP: "127.0.0.1", Port: "9885"}
 	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "9902")
 	host, err := p2pimpl.NewHost(&leader, priKey)
 	if err != nil {
 		t.Fatalf("newhost failure: %v", err)
 	}
-	consensus, err := consensus.New(host, 0, []p2p.Peer{leader, validator}, leader, nil)
+	consensus, err := consensus.New(host, 0, leader, nil)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}


### PR DESCRIPTION
we don't do static peers initialization in consensus anymore.

all peers should be added by calling AddPeers function.

Signed-off-by: Leo Chen <leo@harmony.one>
