### PR TITLE
add catchup logic in announce,prepare phase; ignore viewID check at committed stage

### DIFF
--- a/consensus/config.go
+++ b/consensus/config.go
@@ -14,6 +14,8 @@ const (
 	phaseDuration     time.Duration = 90 * time.Second
 	bootstrapDuration time.Duration = 90 * time.Second
 	maxLogSize        uint32        = 1000
+	// threshold between received consensus message blockNum and my blockNum
+	consensusBlockNumBuffer uint64 = 1
 )
 
 // TimeoutType is the type of timeout in view change protocol

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -184,6 +184,8 @@ func (consensus *Consensus) onAnnounce(msg *msg_pb.Message) {
 		return
 	}
 
+	consensus.tryCatchup()
+
 	consensus.mutex.Lock()
 	defer consensus.mutex.Unlock()
 
@@ -383,6 +385,8 @@ func (consensus *Consensus) onPrepared(msg *msg_pb.Message) {
 		utils.GetLogger().Debug("viewchanging mode just exist after viewchanging")
 		return
 	}
+
+	consensus.tryCatchup()
 
 	if consensus.checkViewID(recvMsg) != nil {
 		utils.GetLogger().Debug("viewID check failed", "viewID", recvMsg.ViewID, "myViewID", consensus.viewID)
@@ -615,10 +619,12 @@ func (consensus *Consensus) onCommitted(msg *msg_pb.Message) {
 		utils.GetLogger().Error("Failed to verify the multi signature for commit phase", "blockNum", recvMsg.BlockNum)
 		return
 	}
-
+	consensus.aggregatedCommitSig = aggSig
+	consensus.commitBitmap = mask
 	utils.GetLogger().Debug("committed message added", "phase", consensus.phase, "myViewID", consensus.viewID, "myBlock", consensus.blockNum, "msgViewID", recvMsg.ViewID, "msgBlock", recvMsg.BlockNum)
 	consensus.pbftLog.AddMessage(recvMsg)
-	if recvMsg.BlockNum > consensus.blockNum {
+
+	if recvMsg.BlockNum-consensus.blockNum > consensusBlockNumBuffer {
 		utils.GetLogger().Debug("onCommitted out of sync", "myBlock", consensus.blockNum, "msgBlock", recvMsg.BlockNum)
 		go func() {
 			select {
@@ -633,18 +639,15 @@ func (consensus *Consensus) onCommitted(msg *msg_pb.Message) {
 		return
 	}
 
+	//	if consensus.checkViewID(recvMsg) != nil {
+	//		utils.GetLogger().Debug("viewID check failed", "viewID", recvMsg.ViewID, "myViewID", consensus.viewID)
+	//		return
+	//	}
+
+	consensus.tryCatchup()
 	consensus.mutex.Lock()
 	defer consensus.mutex.Unlock()
 
-	if consensus.checkViewID(recvMsg) != nil {
-		utils.GetLogger().Debug("viewID check failed", "viewID", recvMsg.ViewID, "myViewID", consensus.viewID)
-		return
-	}
-
-	consensus.aggregatedCommitSig = aggSig
-	consensus.commitBitmap = mask
-
-	go consensus.tryCatchup()
 	if consensus.consensusTimeout[timeoutBootstrap].IsActive() {
 		consensus.consensusTimeout[timeoutBootstrap].Stop()
 		utils.GetLogger().Debug("start consensus timeout; stop bootstrap timeout only once", "viewID", consensus.viewID, "block", consensus.blockNum)
@@ -662,7 +665,6 @@ func (consensus *Consensus) tryCatchup() {
 	//		return
 	//	}
 	currentBlockNum := consensus.blockNum
-	consensus.switchPhase(Announce, true)
 	for {
 		msgs := consensus.pbftLog.GetMessagesByTypeSeq(msg_pb.MessageType_COMMITTED, consensus.blockNum)
 		if len(msgs) == 0 {
@@ -730,6 +732,9 @@ func (consensus *Consensus) tryCatchup() {
 		}
 
 		break
+	}
+	if currentBlockNum < consensus.blockNum {
+		consensus.switchPhase(Announce, true)
 	}
 	// catup up and skip from view change trap
 	if currentBlockNum < consensus.blockNum && consensus.mode.Mode() == ViewChanging {


### PR DESCRIPTION
to make the new node join consensus quickly without multiple state syncing:
add catchup logic in announce, prepare phase;
ignore viewID check at committed stage