### PR TITLE
Fix garbled validator address errors

### DIFF
--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -510,7 +510,7 @@ func (consensus *Consensus) verifySenderKey(msg *msg_pb.Message) (*bls.PublicKey
 	senderAddr := common.BytesToAddress(addrBytes[:])
 
 	if !consensus.IsValidatorInCommittee(senderAddr) {
-		return nil, fmt.Errorf("Validator address %s is not in committee", senderAddr)
+		return nil, fmt.Errorf("Validator address %s is not in committee", senderAddr.Hex())
 	}
 	return senderKey, nil
 }
@@ -525,7 +525,7 @@ func (consensus *Consensus) verifyViewChangeSenderKey(msg *msg_pb.Message) (*bls
 	senderAddr := common.BytesToAddress(addrBytes[:])
 
 	if !consensus.IsValidatorInCommittee(senderAddr) {
-		return nil, common.Address{}, fmt.Errorf("Validator address %s is not in committee", senderAddr)
+		return nil, common.Address{}, fmt.Errorf("Validator address %s is not in committee", senderAddr.Hex())
 	}
 	return senderKey, senderAddr, nil
 }


### PR DESCRIPTION
common.Address is itself a byte array, so the %s format specifier
outputs its (binary) bytes directly without any encoding.  Explicitly
Hex() it.