### PR TITLE
Missing err check after calling consensus.New() in setUpTxGen()

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -153,7 +153,7 @@ type Node struct {
 	ContractAddresses            []common.Address
 
 	// For puzzle contracts
-	AddressNonce map[common.Address]*uint64
+	AddressNonce sync.Map
 
 	// Shard group Message Receiver
 	shardGroupReceiver p2p.GroupReceiver
@@ -323,8 +323,6 @@ func New(host p2p.Host, consensusObj *consensus.Consensus, db ethdb.Database, is
 
 	// Setup initial state of syncing.
 	node.peerRegistrationRecord = make(map[string]*syncConfig)
-
-	node.AddressNonce = make(map[common.Address]*uint64)
 
 	node.startConsensus = make(chan struct{})
 

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -317,9 +317,9 @@ func (node *Node) PostConsensusProcessing(newBlock *types.Block) {
 		if err != nil {
 			utils.GetLogInstance().Error("Error when parsing tx into message")
 		}
-		if _, ok := node.AddressNonce[msg.From()]; ok {
+		if _, ok := node.AddressNonce.Load(msg.From()); ok {
 			nonce := node.GetNonceOfAddress(msg.From())
-			atomic.StoreUint64(node.AddressNonce[msg.From()], nonce)
+			node.AddressNonce.Store(msg.From(), nonce)
 		}
 	}
 

--- a/node/puzzle_contract.go
+++ b/node/puzzle_contract.go
@@ -214,11 +214,15 @@ func (node *Node) CreateTransactionForEndMethod(priKey string) (string, error) {
 
 // GetAndIncreaseAddressNonce get and increase the address's nonce
 func (node *Node) GetAndIncreaseAddressNonce(address common.Address) uint64 {
-	if value, ok := node.AddressNonce[address]; ok {
-		nonce := atomic.AddUint64(value, 1)
+	if value, ok := node.AddressNonce.Load(address); ok {
+		n, ok := value.(uint64)
+		if !ok {
+			return 0
+		}
+		nonce := atomic.AddUint64(&n, 1)
 		return nonce - 1
 	}
 	nonce := node.GetNonceOfAddress(address) + 1
-	node.AddressNonce[address] = &nonce
+	node.AddressNonce.Store(address, nonce)
 	return nonce - 1
 }


### PR DESCRIPTION
There are the following code pieces in setUpTxGen():
	consensusObj, err := consensus.New(myhost, uint32(shardID), p2p.Peer{}, nil)
	txGen := node.New(myhost, consensusObj, nil, false) //Changed it : no longer archival node.

If err != nil and consensusObj is nil, then "node.Consensus = consensusObj" would end up nil after a new node has been created. 

This might be the root cause of #727