### PR TITLE
Make DNS zone configurable via -dns_zone

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -85,8 +85,8 @@ var (
 	metricsReportURL = flag.String("metrics_report_url", "", "If set, reports metrics to this URL.")
 	versionFlag      = flag.Bool("version", false, "Output version info")
 	onlyLogTps       = flag.Bool("only_log_tps", false, "Only log TPS if true")
-
-	dnsFlag = flag.Bool("dns", true, "use harmony dns nodes if true; use libp2p peer discovery if false")
+	dnsZone          = flag.String("dns_zone", "", "if given and not empty, use peers from the zone (default: use libp2p peer discovery instead)")
+	dnsFlag          = flag.Bool("dns", true, "[deprecated] equivalent to -dns_zone t.hmny.io")
 	//Leader needs to have a minimal number of peers to start consensus
 	minPeers = flag.Int("min_peers", 100, "Minimal number of Peers in shard")
 	// Key file to store the private key
@@ -318,7 +318,11 @@ func setUpConsensusAndNode(nodeConfig *nodeconfig.ConfigType) *node.Node {
 	// Current node.
 	chainDBFactory := &shardchain.LDBFactory{RootDir: nodeConfig.DBDir}
 	currentNode := node.New(nodeConfig.Host, currentConsensus, chainDBFactory, *isArchival)
-	currentNode.SetDNSFlag(*dnsFlag)
+	if *dnsZone != "" {
+		currentNode.SetDNSZone(*dnsZone)
+	} else if *dnsFlag {
+		currentNode.SetDNSZone("t.hmny.io")
+	}
 	currentNode.NodeConfig.SetRole(nodeconfig.NewNode)
 	// TODO: add staking support
 	// currentNode.StakingAccount = myAccount

--- a/internal/configs/net/config.go
+++ b/internal/configs/net/config.go
@@ -1,6 +1,0 @@
-package netconfig
-
-var (
-	// DNS harmony dns server for harmony nodes IP
-	DNS = [4]string{"s0.t.hmny.io", "s1.t.hmny.io", "s2.t.hmny.io", "s3.t.hmny.io"}
-)

--- a/node/node.go
+++ b/node/node.go
@@ -508,7 +508,7 @@ func (node *Node) AccountManager() *accounts.Manager {
 	return node.accountManager
 }
 
-// SetDNSFlag indicates whether use harmony dns server to get peer info for node syncing
+// SetDNSZone sets the DNS zone to use to get peer info for node syncing
 func (node *Node) SetDNSZone(zone string) {
 	utils.GetLogger().Info("using DNS zone to get peers", "zone", zone)
 	node.dnsZone = zone

--- a/node/node.go
+++ b/node/node.go
@@ -124,7 +124,7 @@ type Node struct {
 	stateSync              *syncing.StateSync
 	beaconSync             *syncing.StateSync
 	peerRegistrationRecord map[string]*syncConfig // record registration time (unixtime) of peers begin in syncing
-	dnsFlag                bool
+	dnsZone                string
 
 	// The p2p host used to send/receive p2p messages
 	host p2p.Host
@@ -509,7 +509,7 @@ func (node *Node) AccountManager() *accounts.Manager {
 }
 
 // SetDNSFlag indicates whether use harmony dns server to get peer info for node syncing
-func (node *Node) SetDNSFlag(flag bool) {
-	utils.GetLogInstance().Info("SetDNSFlag", "flag", flag)
-	node.dnsFlag = flag
+func (node *Node) SetDNSZone(zone string) {
+	utils.GetLogger().Info("using DNS zone to get peers", "zone", zone)
+	node.dnsZone = zone
 }


### PR DESCRIPTION
If a non-empty zone name is given, obtain syncing peers from the given zone; otherwise, use libp2p peer discovery.

For backward compatibility:

* `-dns=true` (default) is equivalent to `-dns_zone=t.hmny.io`;
* `-dns=false` is equivalent to `-dns-zone=""`;
* `-dns_zone` takes precedence over the `-dns` boolean setting.