### PR TITLE
Do not panic upon out-of-range account index

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -206,7 +206,7 @@ func (node *Node) Blockchain() *core.BlockChain {
 	if err != nil {
 		err = ctxerror.New("cannot get shard chain", "shardID", shardID).
 			WithCause(err)
-		panic(err) //ctxerror.Log15(utils.GetLogger().Crit, err)
+		ctxerror.Log15(utils.GetLogger().Crit, err)
 	}
 	return bc
 }


### PR DESCRIPTION
Out-of-range account index (currently >= 200) translates into a shard ID
(>= 4) not found in the genesis table, so its genesis cannot be
initialized.  Since this can be induced by misconfiguration, do not
panic but just crit out.

This error was seen during drum testnet launch.
