### PR TITLE
fix VDF bug

### DIFF
--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -44,6 +44,10 @@ func (consensus *Consensus) GetNextRnd() ([32]byte, [32]byte, error) {
 		return [32]byte{}, [32]byte{}, errors.New("No available randomness")
 	}
 	vdfOutput := consensus.pendingRnds[0]
+
+	//pop the first vdfOutput from the list
+	consensus.pendingRnds = consensus.pendingRnds[1:]
+
 	rnd := [32]byte{}
 	blockHash := [32]byte{}
 	copy(rnd[:], vdfOutput[:32])

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -414,13 +414,6 @@ func (node *Node) PostConsensusProcessing(newBlock *types.Block) {
 			}()
 		}
 
-		// ConfirmedBlockChannel which is listened by drand leader who will initiate DRG if its a epoch block (first block of a epoch)
-		if node.DRand != nil {
-			go func() {
-				node.ConfirmedBlockChannel <- newBlock
-			}()
-		}
-
 		// TODO: update staking information once per epoch.
 		node.UpdateStakingList(node.QueryStakeInfo())
 		node.printStakingList()


### PR DESCRIPTION
## Issue

Fixed two bugs:
1) duplicate code in node_handler.go
2) clean the VDF list after it is consumed

## Test

#### Test Coverage Data

<!-- run 'go test -cover' in the directory you made change -->

* Before
* After

#### Test/Run Logs
$cd consensus
$ go test -cover
go: downloading github.com/davecgh/go-spew v1.1.1
go: extracting github.com/davecgh/go-spew v1.1.1
PASS
coverage: 21.0% of statements
ok  	github.com/harmony-one/harmony/consensus	9.557s

$cd ../node
haobo@UpstairsLinux:/opt/haobo/work/go/src/github.com/harmony-one/harmony/node$ go test -cover
wait 5 seconds to terminate the process ...
ok  	github.com/harmony-one/harmony/node	7.035s

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## TODO
