### PR TITLE
remove address and use publickey in consensus; clean up consensus code

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -16,7 +16,6 @@ import (
 	"github.com/harmony-one/harmony/core/state"
 	"github.com/harmony-one/harmony/core/types"
 	bls_cosi "github.com/harmony-one/harmony/crypto/bls"
-	common2 "github.com/harmony-one/harmony/internal/common"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/ctxerror"
 	"github.com/harmony-one/harmony/internal/genesis"
@@ -50,17 +49,17 @@ type Consensus struct {
 	consensusTimeout map[TimeoutType]*utils.Timeout
 
 	// Commits collected from validators.
-	prepareSigs          map[common.Address]*bls.Sign // key is the validator's address
-	commitSigs           map[common.Address]*bls.Sign // key is the validator's address
+	prepareSigs          map[string]*bls.Sign // key is the bls public key
+	commitSigs           map[string]*bls.Sign // key is the bls public key
 	aggregatedPrepareSig *bls.Sign
 	aggregatedCommitSig  *bls.Sign
 	prepareBitmap        *bls_cosi.Mask
 	commitBitmap         *bls_cosi.Mask
 
 	// Commits collected from view change
-	bhpSigs      map[common.Address]*bls.Sign // bhpSigs: blockHashPreparedSigs is the signature on m1 type message
-	nilSigs      map[common.Address]*bls.Sign // nilSigs: there is no prepared message when view change, it's signature on m2 type (i.e. nil) messages
-	viewIDSigs   map[common.Address]*bls.Sign // viewIDSigs: every validator sign on |viewID|blockHash| in view changing message
+	bhpSigs      map[string]*bls.Sign // bhpSigs: blockHashPreparedSigs is the signature on m1 type message
+	nilSigs      map[string]*bls.Sign // nilSigs: there is no prepared message when view change, it's signature on m2 type (i.e. nil) messages
+	viewIDSigs   map[string]*bls.Sign // viewIDSigs: every validator sign on |viewID|blockHash| in view changing message
 	bhpBitmap    *bls_cosi.Mask
 	nilBitmap    *bls_cosi.Mask
 	viewIDBitmap *bls_cosi.Mask
@@ -81,19 +80,19 @@ type Consensus struct {
 	leader p2p.Peer
 
 	// Public keys of the committee including leader and validators
-	PublicKeys []*bls.PublicKey
-	// The addresses of my committee
-	CommitteeAddresses map[common.Address]bool
-	pubKeyLock         sync.Mutex
+	PublicKeys          []*bls.PublicKey
+	CommitteePublicKeys map[string]bool
+
+	pubKeyLock sync.Mutex
 
 	// private/public keys of current node
 	priKey *bls.SecretKey
 	PubKey *bls.PublicKey
+
+	SelfAddress common.Address
 	// the publickey of leader
 	LeaderPubKey *bls.PublicKey
 
-	// Leader or validator address in hex
-	SelfAddress common.Address
 	// Consensus Id (View Id) - 4 byte
 	viewID uint32 // TODO(chao): change it to uint64 or add overflow checking mechanism
 
@@ -224,14 +223,13 @@ func New(host p2p.Host, ShardID uint32, leader p2p.Peer, blsPriKey *bls.SecretKe
 		nodeconfig.GetDefaultConfig().SetIsLeader(false)
 	}
 
-	consensus.prepareSigs = map[common.Address]*bls.Sign{}
-	consensus.commitSigs = map[common.Address]*bls.Sign{}
-	consensus.CommitteeAddresses = make(map[common.Address]bool)
+	consensus.prepareSigs = map[string]*bls.Sign{}
+	consensus.commitSigs = map[string]*bls.Sign{}
 
-	consensus.validators.Store(common2.MustAddressToBech32(utils.GetBlsAddress(leader.ConsensusPubKey)), leader)
+	consensus.CommitteePublicKeys = make(map[string]bool)
 
-	// For now use socket address as ID
-	// TODO: populate Id derived from address
+	consensus.validators.Store(leader.ConsensusPubKey.SerializeToHexStr(), leader)
+
 	consensus.SelfAddress = utils.GetBlsAddress(selfPeer.ConsensusPubKey)
 
 	if blsPriKey != nil {

--- a/consensus/consensus_leader_msg_test.go
+++ b/consensus/consensus_leader_msg_test.go
@@ -3,8 +3,6 @@ package consensus
 import (
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/harmony-one/harmony/crypto/bls"
 	"github.com/harmony-one/harmony/internal/ctxerror"
 
@@ -61,8 +59,8 @@ func TestConstructPreparedMessage(test *testing.T) {
 	consensus.blockHash = [32]byte{}
 
 	message := "test string"
-	consensus.prepareSigs[common.Address{}] = leaderPriKey.Sign(message)
-	consensus.prepareSigs[common.Address{}] = validatorPriKey.Sign(message)
+	consensus.prepareSigs[leaderPubKey.SerializeToHexStr()] = leaderPriKey.Sign(message)
+	consensus.prepareSigs[validatorPubKey.SerializeToHexStr()] = validatorPriKey.Sign(message)
 	// According to RJ these failures are benign.
 	if err := consensus.prepareBitmap.SetKey(leaderPubKey, true); err != nil {
 		test.Log(ctxerror.New("prepareBitmap.SetKey").WithCause(err))

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -4,11 +4,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/harmony-one/harmony/crypto/hash"
-	common2 "github.com/harmony-one/harmony/internal/common"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -18,7 +16,6 @@ import (
 	libp2p_peer "github.com/libp2p/go-libp2p-peer"
 	"golang.org/x/crypto/sha3"
 
-	proto_discovery "github.com/harmony-one/harmony/api/proto/discovery"
 	msg_pb "github.com/harmony-one/harmony/api/proto/message"
 	consensus_engine "github.com/harmony-one/harmony/consensus/engine"
 	"github.com/harmony-one/harmony/core/state"
@@ -29,7 +26,6 @@ import (
 	"github.com/harmony-one/harmony/internal/profiler"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
-	"github.com/harmony-one/harmony/p2p/host"
 )
 
 // WaitForNewRandomness listens to the RndChannel to receive new VDF randomness.
@@ -88,16 +84,17 @@ func (consensus *Consensus) Seal(chain consensus_engine.ChainReader, block *type
 	return nil
 }
 
+// Author returns the author of the block header.
+func (consensus *Consensus) Author(header *types.Header) (common.Address, error) {
+	// TODO: implement this
+	return common.Address{}, nil
+}
+
 // Prepare is to prepare ...
 // TODO(RJ): fix it.
 func (consensus *Consensus) Prepare(chain consensus_engine.ChainReader, header *types.Header) error {
 	// TODO: implement prepare method
 	return nil
-}
-
-// GetSelfAddress returns the address in hex
-func (consensus *Consensus) GetSelfAddress() common.Address {
-	return consensus.SelfAddress
 }
 
 // Populates the common basic fields for all consensus message.
@@ -110,8 +107,7 @@ func (consensus *Consensus) populateMessageFields(request *msg_pb.ConsensusReque
 
 	// sender address
 	request.SenderPubkey = consensus.PubKey.Serialize()
-
-	utils.GetLogInstance().Debug("[populateMessageFields]", "myViewID", consensus.viewID, "SenderAddress", consensus.SelfAddress, "blockNum", consensus.blockNum)
+	consensus.getLogger().Debug("[populateMessageFields]", "SenderKey", consensus.PubKey.SerializeToHexStr())
 }
 
 // Signs the consensus message and returns the marshaled message.
@@ -168,33 +164,18 @@ func (consensus *Consensus) DebugPrintPublicKeys() {
 	utils.GetLogInstance().Debug("PublicKeys:", "#", len(consensus.PublicKeys))
 }
 
-// DebugPrintValidators print all validator ip/port/key in string format in Consensus
-func (consensus *Consensus) DebugPrintValidators() {
-	count := 0
-	consensus.validators.Range(func(k, v interface{}) bool {
-		if p, ok := v.(p2p.Peer); ok {
-			str2 := fmt.Sprintf("%s", p.ConsensusPubKey.Serialize())
-			utils.GetLogInstance().Debug("validator:", "IP", p.IP, "Port", p.Port, "address", utils.GetBlsAddress(p.ConsensusPubKey), "Key", str2)
-			count++
-			return true
-		}
-		return false
-	})
-	utils.GetLogInstance().Debug("Validators", "#", count)
-}
-
 // UpdatePublicKeys updates the PublicKeys variable, protected by a mutex
 func (consensus *Consensus) UpdatePublicKeys(pubKeys []*bls.PublicKey) int {
 	consensus.pubKeyLock.Lock()
 	consensus.PublicKeys = append(pubKeys[:0:0], pubKeys...)
-	consensus.CommitteeAddresses = map[common.Address]bool{}
+	consensus.CommitteePublicKeys = map[string]bool{}
 	for _, pubKey := range consensus.PublicKeys {
-		consensus.CommitteeAddresses[utils.GetBlsAddress(pubKey)] = true
+		consensus.CommitteePublicKeys[pubKey.SerializeToHexStr()] = true
 	}
 	// TODO: use pubkey to identify leader rather than p2p.Peer.
 	consensus.leader = p2p.Peer{ConsensusPubKey: pubKeys[0]}
 	consensus.LeaderPubKey = pubKeys[0]
-	prepareBitmap, err := bls_cosi.NewMask(consensus.PublicKeys, consensus.leader.ConsensusPubKey)
+	prepareBitmap, err := bls_cosi.NewMask(consensus.PublicKeys, consensus.LeaderPubKey)
 	if err == nil {
 		consensus.prepareBitmap = prepareBitmap
 	}
@@ -204,7 +185,7 @@ func (consensus *Consensus) UpdatePublicKeys(pubKeys []*bls.PublicKey) int {
 		consensus.commitBitmap = commitBitmap
 	}
 
-	utils.GetLogInstance().Info("My Leader", "info", hex.EncodeToString(consensus.leader.ConsensusPubKey.Serialize()))
+	utils.GetLogInstance().Info("My Leader", "info", consensus.LeaderPubKey.SerializeToHexStr())
 	utils.GetLogInstance().Info("My Committee", "info", consensus.PublicKeys)
 	consensus.pubKeyLock.Unlock()
 	// reset states after update public keys
@@ -260,12 +241,6 @@ func (consensus *Consensus) Finalize(chain consensus_engine.ChainReader, header 
 	}
 	header.Root = state.IntermediateRoot(false)
 	return types.NewBlock(header, txs, receipts), nil
-}
-
-// Author returns the author of the block header.
-func (consensus *Consensus) Author(header *types.Header) (common.Address, error) {
-	// TODO: implement this
-	return common.Address{}, nil
 }
 
 // Sign on the hash of the message
@@ -353,8 +328,8 @@ func (consensus *Consensus) GetViewIDSigsArray() []*bls.Sign {
 func (consensus *Consensus) ResetState() {
 	consensus.phase = Announce
 	consensus.blockHash = [32]byte{}
-	consensus.prepareSigs = map[common.Address]*bls.Sign{}
-	consensus.commitSigs = map[common.Address]*bls.Sign{}
+	consensus.prepareSigs = map[string]*bls.Sign{}
+	consensus.commitSigs = map[string]*bls.Sign{}
 
 	prepareBitmap, _ := bls_cosi.NewMask(consensus.PublicKeys, consensus.LeaderPubKey)
 	commitBitmap, _ := bls_cosi.NewMask(consensus.PublicKeys, consensus.LeaderPubKey)
@@ -372,82 +347,8 @@ func (consensus *Consensus) String() string {
 	} else {
 		duty = "VLD" // validator
 	}
-	return fmt.Sprintf("[duty:%s, PubKey:%s, ShardID:%v, Address:%v]",
-		duty, hex.EncodeToString(consensus.PubKey.Serialize()), consensus.ShardID, consensus.SelfAddress)
-}
-
-// AddPeers adds new peers into the validator map of the consensus
-// and add the public keys
-func (consensus *Consensus) AddPeers(peers []*p2p.Peer) int {
-	count := 0
-
-	for _, peer := range peers {
-		_, ok := consensus.validators.LoadOrStore(common2.MustAddressToBech32(utils.GetBlsAddress(peer.ConsensusPubKey)), *peer)
-		if !ok {
-			consensus.pubKeyLock.Lock()
-			if _, ok := consensus.CommitteeAddresses[peer.ConsensusPubKey.GetAddress()]; !ok {
-				consensus.PublicKeys = append(consensus.PublicKeys, peer.ConsensusPubKey)
-				consensus.CommitteeAddresses[peer.ConsensusPubKey.GetAddress()] = true
-			}
-			consensus.pubKeyLock.Unlock()
-		}
-		count++
-	}
-	return count
-}
-
-// RemovePeers will remove the peer from the validator list and PublicKeys
-// It will be called when leader/node lost connection to peers
-func (consensus *Consensus) RemovePeers(peers []p2p.Peer) int {
-	// early return as most of the cases no peers to remove
-	if len(peers) == 0 {
-		return 0
-	}
-
-	count := 0
-	count2 := 0
-	newList := append(consensus.PublicKeys[:0:0], consensus.PublicKeys...)
-
-	for _, peer := range peers {
-		consensus.validators.Range(func(k, v interface{}) bool {
-			if p, ok := v.(p2p.Peer); ok {
-				// We are using peer.IP and peer.Port to identify the unique peer
-				// FIXME (lc): use a generic way to identify a peer
-				if p.IP == peer.IP && p.Port == peer.Port {
-					consensus.validators.Delete(k)
-					count++
-				}
-				return true
-			}
-			return false
-		})
-
-		for i, pp := range newList {
-			// Not Found the pubkey, if found pubkey, ignore it
-			if reflect.DeepEqual(peer.ConsensusPubKey, pp) {
-				//				consensus.Log.Debug("RemovePeers", "i", i, "pp", pp, "peer.PubKey", peer.PubKey)
-				newList = append(newList[:i], newList[i+1:]...)
-				count2++
-			}
-		}
-	}
-
-	if count2 > 0 {
-		consensus.UpdatePublicKeys(newList)
-
-		// Send out Pong messages to everyone in the shard to keep the publickeys in sync
-		// Or the shard won't be able to reach consensus if public keys are mismatch
-
-		validators := consensus.GetValidatorPeers()
-		pong := proto_discovery.NewPongMessage(validators, consensus.PublicKeys, consensus.leader.ConsensusPubKey, consensus.ShardID)
-		buffer := pong.ConstructPongMessage()
-
-		if err := consensus.host.SendMessageToGroups([]p2p.GroupID{p2p.NewGroupIDByShardID(p2p.ShardID(consensus.ShardID))}, host.ConstructP2pMessage(byte(17), buffer)); err != nil {
-			ctxerror.Warn(utils.GetLogger(), err, "cannot send pong message")
-		}
-	}
-
-	return count2
+	return fmt.Sprintf("[duty:%s, PubKey:%s, ShardID:%v]",
+		duty, consensus.PubKey.SerializeToHexStr(), consensus.ShardID)
 }
 
 // ToggleConsensusCheck flip the flag of whether ignore viewID check during consensus process
@@ -457,25 +358,9 @@ func (consensus *Consensus) ToggleConsensusCheck() {
 	consensus.ignoreViewIDCheck = !consensus.ignoreViewIDCheck
 }
 
-// GetPeerByAddress the validator peer based on validator Address.
-// TODO: deprecate this, as validators network info shouldn't known to everyone
-func (consensus *Consensus) GetPeerByAddress(validatorAddress string) *p2p.Peer {
-	v, ok := consensus.validators.Load(validatorAddress)
-	if !ok {
-		utils.GetLogInstance().Warn("Unrecognized validator", "validatorAddress", validatorAddress, "consensus", consensus)
-		return nil
-	}
-	value, ok := v.(p2p.Peer)
-	if !ok {
-		utils.GetLogInstance().Warn("Invalid validator", "validatorAddress", validatorAddress, "consensus", consensus)
-		return nil
-	}
-	return &value
-}
-
 // IsValidatorInCommittee returns whether the given validator BLS address is part of my committee
-func (consensus *Consensus) IsValidatorInCommittee(validatorBlsAddress common.Address) bool {
-	_, ok := consensus.CommitteeAddresses[validatorBlsAddress]
+func (consensus *Consensus) IsValidatorInCommittee(pubKey *bls.PublicKey) bool {
+	_, ok := consensus.CommitteePublicKeys[pubKey.SerializeToHexStr()]
 	return ok
 }
 
@@ -508,28 +393,24 @@ func (consensus *Consensus) verifySenderKey(msg *msg_pb.Message) (*bls.PublicKey
 	if err != nil {
 		return nil, err
 	}
-	addrBytes := senderKey.GetAddress()
-	senderAddr := common.BytesToAddress(addrBytes[:])
 
-	if !consensus.IsValidatorInCommittee(senderAddr) {
-		return nil, fmt.Errorf("Validator address %s is not in committee", common2.MustAddressToBech32(senderAddr))
+	if !consensus.IsValidatorInCommittee(senderKey) {
+		return nil, fmt.Errorf("Validator %s is not in committee", senderKey.SerializeToHexStr())
 	}
 	return senderKey, nil
 }
 
-func (consensus *Consensus) verifyViewChangeSenderKey(msg *msg_pb.Message) (*bls.PublicKey, common.Address, error) {
+func (consensus *Consensus) verifyViewChangeSenderKey(msg *msg_pb.Message) (*bls.PublicKey, error) {
 	vcMsg := msg.GetViewchange()
 	senderKey, err := bls_cosi.BytesToBlsPublicKey(vcMsg.SenderPubkey)
 	if err != nil {
-		return nil, common.Address{}, err
+		return nil, err
 	}
-	addrBytes := senderKey.GetAddress()
-	senderAddr := common.BytesToAddress(addrBytes[:])
 
-	if !consensus.IsValidatorInCommittee(senderAddr) {
-		return nil, common.Address{}, fmt.Errorf("Validator address %s is not in committee", common2.MustAddressToBech32(senderAddr))
+	if !consensus.IsValidatorInCommittee(senderKey) {
+		return nil, fmt.Errorf("Validator %s is not in committee", senderKey.SerializeToHexStr())
 	}
-	return senderKey, senderAddr, nil
+	return senderKey, nil
 }
 
 // SetViewID set the viewID to the height of the blockchain

--- a/consensus/consensus_service_test.go
+++ b/consensus/consensus_service_test.go
@@ -4,36 +4,13 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/harmony-one/harmony/crypto/bls"
-	common2 "github.com/harmony-one/harmony/internal/common"
 
 	msg_pb "github.com/harmony-one/harmony/api/proto/message"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/p2p/p2pimpl"
 )
-
-func TestGetPeerFromID(t *testing.T) {
-	leaderPriKey := bls.RandPrivateKey()
-	leaderPubKey := leaderPriKey.GetPublicKey()
-	leader := p2p.Peer{IP: "127.0.0.1", Port: "9902", ConsensusPubKey: leaderPubKey}
-	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "9902")
-	host, err := p2pimpl.NewHost(&leader, priKey)
-	if err != nil {
-		t.Fatalf("newhost failure: %v", err)
-	}
-	consensus, err := New(host, 0, leader, leaderPriKey)
-	if err != nil {
-		t.Fatalf("Cannot craeate consensus: %v", err)
-	}
-	leaderAddress := utils.GetAddressFromBlsPubKey(leader.ConsensusPubKey)
-	l := consensus.GetPeerByAddress(common2.MustAddressToBech32(leaderAddress))
-	if l.IP != leader.IP || l.Port != leader.Port {
-		t.Errorf("leader IP not equal")
-	}
-}
 
 func TestPopulateMessageFields(t *testing.T) {
 	leader := p2p.Peer{IP: "127.0.0.1", Port: "9902"}
@@ -83,7 +60,6 @@ func TestSignAndMarshalConsensusMessage(t *testing.T) {
 	}
 	consensus.viewID = 2
 	consensus.blockHash = [32]byte{}
-	consensus.SelfAddress = common.Address{}
 
 	msg := &msg_pb.Message{}
 	marshaledMessage, err := consensus.signAndMarshalConsensusMessage(msg)

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -146,9 +146,9 @@ func (consensus *Consensus) ResetViewChangeState() {
 	consensus.viewIDBitmap = viewIDBitmap
 	consensus.m1Payload = []byte{}
 
-	consensus.bhpSigs = map[common.Address]*bls.Sign{}
-	consensus.nilSigs = map[common.Address]*bls.Sign{}
-	consensus.viewIDSigs = map[common.Address]*bls.Sign{}
+	consensus.bhpSigs = map[string]*bls.Sign{}
+	consensus.nilSigs = map[string]*bls.Sign{}
+	consensus.viewIDSigs = map[string]*bls.Sign{}
 }
 
 func createTimeout() map[TimeoutType]*utils.Timeout {
@@ -183,7 +183,7 @@ func (consensus *Consensus) startViewChange(viewID uint32) {
 }
 
 func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
-	senderKey, validatorAddress, err := consensus.verifyViewChangeSenderKey(msg)
+	senderKey, err := consensus.verifyViewChangeSenderKey(msg)
 	if err != nil {
 		consensus.getLogger().Debug("onViewChange verifySenderKey failed", "error", err)
 		return
@@ -220,29 +220,29 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 	defer consensus.vcLock.Unlock()
 
 	// add self m1 or m2 type message signature and bitmap
-	_, ok1 := consensus.nilSigs[consensus.SelfAddress]
-	_, ok2 := consensus.bhpSigs[consensus.SelfAddress]
+	_, ok1 := consensus.nilSigs[consensus.PubKey.SerializeToHexStr()]
+	_, ok2 := consensus.bhpSigs[consensus.PubKey.SerializeToHexStr()]
 	if !(ok1 || ok2) {
 		// add own signature for newview message
 		preparedMsgs := consensus.pbftLog.GetMessagesByTypeSeq(msg_pb.MessageType_PREPARED, recvMsg.BlockNum)
 		preparedMsg := consensus.pbftLog.FindMessageByMaxViewID(preparedMsgs)
 		if preparedMsg == nil {
 			sign := consensus.priKey.SignHash(NIL)
-			consensus.nilSigs[consensus.SelfAddress] = sign
+			consensus.nilSigs[consensus.PubKey.SerializeToHexStr()] = sign
 			consensus.nilBitmap.SetKey(consensus.PubKey, true)
 		} else {
 			msgToSign := append(preparedMsg.BlockHash[:], preparedMsg.Payload...)
-			consensus.bhpSigs[consensus.SelfAddress] = consensus.priKey.SignHash(msgToSign)
+			consensus.bhpSigs[consensus.PubKey.SerializeToHexStr()] = consensus.priKey.SignHash(msgToSign)
 			consensus.bhpBitmap.SetKey(consensus.PubKey, true)
 		}
 	}
 	// add self m3 type message signature and bitmap
-	_, ok3 := consensus.viewIDSigs[consensus.SelfAddress]
+	_, ok3 := consensus.viewIDSigs[consensus.PubKey.SerializeToHexStr()]
 	if !ok3 {
 		viewIDHash := make([]byte, 4)
 		binary.LittleEndian.PutUint32(viewIDHash, recvMsg.ViewID)
 		sign := consensus.priKey.SignHash(viewIDHash)
-		consensus.viewIDSigs[consensus.SelfAddress] = sign
+		consensus.viewIDSigs[consensus.PubKey.SerializeToHexStr()] = sign
 		consensus.viewIDBitmap.SetKey(consensus.PubKey, true)
 	}
 
@@ -252,9 +252,9 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 
 	// m2 type message
 	if len(recvMsg.Payload) == 0 {
-		_, ok := consensus.nilSigs[validatorAddress]
+		_, ok := consensus.nilSigs[senderKey.SerializeToHexStr()]
 		if ok {
-			consensus.getLogger().Debug("onViewChange already received m2 message from the validator", "validatorAddress", validatorAddress)
+			consensus.getLogger().Debug("onViewChange already received m2 message from the validator", "validatorPubKey", senderKey.SerializeToHexStr())
 			return
 		}
 
@@ -262,12 +262,12 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 			consensus.getLogger().Warn("onViewChange failed to verify signature for m2 type viewchange message")
 			return
 		}
-		consensus.nilSigs[validatorAddress] = recvMsg.ViewchangeSig
+		consensus.nilSigs[senderKey.SerializeToHexStr()] = recvMsg.ViewchangeSig
 		consensus.nilBitmap.SetKey(recvMsg.SenderPubkey, true) // Set the bitmap indicating that this validator signed.
 	} else { // m1 type message
-		_, ok := consensus.bhpSigs[validatorAddress]
+		_, ok := consensus.bhpSigs[senderKey.SerializeToHexStr()]
 		if ok {
-			consensus.getLogger().Debug("onViewChange already received m1 message from the validator", "validatorAddress", validatorAddress)
+			consensus.getLogger().Debug("onViewChange already received m1 message from the validator", "validatorPubKey", senderKey.SerializeToHexStr())
 			return
 		}
 		if !recvMsg.ViewchangeSig.VerifyHash(recvMsg.SenderPubkey, recvMsg.Payload) {
@@ -311,14 +311,14 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 				consensus.pbftLog.AddMessage(&preparedMsg)
 			}
 		}
-		consensus.bhpSigs[validatorAddress] = recvMsg.ViewchangeSig
+		consensus.bhpSigs[senderKey.SerializeToHexStr()] = recvMsg.ViewchangeSig
 		consensus.bhpBitmap.SetKey(recvMsg.SenderPubkey, true) // Set the bitmap indicating that this validator signed.
 	}
 
 	// check and add viewID (m3 type) message signature
-	_, ok := consensus.viewIDSigs[validatorAddress]
+	_, ok := consensus.viewIDSigs[senderKey.SerializeToHexStr()]
 	if ok {
-		consensus.getLogger().Debug("onViewChange already received m3 viewID message from the validator", "validatorAddress", validatorAddress)
+		consensus.getLogger().Debug("onViewChange already received m3 viewID message from the validator", "senderKey.SerializeToHexStr()", senderKey.SerializeToHexStr())
 		return
 	}
 	viewIDHash := make([]byte, 4)
@@ -327,7 +327,7 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 		consensus.getLogger().Warn("onViewChange failed to verify viewID signature", "msgViewID", recvMsg.ViewID)
 		return
 	}
-	consensus.viewIDSigs[validatorAddress] = recvMsg.ViewidSig
+	consensus.viewIDSigs[senderKey.SerializeToHexStr()] = recvMsg.ViewidSig
 	consensus.viewIDBitmap.SetKey(recvMsg.SenderPubkey, true) // Set the bitmap indicating that this validator signed.
 
 	if len(consensus.viewIDSigs) >= consensus.Quorum() {
@@ -353,7 +353,7 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 			blockNumHash := make([]byte, 8)
 			binary.LittleEndian.PutUint64(blockNumHash, consensus.blockNum)
 			commitPayload := append(blockNumHash, consensus.blockHash[:]...)
-			consensus.commitSigs[consensus.SelfAddress] = consensus.priKey.SignHash(commitPayload)
+			consensus.commitSigs[consensus.PubKey.SerializeToHexStr()] = consensus.priKey.SignHash(commitPayload)
 		}
 
 		consensus.mode.SetViewID(recvMsg.ViewID)
@@ -376,7 +376,7 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 // TODO: move to consensus_leader.go later
 func (consensus *Consensus) onNewView(msg *msg_pb.Message) {
 	consensus.getLogger().Debug("onNewView received new view message")
-	senderKey, _, err := consensus.verifyViewChangeSenderKey(msg)
+	senderKey, err := consensus.verifyViewChangeSenderKey(msg)
 	if err != nil {
 		consensus.getLogger().Warn("onNewView verifySenderKey failed", "error", err)
 		return

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -490,11 +490,11 @@ func (node *Node) pingMessageHandler(msgPayload []byte, sender string) int {
 	node.host.ConnectHostPeer(*peer)
 
 	if ping.Node.Role == proto_node.ClientRole {
-		utils.GetLogInstance().Info("Add Client Peer to Node", "Address", node.Consensus.GetSelfAddress(), "Client", peer)
+		utils.GetLogInstance().Info("Add Client Peer to Node", "PubKey", node.Consensus.PubKey.SerializeToHexStr(), "Client", peer)
 		node.ClientPeer = peer
 	} else {
 		node.AddPeers([]*p2p.Peer{peer})
-		utils.GetLogInstance().Info("Add Peer to Node", "Address", node.Consensus.GetSelfAddress(), "Peer", peer, "# Peers", len(node.Consensus.PublicKeys))
+		utils.GetLogInstance().Info("Add Peer to Node", "PubKey", node.Consensus.PubKey.SerializeToHexStr(), "Peer", peer, "# Peers", len(node.Consensus.PublicKeys))
 	}
 
 	return 1

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -169,8 +169,7 @@ func (node *Node) SendNewBlockToUnsync() {
 		}
 
 		// really need to have a unique id independent of ip/port
-		selfPeerAddress := node.Consensus.SelfAddress
-		utils.GetLogInstance().Debug("[SYNC] peerRegistration Record", "selfPeerAddress", selfPeerAddress, "number", len(node.peerRegistrationRecord))
+		utils.GetLogInstance().Debug("[SYNC] peerRegistration Record", "selfPubKey", node.Consensus.PubKey.SerializeToHexStr(), "number", len(node.peerRegistrationRecord))
 
 		for peerID, config := range node.peerRegistrationRecord {
 			elapseTime := time.Now().UnixNano() - config.timestamp


### PR DESCRIPTION
* remove the common.Address or Bech32 address usage in consensus to avoid confusion; use publickey instead
* clean up some codes