### PR TITLE
Change shard state ECDSA address to use common address/byte format

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -334,7 +334,7 @@ func accumulateRewards(
 		numAccounts++
 		account := member.EcdsaAddress
 		getLogger().Info("rewarding block signer",
-			"account", account,
+			"account", common.HexToAddress(account),
 			"node", member.BlsPublicKey.Hex(),
 			"amount", BlockReward)
 		state.AddBalance(account, BlockReward)

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -332,7 +332,7 @@ func accumulateRewards(
 			continue
 		}
 		numAccounts++
-		account := common.HexToAddress(member.EcdsaAddress)
+		account := member.EcdsaAddress
 		getLogger().Info("rewarding block signer",
 			"account", account,
 			"node", member.BlsPublicKey.Hex(),

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -334,7 +334,7 @@ func accumulateRewards(
 		numAccounts++
 		account := member.EcdsaAddress
 		getLogger().Info("rewarding block signer",
-			"account", common.HexToAddress(account),
+			"account", account,
 			"node", member.BlsPublicKey.Hex(),
 			"amount", BlockReward)
 		state.AddBalance(account, BlockReward)

--- a/core/resharding.go
+++ b/core/resharding.go
@@ -199,7 +199,7 @@ func (ss *ShardingState) UpdateShardingState(stakeInfo *map[common.Address]*stru
 		newNodeList := shard.NodeList
 		for _, nodeID := range shard.NodeList {
 			oldBlsPublicKeys[nodeID.BlsPublicKey] = true
-			_, ok := (*stakeInfo)[common.HexToAddress(nodeID.EcdsaAddress)]
+			_, ok := (*stakeInfo)[nodeID.EcdsaAddress]
 			if ok {
 				// newNodeList = append(newNodeList, nodeID)
 			} else {
@@ -213,7 +213,7 @@ func (ss *ShardingState) UpdateShardingState(stakeInfo *map[common.Address]*stru
 	for addr, info := range *stakeInfo {
 		_, ok := oldBlsPublicKeys[info.BlsPublicKey]
 		if !ok {
-			newAddresses = append(newAddresses, types.NodeID{addr.Hex(), info.BlsPublicKey})
+			newAddresses = append(newAddresses, types.NodeID{addr, info.BlsPublicKey})
 		}
 	}
 	return newAddresses
@@ -231,7 +231,7 @@ func GetInitShardState() types.ShardState {
 			pubKey := types.BlsPublicKey{}
 			pubKey.FromLibBLSPublicKey(priKey.GetPublicKey())
 			// TODO: directly read address for bls too
-			curNodeID := types.NodeID{contract.GenesisAccounts[index].Address, pubKey}
+			curNodeID := types.NodeID{common.HexToAddress(contract.GenesisAccounts[index].Address), pubKey}
 			com.NodeList = append(com.NodeList, curNodeID)
 		}
 		shardState = append(shardState, com)

--- a/core/resharding.go
+++ b/core/resharding.go
@@ -27,7 +27,7 @@ const (
 	// GenesisShardNum is the number of shard at genesis
 	GenesisShardNum = 4
 	// GenesisShardSize is the size of each shard at genesis
-	GenesisShardSize = 10
+	GenesisShardSize = 100
 	// CuckooRate is the percentage of nodes getting reshuffled in the second step of cuckoo resharding.
 	CuckooRate = 0.1
 )

--- a/core/resharding_test.go
+++ b/core/resharding_test.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -46,7 +48,7 @@ func fakeGetInitShardState(numberOfShards, numOfNodes int) types.ShardState {
 			nid := strconv.Itoa(int(rand.Int63()))
 			blsPubKey := [48]byte{}
 			copy(blsPubKey1[:], []byte(nid))
-			com.NodeList = append(com.NodeList, types.NodeID{nid, blsPubKey})
+			com.NodeList = append(com.NodeList, types.NodeID{common.BytesToAddress([]byte(nid)), blsPubKey})
 		}
 		shardState = append(shardState, com)
 	}
@@ -61,7 +63,7 @@ func fakeNewNodeList(seed int64) []types.NodeID {
 		nid := strconv.Itoa(int(rand.Int63()))
 		blsPubKey := [48]byte{}
 		copy(blsPubKey1[:], []byte(nid))
-		nodeList = append(nodeList, types.NodeID{nid, blsPubKey})
+		nodeList = append(nodeList, types.NodeID{common.BytesToAddress([]byte(nid)), blsPubKey})
 	}
 	return nodeList
 }
@@ -73,16 +75,16 @@ func TestFakeNewNodeList(t *testing.T) {
 
 func TestShuffle(t *testing.T) {
 	nodeList := []types.NodeID{
-		{"node1", blsPubKey1},
-		{"node2", blsPubKey2},
-		{"node3", blsPubKey3},
-		{"node4", blsPubKey4},
-		{"node5", blsPubKey5},
-		{"node6", blsPubKey6},
-		{"node7", blsPubKey7},
-		{"node8", blsPubKey8},
-		{"node9", blsPubKey9},
-		{"node10", blsPubKey10},
+		{common.Address{0x12}, blsPubKey1},
+		{common.Address{0x22}, blsPubKey2},
+		{common.Address{0x32}, blsPubKey3},
+		{common.Address{0x42}, blsPubKey4},
+		{common.Address{0x52}, blsPubKey5},
+		{common.Address{0x62}, blsPubKey6},
+		{common.Address{0x72}, blsPubKey7},
+		{common.Address{0x82}, blsPubKey8},
+		{common.Address{0x92}, blsPubKey9},
+		{common.Address{0x02}, blsPubKey10},
 	}
 
 	cpList := []types.NodeID{}
@@ -113,12 +115,12 @@ func TestUpdateShardState(t *testing.T) {
 	shardState := fakeGetInitShardState(6, 10)
 	ss := &ShardingState{epoch: 1, rnd: 42, shardState: shardState, numShards: len(shardState)}
 	newNodeList := []types.NodeID{
-		{"node1", blsPubKey1},
-		{"node2", blsPubKey2},
-		{"node3", blsPubKey3},
-		{"node4", blsPubKey4},
-		{"node5", blsPubKey5},
-		{"node6", blsPubKey6},
+		{common.Address{0x12}, blsPubKey1},
+		{common.Address{0x22}, blsPubKey2},
+		{common.Address{0x32}, blsPubKey3},
+		{common.Address{0x42}, blsPubKey4},
+		{common.Address{0x52}, blsPubKey5},
+		{common.Address{0x62}, blsPubKey6},
 	}
 
 	ss.Reshard(newNodeList, 0.2)
@@ -129,9 +131,9 @@ func TestAssignNewNodes(t *testing.T) {
 	shardState := fakeGetInitShardState(2, 2)
 	ss := &ShardingState{epoch: 1, rnd: 42, shardState: shardState, numShards: len(shardState)}
 	newNodes := []types.NodeID{
-		{"node1", blsPubKey1},
-		{"node2", blsPubKey2},
-		{"node3", blsPubKey3},
+		{common.Address{0x12}, blsPubKey1},
+		{common.Address{0x22}, blsPubKey2},
+		{common.Address{0x32}, blsPubKey3},
 	}
 
 	ss.assignNewNodes(newNodes)

--- a/core/types/shard_state.go
+++ b/core/types/shard_state.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"sort"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/bls/ffi/go/bls"
@@ -94,13 +93,13 @@ func CompareBlsPublicKey(k1, k2 BlsPublicKey) int {
 
 // NodeID represents node id (BLS address).
 type NodeID struct {
-	EcdsaAddress string
+	EcdsaAddress common.Address
 	BlsPublicKey BlsPublicKey
 }
 
 // CompareNodeID compares two node IDs.
 func CompareNodeID(id1, id2 *NodeID) int {
-	if c := strings.Compare(id1.EcdsaAddress, id2.EcdsaAddress); c != 0 {
+	if c := bytes.Compare(id1.EcdsaAddress[:], id2.EcdsaAddress[:]); c != 0 {
 		return c
 	}
 	if c := CompareBlsPublicKey(id1.BlsPublicKey, id2.BlsPublicKey); c != 0 {
@@ -205,9 +204,9 @@ func CompareNodeIDByBLSKey(n1 NodeID, n2 NodeID) int {
 
 // Serialize serialize NodeID into bytes
 func (n NodeID) Serialize() []byte {
-	return append(n.BlsPublicKey[:], []byte(n.EcdsaAddress)...)
+	return append(n.EcdsaAddress[:], n.BlsPublicKey[:]...)
 }
 
 func (n NodeID) String() string {
-	return "ECDSA: " + n.EcdsaAddress + ", BLS: " + hex.EncodeToString(n.BlsPublicKey[:])
+	return "ECDSA: " + n.EcdsaAddress.Hex() + ", BLS: " + hex.EncodeToString(n.BlsPublicKey[:])
 }

--- a/core/types/shard_state_test.go
+++ b/core/types/shard_state_test.go
@@ -3,6 +3,8 @@ package types
 import (
 	"bytes"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 var (
@@ -29,14 +31,14 @@ func init() {
 
 func TestGetHashFromNodeList(t *testing.T) {
 	l1 := []NodeID{
-		{"node1", blsPubKey1},
-		{"node2", blsPubKey2},
-		{"node3", blsPubKey3},
+		{common.Address{0x11}, blsPubKey1},
+		{common.Address{0x22}, blsPubKey2},
+		{common.Address{0x33}, blsPubKey3},
 	}
 	l2 := []NodeID{
-		{"node2", blsPubKey2},
-		{"node1", blsPubKey1},
-		{"node3", blsPubKey3},
+		{common.Address{0x22}, blsPubKey2},
+		{common.Address{0x11}, blsPubKey1},
+		{common.Address{0x33}, blsPubKey3},
 	}
 	h1 := GetHashFromNodeList(l1)
 	h2 := GetHashFromNodeList(l2)
@@ -50,17 +52,17 @@ func TestHash(t *testing.T) {
 	com1 := Committee{
 		ShardID: 22,
 		NodeList: []NodeID{
-			{"node11", blsPubKey11},
-			{"node22", blsPubKey22},
-			{"node1", blsPubKey1},
+			{common.Address{0x12}, blsPubKey11},
+			{common.Address{0x23}, blsPubKey22},
+			{common.Address{0x11}, blsPubKey1},
 		},
 	}
 	com2 := Committee{
 		ShardID: 2,
 		NodeList: []NodeID{
-			{"node4", blsPubKey4},
-			{"node5", blsPubKey5},
-			{"node6", blsPubKey6},
+			{common.Address{0x44}, blsPubKey4},
+			{common.Address{0x55}, blsPubKey5},
+			{common.Address{0x66}, blsPubKey6},
 		},
 	}
 	shardState1 := ShardState{com1, com2}
@@ -69,17 +71,17 @@ func TestHash(t *testing.T) {
 	com3 := Committee{
 		ShardID: 2,
 		NodeList: []NodeID{
-			{"node6", blsPubKey6},
-			{"node5", blsPubKey5},
-			{"node4", blsPubKey4},
+			{common.Address{0x66}, blsPubKey6},
+			{common.Address{0x55}, blsPubKey5},
+			{common.Address{0x44}, blsPubKey4},
 		},
 	}
 	com4 := Committee{
 		ShardID: 22,
 		NodeList: []NodeID{
-			{"node1", blsPubKey1},
-			{"node11", blsPubKey11},
-			{"node22", blsPubKey22},
+			{common.Address{0x11}, blsPubKey1},
+			{common.Address{0x12}, blsPubKey11},
+			{common.Address{0x23}, blsPubKey22},
 		},
 	}
 


### PR DESCRIPTION
It's better to have fixed-length bytes than string in the blockchain data structure.