### PR TITLE
Run in archival mode by default

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -94,7 +94,7 @@ var (
 	// isGenesis indicates this node is a genesis node
 	isGenesis = flag.Bool("is_genesis", true, "true means this node is a genesis node")
 	// isArchival indicates this node is an archival node that will save and archive current blockchain
-	isArchival = flag.Bool("is_archival", false, "true means this node is a archival node")
+	isArchival = flag.Bool("is_archival", true, "false makes node faster by turning caching off")
 	// delayCommit is the commit-delay timer, used by Harmony nodes
 	delayCommit = flag.String("delay_commit", "0ms", "how long to delay sending commit messages in consensus, ex: 500ms, 1s")
 	//isNewNode indicates this node is a new node


### PR DESCRIPTION
To opt-out, one can specify the `-is_archival false` option.

Two benefits:

1. Less memory consumption (trie cache can consume up to 256MiB of memory).
2. Better overall shard health (no more manual database syncing