### PR TITLE
[wallet] remove wallet.ini

### DIFF
--- a/scripts/wallet.sh
+++ b/scripts/wallet.sh
@@ -6,11 +6,11 @@ REL=drum
 
 if [ "$OS" == "Darwin" ]; then
    FOLDER=release/$REL/darwin-x86_64/
-   BIN=( wallet wallet.ini libbls384_256.dylib libcrypto.1.0.0.dylib libgmp.10.dylib libgmpxx.4.dylib libmcl.dylib )
+   BIN=( wallet libbls384_256.dylib libcrypto.1.0.0.dylib libgmp.10.dylib libgmpxx.4.dylib libmcl.dylib )
 fi
 if [ "$OS" == "Linux" ]; then
    FOLDER=release/$REL/linux-x86_64/
-   BIN=( wallet wallet.ini libbls384_256.so libcrypto.so.10 libgmp.so.10 libgmpxx.so.4 libmcl.so )
+   BIN=( wallet libbls384_256.so libcrypto.so.10 libgmp.so.10 libgmpxx.so.4 libmcl.so )
 fi
 
 function usage
@@ -56,9 +56,7 @@ function do_download
 		curl http://${BUCKET}.s3.amazonaws.com/${FOLDER}${bin} -o ${bin}
 	done
 
-# set wallet.ini
 	mkdir -p .hmy
-	cp -f wallet.ini .hmy
 	chmod +x wallet
 
 	exit 0


### PR DESCRIPTION
we have switched to use dns based rpc query, no longer need wallet.ini

Signed-off-by: Leo Chen <leo@harmony.one>
