### PR TITLE
fix potential security issue in onCommit for leader

### DIFF
--- a/consensus/pbft_log.go
+++ b/consensus/pbft_log.go
@@ -152,7 +152,7 @@ func (log *PbftLog) GetMessagesByTypeSeqHash(typ msg_pb.MessageType, blockNum ui
 	return found
 }
 
-// HasMatchingAnnounce returns whether the log contains announce type message with given blockNum, viewID and blockHash
+// HasMatchingAnnounce returns whether the log contains announce type message with given blockNum, blockHash
 func (log *PbftLog) HasMatchingAnnounce(blockNum uint64, blockHash common.Hash) bool {
 	found := log.GetMessagesByTypeSeqHash(msg_pb.MessageType_ANNOUNCE, blockNum, blockHash)
 	return len(found) == 1
@@ -161,6 +161,12 @@ func (log *PbftLog) HasMatchingAnnounce(blockNum uint64, blockHash common.Hash) 
 // HasMatchingViewAnnounce returns whether the log contains announce type message with given blockNum, viewID and blockHash
 func (log *PbftLog) HasMatchingViewAnnounce(blockNum uint64, viewID uint32, blockHash common.Hash) bool {
 	found := log.GetMessagesByTypeSeqViewHash(msg_pb.MessageType_ANNOUNCE, blockNum, viewID, blockHash)
+	return len(found) == 1
+}
+
+// HasMatchingViewPrepared returns whether the log contains prepared message with given blockNum, viewID and blockHash
+func (log *PbftLog) HasMatchingViewPrepared(blockNum uint64, viewID uint32, blockHash common.Hash) bool {
+	found := log.GetMessagesByTypeSeqViewHash(msg_pb.MessageType_PREPARED, blockNum, viewID, blockHash)
 	return len(found) == 1
 }
 


### PR DESCRIPTION
The current design for commit message is validator sign on |blockNum|blockHash| message. Thus, it's important for leader to keep track of the order of message it received. Leader must verify it has sent prepared message before accept the commit message from validator.