### PR TITLE
[sc] enable faucet for all shards

### DIFF
--- a/node/contract.go
+++ b/node/contract.go
@@ -23,6 +23,16 @@ const (
 	FaucetContractFund = 8000000
 )
 
+// BuiltInSC is the type of built-in smart contract in blockchain
+type builtInSC uint
+
+// List of smart contract type built-in
+const (
+	scFaucet builtInSC = iota
+	scStaking
+	scLottery
+)
+
 // AddStakingContractToPendingTransactions adds the deposit smart contract the genesis block.
 func (node *Node) AddStakingContractToPendingTransactions() {
 	// Add a contract deployment transaction
@@ -187,18 +197,24 @@ func (node *Node) callGetFreeTokenWithNonce(address common.Address, nonce uint64
 }
 
 // AddContractKeyAndAddress is used to add smart contract related information when node restart and resume with previous state
-func (node *Node) AddContractKeyAndAddress() {
-	// faucet contract
-	contractDeployerKey, _ := ecdsa.GenerateKey(crypto.S256(), strings.NewReader("Test contract key string stream that is fixed so that generated test key are deterministic every time"))
-	node.ContractDeployerKey = contractDeployerKey
-	node.ContractAddresses = append(node.ContractAddresses, crypto.CreateAddress(crypto.PubkeyToAddress(contractDeployerKey.PublicKey), uint64(0)))
-
-	// staking contract
-	node.CurrentStakes = make(map[common.Address]*structs.StakeInfo)
-	stakingPrivKey := contract_constants.GenesisBeaconAccountPriKey
-	node.StakingContractAddress = crypto.CreateAddress(crypto.PubkeyToAddress(stakingPrivKey.PublicKey), uint64(0))
-
-	// lottery
-	lotteryPriKey, _ := crypto.HexToECDSA(contract_constants.DemoAccounts[0].Private)
-	node.DemoContractAddress = crypto.CreateAddress(crypto.PubkeyToAddress(lotteryPriKey.PublicKey), uint64(0))
+// It supports three kinds of on-chain smart contracts for now.
+func (node *Node) AddContractKeyAndAddress(t builtInSC) {
+	switch t {
+	case scFaucet:
+		// faucet contract
+		contractDeployerKey, _ := ecdsa.GenerateKey(crypto.S256(), strings.NewReader("Test contract key string stream that is fixed so that generated test key are deterministic every time"))
+		node.ContractDeployerKey = contractDeployerKey
+		node.ContractAddresses = append(node.ContractAddresses, crypto.CreateAddress(crypto.PubkeyToAddress(contractDeployerKey.PublicKey), uint64(0)))
+	case scStaking:
+		// staking contract
+		node.CurrentStakes = make(map[common.Address]*structs.StakeInfo)
+		stakingPrivKey := contract_constants.GenesisBeaconAccountPriKey
+		node.StakingContractAddress = crypto.CreateAddress(crypto.PubkeyToAddress(stakingPrivKey.PublicKey), uint64(0))
+	case scLottery:
+		// lottery
+		lotteryPriKey, _ := crypto.HexToECDSA(contract_constants.DemoAccounts[0].Private)
+		node.DemoContractAddress = crypto.CreateAddress(crypto.PubkeyToAddress(lotteryPriKey.PublicKey), uint64(0))
+	default:
+		utils.GetLogInstance().Error("AddContractKeyAndAddress", "unknown SC", t)
+	}
 }

--- a/node/node.go
+++ b/node/node.go
@@ -267,18 +267,27 @@ func New(host p2p.Host, consensusObj *consensus.Consensus, db ethdb.Database, is
 
 		node.Consensus.VerifiedNewBlock = make(chan *types.Block)
 
+		// Add Faucet contract to all shards, so that on testnet, we can demo wallet in explorer
+		// TODO (leo): we need to have support of cross-shard tx later so that the token can be transferred from beacon chain shard to other tx shards.
+		if isFirstTime {
+			// Setup one time smart contracts
+			node.AddFaucetContractToPendingTransactions()
+		} else {
+			node.AddContractKeyAndAddress(scFaucet)
+		}
+
 		if node.Consensus.ShardID == 0 {
 			// Contracts only exist in beacon chain
 			if isFirstTime {
 				// Setup one time smart contracts
-				node.AddFaucetContractToPendingTransactions()
 				node.CurrentStakes = make(map[common.Address]*structs.StakeInfo)
 				node.AddStakingContractToPendingTransactions() //This will save the latest information about staked nodes in current staked
 				// TODO(minhdoan): Think of a better approach to deploy smart contract.
 				// This is temporary for demo purpose.
 				node.AddLotteryContract()
 			} else {
-				node.AddContractKeyAndAddress()
+				node.AddContractKeyAndAddress(scStaking)
+				node.AddContractKeyAndAddress(scLottery)
 			}
 		}
 	}


### PR DESCRIPTION
Tested using a new devnet. I can request tokens on all 4 shards.
https://0.harmony.one/#/

Signed-off-by: Leo Chen <leo@harmony.one>