### PR TITLE
add log for pbft log because it stores block by memory

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -19,6 +19,7 @@ import (
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/ctxerror"
 	"github.com/harmony-one/harmony/internal/genesis"
+	"github.com/harmony-one/harmony/internal/memprofiling"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 )
@@ -275,6 +276,7 @@ func New(host p2p.Host, ShardID uint32, leader p2p.Peer, blsPriKey *bls.SecretKe
 
 	consensus.uniqueIDInstance = utils.GetUniqueValidatorIDInstance()
 
+	memprofiling.GetMemProfiling().Add("consensus.pbftLog", consensus.pbftLog)
 	return &consensus, nil
 }
 


### PR DESCRIPTION
add log for pbft log because it stores block by memory