### PR TITLE
Use uint32 as shard ID type instead of [4]byte

### DIFF
--- a/api/proto/node/node_test.go
+++ b/api/proto/node/node_test.go
@@ -75,7 +75,7 @@ func TestConstructBlocksSyncMessage(t *testing.T) {
 	head := &types.Header{
 		Number:  new(big.Int).SetUint64(uint64(10000)),
 		Nonce:   types.EncodeNonce(uint64(10000)),
-		ShardID: types.EncodeShardID(uint32(0)),
+		ShardID: 0,
 		Time:    new(big.Int).SetUint64(uint64(100000)),
 		Root:    root,
 	}

--- a/consensus/consensus_validator_test.go
+++ b/consensus/consensus_validator_test.go
@@ -117,10 +117,10 @@ func TestProcessMessageValidatorAnnounce(test *testing.T) {
 
 func testBlockBytes() ([]byte, error) {
 	return hex.DecodeString("" +
-		// BEGIN 677-byte Block
-		"f902a5" +
-		// BEGIN 672-byte header
-		"f902a0" +
+		// BEGIN 673-byte Block
+		"f902a1" +
+		// BEGIN 668-byte header
+		"f9029c" +
 		// 32-byte ParentHash
 		"a0" +
 		"0000000000000000000000000000000000000000000000000000000000000000" +
@@ -170,9 +170,8 @@ func testBlockBytes() ([]byte, error) {
 		// 8-byte Nonce
 		"88" +
 		"0000000000000000" +
-		// 4-byte ShardID
-		"84" +
-		"00000001" +
+		// single-byte ShardID
+		"01" +
 		// 48-byte PrepareSignature
 		"b0" +
 		"0000000000000000000000000000000000000000000000000000000000000000" +

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -71,7 +71,7 @@ func (b *BlockGen) SetNonce(nonce types.BlockNonce) {
 }
 
 // SetShardID sets the shardID field of the generated block.
-func (b *BlockGen) SetShardID(shardID types.ShardID) {
+func (b *BlockGen) SetShardID(shardID uint32) {
 	b.header.ShardID = shardID
 }
 

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -240,7 +240,7 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 	head := &types.Header{
 		Number:         new(big.Int).SetUint64(g.Number),
 		Nonce:          types.EncodeNonce(g.Nonce),
-		ShardID:        types.EncodeShardID(g.ShardID),
+		ShardID:        g.ShardID,
 		Time:           new(big.Int).SetUint64(g.Timestamp),
 		ParentHash:     g.ParentHash,
 		Extra:          g.ExtraData,

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -45,20 +45,10 @@ var (
 // out on a block.
 type BlockNonce [8]byte
 
-// ShardID is a 32-bit id for the shard a block belongs to
-type ShardID [4]byte
-
 // EncodeNonce converts the given integer to a block nonce.
 func EncodeNonce(i uint64) BlockNonce {
 	var n BlockNonce
 	binary.BigEndian.PutUint64(n[:], i)
-	return n
-}
-
-// EncodeShardID converts the given integer to a shard id.
-func EncodeShardID(i uint32) ShardID {
-	var n ShardID
-	binary.BigEndian.PutUint32(n[:], i)
 	return n
 }
 
@@ -94,11 +84,11 @@ type Header struct {
 	MixDigest   common.Hash    `json:"mixHash"          gencodec:"required"`
 	Nonce       BlockNonce     `json:"nonce"            gencodec:"required"`
 	// Additional Fields
-	ShardID          ShardID     `json:"shardID"          gencodec:"required"`
-	PrepareSignature [48]byte    `json:"prepareSignature"        gencodec:"required"`
-	PrepareBitmap    []byte      `json:"prepareBitmap"           gencodec:"required"` // Contains which validator signed
-	CommitSignature  [48]byte    `json:"commitSignature"        gencodec:"required"`
-	CommitBitmap     []byte      `json:"commitBitmap"           gencodec:"required"` // Contains which validator signed
+	ShardID          uint32      `json:"shardID"          gencodec:"required"`
+	PrepareSignature [48]byte    `json:"prepareSignature" gencodec:"required"`
+	PrepareBitmap    []byte      `json:"prepareBitmap"    gencodec:"required"` // Contains which validator signed
+	CommitSignature  [48]byte    `json:"commitSignature"  gencodec:"required"`
+	CommitBitmap     []byte      `json:"commitBitmap"     gencodec:"required"` // Contains which validator signed
 	RandPreimage     [32]byte    `json:"randPreimage"`
 	RandSeed         [32]byte    `json:"randSeed"`
 	ShardStateHash   common.Hash `json:"shardStateRoot"`
@@ -345,7 +335,7 @@ func (b *Block) MixDigest() common.Hash { return b.header.MixDigest }
 func (b *Block) Nonce() uint64 { return binary.BigEndian.Uint64(b.header.Nonce[:]) }
 
 // ShardID is the header ShardID
-func (b *Block) ShardID() uint32 { return binary.BigEndian.Uint32(b.header.ShardID[:]) }
+func (b *Block) ShardID() uint32 { return b.header.ShardID }
 
 // Bloom returns header bloom.
 func (b *Block) Bloom() Bloom { return b.header.Bloom }

--- a/node/worker/worker.go
+++ b/node/worker/worker.go
@@ -115,7 +115,7 @@ func (w *Worker) UpdateCurrent() error {
 		Number:     num.Add(num, common.Big1),
 		GasLimit:   core.CalcGasLimit(parent, w.gasFloor, w.gasCeil),
 		Time:       big.NewInt(timestamp),
-		ShardID:    types.EncodeShardID(w.chain.ShardID()),
+		ShardID:    w.chain.ShardID(),
 	}
 	return w.makeCurrent(parent, header)
 }
@@ -175,7 +175,7 @@ func New(config *params.ChainConfig, chain *core.BlockChain, engine consensus_en
 		Number:     num.Add(num, common.Big1),
 		GasLimit:   core.CalcGasLimit(parent, worker.gasFloor, worker.gasCeil),
 		Time:       big.NewInt(timestamp),
-		ShardID:    types.EncodeShardID(worker.chain.ShardID()),
+		ShardID:    worker.chain.ShardID(),
 	}
 	worker.makeCurrent(parent, header)
 

--- a/test/chain/main.go
+++ b/test/chain/main.go
@@ -350,7 +350,7 @@ func main() {
 	if n > 0 {
 		blocks, _ := core.GenerateChain(chainConfig, genesis, consensus.NewFaker(), database, n, func(i int, gen *core.BlockGen) {
 			gen.SetCoinbase(FaucetAddress)
-			gen.SetShardID(types.EncodeShardID(0))
+			gen.SetShardID(0)
 			gen.AddTx(pendingTxs[i])
 		})
 		if _, err := chain.InsertChain(blocks); err != nil {


### PR DESCRIPTION
This ~~does not~~ actually does change RLP encoding.

Spun off of #839.