### PR TITLE
Add clean (-c) option

### DIFF
--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -124,6 +124,12 @@ esac
 IDX="${1}"
 shift 1
 
+case $# in
+[1-9]*)
+   usage "extra arguments at the end ($*)"
+   ;;
+esac
+
 killnode
 
 mkdir -p latest

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -105,17 +105,24 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
-if [ -z "$1" ]; then
-   echo "Usage: $0 account_address"
-   echo
-   echo "Please provide account address."
-   echo "For foundational nodes, please follow the instructions in discord #foundational-nodes channel"
-   echo "to generate and register your account address with <genesis at harmony dot one>"
-   echo
-   exit 1
-fi
+usage() {
+   msg "$@"
+   cat <<- ENDEND
+	usage: ${progname} account_address
+	ENDEND
+   exit 64  # EX_USAGE
+}
 
-IDX=$1
+case $# in
+0)
+   usage "Please provide account address." \
+      "For foundational nodes, please follow the instructions in Discord #foundational-nodes channel" \
+      "to generate and register your account address with <genesis at harmony dot one>."
+   ;;
+esac
+
+IDX="${1}"
+shift 1
 
 killnode
 

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -113,6 +113,18 @@ usage() {
    exit 64  # EX_USAGE
 }
 
+unset OPTIND OPTARG opt
+OPTIND=1
+while getopts : opt
+do
+   case "${opt}" in
+   '?') usage "unrecognized option -${OPTARG}";;
+   ':') usage "missing argument for -${OPTARG}";;
+   *) err 70 "unhandled option -${OPTARG}";;  # EX_SOFTWARE
+   esac
+done
+shift $((${OPTIND} - 1))
+
 case $# in
 0)
    usage "Please provide account address." \

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -1,5 +1,26 @@
 #!/bin/bash
 
+unset -v progname
+progname="${0##*/}"
+
+unset -f msg err
+
+msg() {
+   case $# in
+   [1-9]*)
+      echo "${progname}: $*" >&2
+      ;;
+   esac
+}
+
+err() {
+   local code
+   code="${1}"
+   shift 1
+   msg "$@"
+   exit "${code}"
+}
+
 function killnode() {
    local port=$1
 


### PR DESCRIPTION
Add `-c` option, which backs up the contents of log (`latest`) and database (`harmony_db_*`) into a backup directory.

The backup directory is found in `backups/`, named `YYYY-MM-DDTHH:MM:SSZ.XXXXXX`, where `XXXXXX` is a random alphanumeric string chosen by mktemp(1).