### PR TITLE
Fix getFreeToken blocking issue

### DIFF
--- a/node/contract.go
+++ b/node/contract.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"math/big"
 	"strings"
+	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -170,8 +171,8 @@ func (node *Node) CallFaucetContract(address common.Address) common.Hash {
 }
 
 func (node *Node) callGetFreeToken(address common.Address) common.Hash {
-	nonce := node.GetNonceOfAddress(crypto.PubkeyToAddress(node.ContractDeployerKey.PublicKey))
-	return node.callGetFreeTokenWithNonce(address, nonce)
+	nonce := atomic.AddUint64(&node.ContractDeployerCurrentNonce, 1)
+	return node.callGetFreeTokenWithNonce(address, nonce-1)
 }
 
 func (node *Node) callGetFreeTokenWithNonce(address common.Address, nonce uint64) common.Hash {

--- a/node/node.go
+++ b/node/node.go
@@ -144,9 +144,10 @@ type Node struct {
 	Address    common.Address
 
 	// For test only
-	TestBankKeys        []*ecdsa.PrivateKey
-	ContractDeployerKey *ecdsa.PrivateKey
-	ContractAddresses   []common.Address
+	TestBankKeys                 []*ecdsa.PrivateKey
+	ContractDeployerKey          *ecdsa.PrivateKey
+	ContractDeployerCurrentNonce uint64 // The nonce of the deployer contract at current block
+	ContractAddresses            []common.Address
 
 	// Shard group Message Receiver
 	shardGroupReceiver p2p.GroupReceiver

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -11,8 +11,11 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/harmony-one/harmony/core"
 
@@ -314,6 +317,10 @@ func (node *Node) PostConsensusProcessing(newBlock *types.Block) {
 	}
 
 	node.AddNewBlock(newBlock)
+
+	// Update contract deployer's nonce so default contract like faucet can issue transaction with current nonce
+	nonce := node.GetNonceOfAddress(crypto.PubkeyToAddress(node.ContractDeployerKey.PublicKey))
+	atomic.StoreUint64(&node.ContractDeployerCurrentNonce, nonce)
 
 	if node.Consensus.ShardID == 0 {
 


### PR DESCRIPTION
Fixing issue: https://github.com/harmony-one/harmony/issues/711, which is due to our design of faucet where we use a master account to call the contract for the users (so they don't have to pay tx fees). This fix streamline the nonce so multiple calls can have correct and non-overlapping nonce.

Tested locally a single block can handle multiple (11) getFreeToken request at once.

PROPOSING NEW BLOCK ------------------------------------------------ port=9005 ip=127.0.0.1 blockNum=2 threshold=1 pendingTransactions=11
DEBUG[04-20|16:32:37.823] Selecting Transactions                   port=9005 ip=127.0.0.1 remainPending=0 selected=11 invalidDiscarded=0
DEBUG[04-20|16:32:37.826] Successfully proposed new block          port=9005 ip=127.0.0.1 blockNum=2 numTxs=11