### PR TITLE
[wallet] use ethereum keystore in wallet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ go.sum
 
 # bnkey
 test/.bnkey
+
+# exported keys
+.hmy/*.key


### PR DESCRIPTION
ethereum compatible keystore
support passphrase for wallet new/list/import functions
support export keystore using encrypted json format

https://github.com/harmony-one/harmony/issues/824

Signed-off-by: Leo Chen <leo@harmony.one>