### PR TITLE
Fix connection logging

### DIFF
--- a/internal/utils/connlogger.go
+++ b/internal/utils/connlogger.go
@@ -17,7 +17,7 @@ type ConnLogger struct {
 }
 
 func netLogger(n net.Network, l log.Logger) log.Logger {
-	return l.New("net",
+	return l.New(
 		"netLocalPeer", n.LocalPeer(),
 		"netListenAddresses", n.ListenAddresses())
 }


### PR DESCRIPTION
An extra argument was passed and it was causing `LOG15_ERROR` context messages in connection logs.