### PR TITLE
Log errors, mostly at warn (or fatal for UT) level

### DIFF
--- a/api/client/service/client.go
+++ b/api/client/service/client.go
@@ -33,8 +33,8 @@ func NewClient(ip, port string) (*Client, error) {
 }
 
 // Close closes the Client.
-func (client *Client) Close() {
-	client.conn.Close()
+func (client *Client) Close() error {
+	return client.conn.Close()
 }
 
 // GetBalance gets account balance from the client service.

--- a/api/client/service/server.go
+++ b/api/client/service/server.go
@@ -8,6 +8,9 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	proto "github.com/harmony-one/harmony/api/client/service/proto"
 	"github.com/harmony-one/harmony/core/state"
+	"github.com/harmony-one/harmony/internal/ctxerror"
+	"github.com/harmony-one/harmony/internal/utils"
+
 	"google.golang.org/grpc"
 )
 
@@ -64,7 +67,11 @@ func (s *Server) Start(ip, port string) (*grpc.Server, error) {
 	var opts []grpc.ServerOption
 	grpcServer := grpc.NewServer(opts...)
 	proto.RegisterClientServiceServer(grpcServer, s)
-	go grpcServer.Serve(lis)
+	go func() {
+		if err := grpcServer.Serve(lis); err != nil {
+			ctxerror.Warn(utils.GetLogger(), err, "grpcServer.Serve() failed")
+		}
+	}()
 	return grpcServer, nil
 }
 

--- a/api/proto/message/client.go
+++ b/api/proto/message/client.go
@@ -32,8 +32,8 @@ func NewClient(ip string) *Client {
 }
 
 // Close closes the Client.
