### PR TITLE
attack viewchange [Idea| WIP]

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/harmony-one/harmony/consensus"
 	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/drand"
+	attack "github.com/harmony-one/harmony/internal/attack"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/profiler"
 	"github.com/harmony-one/harmony/internal/utils"
@@ -92,6 +93,7 @@ var (
 	isNewNode    = flag.Bool("is_newnode", false, "true means this node is a new node")
 	accountIndex = flag.Int("account_index", 0, "the index of the staking account to use")
 	shardID      = flag.Int("shard_id", -1, "the shard ID of this node")
+	delayAttack  = flag.Bool("delayAttack", false, "delay response of the node indefinetely")
 	// logConn logs incoming/outgoing connections
 	logConn = flag.Bool("log_conn", false, "log incoming/outgoing connections")
 )
@@ -217,6 +219,11 @@ func setUpConsensusAndNode(nodeConfig *nodeconfig.ConfigType) (*consensus.Consen
 	// TODO: consensus object shouldn't start here
 	// TODO(minhdoan): During refactoring, found out that the peers list is actually empty. Need to clean up the logic of consensus later.
 	currentConsensus, err := consensus.New(nodeConfig.Host, nodeConfig.ShardID, nodeConfig.Leader, nodeConfig.ConsensusPriKey)
+	attackInstance := attack.GetInstance()
+	if *delayAttack {
+		attackInstance.SetDelayResponseAttack()
+	}
+	currentConsensus.DelayAttack = attackInstance
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error :%v \n", err)
 		os.Exit(1)

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -17,6 +17,7 @@ import (
 	"github.com/harmony-one/harmony/core/state"
 	"github.com/harmony-one/harmony/core/types"
 	bls_cosi "github.com/harmony-one/harmony/crypto/bls"
+	attack "github.com/harmony-one/harmony/internal/attack"
 	"github.com/harmony-one/harmony/internal/ctxerror"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/internal/utils/contract"
@@ -148,6 +149,7 @@ type Consensus struct {
 
 	// Staking information finder
 	stakeInfoFinder StakeInfoFinder
+	DelayAttack     *attack.Model
 }
 
 // StakeInfoFinder returns the stake information finder instance this

--- a/consensus/consensus_validator.go
+++ b/consensus/consensus_validator.go
@@ -129,7 +129,10 @@ func (consensus *Consensus) processPreparedMessage(message *msg_pb.Message) {
 	//#### END Read payload data
 
 	// Update readyByConsensus for attack.
-	attack.GetInstance().UpdateConsensusReady(consensusID)
+	if consensus.DelayAttack.AttackEnabled {
+		consensus.DelayAttack.UpdateConsensusReady(consensusID)
+		consensus.DelayAttack.DelayResponse()
+	}
 
 	if err := consensus.checkConsensusMessage(message, consensus.leader.ConsensusPubKey); err != nil {
 		utils.GetLogInstance().Debug("processPreparedMessage error", "error", err)

--- a/consensus/consensus_validator_test.go
+++ b/consensus/consensus_validator_test.go
@@ -14,6 +14,7 @@ import (
 	msg_pb "github.com/harmony-one/harmony/api/proto/message"
 	"github.com/harmony-one/harmony/core/types"
 	bls_cosi "github.com/harmony-one/harmony/crypto/bls"
+	attack "github.com/harmony-one/harmony/internal/attack"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 	mock_host "github.com/harmony-one/harmony/p2p/host/mock"
@@ -102,6 +103,7 @@ func TestProcessMessageValidatorAnnounce(test *testing.T) {
 	}
 
 	consensusValidator1, err := New(m, 0, leader, bls_cosi.RandPrivateKey())
+	consensusValidator1.DelayAttack = attack.GetInstance()
 	if err != nil {
 		test.Fatalf("Cannot craeate consensus: %v", err)
 	}
@@ -167,7 +169,7 @@ func TestProcessMessageValidatorPrepared(test *testing.T) {
 		test.Fatalf("Cannot craeate consensus: %v", err)
 	}
 	consensusValidator1.ChainReader = MockChainReader{}
-
+	consensusValidator1.DelayAttack = attack.GetInstance()
 	// Get actual consensus messages.
 	announceMsg, err = proto.GetConsensusMessagePayload(announceMsg)
 	if err != nil {
@@ -269,7 +271,7 @@ func TestProcessMessageValidatorCommitted(test *testing.T) {
 	}
 	consensusValidator1.ChainReader = MockChainReader{}
 	consensusValidator1.OnConsensusDone = func(newBlock *types.Block) {}
-
+	consensusValidator1.DelayAttack = attack.GetInstance()
 	if err = protobuf.Unmarshal(announceMsg, message); err != nil {
 		test.Errorf("Failed to unmarshal message payload")
 	}

--- a/internal/attack/attack.go
+++ b/internal/attack/attack.go
@@ -12,8 +12,8 @@ import (
 // Constants used for attack model.
 const (
 	DroppingTickDuration    = 2 * time.Second
-	HitRate                 = 10
-	DelayResponseDuration   = 10 * time.Second
+	HitRate                 = 2
+	DelayResponseDuration   = 90 * time.Second
 	ConsensusIDThresholdMin = 10
 	ConsensusIDThresholdMax = 100
 )
@@ -61,6 +61,13 @@ func (attack *Model) SetAttackEnabled(AttackEnabled bool) {
 		attack.attackType = Type(rand.Intn(3))
 		attack.ConsensusIDThreshold = uint32(ConsensusIDThresholdMin + rand.Intn(ConsensusIDThresholdMax-ConsensusIDThresholdMin))
 	}
+}
+
+// SetDelayResponseAttack sets attack to DelayResponse enabled.
+func (attack *Model) SetDelayResponseAttack() {
+	attack.AttackEnabled = true
+	attack.attackType = Type(1)
+	attack.ConsensusIDThreshold = 0
 }
 
 // Run runs enabled attacks.


### PR DESCRIPTION
## Issue

To enable functionality to attack the consensus mechanism in general and view-change in particular.
Currently implemented `delayResponse` attack.

## TODO

- [ ] Merge new deploy-malicious.sh script into deploy.sh
- [ ] Cleanup old attack mode code.
- [ ] Implement other attack models