### PR TITLE
Support non-interactive passphrase

### DIFF
--- a/internal/utils/passphrase.go
+++ b/internal/utils/passphrase.go
@@ -2,8 +2,14 @@ package utils
 
 import (
 	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
 	"syscall"
 
+	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -18,4 +24,57 @@ func AskForPassphrase(prompt string) string {
 	fmt.Println()
 
 	return password
+}
+
+// readAllAsString reads the entire file contents as a string.
+func readAllAsString(r io.Reader) (data string, err error) {
+	bytes, err := ioutil.ReadAll(r)
+	return string(bytes), err
+}
+
+// GetPassphraseFromSource reads a passphrase such as a key-encrypting one
+// non-interactively from the given source.
+//
+// The source can be "pass:password", "env:var", "file:pathname", "fd:number",
+// or "stdin".  See “PASS PHRASE ARGUMENTS” section of openssl(1) for details.
+func GetPassphraseFromSource(src string) (pass string, err error) {
+	switch src {
+	case "stdin":
+		return readAllAsString(os.Stdin)
+	}
+	methodArg := strings.SplitN(src, ":", 2)
+	if len(methodArg) < 2 {
+		return "", errors.Errorf("invalid passphrase reading method %#v", src)
+	}
+	method := methodArg[0]
+	arg := methodArg[1]
+	switch method {
+	case "pass":
+		return arg, nil
+	case "env":
+		pass, ok := os.LookupEnv(arg)
+		if !ok {
+			return "", errors.Errorf("environment variable %#v undefined", arg)
+		}
+		return pass, nil
+	case "file":
+		f, err := os.Open(arg)
+		if err != nil {
+			return "", errors.Wrapf(err, "cannot open file %#v", arg)
+		}
+		defer func() { _ = f.Close() }()
+		return readAllAsString(f)
+	case "fd":
+		fd, err := strconv.ParseUint(arg, 10, 0)
+		if err != nil {
+			return "", errors.Wrapf(err, "invalid fd literal %#v", arg)
+		}
+		f := os.NewFile(uintptr(fd), "(passphrase-source)")
+		if f == nil {
+			return "", errors.Errorf("cannot open fd %#v", fd)
+		}
+		defer func() { _ = f.Close() }()
+		return readAllAsString(f)
+	}
+	return "", errors.Errorf("invalid passphrase reading method %#v", method)
 }

--- a/internal/utils/passphrase_test.go
+++ b/internal/utils/passphrase_test.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/pkg/errors"
+
+	testutils "github.com/harmony-one/harmony/internal/utils/testing"
+)
+
+func exerciseGetPassphraseFromSource(t *testing.T, source, expected string) {
+	if actual, err := GetPassphraseFromSource(source); err != nil {
+		t.Fatal(errors.Wrap(err, "cannot read passphrase"))
+	} else if actual != expected {
+		t.Errorf("expected passphrase %#v; got %#v", expected, actual)
+	}
+}
+
+func TestGetPassphraseFromSource_Pass(t *testing.T) {
+	exerciseGetPassphraseFromSource(t, "pass:hello world", "hello world")
+}
+
+func TestGetPassphraseFromSource_File(t *testing.T) {
+	expected := "\nhello world\n"
+	t.Run("stdin", func(t *testing.T) {
+		f := testutils.NewTempFileWithContents(t, []byte(expected))
+		savedStdin := os.Stdin
+		defer func() { os.Stdin = savedStdin }()
+		os.Stdin = f
+		exerciseGetPassphraseFromSource(t, "stdin", expected)
+	})
+	t.Run("file", func(t *testing.T) {
+		f := testutils.NewTempFileWithContents(t, []byte(expected))
+		defer testutils.CloseAndRemoveTempFile(t, f)
+		exerciseGetPassphraseFromSource(t, "file:"+f.Name(), expected)
+	})
+	t.Run("fd", func(t *testing.T) {
+		f := testutils.NewTempFileWithContents(t, []byte(expected))
+		defer testutils.CloseAndRemoveTempFile(t, f)
+		exerciseGetPassphraseFromSource(t, fmt.Sprintf("fd:%d", f.Fd()), expected)
+	})
+}

--- a/internal/utils/testing/tempfile.go
+++ b/internal/utils/testing/tempfile.go
@@ -1,0 +1,46 @@
+package testutils
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+// NewTempFile creates a new, empty temp file for testing.  Errors are fatal.
+func NewTempFile(t *testing.T) *os.File {
+	pattern := strings.ReplaceAll(t.Name(), string(os.PathSeparator), "_")
+	f, err := ioutil.TempFile("", pattern)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "cannot create temp file"))
+	}
+	return f
+}
+
+// NewTempFileWithContents creates a new, empty temp file for testing,
+// with the given contents.  The read/write offset is set to the beginning.
+// Errors are fatal.
+func NewTempFileWithContents(t *testing.T, contents []byte) *os.File {
+	f := NewTempFile(t)
+	if _, err := f.Write(contents); err != nil {
+		t.Fatal(errors.Wrapf(err, "cannot write contents into %s", f.Name()))
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		t.Fatal(errors.Wrapf(err, "cannot rewind test file %s", f.Name()))
+	}
+	return f
+}
+
+// CloseAndRemoveTempFile closes/removes the temp file.  Errors are logged.
+func CloseAndRemoveTempFile(t *testing.T, f *os.File) {
+	fn := f.Name()
+	if err := f.Close(); err != nil {
+		t.Log(errors.Wrapf(err, "cannot close test file %s", fn))
+	}
+	if err := os.Remove(fn); err != nil {
+		t.Log(errors.Wrapf(err, "cannot remove test file %s", fn))
+	}
+}


### PR DESCRIPTION
Add openssl(1)-compatible non-interactive passphrase argument handling:

* `harmony -pass stdin` reads the passphrase from standard input (file descriptor 0)
* `harmony -pass fd:3` reads the passphrase from file descriptor 3
* `harmony -pass file:omg.txt` reads the passphrase from file named `omg.txt` (beware permission)
* `harmony -pass pass:omgwtfbbq` uses the string `omgwtfbbq` itself as a passphrase (INSECURE)
