### PR TITLE
fix deploy.sh not work on ubuntu bash environment

### DIFF
--- a/test/deploy.sh
+++ b/test/deploy.sh
@@ -161,7 +161,7 @@ while IFS='' read -r line || [[ -n "$line" ]]; do
      echo "launching new node ..."
      (sleep $NUM_NN; $DRYRUN $ROOT/bin/harmony -ip $ip -port $port -log_folder $log_folder $DB -account_index $i  -min_peers $MIN $HMY_OPT2 -key /tmp/$ip-$port.key 2>&1 | tee -a $LOG_FILE ) &
   fi
-  (( i++ ))
+  i=$((i+1))
 done < $config
 
 # Emulate node offline


### PR DESCRIPTION
The deploy.sh doesn't work on my ubuntu 18.04 bash environment. This fixes it.