-func (client *Client) Close() {
-	client.conn.Close()
+func (client *Client) Close() error {
+	return client.conn.Close()
 }
 
 // Process processes message.

--- a/api/proto/message/client_test.go
+++ b/api/proto/message/client_test.go
@@ -10,7 +10,9 @@ const (
 
 func TestClient(t *testing.T) {
 	s := NewServer(nil, nil, nil)
-	s.Start()
+	if _, err := s.Start(); err != nil {
+		t.Fatalf("cannot start server: %s", err)
+	}
 
 	client := NewClient(testIP)
 	_, err := client.Process(&Message{})

--- a/api/proto/message/server.go
+++ b/api/proto/message/server.go
@@ -10,6 +10,7 @@ import (
 	"net"
 
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/harmony-one/harmony/internal/ctxerror"
 	"github.com/harmony-one/harmony/internal/utils"
 
 	"google.golang.org/grpc"
@@ -88,7 +89,11 @@ func (s *Server) Start() (*grpc.Server, error) {
 	var opts []grpc.ServerOption
 	s.server = grpc.NewServer(opts...)
 	RegisterClientServiceServer(s.server, s)
-	go s.server.Serve(lis)
+	go func() {
+		if err := s.server.Serve(lis); err != nil {
+			ctxerror.Warn(utils.GetLogger(), err, "server.Serve() failed")
+		}
+	}()
 	return s.server, nil
 }
 

--- a/api/proto/message/server_test.go
+++ b/api/proto/message/server_test.go
@@ -7,7 +7,9 @@ import (
 
 func TestServerStart(t *testing.T) {
 	s := NewServer(nil, nil, nil)
-	s.Start()
+	if _, err := s.Start(); err != nil {
+		t.Fatalf("cannot start server: %s", err)
+	}
 	time.Sleep(time.Second)
 	s.Stop()
 }

--- a/api/proto/node/node_test.go
+++ b/api/proto/node/node_test.go
@@ -83,8 +83,12 @@ func TestConstructBlocksSyncMessage(t *testing.T) {
 	head.GasLimit = 10000000000
 	head.Difficulty = params.GenesisDifficulty
 
-	statedb.Commit(false)
-	statedb.Database().TrieDB().Commit(root, true)
+	if _, err := statedb.Commit(false); err != nil {
+		t.Fatalf("statedb.Commit() failed: %s", err)
+	}
+	if err := statedb.Database().TrieDB().Commit(root, true); err != nil {
+		t.Fatalf("statedb.Database().TrieDB().Commit() failed: %s", err)
+	}
 
 	block1 := types.NewBlock(head, nil, nil)
 

--- a/api/service/explorer/storage_test.go
+++ b/api/service/explorer/storage_test.go
@@ -34,7 +34,9 @@ func TestGetTXKey(t *testing.T) {
 
 func TestInit(t *testing.T) {
 	ins := GetStorageInstance("1.1.1.1", "3333", true)
-	ins.GetDB().Put([]byte{1}, []byte{2})
+	if err := ins.GetDB().Put([]byte{1}, []byte{2}); err != nil {
+		t.Fatal("(*LDBDatabase).Put failed:", err)
+	}
 	value, err := ins.GetDB().Get([]byte{1})
 	assert.Equal(t, bytes.Compare(value, []byte{2}), 0, "value should be []byte{2}")
 	assert.Nil(t, err, "error should be nil")

--- a/api/service/staking/service.go
+++ b/api/service/staking/service.go
@@ -23,6 +23,7 @@ import (
 	"github.com/harmony-one/harmony/contracts"
 	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/core/types"
+	"github.com/harmony-one/harmony/internal/ctxerror"
 	hmykey "github.com/harmony-one/harmony/internal/keystore"
 	"github.com/harmony-one/harmony/internal/utils"
 	contract_constants "github.com/harmony-one/harmony/internal/utils/contract"
@@ -114,11 +115,12 @@ func (s *Service) DoService() {
 	//	return
 	//}
 
-	if msg := s.createStakingMessage(); msg != nil {
-		s.host.SendMessageToGroups([]p2p.GroupID{p2p.GroupIDBeacon}, host.ConstructP2pMessage(byte(17), msg))
-		utils.GetLogInstance().Info("Sent staking transaction to the network.")
-	} else {
+	if msg := s.createStakingMessage(); msg == nil {
 		utils.GetLogInstance().Error("Can not create staking transaction")
+	} else if err := s.host.SendMessageToGroups([]p2p.GroupID{p2p.GroupIDBeacon}, host.ConstructP2pMessage(byte(17), msg)); err != nil {
+		ctxerror.Warn(utils.GetLogger(), err, "cannot send staking message")
+	} else {
+		utils.GetLogInstance().Info("Sent staking transaction to the network.")
 	}
 }
 

--- a/api/service/syncing/downloader/server.go
+++ b/api/service/syncing/downloader/server.go
@@ -6,6 +6,9 @@ import (
 	"net"
 
 	pb "github.com/harmony-one/harmony/api/service/syncing/downloader/proto"
+	"github.com/harmony-one/harmony/internal/ctxerror"
+	"github.com/harmony-one/harmony/internal/utils"
+
 	"google.golang.org/grpc"
 )
 
@@ -39,7 +42,12 @@ func (s *Server) Start(ip, port string) (*grpc.Server, error) {
 	var opts []grpc.ServerOption
 	grpcServer := grpc.NewServer(opts...)
 	pb.RegisterDownloaderServer(grpcServer, s)
-	go grpcServer.Serve(lis)
+	go func() {
+		if err := grpcServer.Serve(lis); err != nil {
+			ctxerror.Warn(utils.GetLogger(), err, "(*grpc.Server).Serve failed")
+		}
+	}()
+
 	s.GrpcServer = grpcServer
 
 	return grpcServer, nil

--- a/cmd/client/txgen/main.go
+++ b/cmd/client/txgen/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/harmony-one/harmony/consensus"
 	"github.com/harmony-one/harmony/core"
+	"github.com/harmony-one/harmony/internal/ctxerror"
 	"github.com/harmony-one/harmony/internal/shardchain"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -198,7 +199,10 @@ syncLoop:
 				if block.NumberU64()-txGen.Blockchain().CurrentBlock().NumberU64() == 1 {
 					txGen.AddNewBlock(block)
 					stateMutex.Lock()
-					txGen.Worker.UpdateCurrent()
+					if err := txGen.Worker.UpdateCurrent(); err != nil {
+						ctxerror.Warn(utils.GetLogger(), err,
+							"(*Worker).UpdateCurrent failed")
+					}
 					stateMutex.Unlock()
 					readySignal <- shardID
 				}

--- a/consensus/consensus_leader_msg_test.go
+++ b/consensus/consensus_leader_msg_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/harmony-one/harmony/crypto/bls"
+	"github.com/harmony-one/harmony/internal/ctxerror"
 
 	protobuf "github.com/golang/protobuf/proto"
 	"github.com/harmony-one/harmony/api/proto"
@@ -62,8 +63,13 @@ func TestConstructPreparedMessage(test *testing.T) {
 	message := "test string"
 	consensus.prepareSigs[common.Address{}] = leaderPriKey.Sign(message)
 	consensus.prepareSigs[common.Address{}] = validatorPriKey.Sign(message)
-	consensus.prepareBitmap.SetKey(leaderPubKey, true)
-	consensus.prepareBitmap.SetKey(validatorPubKey, true)
+	// According to RJ these failures are benign.
+	if err := consensus.prepareBitmap.SetKey(leaderPubKey, true); err != nil {
+		test.Log(ctxerror.New("prepareBitmap.SetKey").WithCause(err))
+	}
+	if err := consensus.prepareBitmap.SetKey(validatorPubKey, true); err != nil {
+		test.Log(ctxerror.New("prepareBitmap.SetKey").WithCause(err))
+	}
 
 	msgBytes, _ := consensus.constructPreparedMessage()
 	msgPayload, _ := proto.GetConsensusMessagePayload(msgBytes)

--- a/internal/ctxerror/ctxerror.go
+++ b/internal/ctxerror/ctxerror.go
@@ -8,6 +8,8 @@ package ctxerror
 
 import (
 	"fmt"
+
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // CtxError is a context-aware error container.
@@ -121,4 +123,41 @@ func Log15(f Log15Func, e error) {
 	} else {
 		f(e.Error())
 	}
+}
+
+// Log15WithMsg logs an error with a message prefix using a log15-style
+// logging function.  It is a shortcut for a common pattern of prepending a
+// context prefix.
+func Log15WithMsg(f Log15Func, e error, msg string, ctx ...interface{}) {
+	Log15(f, New(msg, ctx...).WithCause(e))
+}
+
+// Trace logs an error with a message prefix using a log15-style logger.
+func Trace(l log.Logger, e error, msg string, ctx ...interface{}) {
+	Log15WithMsg(l.Trace, e, msg, ctx...)
+}
+
+// Debug logs an error with a message prefix using a log15-style logger.
+func Debug(l log.Logger, e error, msg string, ctx ...interface{}) {
+	Log15WithMsg(l.Debug, e, msg, ctx...)
+}
+
+// Info logs an error with a message prefix using a log15-style logger.
+func Info(l log.Logger, e error, msg string, ctx ...interface{}) {
+	Log15WithMsg(l.Info, e, msg, ctx...)
+}
+
+// Warn logs an error with a message prefix using a log15-style logger.
+func Warn(l log.Logger, e error, msg string, ctx ...interface{}) {
+	Log15WithMsg(l.Warn, e, msg, ctx...)
+}
+
+// Error logs an error with a message prefix using a log15-style logger.
+func Error(l log.Logger, e error, msg string, ctx ...interface{}) {
+	Log15WithMsg(l.Error, e, msg, ctx...)
+}
+
+// Crit logs an error with a message prefix using a log15-style logger.
+func Crit(l log.Logger, e error, msg string, ctx ...interface{}) {
+	Log15WithMsg(l.Crit, e, msg, ctx...)
 }


### PR DESCRIPTION
`Warn` level was chosen for the current behavior: Alert about uncaught failures but do not alter the code path (yet).  More proper error handling will come later.

This PR handles about 60 errors.  There are ~150 more, but I am moving onto Bech32 for now.  One c an see the current tally by running `errcheck ./...` from the repo root.