### PR TITLE
use single source of truth instead having is_leader truth in 2 objects

### DIFF
--- a/api/service/discovery/discovery_test.go
+++ b/api/service/discovery/discovery_test.go
@@ -37,7 +37,7 @@ func TestDiscoveryService(t *testing.T) {
 
 	config := service.NodeConfig{}
 
-	dService = New(host, config, nil, nil)
+	dService = New(host, config, nil, nil, nil)
 
 	if dService == nil {
 		t.Fatalf("unable to create new discovery service")

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -390,7 +390,6 @@ func main() {
 
 	utils.GetLogInstance().Info("==== New Harmony Node ====", "BlsPubKey", hex.EncodeToString(nodeConfig.ConsensusPubKey.Serialize()), "ShardID", nodeConfig.ShardID, "ShardGroupID", nodeConfig.GetShardGroupID(), "BeaconGroupID", nodeConfig.GetBeaconGroupID(), "ClientGroupID", nodeConfig.GetClientGroupID(), "Role", currentNode.NodeConfig.Role(), "multiaddress", fmt.Sprintf("/ip4/%s/tcp/%s/p2p/%s", *ip, *port, nodeConfig.Host.GetID().Pretty()))
 
-	currentNode.MaybeKeepSendingPongMessage()
 	go currentNode.SupportSyncing()
 	currentNode.ServiceManagerSetup()
 	currentNode.StartRPC(*port)

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/harmony-one/harmony/core/state"
 	"github.com/harmony-one/harmony/core/types"
 	bls_cosi "github.com/harmony-one/harmony/crypto/bls"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/p2p/host"
@@ -324,7 +325,7 @@ func (consensus *Consensus) ResetState() {
 // Returns a string representation of this consensus
 func (consensus *Consensus) String() string {
 	var duty string
-	if consensus.IsLeader {
+	if nodeconfig.GetDefaultConfig().IsLeader() {
 		duty = "LDR" // leader
 	} else {
 		duty = "VLD" // validator

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/harmony-one/harmony/crypto/bls"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/p2p/p2pimpl"
@@ -24,7 +25,7 @@ func TestNew(test *testing.T) {
 		test.Errorf("Consensus Id is initialized to the wrong value: %d", consensus.consensusID)
 	}
 
-	if !consensus.IsLeader {
+	if !nodeconfig.GetDefaultConfig().IsLeader() {
 		test.Error("Consensus should belong to a leader")
 	}
 

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -14,6 +14,7 @@ import (
 	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/core/types"
 	bls_cosi "github.com/harmony-one/harmony/crypto/bls"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/p2p/host"
@@ -638,7 +639,7 @@ func (consensus *Consensus) onNewView(msg *msg_pb.Message) {
 
 // Start waits for the next new block and run consensus
 func (consensus *Consensus) Start(blockChannel chan *types.Block, stopChan chan struct{}, stoppedChan chan struct{}, startChannel chan struct{}) {
-	if consensus.IsLeader {
+	if nodeconfig.GetDefaultConfig().IsLeader() {
 		<-startChannel
 	}
 	go func() {

--- a/node/node.go
+++ b/node/node.go
@@ -210,6 +210,13 @@ func (node *Node) getTransactionsForNewBlock(maxNumTxs int) types.Transactions {
 	return selected
 }
 
+// MaybeKeepSendingPongMessage keeps sending pong message if the current node is a leader.
+func (node *Node) MaybeKeepSendingPongMessage() {
+	if nodeconfig.GetDefaultConfig().IsLeader() {
+		go node.SendPongMessage()
+	}
+}
+
 // StartServer starts a server and process the requests by a handler.
 func (node *Node) StartServer() {
 	select {}
@@ -319,7 +326,7 @@ func New(host p2p.Host, consensusObj *consensus.Consensus, db ethdb.Database, is
 
 	node.ContractCaller = contracts.NewContractCaller(&db, node.blockchain, params.TestChainConfig)
 
-	if consensusObj != nil && consensusObj.IsLeader {
+	if consensusObj != nil && nodeconfig.GetDefaultConfig().IsLeader() {
 		node.State = NodeLeader
 	} else {
 		node.State = NodeInit

--- a/node/node.go
+++ b/node/node.go
@@ -210,13 +210,6 @@ func (node *Node) getTransactionsForNewBlock(maxNumTxs int) types.Transactions {
 	return selected
 }
 
-// MaybeKeepSendingPongMessage keeps sending pong message if the current node is a leader.
-func (node *Node) MaybeKeepSendingPongMessage() {
-	if nodeconfig.GetDefaultConfig().IsLeader() {
-		go node.SendPongMessage()
-	}
-}
-
 // StartServer starts a server and process the requests by a handler.
 func (node *Node) StartServer() {
 	select {}

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -269,7 +269,7 @@ func (node *Node) VerifyNewBlock(newBlock *types.Block) bool {
 // 1. add the new block to blockchain
 // 2. [leader] send new block to the client
 func (node *Node) PostConsensusProcessing(newBlock *types.Block) {
-	if node.Consensus.IsLeader {
+	if nodeconfig.GetDefaultConfig().IsLeader() {
 		node.BroadcastNewBlock(newBlock)
 	} else {
 		utils.GetLogInstance().Info("BINGO !!! Reached Consensus", "ConsensusID", node.Consensus.GetConsensusID())
@@ -318,7 +318,7 @@ func (node *Node) PostConsensusProcessing(newBlock *types.Block) {
 		if core.IsEpochBlock(newBlock) {
 			shardState := node.blockchain.StoreNewShardState(newBlock, &node.CurrentStakes)
 			if shardState != nil {
-				if node.Consensus.IsLeader {
+				if nodeconfig.GetDefaultConfig().IsLeader() {
 					epochShardState := types.EpochShardState{Epoch: core.GetEpochFromBlockNumber(newBlock.NumberU64()), ShardState: shardState}
 					epochShardStateMessage := proto_node.ConstructEpochShardStateMessage(epochShardState)
 					// Broadcast new shard state
@@ -599,7 +599,7 @@ func (node *Node) processEpochShardState(epochShardState *types.EpochShardState)
 		node.DRand.UpdatePublicKeys(publicKeys)
 
 		aboutLeader := ""
-		if node.Consensus.IsLeader {
+		if nodeconfig.GetDefaultConfig().IsLeader() {
 			aboutLeader = "I am not leader anymore"
 			if isNextLeader {
 				aboutLeader = "I am still leader"
@@ -706,7 +706,7 @@ func (node *Node) retrieveEpochShardState() (*types.EpochShardState, error) {
 // ConsensusMessageHandler passes received message in node_handler to consensus
 func (node *Node) ConsensusMessageHandler(msgPayload []byte) {
 	if node.Consensus.ConsensusVersion == "v1" {
-		if node.Consensus.IsLeader {
+		if nodeconfig.GetDefaultConfig().IsLeader() {
 			node.Consensus.ProcessMessageLeader(msgPayload)
 		} else {
 			node.Consensus.ProcessMessageValidator(msgPayload)

--- a/node/service_setup.go
+++ b/node/service_setup.go
@@ -21,7 +21,7 @@ func (node *Node) setupForShardLeader() {
 	nodeConfig, chanPeer := node.initNodeConfiguration()
 
 	// Register peer discovery service. No need to do staking for beacon chain node.
-	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, node.AddBeaconPeer))
+	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, node.AddBeaconPeer, node.SendPongMessage))
 	// Register networkinfo service. "0" is the beacon shard ID
 	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, node.NodeConfig.GetShardGroupID(), chanPeer, nil))
 
@@ -46,7 +46,7 @@ func (node *Node) setupForShardValidator() {
 	// Register client support service.
 	node.serviceManager.RegisterService(service.ClientSupport, clientsupport.New(node.blockchain.State, node.CallFaucetContract, node.getDeployedStakingContract, node.SelfPeer.IP, node.SelfPeer.Port))
 	// Register peer discovery service. "0" is the beacon shard ID. No need to do staking for beacon chain node.
-	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, node.AddBeaconPeer))
+	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, node.AddBeaconPeer, node.SendPongMessage))
 	// Register networkinfo service. "0" is the beacon shard ID
 	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, node.NodeConfig.GetShardGroupID(), chanPeer, nil))
 	// Register consensus service.
@@ -60,7 +60,7 @@ func (node *Node) setupForBeaconLeader() {
 	nodeConfig, chanPeer := node.initNodeConfiguration()
 
 	// Register peer discovery service. No need to do staking for beacon chain node.
-	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, nil))
+	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, nil, node.SendPongMessage))
 	// Register networkinfo service.
 	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, node.NodeConfig.GetShardGroupID(), chanPeer, nil))
 
@@ -88,7 +88,7 @@ func (node *Node) setupForBeaconValidator() {
 	// Register client support service.
 	node.serviceManager.RegisterService(service.ClientSupport, clientsupport.New(node.blockchain.State, node.CallFaucetContract, node.getDeployedStakingContract, node.SelfPeer.IP, node.SelfPeer.Port))
 	// Register peer discovery service. No need to do staking for beacon chain node.
-	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, nil))
+	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, nil, node.SendPongMessage))
 	// Register networkinfo service.
 	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, node.NodeConfig.GetShardGroupID(), chanPeer, nil))
 	// Register consensus service.
@@ -106,7 +106,7 @@ func (node *Node) setupForNewNode() {
 	// Register staking service.
 	node.serviceManager.RegisterService(service.Staking, staking.New(node.host, node.StakingAccount, node.beaconChain, node.NodeConfig.ConsensusPubKey))
 	// Register peer discovery service. "0" is the beacon shard ID
-	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, node.AddBeaconPeer))
+	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, node.AddBeaconPeer, node.SendPongMessage))
 	// Register networkinfo service. "0" is the beacon shard ID
 	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, node.NodeConfig.GetBeaconGroupID(), chanPeer, nil))
 
@@ -117,7 +117,7 @@ func (node *Node) setupForClientNode() {
 	nodeConfig, chanPeer := node.initNodeConfiguration()
 
 	// Register peer discovery service.
-	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, node.AddBeaconPeer))
+	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, node.AddBeaconPeer, node.SendPongMessage))
 	// Register networkinfo service. "0" is the beacon shard ID
 	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, p2p.GroupIDBeacon, chanPeer, nil))
 }


### PR DESCRIPTION
1/ use a single source of truth instead of having is_leader in 2 objects. that would cause inconsistency in case you missed to update it at both places.
2/ no more quickly adding code in main file.