### PR TITLE
Make -account handle both base16 and bech32

### DIFF
--- a/internal/genesis/genesis.go
+++ b/internal/genesis/genesis.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/harmony-one/harmony/internal/common"
 	"github.com/harmony-one/harmony/internal/utils"
 )
 
@@ -40,13 +41,14 @@ func BeaconAccountPriKey() *ecdsa.PrivateKey {
 // the account address could be from GenesisAccounts or from GenesisFNAccounts
 // the account index can be used to determin the shard of the account
 func FindAccount(address string) (int, *DeployAccount) {
+	addr := common.ParseAddr(address)
 	for i, acc := range GenesisAccounts {
-		if address == acc.Address {
+		if addr == common.ParseAddr(acc.Address) {
 			return i, &acc
 		}
 	}
 	for i, acc := range GenesisFNAccounts {
-		if address == acc.Address {
+		if addr == common.ParseAddr(acc.Address) {
 			return i + 8, &acc
 		}
 	}


### PR DESCRIPTION
SSIA.  Previously whatever string form—bech32 OR base16—in foundational.go or genesis.go needed to be used (case-sensitive too) as `-account` argument, and the other form was rejected.  With this change the code accepts both versions, case-insensitively.