### PR TITLE
use single source of truth instead having is_leader truth in 2 objects

### DIFF
--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/harmony-one/harmony/core/state"
 	"github.com/harmony-one/harmony/core/types"
 	bls_cosi "github.com/harmony-one/harmony/crypto/bls"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/p2p/host"
@@ -324,7 +325,7 @@ func (consensus *Consensus) ResetState() {
 // Returns a string representation of this consensus
 func (consensus *Consensus) String() string {
 	var duty string
-	if consensus.IsLeader {
+	if nodeconfig.GetDefaultConfig().IsLeader() {
 		duty = "LDR" // leader
 	} else {
 		duty = "VLD" // validator

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/harmony-one/harmony/crypto/bls"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/p2p/p2pimpl"
@@ -24,7 +25,7 @@ func TestNew(test *testing.T) {
 		test.Errorf("Consensus Id is initialized to the wrong value: %d", consensus.consensusID)
 	}
 
-	if !consensus.IsLeader {
+	if !nodeconfig.GetDefaultConfig().IsLeader() {
 		test.Error("Consensus should belong to a leader")
 	}
 

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -14,6 +14,7 @@ import (
 	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/core/types"
 	bls_cosi "github.com/harmony-one/harmony/crypto/bls"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/p2p/host"
@@ -638,7 +639,7 @@ func (consensus *Consensus) onNewView(msg *msg_pb.Message) {
 
 // Start waits for the next new block and run consensus
 func (consensus *Consensus) Start(blockChannel chan *types.Block, stopChan chan struct{}, stoppedChan chan struct{}, startChannel chan struct{}) {
-	if consensus.IsLeader {
+	if nodeconfig.GetDefaultConfig().IsLeader() {
 		<-startChannel
 	}
 	go func() {

--- a/node/node.go
+++ b/node/node.go
@@ -210,6 +210,13 @@ func (node *Node) getTransactionsForNewBlock(maxNumTxs int) types.Transactions {
 	return selected
 }
 
+// MaybeKeepSendingPongMessage keeps sending pong message if the current node is a leader.
+func (node *Node) MaybeKeepSendingPongMessage() {
+	if nodeconfig.GetDefaultConfig().IsLeader() {
+		go node.SendPongMessage()
+	}
+}
+
 // StartServer starts a server and process the requests by a handler.
 func (node *Node) StartServer() {
 	select {}
@@ -319,7 +326,7 @@ func New(host p2p.Host, consensusObj *consensus.Consensus, db ethdb.Database, is
 
 	node.ContractCaller = contracts.NewContractCaller(&db, node.blockchain, params.TestChainConfig)
 
-	if consensusObj != nil && consensusObj.IsLeader {
+	if consensusObj != nil && nodeconfig.GetDefaultConfig().IsLeader() {
 		node.State = NodeLeader
 	} else {
 		node.State = NodeInit

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -269,7 +269,7 @@ func (node *Node) VerifyNewBlock(newBlock *types.Block) bool {
 // 1. add the new block to blockchain
 // 2. [leader] send new block to the client
 func (node *Node) PostConsensusProcessing(newBlock *types.Block) {
-	if node.Consensus.IsLeader {
+	if nodeconfig.GetDefaultConfig().IsLeader() {
 		node.BroadcastNewBlock(newBlock)
 	} else {
 		utils.GetLogInstance().Info("BINGO !!! Reached Consensus", "ConsensusID", node.Consensus.GetConsensusID())
@@ -318,7 +318,7 @@ func (node *Node) PostConsensusProcessing(newBlock *types.Block) {
 		if core.IsEpochBlock(newBlock) {
 			shardState := node.blockchain.StoreNewShardState(newBlock, &node.CurrentStakes)
 			if shardState != nil {
-				if node.Consensus.IsLeader {
+				if nodeconfig.GetDefaultConfig().IsLeader() {
 					epochShardState := types.EpochShardState{Epoch: core.GetEpochFromBlockNumber(newBlock.NumberU64()), ShardState: shardState}
 					epochShardStateMessage := proto_node.ConstructEpochShardStateMessage(epochShardState)
 					// Broadcast new shard state
@@ -599,7 +599,7 @@ func (node *Node) processEpochShardState(epochShardState *types.EpochShardState)
 		node.DRand.UpdatePublicKeys(publicKeys)
 
 		aboutLeader := ""
-		if node.Consensus.IsLeader {
+		if nodeconfig.GetDefaultConfig().IsLeader() {
 			aboutLeader = "I am not leader anymore"
 			if isNextLeader {
 				aboutLeader = "I am still leader"
@@ -706,7 +706,7 @@ func (node *Node) retrieveEpochShardState() (*types.EpochShardState, error) {
 // ConsensusMessageHandler passes received message in node_handler to consensus
 func (node *Node) ConsensusMessageHandler(msgPayload []byte) {
 	if node.Consensus.ConsensusVersion == "v1" {
-		if node.Consensus.IsLeader {
+		if nodeconfig.GetDefaultConfig().IsLeader() {
 			node.Consensus.ProcessMessageLeader(msgPayload)
 		} else {
 			node.Consensus.ProcessMessageValidator(msgPayload)


### PR DESCRIPTION
1/ use a single source of truth instead of having is_leader in 2 objects. that would cause inconsistency in case you missed to update it at both places.
2/ Clean up code in main file
