### PR TITLE
Set init consensus ID

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -266,6 +266,12 @@ func setUpConsensusAndNode(nodeConfig *nodeconfig.ConfigType) (*consensus.Consen
 	// This needs to be executed after consensus and drand are setup
 	currentNode.InitGenesisShardState()
 
+	// Set the consensus ID to be the current block number
+	height := currentNode.Blockchain().CurrentBlock().NumberU64()
+
+	consensus.SetConsensusID(uint32(height))
+	utils.GetLogInstance().Info("Init Blockchain", "height", height)
+
 	// Assign closure functions to the consensus object
 	consensus.BlockVerifier = currentNode.VerifyNewBlock
 	consensus.OnConsensusDone = currentNode.PostConsensusProcessing

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -231,6 +231,11 @@ func New(host p2p.Host, ShardID uint32, leader p2p.Peer, blsPriKey *bls.SecretKe
 	return &consensus, nil
 }
 
+// SetConsensusID set the consensusID to the height of the blockchain
+func (consensus *Consensus) SetConsensusID(height uint32) {
+	consensus.consensusID = height
+}
+
 // RegisterPRndChannel registers the channel for receiving randomness preimage from DRG protocol
 func (consensus *Consensus) RegisterPRndChannel(pRndChannel chan []byte) {
 	consensus.PRndChannel = pRndChannel

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -117,3 +117,22 @@ func TestSignAndMarshalConsensusMessage(t *testing.T) {
 		t.Error("No signature is signed on the consensus message.")
 	}
 }
+
+func TestSetConsensusID(t *testing.T) {
+	leader := p2p.Peer{IP: "127.0.0.1", Port: "9902"}
+	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "9902")
+	host, err := p2pimpl.NewHost(&leader, priKey)
+	if err != nil {
+		t.Fatalf("newhost failure: %v", err)
+	}
+	consensus, err := New(host, 0, leader, bls.RandPrivateKey())
+	if err != nil {
+		t.Fatalf("Cannot craeate consensus: %v", err)
+	}
+
+	height := uint32(1000)
+	consensus.SetConsensusID(height)
+	if consensus.consensusID != height {
+		t.Errorf("Cannot set consensus ID. Got: %v, Expected: %v", consensus.consensusID, height)
+	}
+}

--- a/test/deploy.sh
+++ b/test/deploy.sh
@@ -8,6 +8,8 @@ USER=$(whoami)
 set -x
 set -eo pipefail
 
+export GO111MODULE=on
+
 function check_result() {
    find $log_folder -name leader-*.log > $log_folder/all-leaders.txt
    find $log_folder -name validator-*.log > $log_folder/all-validators.txt


### PR DESCRIPTION
The consensusID always starts from 0, which is used to display as the block height in explorer in our current design. This can be confusing as in Issue (https://github.com/harmony-one/harmony/issues/714)

So, the solution is when we launch a blockchain with persisted data from the previous launch, we set the init consensus ID to be the block height restored from persisted data. So, it at least displays the right block height.