### PR TITLE
fix timeout duration bug

### DIFF
--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -583,7 +583,7 @@ func (consensus *Consensus) checkViewID(msg *PbftMessage) error {
 		utils.GetLogger().Warn("view id is low", "myViewId", consensus.viewID, "theirViewId", msg.ViewID)
 		// notify state syncing to start
 		// TODO ek/cm - think more about this
-		consensus.SetMode(Syncing)
+		consensus.mode.SetMode(Syncing)
 		select {
 		case consensus.ViewIDLowChan <- struct{}{}:
 		default:

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -12,7 +12,6 @@ import (
 	"github.com/harmony-one/harmony/api/service/syncing"
 	"github.com/harmony-one/harmony/api/service/syncing/downloader"
 	downloader_pb "github.com/harmony-one/harmony/api/service/syncing/downloader/proto"
-	"github.com/harmony-one/harmony/consensus"
 	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/core/types"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
@@ -113,7 +112,6 @@ SyncingLoop:
 				utils.GetLogInstance().Debug("[SYNC] out of sync, doing syncing", "willJoinConsensus", willJoinConsensus)
 				node.stateMutex.Lock()
 				node.State = NodeNotInSync
-				node.Consensus.SetMode(consensus.Syncing)
 				node.stateMutex.Unlock()
 				node.stateSync.SyncLoop(bc, worker, willJoinConsensus, false)
 				getLogger().Debug("now in sync")


### PR DESCRIPTION
The previous code sets viewchanging viewID into the consensus.viewID, which is incorrect. This will make the timeout of viewchange period to be always 0. But we want it to be a non-zero value, which depends on how many consecutive view changing happen before the new leader response with newview message