### PR TITLE
Add address format and exportPriKey utility in wallet

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -237,7 +237,7 @@ func (ks *KeyStore) Delete(a accounts.Account, passphrase string) error {
 	// Decrypting the key isn't really necessary, but we do
 	// it anyway to check the password and zero out the key
 	// immediately afterwards.
-	a, key, err := ks.getDecryptedKey(a, passphrase)
+	a, key, err := ks.GetDecryptedKey(a, passphrase)
 	if key != nil {
 		zeroKey(key.PrivateKey)
 	}
@@ -291,7 +291,7 @@ func (ks *KeyStore) SignTx(a accounts.Account, tx *types.Transaction, chainID *b
 // can be decrypted with the given passphrase. The produced signature is in the
 // [R || S || V] format where V is 0 or 1.
 func (ks *KeyStore) SignHashWithPassphrase(a accounts.Account, passphrase string, hash []byte) (signature []byte, err error) {
-	_, key, err := ks.getDecryptedKey(a, passphrase)
+	_, key, err := ks.GetDecryptedKey(a, passphrase)
 	if err != nil {
 		return nil, err
 	}
@@ -302,7 +302,7 @@ func (ks *KeyStore) SignHashWithPassphrase(a accounts.Account, passphrase string
 // SignTxWithPassphrase signs the transaction if the private key matching the
 // given address can be decrypted with the given passphrase.
 func (ks *KeyStore) SignTxWithPassphrase(a accounts.Account, passphrase string, tx *types.Transaction, chainID *big.Int) (*types.Transaction, error) {
-	_, key, err := ks.getDecryptedKey(a, passphrase)
+	_, key, err := ks.GetDecryptedKey(a, passphrase)
 	if err != nil {
 		return nil, err
 	}
@@ -340,7 +340,7 @@ func (ks *KeyStore) Lock(addr common.Address) error {
 // shortens the active unlock timeout. If the address was previously unlocked
 // indefinitely the timeout is not altered.
 func (ks *KeyStore) TimedUnlock(a accounts.Account, passphrase string, timeout time.Duration) error {
-	a, key, err := ks.getDecryptedKey(a, passphrase)
+	a, key, err := ks.GetDecryptedKey(a, passphrase)
 	if err != nil {
 		return err
 	}
@@ -377,7 +377,8 @@ func (ks *KeyStore) Find(a accounts.Account) (accounts.Account, error) {
 	return a, err
 }
 
-func (ks *KeyStore) getDecryptedKey(a accounts.Account, auth string) (accounts.Account, *Key, error) {
+// GetDecryptedKey decrypt and return the key for the account.
+func (ks *KeyStore) GetDecryptedKey(a accounts.Account, auth string) (accounts.Account, *Key, error) {
 	a, err := ks.Find(a)
 	if err != nil {
 		return a, nil, err
@@ -422,7 +423,7 @@ func (ks *KeyStore) NewAccount(passphrase string) (accounts.Account, error) {
 
 // Export exports as a JSON key, encrypted with newPassphrase.
 func (ks *KeyStore) Export(a accounts.Account, passphrase, newPassphrase string) (keyJSON []byte, err error) {
-	_, key, err := ks.getDecryptedKey(a, passphrase)
+	_, key, err := ks.GetDecryptedKey(a, passphrase)
 	if err != nil {
 		return nil, err
 	}
@@ -468,7 +469,7 @@ func (ks *KeyStore) importKey(key *Key, passphrase string) (accounts.Account, er
 
 // Update changes the passphrase of an existing account.
 func (ks *KeyStore) Update(a accounts.Account, passphrase, newPassphrase string) error {
-	a, key, err := ks.getDecryptedKey(a, passphrase)
+	a, key, err := ks.GetDecryptedKey(a, passphrase)
 	if err != nil {
 		return err
 	}

--- a/cmd/client/wallet/main.go
+++ b/cmd/client/wallet/main.go
@@ -144,7 +144,7 @@ func main() {
 		fmt.Println("    9. blsgen        - Generate a bls key and store private key locally.")
 		fmt.Println("        --nopass         - The private key has no passphrase (for test only)")
 		fmt.Println("   10. format        - Shows different encoding formats of specific address")
-		fmt.Println("        --address        - The address to display the various format for")
+		fmt.Println("        --address        - The address to display the different encoding formats for")
 		os.Exit(1)
 	}
 

--- a/cmd/client/wallet/main.go
+++ b/cmd/client/wallet/main.go
@@ -436,7 +436,6 @@ func formatAddressCommand() {
 
 	if *formatAddressPtr == "" {
 		fmt.Println("Please specify the --address to show formats for.")
-		return
 	} else {
 		address := common2.ParseAddr(*formatAddressPtr)
 

--- a/cmd/client/wallet/main.go
+++ b/cmd/client/wallet/main.go
@@ -89,6 +89,9 @@ var (
 
 	balanceCommand    = flag.NewFlagSet("balances", flag.ExitOnError)
 	balanceAddressPtr = balanceCommand.String("address", "", "Specify the account address to check balance for")
+
+	formatCommand    = flag.NewFlagSet("format", flag.ExitOnError)
+	formatAddressPtr = formatCommand.String("address", "", "Specify the account address to display different encoding formats")
 )
 
 var (
@@ -140,6 +143,8 @@ func main() {
 		fmt.Println("        --account        - Specify the account to export. Empty will export every key.")
 		fmt.Println("    9. blsgen        - Generate a bls key and store private key locally.")
 		fmt.Println("        --nopass         - The private key has no passphrase (for test only)")
+		fmt.Println("   10. format        - Shows different encoding formats of specific address")
+		fmt.Println("        --address        - The address to display the various format for")
 		os.Exit(1)
 	}
 
@@ -198,6 +203,8 @@ ARG:
 	case "transfer":
 		readProfile(profile)
 		processTransferCommand()
+	case "format":
+		formatAddressCommand()
 	default:
 		fmt.Printf("Unknown action: %s\n", os.Args[1])
 		flag.PrintDefaults()
@@ -418,6 +425,23 @@ func processBalancesCommand() {
 				fmt.Printf("    Balance in Shard %d:  connection failed \n", shardID)
 			}
 		}
+	}
+}
+
+func formatAddressCommand() {
+	if err := formatCommand.Parse(os.Args[2:]); err != nil {
+		fmt.Println(ctxerror.New("failed to parse flags").WithCause(err))
+		return
+	}
+
+	if *formatAddressPtr == "" {
+		fmt.Println("Please specify the --address to show formats for.")
+		return
+	} else {
+		address := common2.ParseAddr(*formatAddressPtr)
+
+		fmt.Printf("account address in Bech32: %s\n", common2.MustAddressToBech32(address))
+		fmt.Printf("account address in Base16 (deprecated): %s\n", address.Hex())
 	}
 }
 


### PR DESCRIPTION
 ./bin/wallet format --address 0x053515CC2CAae77F7e2F0A9C48A27c8f6D76E99d
account address in Bech32: one1q563tnpv4tnh7l30p2wy3gnu3akhd6va97w7ku
account address in Base16 (deprecated): 0x053515CC2CAae77F7e2F0A9C48A27c8f6D76E99d

./bin/wallet format --address one1djwg5f0l3ccnscupqz6htcqsjnl85jt8xvpwhc
account address in Bech32: one1djwg5f0l3ccnscupqz6htcqsjnl85jt8xvpwhc
account address in Base16 (deprecated): 0x6c9C8a25Ff8e3138638100B575e01094Fe7a4967