### PR TITLE
Fix “multiple key files found” if pwd is $HOME

### DIFF
--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -143,7 +143,8 @@ case "${BLSKEYFILE}" in
          BLSKEYFILE="${f}"
          ;;
       *)
-         err 69 "multiple key files found (${f}, ${BLSKEYFILE}); please use -k to specify"
+         [ "${f}" -ef "${BLSKEYFILE}" ] || \
+            err 69 "multiple key files found (${f}, ${BLSKEYFILE}); please use -k to specify"
          ;;
       esac
    done


### PR DESCRIPTION
This is because the same file will be discovered twice.  Identify this case by using the same-file test(1) predicate (`X -ef Y`) and error out if the files are distinct.
