### PR TITLE
use serialized public key instead of standard public key in wallet tool

### DIFF
--- a/cmd/client/wallet/main.go
+++ b/cmd/client/wallet/main.go
@@ -358,7 +358,7 @@ func processBlsgenCommand() {
 	privateKey, fileName := blsgen.GenBlsKeyWithPassPhrase(password)
 	publickKey := privateKey.GetPublicKey()
 	fmt.Printf("Bls private key: %s\n", privateKey.GetHexString())
-	fmt.Printf("Bls public key: %s\n", publickKey.GetHexString())
+	fmt.Printf("Bls serialized public key: %s\n", publickKey.SerializeToHexStr())
 	fmt.Printf("File storing the ENCRYPTED private key with your passphrase: %s\n", fileName)
 }
 

--- a/internal/blsgen/lib.go
+++ b/internal/blsgen/lib.go
@@ -29,7 +29,8 @@ func toISO8601(t time.Time) string {
 
 func keyFileName(publicKey *ffi_bls.PublicKey) string {
 	ts := time.Now().UTC()
-	return fmt.Sprintf("UTC--%s--bls", toISO8601(ts))
+	serializedPublicKey := publicKey.SerializeToHexStr()
+	return fmt.Sprintf("UTC--%s--bls_%s", toISO8601(ts), serializedPublicKey)
 }
 
 // GenBlsKeyWithPassPhrase generates bls key with passphrase and write into disk.


### PR DESCRIPTION
use serialized public key instead of standard public key in wallet tool