### PR TITLE
VRF using BLS integration to harmony, replacing VRF p256

### DIFF
--- a/drand/drand.go
+++ b/drand/drand.go
@@ -12,7 +12,7 @@ import (
 	"github.com/harmony-one/harmony/core/types"
 	bls_cosi "github.com/harmony-one/harmony/crypto/bls"
 	"github.com/harmony-one/harmony/crypto/vrf"
-	"github.com/harmony-one/harmony/crypto/vrf/p256"
+	vrf_bls "github.com/harmony-one/harmony/crypto/vrf/bls"
 	"github.com/harmony-one/harmony/p2p"
 )
 
@@ -114,9 +114,11 @@ func New(host p2p.Host, ShardID uint32, peers []p2p.Peer, leader p2p.Peer, confi
 	}
 
 	// VRF keys
-	priKey, pubKey := p256.GenerateKey()
-	dRand.vrfPriKey = &priKey
-	dRand.vrfPubKey = &pubKey
+	sk := vrf_bls.NewVRFSigner(blsPriKey)
+	pk := vrf_bls.NewVRFVerifier(blsPriKey.GetPublicKey())
+	dRand.vrfPriKey = &sk
+	dRand.vrfPubKey = &pk
+
 	dRand.ShardID = ShardID
 
 	return &dRand

--- a/drand/drand.go
+++ b/drand/drand.go
@@ -111,13 +111,13 @@ func New(host p2p.Host, ShardID uint32, peers []p2p.Peer, leader p2p.Peer, confi
 	if blsPriKey != nil {
 		dRand.priKey = blsPriKey
 		dRand.pubKey = blsPriKey.GetPublicKey()
-	}
 
-	// VRF keys
-	sk := vrf_bls.NewVRFSigner(blsPriKey)
-	pk := vrf_bls.NewVRFVerifier(blsPriKey.GetPublicKey())
-	dRand.vrfPriKey = &sk
-	dRand.vrfPubKey = &pk
+		// VRF keys
+		sk := vrf_bls.NewVRFSigner(blsPriKey)
+		pk := vrf_bls.NewVRFVerifier(blsPriKey.GetPublicKey())
+		dRand.vrfPriKey = &sk
+		dRand.vrfPubKey = &pk
+	}
 
 	dRand.ShardID = ShardID
 

--- a/drand/drand_leader.go
+++ b/drand/drand_leader.go
@@ -160,7 +160,6 @@ func (dRand *DRand) processCommitMessage(message *msg_pb.Message) {
 	senderVerifier := vrf_bls.NewVRFVerifier(senderPubKey)
 	expectedRand, err := senderVerifier.ProofToHash(dRand.blockHash[:], proof)
 
-
 	if err != nil || !bytes.Equal(expectedRand[:], rand) {
 		utils.Logger().Error().
 			Err(err).

--- a/drand/drand_validator_msg.go
+++ b/drand/drand_validator_msg.go
@@ -21,9 +21,7 @@ func (dRand *DRand) constructCommitMessage(vrf [32]byte, proof []byte) []byte {
 	drandMsg.BlockHash = dRand.blockHash[:]
 	drandMsg.ShardId = dRand.ShardID
 	drandMsg.Payload = append(vrf[:], proof...)
-	// Adding the public key into payload so leader can verify the vrf
-	// TODO: change the curve to follow the same curve with consensus, so the public key doesn't need to be attached.
-	drandMsg.Payload = append(drandMsg.Payload, (*dRand.vrfPubKey).Serialize()...)
+
 	marshaledMessage, err := dRand.signAndMarshalDRandMessage(message)
 	if err != nil {
 		utils.Logger().Error().Err(err).Msg("Failed to sign and marshal the commit message")


### PR DESCRIPTION
## Issue

Use the BLS signature instead of P256 signature for VRF

## Test

Tested the VRF verification across 10 epoches. 

 
