### PR TITLE
Fix multi shard client communication

### DIFF
--- a/cmd/client/wallet/main.go
+++ b/cmd/client/wallet/main.go
@@ -542,7 +542,9 @@ func readPrivateKeys() []*ecdsa.PrivateKey {
 // submitTransaction submits the transaction to the Harmony network
 func submitTransaction(tx *types.Transaction, walletNode *node.Node, shardID uint32) error {
 	msg := proto_node.ConstructTransactionListMessageAccount(types.Transactions{tx})
-	err := walletNode.GetHost().SendMessageToGroups([]p2p.GroupID{p2p.GroupIDBeaconClient}, p2p_host.ConstructP2pMessage(byte(0), msg))
+	clientGroup := p2p.NewClientGroupIDByShardID(p2p.ShardID(shardID))
+
+	err := walletNode.GetHost().SendMessageToGroups([]p2p.GroupID{clientGroup}, p2p_host.ConstructP2pMessage(byte(0), msg))
 	if err != nil {
 		fmt.Printf("Error in SubmitTransaction: %v\n", err)
 		return err

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -208,7 +208,6 @@ func setUpConsensusAndNode(nodeConfig *nodeconfig.ConfigType) (*consensus.Consen
 
 	// Current node.
 	currentNode := node.New(nodeConfig.Host, consensus, nodeConfig.MainDB, *isArchival)
-	currentNode.Consensus.OfflinePeers = currentNode.OfflinePeers
 	currentNode.NodeConfig.SetRole(nodeconfig.NewNode)
 	currentNode.AccountKey = nodeConfig.StakingPriKey
 

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -226,6 +226,7 @@ func setUpConsensusAndNode(nodeConfig *nodeconfig.ConfigType) (*consensus.Consen
 				currentNode.NodeConfig.SetIsLeader(false)
 			}
 			currentNode.NodeConfig.SetShardGroupID(p2p.GroupIDBeacon)
+			currentNode.NodeConfig.SetClientGroupID(p2p.GroupIDBeaconClient)
 		} else {
 			if nodeConfig.StringRole == "leader" {
 				currentNode.NodeConfig.SetRole(nodeconfig.ShardLeader)
@@ -235,6 +236,7 @@ func setUpConsensusAndNode(nodeConfig *nodeconfig.ConfigType) (*consensus.Consen
 				currentNode.NodeConfig.SetIsLeader(false)
 			}
 			currentNode.NodeConfig.SetShardGroupID(p2p.NewGroupIDByShardID(p2p.ShardID(nodeConfig.ShardID)))
+			currentNode.NodeConfig.SetClientGroupID(p2p.NewClientGroupIDByShardID(p2p.ShardID(nodeConfig.ShardID)))
 		}
 	} else {
 		if *isNewNode {

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -112,12 +112,6 @@ type Consensus struct {
 
 	// The p2p host used to send/receive p2p messages
 	host p2p.Host
-
-	// Signal channel for lost validators
-	OfflinePeers chan p2p.Peer
-
-	// List of offline Peers
-	OfflinePeerList []p2p.Peer
 }
 
 // BlockConsensusStatus used to keep track of the consensus status of multiple blocks received so far
@@ -225,7 +219,6 @@ func New(host p2p.Host, ShardID uint32, leader p2p.Peer, blsPriKey *bls.SecretKe
 	}
 
 	consensus.uniqueIDInstance = utils.GetUniqueValidatorIDInstance()
-	consensus.OfflinePeerList = make([]p2p.Peer, 0)
 
 	//	consensus.Log.Info("New Consensus", "IP", ip, "Port", port, "NodeID", consensus.nodeID, "priKey", consensus.priKey, "PubKey", consensus.PubKey)
 	return &consensus, nil
@@ -404,9 +397,6 @@ func (consensus *Consensus) ResetState() {
 
 	consensus.aggregatedPrepareSig = nil
 	consensus.aggregatedCommitSig = nil
-
-	// Clear the OfflinePeersList again
-	consensus.OfflinePeerList = make([]p2p.Peer, 0)
 }
 
 // Returns a string representation of this consensus

--- a/consensus/consensus_leader.go
+++ b/consensus/consensus_leader.go
@@ -50,11 +50,6 @@ func (consensus *Consensus) WaitForNewBlock(blockChannel chan *types.Block, stop
 				newBlock := <-blockChannel
 				// TODO: think about potential race condition
 
-				c := consensus.RemovePeers(consensus.OfflinePeerList)
-				if c > 0 {
-					utils.GetLogInstance().Debug("WaitForNewBlock", "removed peers", c)
-				}
-
 				if consensus.ShardID == 0 {
 					if core.IsEpochBlock(newBlock) { // Only beacon chain do randomness generation
 						// Receive pRnd from DRG protocol

--- a/node/node.go
+++ b/node/node.go
@@ -306,7 +306,8 @@ func New(host p2p.Host, consensusObj *consensus.Consensus, db ethdb.Database, is
 	go node.ReceiveGroupMessage()
 
 	// start the goroutine to receive global message, used for cross-shard TX
-	// go node.ReceiveGlobalMessage()
+	// FIXME (leo): we use beacon client topic as the global topic for now
+	go node.ReceiveGlobalMessage()
 
 	// Setup initial state of syncing.
 	node.peerRegistrationRecord = make(map[string]*syncConfig)
@@ -409,7 +410,7 @@ func (node *Node) initNodeConfiguration() (service.NodeConfig, chan p2p.Peer) {
 		utils.GetLogInstance().Error("Failed to create shard receiver", "msg", err)
 	}
 
-	node.globalGroupReceiver, err = node.host.GroupReceiver(p2p.GroupIDGlobal)
+	node.globalGroupReceiver, err = node.host.GroupReceiver(p2p.GroupIDBeaconClient)
 	if err != nil {
 		utils.GetLogInstance().Error("Failed to create global receiver", "msg", err)
 	}

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -34,6 +34,25 @@ const (
 	MaxNumberOfTransactionsPerBlock = 8000
 )
 
+// ReceiveGlobalMessage use libp2p pubsub mechanism to receive global broadcast messages
+func (node *Node) ReceiveGlobalMessage() {
+	ctx := context.Background()
+	for {
+		if node.globalGroupReceiver == nil {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		msg, sender, err := node.globalGroupReceiver.Receive(ctx)
+		if sender != node.host.GetID() {
+			utils.GetLogInstance().Info("[PUBSUB]", "received global msg", len(msg), "sender", sender)
+			if err == nil {
+				// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
+				go node.messageHandler(msg[5:], string(sender))
+			}
+		}
+	}
+}
+
 // ReceiveGroupMessage use libp2p pubsub mechanism to receive broadcast messages
 func (node *Node) ReceiveGroupMessage() {
 	ctx := context.Background()

--- a/test/deploy.sh
+++ b/test/deploy.sh
@@ -55,7 +55,6 @@ USAGE: $ME [OPTIONS] config_file_name
    -D duration    txgen run duration (default: $DURATION)
    -m min_peers   minimal number of peers to start consensus (default: $MIN)
    -s shards      number of shards (default: $SHARDS)
-   -k nodeport    kill the node with specified port number (default: $KILLPORT)
    -n             dryrun mode (default: $DRYRUN)
    -S             enable sync test (default: $SYNC)
 
@@ -75,11 +74,10 @@ TXGEN=true
 DURATION=60
 MIN=5
 SHARDS=2
-KILLPORT=9004
 SYNC=true
 DRYRUN=
 
-while getopts "hdtD:m:s:k:nS" option; do
+while getopts "hdtD:m:s:nS" option; do
    case $option in
       h) usage ;;
       d) DB='-db_supported' ;;
@@ -87,7 +85,6 @@ while getopts "hdtD:m:s:k:nS" option; do
       D) DURATION=$OPTARG ;;
       m) MIN=$OPTARG ;;
       s) SHARDS=$OPTARG ;;
-      k) KILLPORT=$OPTARG ;;
       n) DRYRUN=echo ;;
       S) SYNC=true ;;
    esac
@@ -165,11 +162,6 @@ while IFS='' read -r line || [[ -n "$line" ]]; do
   fi
   i=$((i+1))
 done < $config
-
-# Emulate node offline
-if [ "$SYNC" == "false" ]; then
- (sleep 45; killnode $KILLPORT) &
-fi
 
 if [ "$TXGEN" == "true" ]; then
    echo "launching txgen ... wait"


### PR DESCRIPTION
## Issue

The current 1+3 shards p2p communication is using beacon client topic for all client communication, which is wrong.  Each shard should have its own client topic for communication with their own clients.

This patch set fixed the client side multi-shard communication by using shard specific topic for communication. Each shard has a unique topic to talk to shard client.

## Test

Tested locally by:

* launch a blockchain with 4 shards
* use local wallet.ini to talk to four shards
* getFreeToken from all shards
* do the token transfer on different shards with different tx amount
* all tx went through

#### Test/Run Logs

The full test log is available at https://gist.github.com/LeoHChen/d7161b16f5f8ecf3c28eb05c23ccc11b
