### PR TITLE
Mainnet preparation

### DIFF
--- a/api/service/manager.go
+++ b/api/service/manager.go
@@ -144,7 +144,6 @@ func (m *Manager) TakeAction(action *Action) {
 		return
 	}
 	if service, ok := m.services[action.ServiceType]; ok {
-		utils.GetLogInstance().Info("Take Action", "action", action.Action, "service", action.ServiceType)
 		switch action.Action {
 		case Start:
 			service.StartService()

--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -510,7 +510,7 @@ func (ss *StateSync) updateBlockAndStatus(block *types.Block, bc *core.BlockChai
 		return false
 	}
 	ss.syncMux.Lock()
-	if err := worker.UpdateCurrent(); err != nil {
+	if err := worker.UpdateCurrent(block.Header().Coinbase); err != nil {
 		ctxerror.Warn(utils.GetLogger(), err, "(*Worker).UpdateCurrent failed")
 	}
 	ss.syncMux.Unlock()

--- a/cmd/client/txgen/main.go
+++ b/cmd/client/txgen/main.go
@@ -195,7 +195,7 @@ syncLoop:
 				if block.NumberU64()-txGen.Blockchain().CurrentBlock().NumberU64() == 1 {
 					txGen.AddNewBlock(block)
 					stateMutex.Lock()
-					if err := txGen.Worker.UpdateCurrent(); err != nil {
+					if err := txGen.Worker.UpdateCurrent(block.Coinbase()); err != nil {
 						ctxerror.Warn(utils.GetLogger(), err,
 							"(*Worker).UpdateCurrent failed")
 					}

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -302,6 +302,8 @@ func setUpConsensusAndNode(nodeConfig *nodeconfig.ConfigType) *node.Node {
 	// TODO: consensus object shouldn't start here
 	// TODO(minhdoan): During refactoring, found out that the peers list is actually empty. Need to clean up the logic of consensus later.
 	currentConsensus, err := consensus.New(nodeConfig.Host, nodeConfig.ShardID, nodeConfig.Leader, nodeConfig.ConsensusPriKey)
+	currentConsensus.SelfAddress = common.ParseAddr(genesisAccount.Address)
+
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error :%v \n", err)
 		os.Exit(1)

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -250,8 +250,6 @@ func New(host p2p.Host, ShardID uint32, leader p2p.Peer, blsPriKey *bls.SecretKe
 
 	consensus.validators.Store(leader.ConsensusPubKey.SerializeToHexStr(), leader)
 
-	consensus.SelfAddress = utils.GetBlsAddress(selfPeer.ConsensusPubKey)
-
 	if blsPriKey != nil {
 		consensus.priKey = blsPriKey
 		consensus.PubKey = blsPriKey.GetPublicKey()

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -117,7 +117,7 @@ func (consensus *Consensus) announce(block *types.Block) {
 	if err := consensus.host.SendMessageToGroups([]p2p.GroupID{p2p.NewGroupIDByShardID(p2p.ShardID(consensus.ShardID))}, host.ConstructP2pMessage(byte(17), msgToSend)); err != nil {
 		consensus.getLogger().Warn("[Announce] Cannot send announce message", "groupID", p2p.NewGroupIDByShardID(p2p.ShardID(consensus.ShardID)))
 	} else {
-		consensus.getLogger().Debug("[Announce] Sent Announce Message!!", "BlockHash", block.Hash(), "BlockNum", block.NumberU64())
+		consensus.getLogger().Debug("[Announce] Sent Announce Message!!", "BlockHash", block.Hash(), "BlockNum", block.NumberU64(), "announce receipt hash", block.ReceiptHash(), "announce receipt hash2", block.Header().ReceiptHash)
 	}
 
 	consensus.getLogger().Debug("[Announce] Switching phase", "From", consensus.phase, "To", Prepare)

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -895,7 +895,7 @@ func (consensus *Consensus) Start(blockChannel chan *types.Block, stopChan chan 
 						// Verify the randomness
 						_ = blockHash
 						consensus.getLogger().Info("[ConsensusMainLoop] Adding randomness into new block", "rnd", rnd)
-						newBlock.AddVdf([258]byte{}) // TODO(HB): add real vdf
+						// newBlock.AddVdf([258]byte{}) // TODO(HB): add real vdf
 					} else {
 						//consensus.getLogger().Info("Failed to get randomness", "error", err)
 					}

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -117,7 +117,7 @@ func (consensus *Consensus) announce(block *types.Block) {
 	if err := consensus.host.SendMessageToGroups([]p2p.GroupID{p2p.NewGroupIDByShardID(p2p.ShardID(consensus.ShardID))}, host.ConstructP2pMessage(byte(17), msgToSend)); err != nil {
 		consensus.getLogger().Warn("[Announce] Cannot send announce message", "groupID", p2p.NewGroupIDByShardID(p2p.ShardID(consensus.ShardID)))
 	} else {
-		consensus.getLogger().Debug("[Announce] Sent Announce Message!!", "BlockHash", block.Hash(), "BlockNum", block.NumberU64(), "announce receipt hash", block.ReceiptHash(), "announce receipt hash2", block.Header().ReceiptHash)
+		consensus.getLogger().Debug("[Announce] Sent Announce Message!!", "BlockHash", block.Hash(), "BlockNum", block.NumberU64())
 	}
 
 	consensus.getLogger().Debug("[Announce] Switching phase", "From", consensus.phase, "To", Prepare)

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -88,7 +88,7 @@ func (v *BlockValidator) ValidateState(block, parent *types.Block, statedb *stat
 	// Tre receipt Trie's root (R = (Tr [[H1, R1], ... [Hn, R1]]))
 	receiptSha := types.DeriveSha(receipts)
 	if receiptSha != header.ReceiptHash {
-		return fmt.Errorf("invalid receipt root hash (remote: %x local: %x)", header.ReceiptHash, receiptSha)
+		return fmt.Errorf("invalid receipt root hash (remote: %x local: %x) len-receipt %d", header.ReceiptHash, receiptSha, len(receipts))
 	}
 	// Validate the state root against the received state root and throw
 	// an error if they don't match.

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -88,7 +88,7 @@ func (v *BlockValidator) ValidateState(block, parent *types.Block, statedb *stat
 	// Tre receipt Trie's root (R = (Tr [[H1, R1], ... [Hn, R1]]))
 	receiptSha := types.DeriveSha(receipts)
 	if receiptSha != header.ReceiptHash {
-		return fmt.Errorf("invalid receipt root hash (remote: %x local: %x) len-receipt %d", header.ReceiptHash, receiptSha, len(receipts))
+		return fmt.Errorf("invalid receipt root hash (remote: %x local: %x)", header.ReceiptHash, receiptSha)
 	}
 	// Validate the state root against the received state root and throw
 	// an error if they don't match.

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1696,7 +1696,8 @@ func (bc *BlockChain) GetVdfByNumber(number uint64) [32]byte {
 		return [32]byte{}
 	}
 	result := [32]byte{}
-	copy(result[:], header.Vdf[:32])
+	//copy(result[:], header.Vdf[:32])
+	// TODO: add real vdf
 	return result
 }
 
@@ -1706,7 +1707,9 @@ func (bc *BlockChain) GetVrfByNumber(number uint64) [32]byte {
 	if header == nil {
 		return [32]byte{}
 	}
-	return header.Vrf
+	//return header.Vrf
+	// TODO: add real vrf
+	return [32]byte{}
 }
 
 // GetShardState returns the shard state for the given epoch,

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -259,9 +259,6 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 		ShardStateHash: g.ShardStateHash,
 		ShardState:     shardStateBytes,
 	}
-	if g.GasLimit == 0 {
-		head.GasLimit = 10000000000 // TODO(RJ): figure out better solution. // params.GenesisGasLimit
-	}
 	statedb.Commit(false)
 	statedb.Database().TrieDB().Commit(root, true)
 

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -26,7 +26,7 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 )
 
-// MaxTrieCacheGen is trie cache generation limit after which to evict trie nodes from memory.
+// MaxTrieCacheGen limit after which to evict trie nodes from memory.
 var MaxTrieCacheGen = uint16(120)
 
 const (
@@ -72,13 +72,19 @@ type Trie interface {
 }
 
 // NewDatabase creates a backing store for state. The returned database is safe for
-// concurrent use and retains cached trie nodes in memory. The pool is an optional
-// intermediate trie-node memory pool between the low level storage layer and the
-// high level trie abstraction.
+// concurrent use and retains a few recent expanded trie nodes in memory. To keep
+// more historical state in memory, use the NewDatabaseWithCache constructor.
 func NewDatabase(db ethdb.Database) Database {
+	return NewDatabaseWithCache(db, 0)
+}
+
+// NewDatabaseWithCache creates a backing store for state. The returned database is safe for
+// concurrent use and retains both a few recent expanded trie nodes in memory, as
+// well as a lot of collapsed RLP trie nodes in a large memory cache.
+func NewDatabaseWithCache(db ethdb.Database, cache int) Database {
 	csc, _ := lru.New(codeSizeCacheSize)
 	return &cachingDB{
-		db:            trie.NewDatabase(db),
+		db:            trie.NewDatabaseWithCache(db, cache),
 		codeSizeCache: csc,
 	}
 }

--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -35,22 +35,22 @@ type DumpAccount struct {
 	Storage  map[string]string `json:"storage"`
 }
 
-// Dump is the structure of root hash and associated accounts.
+// Dump ...
 type Dump struct {
 	Root     string                 `json:"root"`
 	Accounts map[string]DumpAccount `json:"accounts"`
 }
 
-// RawDump returns Dump from given DB.
-func (stateDB *DB) RawDump() Dump {
+// RawDump ...
+func (db *DB) RawDump() Dump {
 	dump := Dump{
-		Root:     fmt.Sprintf("%x", stateDB.trie.Hash()),
+		Root:     fmt.Sprintf("%x", db.trie.Hash()),
 		Accounts: make(map[string]DumpAccount),
 	}
 
-	it := trie.NewIterator(stateDB.trie.NodeIterator(nil))
+	it := trie.NewIterator(db.trie.NodeIterator(nil))
 	for it.Next() {
-		addr := stateDB.trie.GetKey(it.Key)
+		addr := db.trie.GetKey(it.Key)
 		var data Account
 		if err := rlp.DecodeBytes(it.Value, &data); err != nil {
 			panic(err)
@@ -62,21 +62,21 @@ func (stateDB *DB) RawDump() Dump {
 			Nonce:    data.Nonce,
 			Root:     common.Bytes2Hex(data.Root[:]),
 			CodeHash: common.Bytes2Hex(data.CodeHash),
-			Code:     common.Bytes2Hex(obj.Code(stateDB.db)),
+			Code:     common.Bytes2Hex(obj.Code(db.db)),
 			Storage:  make(map[string]string),
 		}
-		storageIt := trie.NewIterator(obj.getTrie(stateDB.db).NodeIterator(nil))
+		storageIt := trie.NewIterator(obj.getTrie(db.db).NodeIterator(nil))
 		for storageIt.Next() {
-			account.Storage[common.Bytes2Hex(stateDB.trie.GetKey(storageIt.Key))] = common.Bytes2Hex(storageIt.Value)
+			account.Storage[common.Bytes2Hex(db.trie.GetKey(storageIt.Key))] = common.Bytes2Hex(storageIt.Value)
 		}
 		dump.Accounts[common.Bytes2Hex(addr)] = account
 	}
 	return dump
 }
 
-// Dump dumps into []byte.
-func (stateDB *DB) Dump() []byte {
-	json, err := json.MarshalIndent(stateDB.RawDump(), "", "    ")
+// Dump ...
+func (db *DB) Dump() []byte {
+	json, err := json.MarshalIndent(db.RawDump(), "", "    ")
 	if err != nil {
 		fmt.Println("dump err", err)
 	}

--- a/core/state/managed_state.go
+++ b/core/state/managed_state.go
@@ -28,7 +28,7 @@ type account struct {
 	nonces      []bool
 }
 
-// ManagedState is the managed state.
+// ManagedState ...
 type ManagedState struct {
 	*DB
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"math/big"
 	"sort"
-	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -87,8 +86,6 @@ type DB struct {
 	journal        *journal
 	validRevisions []revision
 	nextRevisionID int
-
-	lock sync.Mutex
 }
 
 // New creates a new state from a given trie.
@@ -109,118 +106,118 @@ func New(root common.Hash, db Database) (*DB, error) {
 }
 
 // setError remembers the first non-nil error it is called with.
-func (stateDB *DB) setError(err error) {
-	if stateDB.dbErr == nil {
-		stateDB.dbErr = err
+func (db *DB) setError(err error) {
+	if db.dbErr == nil {
+		db.dbErr = err
 	}
 }
 
-func (stateDB *DB) Error() error {
-	return stateDB.dbErr
+func (db *DB) Error() error {
+	return db.dbErr
 }
 
 // Reset clears out all ephemeral state objects from the state db, but keeps
 // the underlying state trie to avoid reloading data for the next operations.
-func (stateDB *DB) Reset(root common.Hash) error {
-	tr, err := stateDB.db.OpenTrie(root)
+func (db *DB) Reset(root common.Hash) error {
+	tr, err := db.db.OpenTrie(root)
 	if err != nil {
 		return err
 	}
-	stateDB.trie = tr
-	stateDB.stateObjects = make(map[common.Address]*Object)
-	stateDB.stateObjectsDirty = make(map[common.Address]struct{})
-	stateDB.thash = common.Hash{}
-	stateDB.bhash = common.Hash{}
-	stateDB.txIndex = 0
-	stateDB.logs = make(map[common.Hash][]*types.Log)
-	stateDB.logSize = 0
-	stateDB.preimages = make(map[common.Hash][]byte)
-	stateDB.clearJournalAndRefund()
+	db.trie = tr
+	db.stateObjects = make(map[common.Address]*Object)
+	db.stateObjectsDirty = make(map[common.Address]struct{})
+	db.thash = common.Hash{}
+	db.bhash = common.Hash{}
+	db.txIndex = 0
+	db.logs = make(map[common.Hash][]*types.Log)
+	db.logSize = 0
+	db.preimages = make(map[common.Hash][]byte)
+	db.clearJournalAndRefund()
 	return nil
 }
 
-// AddLog adds logs into stateDB
-func (stateDB *DB) AddLog(log *types.Log) {
-	stateDB.journal.append(addLogChange{txhash: stateDB.thash})
+// AddLog ...
+func (db *DB) AddLog(log *types.Log) {
+	db.journal.append(addLogChange{txhash: db.thash})
 
-	log.TxHash = stateDB.thash
-	log.BlockHash = stateDB.bhash
-	log.TxIndex = uint(stateDB.txIndex)
-	log.Index = stateDB.logSize
-	stateDB.logs[stateDB.thash] = append(stateDB.logs[stateDB.thash], log)
-	stateDB.logSize++
+	log.TxHash = db.thash
+	log.BlockHash = db.bhash
+	log.TxIndex = uint(db.txIndex)
+	log.Index = db.logSize
+	db.logs[db.thash] = append(db.logs[db.thash], log)
+	db.logSize++
 }
 
-// GetLogs gets logs from stateDB given a hash
-func (stateDB *DB) GetLogs(hash common.Hash) []*types.Log {
-	return stateDB.logs[hash]
+// GetLogs ...
+func (db *DB) GetLogs(hash common.Hash) []*types.Log {
+	return db.logs[hash]
 }
 
-// Logs returns a list of Log.
-func (stateDB *DB) Logs() []*types.Log {
+// Logs ...
+func (db *DB) Logs() []*types.Log {
 	var logs []*types.Log
-	for _, lgs := range stateDB.logs {
+	for _, lgs := range db.logs {
 		logs = append(logs, lgs...)
 	}
 	return logs
 }
 
 // AddPreimage records a SHA3 preimage seen by the VM.
-func (stateDB *DB) AddPreimage(hash common.Hash, preimage []byte) {
-	if _, ok := stateDB.preimages[hash]; !ok {
-		stateDB.journal.append(addPreimageChange{hash: hash})
+func (db *DB) AddPreimage(hash common.Hash, preimage []byte) {
+	if _, ok := db.preimages[hash]; !ok {
+		db.journal.append(addPreimageChange{hash: hash})
 		pi := make([]byte, len(preimage))
 		copy(pi, preimage)
-		stateDB.preimages[hash] = pi
+		db.preimages[hash] = pi
 	}
 }
 
 // Preimages returns a list of SHA3 preimages that have been submitted.
-func (stateDB *DB) Preimages() map[common.Hash][]byte {
-	return stateDB.preimages
+func (db *DB) Preimages() map[common.Hash][]byte {
+	return db.preimages
 }
 
 // AddRefund adds gas to the refund counter
-func (stateDB *DB) AddRefund(gas uint64) {
-	stateDB.journal.append(refundChange{prev: stateDB.refund})
-	stateDB.refund += gas
+func (db *DB) AddRefund(gas uint64) {
+	db.journal.append(refundChange{prev: db.refund})
+	db.refund += gas
 }
 
 // SubRefund removes gas from the refund counter.
 // This method will panic if the refund counter goes below zero
-func (stateDB *DB) SubRefund(gas uint64) {
-	stateDB.journal.append(refundChange{prev: stateDB.refund})
-	if gas > stateDB.refund {
+func (db *DB) SubRefund(gas uint64) {
+	db.journal.append(refundChange{prev: db.refund})
+	if gas > db.refund {
 		panic("Refund counter below zero")
 	}
-	stateDB.refund -= gas
+	db.refund -= gas
 }
 
 // Exist reports whether the given account address exists in the state.
 // Notably this also returns true for suicided accounts.
-func (stateDB *DB) Exist(addr common.Address) bool {
-	return stateDB.getStateObject(addr) != nil
+func (db *DB) Exist(addr common.Address) bool {
+	return db.getStateObject(addr) != nil
 }
 
 // Empty returns whether the state object is either non-existent
 // or empty according to the EIP161 specification (balance = nonce = code = 0)
-func (stateDB *DB) Empty(addr common.Address) bool {
-	so := stateDB.getStateObject(addr)
+func (db *DB) Empty(addr common.Address) bool {
+	so := db.getStateObject(addr)
 	return so == nil || so.empty()
 }
 
 // GetBalance retrieves the balance from the given address or 0 if object not found
-func (stateDB *DB) GetBalance(addr common.Address) *big.Int {
-	stateObject := stateDB.getStateObject(addr)
+func (db *DB) GetBalance(addr common.Address) *big.Int {
+	stateObject := db.getStateObject(addr)
 	if stateObject != nil {
 		return stateObject.Balance()
 	}
 	return common.Big0
 }
 
-// GetNonce returns the nonce of the given address.
-func (stateDB *DB) GetNonce(addr common.Address) uint64 {
-	stateObject := stateDB.getStateObject(addr)
+// GetNonce ...
+func (db *DB) GetNonce(addr common.Address) uint64 {
+	stateObject := db.getStateObject(addr)
 	if stateObject != nil {
 		return stateObject.Nonce()
 	}
@@ -228,34 +225,34 @@ func (stateDB *DB) GetNonce(addr common.Address) uint64 {
 	return 0
 }
 
-// GetCode returns code of a given address.
-func (stateDB *DB) GetCode(addr common.Address) []byte {
-	stateObject := stateDB.getStateObject(addr)
+// GetCode ...
+func (db *DB) GetCode(addr common.Address) []byte {
+	stateObject := db.getStateObject(addr)
 	if stateObject != nil {
-		return stateObject.Code(stateDB.db)
+		return stateObject.Code(db.db)
 	}
 	return nil
 }
 
-// GetCodeSize returns code size of a given address in stateDB.
-func (stateDB *DB) GetCodeSize(addr common.Address) int {
-	stateObject := stateDB.getStateObject(addr)
+// GetCodeSize ...
+func (db *DB) GetCodeSize(addr common.Address) int {
+	stateObject := db.getStateObject(addr)
 	if stateObject == nil {
 		return 0
 	}
 	if stateObject.code != nil {
 		return len(stateObject.code)
 	}
-	size, err := stateDB.db.ContractCodeSize(stateObject.addrHash, common.BytesToHash(stateObject.CodeHash()))
+	size, err := db.db.ContractCodeSize(stateObject.addrHash, common.BytesToHash(stateObject.CodeHash()))
 	if err != nil {
-		stateDB.setError(err)
+		db.setError(err)
 	}
 	return size
 }
 
-// GetCodeHash returns code hash of a given address.
-func (stateDB *DB) GetCodeHash(addr common.Address) common.Hash {
-	stateObject := stateDB.getStateObject(addr)
+// GetCodeHash ...
+func (db *DB) GetCodeHash(addr common.Address) common.Hash {
+	stateObject := db.getStateObject(addr)
 	if stateObject == nil {
 		return common.Hash{}
 	}
@@ -263,25 +260,25 @@ func (stateDB *DB) GetCodeHash(addr common.Address) common.Hash {
 }
 
 // GetState retrieves a value from the given account's storage trie.
-func (stateDB *DB) GetState(addr common.Address, hash common.Hash) common.Hash {
-	stateObject := stateDB.getStateObject(addr)
+func (db *DB) GetState(addr common.Address, hash common.Hash) common.Hash {
+	stateObject := db.getStateObject(addr)
 	if stateObject != nil {
-		return stateObject.GetState(stateDB.db, hash)
+		return stateObject.GetState(db.db, hash)
 	}
 	return common.Hash{}
 }
 
 // GetProof returns the MerkleProof for a given Account
-func (stateDB *DB) GetProof(a common.Address) ([][]byte, error) {
+func (db *DB) GetProof(a common.Address) ([][]byte, error) {
 	var proof proofList
-	err := stateDB.trie.Prove(crypto.Keccak256(a.Bytes()), 0, &proof)
+	err := db.trie.Prove(crypto.Keccak256(a.Bytes()), 0, &proof)
 	return [][]byte(proof), err
 }
 
 // GetStorageProof returns the StorageProof for given key
-func (stateDB *DB) GetStorageProof(a common.Address, key common.Hash) ([][]byte, error) {
+func (db *DB) GetStorageProof(a common.Address, key common.Hash) ([][]byte, error) {
 	var proof proofList
-	trie := stateDB.StorageTrie(a)
+	trie := db.StorageTrie(a)
 	if trie == nil {
 		return proof, errors.New("storage trie for requested address does not exist")
 	}
@@ -290,33 +287,33 @@ func (stateDB *DB) GetStorageProof(a common.Address, key common.Hash) ([][]byte,
 }
 
 // GetCommittedState retrieves a value from the given account's committed storage trie.
-func (stateDB *DB) GetCommittedState(addr common.Address, hash common.Hash) common.Hash {
-	stateObject := stateDB.getStateObject(addr)
+func (db *DB) GetCommittedState(addr common.Address, hash common.Hash) common.Hash {
+	stateObject := db.getStateObject(addr)
 	if stateObject != nil {
-		return stateObject.GetCommittedState(stateDB.db, hash)
+		return stateObject.GetCommittedState(db.db, hash)
 	}
 	return common.Hash{}
 }
 
 // Database retrieves the low level database supporting the lower level trie ops.
-func (stateDB *DB) Database() Database {
-	return stateDB.db
+func (db *DB) Database() Database {
+	return db.db
 }
 
 // StorageTrie returns the storage trie of an account.
 // The return value is a copy and is nil for non-existent accounts.
-func (stateDB *DB) StorageTrie(addr common.Address) Trie {
-	stateObject := stateDB.getStateObject(addr)
+func (db *DB) StorageTrie(addr common.Address) Trie {
+	stateObject := db.getStateObject(addr)
 	if stateObject == nil {
 		return nil
 	}
-	cpy := stateObject.deepCopy(stateDB)
-	return cpy.updateTrie(stateDB.db)
+	cpy := stateObject.deepCopy(db)
+	return cpy.updateTrie(db.db)
 }
 
-// HasSuicided checks if the state object of the given addr is suicided.
-func (stateDB *DB) HasSuicided(addr common.Address) bool {
-	stateObject := stateDB.getStateObject(addr)
+// HasSuicided ...
+func (db *DB) HasSuicided(addr common.Address) bool {
+	stateObject := db.getStateObject(addr)
 	if stateObject != nil {
 		return stateObject.suicided
 	}
@@ -328,50 +325,50 @@ func (stateDB *DB) HasSuicided(addr common.Address) bool {
  */
 
 // AddBalance adds amount to the account associated with addr.
-func (stateDB *DB) AddBalance(addr common.Address, amount *big.Int) {
-	stateObject := stateDB.GetOrNewStateObject(addr)
+func (db *DB) AddBalance(addr common.Address, amount *big.Int) {
+	stateObject := db.GetOrNewStateObject(addr)
 	if stateObject != nil {
 		stateObject.AddBalance(amount)
 	}
 }
 
 // SubBalance subtracts amount from the account associated with addr.
-func (stateDB *DB) SubBalance(addr common.Address, amount *big.Int) {
-	stateObject := stateDB.GetOrNewStateObject(addr)
+func (db *DB) SubBalance(addr common.Address, amount *big.Int) {
+	stateObject := db.GetOrNewStateObject(addr)
 	if stateObject != nil {
 		stateObject.SubBalance(amount)
 	}
 }
 
-// SetBalance sets balance of an address.
-func (stateDB *DB) SetBalance(addr common.Address, amount *big.Int) {
-	stateObject := stateDB.GetOrNewStateObject(addr)
+// SetBalance ...
+func (db *DB) SetBalance(addr common.Address, amount *big.Int) {
+	stateObject := db.GetOrNewStateObject(addr)
 	if stateObject != nil {
 		stateObject.SetBalance(amount)
 	}
 }
 
-// SetNonce sets nonce of a given address.
-func (stateDB *DB) SetNonce(addr common.Address, nonce uint64) {
-	stateObject := stateDB.GetOrNewStateObject(addr)
+// SetNonce ...
+func (db *DB) SetNonce(addr common.Address, nonce uint64) {
+	stateObject := db.GetOrNewStateObject(addr)
 	if stateObject != nil {
 		stateObject.SetNonce(nonce)
 	}
 }
 
-// SetCode sets code of a given address.
-func (stateDB *DB) SetCode(addr common.Address, code []byte) {
-	stateObject := stateDB.GetOrNewStateObject(addr)
+// SetCode ...
+func (db *DB) SetCode(addr common.Address, code []byte) {
+	stateObject := db.GetOrNewStateObject(addr)
 	if stateObject != nil {
 		stateObject.SetCode(crypto.Keccak256Hash(code), code)
 	}
 }
 
-// SetState sets hash value of a given address.
-func (stateDB *DB) SetState(addr common.Address, key, value common.Hash) {
-	stateObject := stateDB.GetOrNewStateObject(addr)
+// SetState ...
+func (db *DB) SetState(addr common.Address, key, value common.Hash) {
+	stateObject := db.GetOrNewStateObject(addr)
 	if stateObject != nil {
-		stateObject.SetState(stateDB.db, key, value)
+		stateObject.SetState(db.db, key, value)
 	}
 }
 
@@ -380,12 +377,12 @@ func (stateDB *DB) SetState(addr common.Address, key, value common.Hash) {
 //
 // The account's state object is still available until the state is committed,
 // getStateObject will return a non-nil account after Suicide.
-func (stateDB *DB) Suicide(addr common.Address) bool {
-	stateObject := stateDB.getStateObject(addr)
+func (db *DB) Suicide(addr common.Address) bool {
+	stateObject := db.getStateObject(addr)
 	if stateObject == nil {
 		return false
 	}
-	stateDB.journal.append(suicideChange{
+	db.journal.append(suicideChange{
 		account:     &addr,
 		prev:        stateObject.suicided,
 		prevbalance: new(big.Int).Set(stateObject.Balance()),
@@ -401,26 +398,26 @@ func (stateDB *DB) Suicide(addr common.Address) bool {
 //
 
 // updateStateObject writes the given object to the trie.
-func (stateDB *DB) updateStateObject(stateObject *Object) {
+func (db *DB) updateStateObject(stateObject *Object) {
 	addr := stateObject.Address()
 	data, err := rlp.EncodeToBytes(stateObject)
 	if err != nil {
 		panic(fmt.Errorf("can't encode object at %x: %v", addr[:], err))
 	}
-	stateDB.setError(stateDB.trie.TryUpdate(addr[:], data))
+	db.setError(db.trie.TryUpdate(addr[:], data))
 }
 
 // deleteStateObject removes the given object from the state trie.
-func (stateDB *DB) deleteStateObject(stateObject *Object) {
+func (db *DB) deleteStateObject(stateObject *Object) {
 	stateObject.deleted = true
 	addr := stateObject.Address()
-	stateDB.setError(stateDB.trie.TryDelete(addr[:]))
+	db.setError(db.trie.TryDelete(addr[:]))
 }
 
 // Retrieve a state object given by the address. Returns nil if not found.
-func (stateDB *DB) getStateObject(addr common.Address) (stateObject *Object) {
+func (db *DB) getStateObject(addr common.Address) (stateObject *Object) {
 	// Prefer 'live' objects.
-	if obj := stateDB.stateObjects[addr]; obj != nil {
+	if obj := db.stateObjects[addr]; obj != nil {
 		if obj.deleted {
 			return nil
 		}
@@ -428,9 +425,9 @@ func (stateDB *DB) getStateObject(addr common.Address) (stateObject *Object) {
 	}
 
 	// Load the object from the database.
-	enc, err := stateDB.trie.TryGet(addr[:])
+	enc, err := db.trie.TryGet(addr[:])
 	if len(enc) == 0 {
-		stateDB.setError(err)
+		db.setError(err)
 		return nil
 	}
 	var data Account
@@ -439,36 +436,36 @@ func (stateDB *DB) getStateObject(addr common.Address) (stateObject *Object) {
 		return nil
 	}
 	// Insert into the live set.
-	obj := newObject(stateDB, addr, data)
-	stateDB.setStateObject(obj)
+	obj := newObject(db, addr, data)
+	db.setStateObject(obj)
 	return obj
 }
 
-func (stateDB *DB) setStateObject(object *Object) {
-	stateDB.stateObjects[object.Address()] = object
+func (db *DB) setStateObject(object *Object) {
+	db.stateObjects[object.Address()] = object
 }
 
 // GetOrNewStateObject retrieves a state object or create a new state object if nil.
-func (stateDB *DB) GetOrNewStateObject(addr common.Address) *Object {
-	stateObject := stateDB.getStateObject(addr)
+func (db *DB) GetOrNewStateObject(addr common.Address) *Object {
+	stateObject := db.getStateObject(addr)
 	if stateObject == nil || stateObject.deleted {
-		stateObject, _ = stateDB.createObject(addr)
+		stateObject, _ = db.createObject(addr)
 	}
 	return stateObject
 }
 
 // createObject creates a new state object. If there is an existing account with
 // the given address, it is overwritten and returned as the second return value.
-func (stateDB *DB) createObject(addr common.Address) (newobj, prev *Object) {
-	prev = stateDB.getStateObject(addr)
-	newobj = newObject(stateDB, addr, Account{})
+func (db *DB) createObject(addr common.Address) (newobj, prev *Object) {
+	prev = db.getStateObject(addr)
+	newobj = newObject(db, addr, Account{})
 	newobj.setNonce(0) // sets the object to dirty
 	if prev == nil {
-		stateDB.journal.append(createObjectChange{account: &addr})
+		db.journal.append(createObjectChange{account: &addr})
 	} else {
-		stateDB.journal.append(resetObjectChange{prev: prev})
+		db.journal.append(resetObjectChange{prev: prev})
 	}
-	stateDB.setStateObject(newobj)
+	db.setStateObject(newobj)
 	return newobj, prev
 }
 
@@ -482,22 +479,22 @@ func (stateDB *DB) createObject(addr common.Address) (newobj, prev *Object) {
 //   2. tx_create(sha(account ++ nonce)) (note that this gets the address of 1)
 //
 // Carrying over the balance ensures that Ether doesn't disappear.
-func (stateDB *DB) CreateAccount(addr common.Address) {
-	new, prev := stateDB.createObject(addr)
+func (db *DB) CreateAccount(addr common.Address) {
+	newObj, prev := db.createObject(addr)
 	if prev != nil {
-		new.setBalance(prev.data.Balance)
+		newObj.setBalance(prev.data.Balance)
 	}
 }
 
-// ForEachStorage runs a function on every item in state DB.
-func (stateDB *DB) ForEachStorage(addr common.Address, cb func(key, value common.Hash) bool) {
-	so := stateDB.getStateObject(addr)
+// ForEachStorage ...
+func (db *DB) ForEachStorage(addr common.Address, cb func(key, value common.Hash) bool) {
+	so := db.getStateObject(addr)
 	if so == nil {
 		return
 	}
-	it := trie.NewIterator(so.getTrie(stateDB.db).NodeIterator(nil))
+	it := trie.NewIterator(so.getTrie(db.db).NodeIterator(nil))
 	for it.Next() {
-		key := common.BytesToHash(stateDB.trie.GetKey(it.Key))
+		key := common.BytesToHash(db.trie.GetKey(it.Key))
 		if value, dirty := so.dirtyStorage[key]; dirty {
 			cb(key, value)
 			continue
@@ -508,29 +505,26 @@ func (stateDB *DB) ForEachStorage(addr common.Address, cb func(key, value common
 
 // Copy creates a deep, independent copy of the state.
 // Snapshots of the copied state cannot be applied to the copy.
-func (stateDB *DB) Copy() *DB {
-	stateDB.lock.Lock()
-	defer stateDB.lock.Unlock()
-
+func (db *DB) Copy() *DB {
 	// Copy all the basic fields, initialize the memory ones
 	state := &DB{
-		db:                stateDB.db,
-		trie:              stateDB.db.CopyTrie(stateDB.trie),
-		stateObjects:      make(map[common.Address]*Object, len(stateDB.journal.dirties)),
-		stateObjectsDirty: make(map[common.Address]struct{}, len(stateDB.journal.dirties)),
-		refund:            stateDB.refund,
-		logs:              make(map[common.Hash][]*types.Log, len(stateDB.logs)),
-		logSize:           stateDB.logSize,
+		db:                db.db,
+		trie:              db.db.CopyTrie(db.trie),
+		stateObjects:      make(map[common.Address]*Object, len(db.journal.dirties)),
+		stateObjectsDirty: make(map[common.Address]struct{}, len(db.journal.dirties)),
+		refund:            db.refund,
+		logs:              make(map[common.Hash][]*types.Log, len(db.logs)),
+		logSize:           db.logSize,
 		preimages:         make(map[common.Hash][]byte),
 		journal:           newJournal(),
 	}
 	// Copy the dirty states, logs, and preimages
-	for addr := range stateDB.journal.dirties {
+	for addr := range db.journal.dirties {
 		// As documented [here](https://github.com/ethereum/go-ethereum/pull/16485#issuecomment-380438527),
 		// and in the Finalise-method, there is a case where an object is in the journal but not
 		// in the stateObjects: OOG after touch on ripeMD prior to Byzantium. Thus, we need to check for
 		// nil
-		if object, exist := stateDB.stateObjects[addr]; exist {
+		if object, exist := db.stateObjects[addr]; exist {
 			state.stateObjects[addr] = object.deepCopy(state)
 			state.stateObjectsDirty[addr] = struct{}{}
 		}
@@ -538,13 +532,13 @@ func (stateDB *DB) Copy() *DB {
 	// Above, we don't copy the actual journal. This means that if the copy is copied, the
 	// loop above will be a no-op, since the copy's journal is empty.
 	// Thus, here we iterate over stateObjects, to enable copies of copies
-	for addr := range stateDB.stateObjectsDirty {
+	for addr := range db.stateObjectsDirty {
 		if _, exist := state.stateObjects[addr]; !exist {
-			state.stateObjects[addr] = stateDB.stateObjects[addr].deepCopy(state)
+			state.stateObjects[addr] = db.stateObjects[addr].deepCopy(state)
 			state.stateObjectsDirty[addr] = struct{}{}
 		}
 	}
-	for hash, logs := range stateDB.logs {
+	for hash, logs := range db.logs {
 		cpy := make([]*types.Log, len(logs))
 		for i, l := range logs {
 			cpy[i] = new(types.Log)
@@ -552,132 +546,132 @@ func (stateDB *DB) Copy() *DB {
 		}
 		state.logs[hash] = cpy
 	}
-	for hash, preimage := range stateDB.preimages {
+	for hash, preimage := range db.preimages {
 		state.preimages[hash] = preimage
 	}
 	return state
 }
 
 // Snapshot returns an identifier for the current revision of the state.
-func (stateDB *DB) Snapshot() int {
-	id := stateDB.nextRevisionID
-	stateDB.nextRevisionID++
-	stateDB.validRevisions = append(stateDB.validRevisions, revision{id, stateDB.journal.length()})
+func (db *DB) Snapshot() int {
+	id := db.nextRevisionID
+	db.nextRevisionID++
+	db.validRevisions = append(db.validRevisions, revision{id, db.journal.length()})
 	return id
 }
 
 // RevertToSnapshot reverts all state changes made since the given revision.
-func (stateDB *DB) RevertToSnapshot(revid int) {
+func (db *DB) RevertToSnapshot(revid int) {
 	// Find the snapshot in the stack of valid snapshots.
-	idx := sort.Search(len(stateDB.validRevisions), func(i int) bool {
-		return stateDB.validRevisions[i].id >= revid
+	idx := sort.Search(len(db.validRevisions), func(i int) bool {
+		return db.validRevisions[i].id >= revid
 	})
-	if idx == len(stateDB.validRevisions) || stateDB.validRevisions[idx].id != revid {
+	if idx == len(db.validRevisions) || db.validRevisions[idx].id != revid {
 		panic(fmt.Errorf("revision id %v cannot be reverted", revid))
 	}
-	snapshot := stateDB.validRevisions[idx].journalIndex
+	snapshot := db.validRevisions[idx].journalIndex
 
 	// Replay the journal to undo changes and remove invalidated snapshots
-	stateDB.journal.revert(stateDB, snapshot)
-	stateDB.validRevisions = stateDB.validRevisions[:idx]
+	db.journal.revert(db, snapshot)
+	db.validRevisions = db.validRevisions[:idx]
 }
 
 // GetRefund returns the current value of the refund counter.
-func (stateDB *DB) GetRefund() uint64 {
-	return stateDB.refund
+func (db *DB) GetRefund() uint64 {
+	return db.refund
 }
 
-// Finalise finalises the state by removing the self destructed objects
+// Finalise finalises the state by removing the db destructed objects
 // and clears the journal as well as the refunds.
-func (stateDB *DB) Finalise(deleteEmptyObjects bool) {
-	for addr := range stateDB.journal.dirties {
-		stateObject, exist := stateDB.stateObjects[addr]
+func (db *DB) Finalise(deleteEmptyObjects bool) {
+	for addr := range db.journal.dirties {
+		stateObject, exist := db.stateObjects[addr]
 		if !exist {
 			// ripeMD is 'touched' at block 1714175, in tx 0x1237f737031e40bcde4a8b7e717b2d15e3ecadfe49bb1bbc71ee9deb09c6fcf2
 			// That tx goes out of gas, and although the notion of 'touched' does not exist there, the
 			// touch-event will still be recorded in the journal. Since ripeMD is a special snowflake,
 			// it will persist in the journal even though the journal is reverted. In this special circumstance,
-			// it may exist in `s.journal.dirties` but not in `s.stateObjects`.
+			// it may exist in `db.journal.dirties` but not in `db.stateObjects`.
 			// Thus, we can safely ignore it here
 			continue
 		}
 
 		if stateObject.suicided || (deleteEmptyObjects && stateObject.empty()) {
-			stateDB.deleteStateObject(stateObject)
+			db.deleteStateObject(stateObject)
 		} else {
-			stateObject.updateRoot(stateDB.db)
-			stateDB.updateStateObject(stateObject)
+			stateObject.updateRoot(db.db)
+			db.updateStateObject(stateObject)
 		}
-		stateDB.stateObjectsDirty[addr] = struct{}{}
+		db.stateObjectsDirty[addr] = struct{}{}
 	}
 	// Invalidate journal because reverting across transactions is not allowed.
-	stateDB.clearJournalAndRefund()
+	db.clearJournalAndRefund()
 }
 
 // IntermediateRoot computes the current root hash of the state trie.
 // It is called in between transactions to get the root hash that
 // goes into transaction receipts.
-func (stateDB *DB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
-	stateDB.Finalise(deleteEmptyObjects)
-	return stateDB.trie.Hash()
+func (db *DB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
+	db.Finalise(deleteEmptyObjects)
+	return db.trie.Hash()
 }
 
 // Prepare sets the current transaction hash and index and block hash which is
 // used when the EVM emits new state logs.
-func (stateDB *DB) Prepare(thash, bhash common.Hash, ti int) {
-	stateDB.thash = thash
-	stateDB.bhash = bhash
-	stateDB.txIndex = ti
+func (db *DB) Prepare(thash, bhash common.Hash, ti int) {
+	db.thash = thash
+	db.bhash = bhash
+	db.txIndex = ti
 }
 
-func (stateDB *DB) clearJournalAndRefund() {
-	stateDB.journal = newJournal()
-	stateDB.validRevisions = stateDB.validRevisions[:0]
-	stateDB.refund = 0
+func (db *DB) clearJournalAndRefund() {
+	db.journal = newJournal()
+	db.validRevisions = db.validRevisions[:0]
+	db.refund = 0
 }
 
 // Commit writes the state to the underlying in-memory trie database.
-func (stateDB *DB) Commit(deleteEmptyObjects bool) (root common.Hash, err error) {
-	defer stateDB.clearJournalAndRefund()
+func (db *DB) Commit(deleteEmptyObjects bool) (root common.Hash, err error) {
+	defer db.clearJournalAndRefund()
 
-	for addr := range stateDB.journal.dirties {
-		stateDB.stateObjectsDirty[addr] = struct{}{}
+	for addr := range db.journal.dirties {
+		db.stateObjectsDirty[addr] = struct{}{}
 	}
 	// Commit objects to the trie.
-	for addr, stateObject := range stateDB.stateObjects {
-		_, isDirty := stateDB.stateObjectsDirty[addr]
+	for addr, stateObject := range db.stateObjects {
+		_, isDirty := db.stateObjectsDirty[addr]
 		switch {
 		case stateObject.suicided || (isDirty && deleteEmptyObjects && stateObject.empty()):
 			// If the object has been removed, don't bother syncing it
 			// and just mark it for deletion in the trie.
-			stateDB.deleteStateObject(stateObject)
+			db.deleteStateObject(stateObject)
 		case isDirty:
 			// Write any contract code associated with the state object
 			if stateObject.code != nil && stateObject.dirtyCode {
-				stateDB.db.TrieDB().InsertBlob(common.BytesToHash(stateObject.CodeHash()), stateObject.code)
+				db.db.TrieDB().InsertBlob(common.BytesToHash(stateObject.CodeHash()), stateObject.code)
 				stateObject.dirtyCode = false
 			}
 			// Write any storage changes in the state object to its storage trie.
-			if err := stateObject.CommitTrie(stateDB.db); err != nil {
+			if err := stateObject.CommitTrie(db.db); err != nil {
 				return common.Hash{}, err
 			}
 			// Update the object in the main account trie.
-			stateDB.updateStateObject(stateObject)
+			db.updateStateObject(stateObject)
 		}
-		delete(stateDB.stateObjectsDirty, addr)
+		delete(db.stateObjectsDirty, addr)
 	}
 	// Write trie changes.
-	root, err = stateDB.trie.Commit(func(leaf []byte, parent common.Hash) error {
+	root, err = db.trie.Commit(func(leaf []byte, parent common.Hash) error {
 		var account Account
 		if err := rlp.DecodeBytes(leaf, &account); err != nil {
 			return nil
 		}
 		if account.Root != emptyState {
-			stateDB.db.TrieDB().Reference(account.Root, parent)
+			db.db.TrieDB().Reference(account.Root, parent)
 		}
 		code := common.BytesToHash(account.CodeHash)
 		if code != emptyCode {
-			stateDB.db.TrieDB().Reference(code, parent)
+			db.db.TrieDB().Reference(code, parent)
 		}
 		return nil
 	})

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/harmony-one/harmony/core/types"
-	common2 "github.com/harmony-one/harmony/internal/common"
 )
 
 // Tests that updating a state trie does not leak any database writes prior to
@@ -281,7 +280,7 @@ func newTestAction(addr common.Address, r *rand.Rand) testAction {
 	action := actions[r.Intn(len(actions))]
 	var nameargs []string
 	if !action.noAddr {
-		nameargs = append(nameargs, common2.MustAddressToBech32(addr))
+		nameargs = append(nameargs, addr.Hex())
 	}
 	for _, i := range action.args {
 		action.args[i] = rand.Int63n(100)
@@ -367,7 +366,7 @@ func (test *snapshotTest) checkEqual(state, checkstate *DB) error {
 		var err error
 		checkeq := func(op string, a, b interface{}) bool {
 			if err == nil && !reflect.DeepEqual(a, b) {
-				err = fmt.Errorf("got %s(%s) == %v, want %v", op, common2.MustAddressToBech32(addr), a, b)
+				err = fmt.Errorf("got %s(%s) == %v, want %v", op, addr.Hex(), a, b)
 				return false
 			}
 			return true

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/harmony-one/harmony/core/types"
+	common2 "github.com/harmony-one/harmony/internal/common"
 )
 
 // Tests that updating a state trie does not leak any database writes prior to
@@ -280,7 +281,7 @@ func newTestAction(addr common.Address, r *rand.Rand) testAction {
 	action := actions[r.Intn(len(actions))]
 	var nameargs []string
 	if !action.noAddr {
-		nameargs = append(nameargs, addr.Hex())
+		nameargs = append(nameargs, common2.MustAddressToBech32(addr))
 	}
 	for _, i := range action.args {
 		action.args[i] = rand.Int63n(100)
@@ -366,7 +367,7 @@ func (test *snapshotTest) checkEqual(state, checkstate *DB) error {
 		var err error
 		checkeq := func(op string, a, b interface{}) bool {
 			if err == nil && !reflect.DeepEqual(a, b) {
-				err = fmt.Errorf("got %s(%s) == %v, want %v", op, addr.Hex(), a, b)
+				err = fmt.Errorf("got %s(%s) == %v, want %v", op, common2.MustAddressToBech32(addr), a, b)
 				return false
 			}
 			return true

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -59,6 +59,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.DB, cfg vm.C
 		receipts types.Receipts
 		usedGas  = new(uint64)
 		header   = block.Header()
+		coinbase = block.Header().Coinbase
 		allLogs  []*types.Log
 		gp       = new(GasPool).AddGas(block.GasLimit())
 	)
@@ -69,7 +70,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.DB, cfg vm.C
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
 		statedb.Prepare(tx.Hash(), block.Hash(), i)
-		receipt, _, err := ApplyTransaction(p.config, p.bc, &block.Header().Coinbase, gp, statedb, header, tx, usedGas, cfg)
+		receipt, _, err := ApplyTransaction(p.config, p.bc, &coinbase, gp, statedb, header, tx, usedGas, cfg)
 		if err != nil {
 			return nil, nil, 0, err
 		}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -25,6 +25,7 @@ import (
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/core/vm"
 	"github.com/harmony-one/harmony/internal/ctxerror"
+	"github.com/harmony-one/harmony/internal/utils"
 )
 
 // StateProcessor is a basic Processor, which takes care of transitioning
@@ -68,7 +69,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.DB, cfg vm.C
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
 		statedb.Prepare(tx.Hash(), block.Hash(), i)
-		receipt, _, err := ApplyTransaction(p.config, p.bc, nil, gp, statedb, header, tx, usedGas, cfg)
+		receipt, _, err := ApplyTransaction(p.config, p.bc, &block.Header().Coinbase, gp, statedb, header, tx, usedGas, cfg)
 		if err != nil {
 			return nil, nil, 0, err
 		}
@@ -93,6 +94,11 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	if err != nil {
 		return nil, 0, err
 	}
+	utils.GetLogInstance().Info("Root before transaction", "root", statedb.IntermediateRoot(false).Bytes())
+	utils.GetLogInstance().Info("config", "config", config)
+	utils.GetLogInstance().Info("tx", "txHash", tx.Hash(), "tx", tx)
+	utils.GetLogInstance().Info("header", "header", header)
+	utils.GetLogInstance().Info("author", "author", author)
 	// Create a new context to be used in the EVM environment
 	context := NewEVMContext(msg, header, bc, author)
 	// Create a new environment which holds all relevant information
@@ -112,6 +118,7 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	}
 	*usedGas += gas
 
+	utils.GetLogInstance().Info("Root after transaction", "root", statedb.IntermediateRoot(false).Bytes())
 	// Create a new receipt for the transaction, storing the intermediate root and gas used by the tx
 	// based on the eip phase, we're passing whether the root touch-delete accounts.
 	receipt := types.NewReceipt(root, failed, *usedGas)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -25,7 +25,6 @@ import (
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/core/vm"
 	"github.com/harmony-one/harmony/internal/ctxerror"
-	"github.com/harmony-one/harmony/internal/utils"
 )
 
 // StateProcessor is a basic Processor, which takes care of transitioning
@@ -95,11 +94,6 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	if err != nil {
 		return nil, 0, err
 	}
-	utils.GetLogInstance().Info("Root before transaction", "root", statedb.IntermediateRoot(false).Bytes())
-	utils.GetLogInstance().Info("config", "config", config)
-	utils.GetLogInstance().Info("tx", "txHash", tx.Hash(), "tx", tx)
-	utils.GetLogInstance().Info("header", "header", header)
-	utils.GetLogInstance().Info("author", "author", author)
 	// Create a new context to be used in the EVM environment
 	context := NewEVMContext(msg, header, bc, author)
 	// Create a new environment which holds all relevant information
@@ -119,7 +113,6 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	}
 	*usedGas += gas
 
-	utils.GetLogInstance().Info("Root after transaction", "root", statedb.IntermediateRoot(false).Bytes())
 	// Create a new receipt for the transaction, storing the intermediate root and gas used by the tx
 	// based on the eip phase, we're passing whether the root touch-delete accounts.
 	receipt := types.NewReceipt(root, failed, *usedGas)

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -241,6 +241,7 @@ func NewBlock(header *Header, txs []*Transaction, receipts []*Receipt) *Block {
 	} else {
 		b.header.ReceiptHash = DeriveSha(Receipts(receipts))
 		b.header.Bloom = CreateBloom(receipts)
+		utils.GetLogInstance().Info("Receipt Root Proposed2", "root", b.header.ReceiptHash.Hex(), "len", len(receipts))
 	}
 
 	return b

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -89,13 +89,8 @@ type Header struct {
 	ShardID             uint32      `json:"shardID"          gencodec:"required"`
 	LastCommitSignature [96]byte    `json:"lastCommitSignature"  gencodec:"required"`
 	LastCommitBitmap    []byte      `json:"lastCommitBitmap"     gencodec:"required"` // Contains which validator signed
-	Vrf                 [32]byte    `json:"vrf"`
-	VrfProof            [96]byte    `json:"vrfProof"`
-	Vdf                 [258]byte   `json:"vdf"`
-	VdfProof            [258]byte   `json:"vdfProof"`
 	ShardStateHash      common.Hash `json:"shardStateRoot"`
 	ShardState          []byte      `json:"shardState"`
-	CrossLinks          []byte      `json:"crossLinks"`
 }
 
 // field type overrides for gencodec
@@ -279,10 +274,10 @@ func CopyHeader(h *Header) *Header {
 		cpy.ShardState = make([]byte, len(h.ShardState))
 		copy(cpy.ShardState, h.ShardState)
 	}
-	if len(h.CrossLinks) > 0 {
-		cpy.CrossLinks = make([]byte, len(h.CrossLinks))
-		copy(cpy.CrossLinks, h.CrossLinks)
-	}
+	//if len(h.CrossLinks) > 0 {
+	//	cpy.CrossLinks = make([]byte, len(h.CrossLinks))
+	//	copy(cpy.CrossLinks, h.CrossLinks)
+	//}
 	return &cpy
 }
 
@@ -488,15 +483,15 @@ func Number(b1, b2 *Block) bool {
 	return b1.header.Number.Cmp(b2.header.Number) < 0
 }
 
-// AddVdf add vdf into block header
-func (b *Block) AddVdf(vdf [258]byte) {
-	b.header.Vdf = vdf
-}
-
-// AddVrf add vrf into block header
-func (b *Block) AddVrf(vrf [32]byte) {
-	b.header.Vrf = vrf
-}
+//// AddVdf add vdf into block header
+//func (b *Block) AddVdf(vdf [258]byte) {
+//	b.header.Vdf = vdf
+//}
+//
+//// AddVrf add vrf into block header
+//func (b *Block) AddVrf(vrf [32]byte) {
+//	b.header.Vrf = vrf
+//}
 
 // AddShardState add shardState into block header
 func (b *Block) AddShardState(shardState ShardState) error {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -236,7 +236,6 @@ func NewBlock(header *Header, txs []*Transaction, receipts []*Receipt) *Block {
 	} else {
 		b.header.ReceiptHash = DeriveSha(Receipts(receipts))
 		b.header.Bloom = CreateBloom(receipts)
-		utils.GetLogInstance().Info("Receipt Root Proposed2", "root", b.header.ReceiptHash.Hex(), "len", len(receipts))
 	}
 
 	return b

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -265,6 +265,9 @@ func CopyHeader(h *Header) *Header {
 	if cpy.Number = new(big.Int); h.Number != nil {
 		cpy.Number.Set(h.Number)
 	}
+	if cpy.ViewID = new(big.Int); h.ViewID != nil {
+		cpy.ViewID.Set(h.ViewID)
+	}
 	if cpy.Epoch = new(big.Int); h.Epoch != nil {
 		cpy.Epoch.Set(h.Epoch)
 	}

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -22,8 +22,6 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-
-	common2 "github.com/harmony-one/harmony/internal/common"
 )
 
 // precompiledTest defines the input/output pairs for precompiled contract tests.
@@ -339,7 +337,7 @@ var bn256PairingTests = []precompiledTest{
 }
 
 func testPrecompiled(addr string, test precompiledTest, t *testing.T) {
-	p := PrecompiledContractsByzantium[common2.ParseAddr(addr)]
+	p := PrecompiledContractsByzantium[common.HexToAddress(addr)]
 	in := common.Hex2Bytes(test.input)
 	contract := NewContract(AccountRef(common.HexToAddress("1337")),
 		nil, new(big.Int), p.RequiredGas(in))
@@ -356,7 +354,7 @@ func benchmarkPrecompiled(addr string, test precompiledTest, bench *testing.B) {
 	if test.noBenchmark {
 		return
 	}
-	p := PrecompiledContractsByzantium[common2.ParseAddr(addr)]
+	p := PrecompiledContractsByzantium[common.HexToAddress(addr)]
 	in := common.Hex2Bytes(test.input)
 	reqGas := p.RequiredGas(in)
 	contract := NewContract(AccountRef(common.HexToAddress("1337")),

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -102,7 +102,7 @@ type Context struct {
 type EVM struct {
 	// Context provides auxiliary blockchain related information
 	Context
-	// StateDB gives access to the underlying state
+	// DB gives access to the underlying state
 	StateDB StateDB
 	// Depth is the current call stack
 	depth int
@@ -338,6 +338,12 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	// only.
 	contract := NewContract(caller, to, new(big.Int), gas)
 	contract.SetCallCode(&addr, evm.StateDB.GetCodeHash(addr), evm.StateDB.GetCode(addr))
+
+	// We do an AddBalance of zero here, just in order to trigger a touch.
+	// This doesn't matter on Mainnet, where all empties are gone at the time of Byzantium,
+	// but is the correct thing to do and matters on other networks, in tests, and potential
+	// future scenarios
+	evm.StateDB.AddBalance(addr, bigZero)
 
 	// When an error was returned by the EVM or when setting the creation code
 	// above we revert to the snapshot and consume any gas remaining. Additionally

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -121,7 +121,9 @@ func gasSStore(gt params.GasTable, evm *EVM, contract *Contract, stack *Stack, m
 		current = evm.StateDB.GetState(contract.Address(), common.BigToHash(x))
 	)
 	// The legacy gas metering only takes into consideration the current state
-	if !evm.chainRules.IsConstantinople {
+	// Legacy rules should be applied if we are in Petersburg (removal of EIP-1283)
+	// OR Constantinople is not active
+	if evm.chainRules.IsPetersburg || !evm.chainRules.IsConstantinople {
 		// This checks for 3 scenario's and calculates gas accordingly:
 		//
 		// 1. From a zero-value address to a non-zero value         (NEW VALUE)

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -544,7 +544,12 @@ func opExtCodeCopy(pc *uint64, interpreter *EVMInterpreter, contract *Contract, 
 // this account should be regarded as a non-existent account and zero should be returned.
 func opExtCodeHash(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	slot := stack.peek()
-	slot.SetBytes(interpreter.evm.StateDB.GetCodeHash(common.BigToAddress(slot)).Bytes())
+	address := common.BigToAddress(slot)
+	if interpreter.evm.StateDB.Empty(address) {
+		slot.SetUint64(0)
+	} else {
+		slot.SetBytes(interpreter.evm.StateDB.GetCodeHash(address).Bytes())
+	}
 	return nil, nil
 }
 

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -99,16 +99,17 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 	// the jump table was initialised. If it was not
 	// we'll set the default jump table.
 	if !cfg.JumpTable[STOP].valid {
-		switch {
-		case evm.ChainConfig().IsConstantinople(evm.BlockNumber):
-			cfg.JumpTable = constantinopleInstructionSet
-		case evm.ChainConfig().IsByzantium(evm.BlockNumber):
-			cfg.JumpTable = byzantiumInstructionSet
-		case evm.ChainConfig().IsHomestead(evm.BlockNumber):
-			cfg.JumpTable = homesteadInstructionSet
-		default:
-			cfg.JumpTable = frontierInstructionSet
-		}
+		//switch {
+		//case evm.ChainConfig().IsConstantinople(evm.BlockNumber):
+		//	cfg.JumpTable = constantinopleInstructionSet
+		//case evm.ChainConfig().IsByzantium(evm.BlockNumber):
+		//	cfg.JumpTable = byzantiumInstructionSet
+		//case evm.ChainConfig().IsHomestead(evm.BlockNumber):
+		//	cfg.JumpTable = homesteadInstructionSet
+		//default:
+		//	cfg.JumpTable = frontierInstructionSet
+		//}
+		cfg.JumpTable = constantinopleInstructionSet
 	}
 
 	return &EVMInterpreter{

--- a/core/vm/logger_json.go
+++ b/core/vm/logger_json.go
@@ -1,0 +1,89 @@
+// Copyright 2017 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package vm
+
+import (
+	"encoding/json"
+	"io"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
+)
+
+// JSONLogger ...
+type JSONLogger struct {
+	encoder *json.Encoder
+	cfg     *LogConfig
+}
+
+// NewJSONLogger creates a new EVM tracer that prints execution steps as JSON objects
+// into the provided stream.
+func NewJSONLogger(cfg *LogConfig, writer io.Writer) *JSONLogger {
+	l := &JSONLogger{json.NewEncoder(writer), cfg}
+	if l.cfg == nil {
+		l.cfg = &LogConfig{}
+	}
+	return l
+}
+
+// CaptureStart ...
+func (l *JSONLogger) CaptureStart(from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) error {
+	return nil
+}
+
+// CaptureState outputs state information on the logger.
+func (l *JSONLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost uint64, memory *Memory, stack *Stack, contract *Contract, depth int, err error) error {
+	log := StructLog{
+		Pc:            pc,
+		Op:            op,
+		Gas:           gas,
+		GasCost:       cost,
+		MemorySize:    memory.Len(),
+		Storage:       nil,
+		Depth:         depth,
+		RefundCounter: env.StateDB.GetRefund(),
+		Err:           err,
+	}
+	if !l.cfg.DisableMemory {
+		log.Memory = memory.Data()
+	}
+	if !l.cfg.DisableStack {
+		log.Stack = stack.Data()
+	}
+	return l.encoder.Encode(log)
+}
+
+// CaptureFault outputs state information on the logger.
+func (l *JSONLogger) CaptureFault(env *EVM, pc uint64, op OpCode, gas, cost uint64, memory *Memory, stack *Stack, contract *Contract, depth int, err error) error {
+	return nil
+}
+
+// CaptureEnd is triggered at end of execution.
+func (l *JSONLogger) CaptureEnd(output []byte, gasUsed uint64, t time.Duration, err error) error {
+	type endLog struct {
+		Output  string              `json:"output"`
+		GasUsed math.HexOrDecimal64 `json:"gasUsed"`
+		Time    time.Duration       `json:"time"`
+		Err     string              `json:"error,omitempty"`
+	}
+	if err != nil {
+		return l.encoder.Encode(endLog{common.Bytes2Hex(output), math.HexOrDecimal64(gasUsed), t, err.Error()})
+	}
+	return l.encoder.Encode(endLog{common.Bytes2Hex(output), math.HexOrDecimal64(gasUsed), t, ""})
+}

--- a/core/vm/logger_test.go
+++ b/core/vm/logger_test.go
@@ -46,10 +46,7 @@ type dummyStatedb struct {
 	state.DB
 }
 
-// GetRefund ...
-func (*dummyStatedb) GetRefund() uint64 {
-	return 1337
-}
+func (*dummyStatedb) GetRefund() uint64 { return 1337 }
 
 func TestStoreCapture(t *testing.T) {
 	var (

--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -22,7 +22,7 @@ import (
 	"github.com/harmony-one/harmony/core/vm"
 )
 
-// NewEnv returns new EVM.
+// NewEnv ...
 func NewEnv(cfg *Config) *vm.EVM {
 	context := vm.Context{
 		CanTransfer: core.CanTransfer,

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -149,7 +149,6 @@ func BenchmarkCall(b *testing.B) {
 		}
 	}
 }
-
 func benchmarkEVMCreate(bench *testing.B, code string) {
 	var (
 		statedb, _ = state.New(common.Hash{}, state.NewDatabase(ethdb.NewMemDatabase()))

--- a/drand/drand_leader.go
+++ b/drand/drand_leader.go
@@ -121,7 +121,7 @@ func (dRand *DRand) processCommitMessage(message *msg_pb.Message) {
 		utils.GetLogInstance().Debug("Failed to deserialize BLS public key", "error", err)
 		return
 	}
-	validatorAddress := utils.GetBlsAddress(senderPubKey)
+	validatorAddress := senderPubKey.SerializeToHexStr()
 
 	if !dRand.IsValidatorInCommittee(validatorAddress) {
 		utils.GetLogInstance().Error("Invalid validator", "validatorAddress", validatorAddress)

--- a/drand/drand_leader.go
+++ b/drand/drand_leader.go
@@ -33,7 +33,8 @@ func (dRand *DRand) WaitForEpochBlock(blockChannel chan *types.Block, stopChan c
 				if core.IsEpochLastBlock(newBlock) {
 					dRand.init(newBlock)
 				}
-				pRnd := newBlock.Header().Vrf
+				// TODO: use real vrf
+				pRnd := [32]byte{} //newBlock.Header().Vrf
 				zeros := [32]byte{}
 				if core.IsEpochBlock(newBlock) && !bytes.Equal(pRnd[:], zeros[:]) {
 					// The epoch block should contain the randomness preimage pRnd

--- a/internal/configs/node/config.go
+++ b/internal/configs/node/config.go
@@ -127,6 +127,9 @@ var onceForConfigs sync.Once
 func GetShardConfig(shardID uint32) *ConfigType {
 	onceForConfigs.Do(func() {
 		shardConfigs = make([]ConfigType, MaxShards)
+		for i := range shardConfigs {
+			shardConfigs[i].ShardID = uint32(i)
+		}
 	})
 	if int(shardID) >= cap(shardConfigs) {
 		return nil

--- a/internal/hmyapi/backend.go
+++ b/internal/hmyapi/backend.go
@@ -40,7 +40,7 @@ type Backend interface {
 	GetBlock(ctx context.Context, blockHash common.Hash) (*types.Block, error)
 	GetReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error)
 	// GetTd(blockHash common.Hash) *big.Int
-	// GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header) (*vm.EVM, func() error, error)
+	// GetEVM(ctx context.Context, msg core.Message, state *state.DB, header *types.Header) (*vm.EVM, func() error, error)
 	SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription
 	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription
 	SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) event.Subscription

--- a/internal/shardchain/shardchains.go
+++ b/internal/shardchain/shardchains.go
@@ -1,9 +1,10 @@
 package shardchain
 
 import (
+	"math/big"
 	"sync"
 
-	"github.com/harmony-one/harmony/internal/configs/node"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -102,7 +103,7 @@ func (sc *CollectionImpl) ShardChain(shardID uint32, networkType nodeconfig.Netw
 		chainConfig = *params.TestnetChainConfig
 	}
 
-	//chainConfig.ChainID = big.NewInt(int64(shardID))
+	chainConfig.ChainID = big.NewInt(int64(shardID))
 
 	bc, err := core.NewBlockChain(
 		db, cacheConfig, &chainConfig, sc.engine, vm.Config{}, nil,

--- a/internal/shardchain/shardchains.go
+++ b/internal/shardchain/shardchains.go
@@ -1,10 +1,9 @@
 package shardchain
 
 import (
-	"math/big"
 	"sync"
 
-	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
+	"github.com/harmony-one/harmony/internal/configs/node"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -103,7 +102,7 @@ func (sc *CollectionImpl) ShardChain(shardID uint32, networkType nodeconfig.Netw
 		chainConfig = *params.TestnetChainConfig
 	}
 
-	chainConfig.ChainID = big.NewInt(int64(shardID))
+	//chainConfig.ChainID = big.NewInt(int64(shardID))
 
 	bc, err := core.NewBlockChain(
 		db, cacheConfig, &chainConfig, sc.engine, vm.Config{}, nil,

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -225,14 +225,6 @@ func IsPrivateIP(ip net.IP) bool {
 	return false
 }
 
-// GetBlsAddress returns the address of consensus BLS pubKey.
-func GetBlsAddress(key *bls.PublicKey) common.Address {
-	addr := common.Address{}
-	addrBytes := key.GetAddress()
-	addr.SetBytes(addrBytes[:])
-	return addr
-}
-
 // GetPortFromDiff returns the port from base and the diff.
 func GetPortFromDiff(port string, diff int) string {
 	if portNum, err := strconv.Atoi(port); err == nil {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -6,9 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/harmony-one/bls/ffi/go/bls"
-	"github.com/harmony-one/harmony/crypto/pki"
-	p2p "github.com/harmony-one/harmony/p2p"
+	"github.com/harmony-one/harmony/p2p"
 	crypto "github.com/libp2p/go-libp2p-crypto"
 	"github.com/stretchr/testify/assert"
 )
@@ -205,30 +203,4 @@ func TestStringsToPeers(t *testing.T) {
 			}
 		}
 	}
-}
-
-func TestGetBlsAddress(t *testing.T) {
-	pubKey1 := pki.GetBLSPrivateKeyFromInt(333).GetPublicKey()
-	pubKey2 := pki.GetBLSPrivateKeyFromInt(1024).GetPublicKey()
-	tests := []struct {
-		key      *bls.PublicKey
-		expected string
-	}{
-		{
-			pubKey1,
-			"0x489e9EC9863A29B086Fb979cefCA02277FbE513d",
-		},
-		{
-			pubKey2,
-			"0x836a098a5E04015c2c331657a1B90DBCb154fb37",
-		},
-	}
-
-	for _, test := range tests {
-		result := GetBlsAddress(test.key)
-		if result.Hex() != test.expected {
-			t.Errorf("Hex Of %x is: %s, got: %s", test.key, test.expected, result.Hex())
-		}
-	}
-
 }

--- a/node/contract.go
+++ b/node/contract.go
@@ -18,6 +18,7 @@ import (
 	"github.com/harmony-one/harmony/contracts/structs"
 	"github.com/harmony-one/harmony/core/types"
 	common2 "github.com/harmony-one/harmony/internal/common"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/genesis"
 	"github.com/harmony-one/harmony/internal/utils"
 )
@@ -127,6 +128,9 @@ func (node *Node) QueryStakeInfo() *structs.StakeInfoReturnValue {
 }
 
 func (node *Node) getDeployedStakingContract() common.Address {
+	if node.NodeConfig.GetNetworkType() == nodeconfig.Mainnet {
+		return common.Address{}
+	}
 	return node.StakingContractAddress
 }
 
@@ -169,6 +173,9 @@ func (node *Node) AddFaucetContractToPendingTransactions() {
 
 // CallFaucetContract invokes the faucet contract to give the walletAddress initial money
 func (node *Node) CallFaucetContract(address common.Address) common.Hash {
+	if node.NodeConfig.GetNetworkType() == nodeconfig.Mainnet {
+		return common.Hash{}
+	}
 	// Temporary code to workaround explorer issue for searching new addresses (https://github.com/harmony-one/harmony/issues/503)
 	nonce := atomic.AddUint64(&node.ContractDeployerCurrentNonce, 1)
 	tx, _ := types.SignTx(types.NewTransaction(nonce-1, address, node.Consensus.ShardID, big.NewInt(0), params.TxGasContractCreation*10, nil, nil), types.HomesteadSigner{}, node.ContractDeployerKey)

--- a/node/node.go
+++ b/node/node.go
@@ -204,7 +204,7 @@ type Node struct {
 
 // Blockchain returns the blockchain for the node's current shard.
 func (node *Node) Blockchain() *core.BlockChain {
-	shardID := node.Consensus.ShardID
+	shardID := node.NodeConfig.ShardID
 	bc, err := node.shardChains.ShardChain(shardID, node.NodeConfig.GetNetworkType())
 	if err != nil {
 		err = ctxerror.New("cannot get shard chain", "shardID", shardID).

--- a/node/node.go
+++ b/node/node.go
@@ -205,7 +205,7 @@ type Node struct {
 // Blockchain returns the blockchain for the node's current shard.
 func (node *Node) Blockchain() *core.BlockChain {
 	shardID := node.Consensus.ShardID
-	bc, err := node.shardChains.ShardChain(shardID)
+	bc, err := node.shardChains.ShardChain(shardID, node.NodeConfig.GetNetworkType())
 	if err != nil {
 		err = ctxerror.New("cannot get shard chain", "shardID", shardID).
 			WithCause(err)
@@ -216,7 +216,7 @@ func (node *Node) Blockchain() *core.BlockChain {
 
 // Beaconchain returns the beaconchain from node.
 func (node *Node) Beaconchain() *core.BlockChain {
-	bc, err := node.shardChains.ShardChain(0)
+	bc, err := node.shardChains.ShardChain(0, node.NodeConfig.GetNetworkType())
 	if err != nil {
 		err = ctxerror.New("cannot get beaconchain").WithCause(err)
 		ctxerror.Log15(utils.GetLogger().Crit, err)
@@ -250,9 +250,9 @@ func (node *Node) AddPendingTransaction(newTx *types.Transaction) {
 
 // Take out a subset of valid transactions from the pending transaction list
 // Note the pending transaction list will then contain the rest of the txs
-func (node *Node) getTransactionsForNewBlock(maxNumTxs int) types.Transactions {
+func (node *Node) getTransactionsForNewBlock(maxNumTxs int, coinbase common.Address) types.Transactions {
 	node.pendingTxMutex.Lock()
-	selected, unselected, invalid := node.Worker.SelectTransactionsForNewBlock(node.pendingTransactions, maxNumTxs)
+	selected, unselected, invalid := node.Worker.SelectTransactionsForNewBlock(node.pendingTransactions, maxNumTxs, coinbase)
 
 	node.pendingTransactions = unselected
 	node.reducePendingTransactions()
@@ -324,7 +324,7 @@ func New(host p2p.Host, consensusObj *consensus.Consensus, chainDBFactory shardc
 		node.ConfirmedBlockChannel = make(chan *types.Block)
 		node.BeaconBlockChannel = make(chan *types.Block)
 		node.TxPool = core.NewTxPool(core.DefaultTxPoolConfig, node.Blockchain().Config(), chain)
-		node.Worker = worker.New(node.Blockchain().Config(), chain, node.Consensus, node.Consensus.SelfAddress, node.Consensus.ShardID)
+		node.Worker = worker.New(node.Blockchain().Config(), chain, node.Consensus, node.Consensus.ShardID)
 
 		node.Consensus.VerifiedNewBlock = make(chan *types.Block)
 		// the sequence number is the next block number to be added in consensus protocol, which is always one more than current chain header block
@@ -363,6 +363,8 @@ func New(host p2p.Host, consensusObj *consensus.Consensus, chainDBFactory shardc
 		}
 	}
 
+	utils.GetLogInstance().Info("Genesis block hash",
+		"hash", node.Blockchain().GetBlockByNumber(0).Hash().Hex(), "state root", node.Blockchain().GetBlockByNumber(0).Header().Root.Hex())
 	if consensusObj != nil && nodeconfig.GetDefaultConfig().IsLeader() {
 		node.State = NodeLeader
 	} else {

--- a/node/node_genesis.go
+++ b/node/node_genesis.go
@@ -93,7 +93,7 @@ func (node *Node) SetupGenesisBlock(db ethdb.Database, shardID uint32, myShardSt
 
 	// Initialize shard state
 	// TODO: add ShardID into chainconfig and change ChainID to NetworkID
-	chainConfig.ChainID = big.NewInt(int64(shardID)) // Use ChainID as piggybacked ShardID
+	//chainConfig.ChainID = big.NewInt(int64(shardID)) // Use ChainID as piggybacked ShardID
 
 	gspec := core.Genesis{
 		Config:         &chainConfig,

--- a/node/node_genesis.go
+++ b/node/node_genesis.go
@@ -2,19 +2,18 @@ package node
 
 import (
 	"crypto/ecdsa"
+	"errors"
 	"math/big"
 	"math/rand"
 	"strings"
 
-	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
-
 	"github.com/ethereum/go-ethereum/common"
+
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/pkg/errors"
-
 	"github.com/harmony-one/harmony/common/denominations"
 	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/core/types"
@@ -70,10 +69,12 @@ func (node *Node) SetupGenesisBlock(db ethdb.Database, shardID uint32, myShardSt
 	switch node.NodeConfig.GetNetworkType() {
 	case nodeconfig.Mainnet:
 		chainConfig = *params.MainnetChainConfig
-		foundationAddress := common.HexToAddress("0xE25ABC3f7C3d5fB7FB81EAFd421FF1621A61107c")
-		genesisFunds := big.NewInt(GenesisFund)
-		genesisFunds = genesisFunds.Mul(genesisFunds, big.NewInt(denominations.One))
-		genesisAlloc[foundationAddress] = core.GenesisAccount{Balance: genesisFunds}
+		if shardID == 0 {
+			foundationAddress := common.HexToAddress("0xE25ABC3f7C3d5fB7FB81EAFd421FF1621A61107c")
+			genesisFunds := big.NewInt(GenesisFund)
+			genesisFunds = genesisFunds.Mul(genesisFunds, big.NewInt(denominations.One))
+			genesisAlloc[foundationAddress] = core.GenesisAccount{Balance: genesisFunds}
+		}
 	case nodeconfig.Testnet:
 		fallthrough
 	case nodeconfig.Devnet:
@@ -98,6 +99,7 @@ func (node *Node) SetupGenesisBlock(db ethdb.Database, shardID uint32, myShardSt
 		Config:         &chainConfig,
 		Alloc:          genesisAlloc,
 		ShardID:        shardID,
+		GasLimit:       params.GenesisGasLimit * 1000,
 		ShardStateHash: myShardState.Hash(),
 		ShardState:     myShardState.DeepCopy(),
 	}

--- a/node/node_genesis.go
+++ b/node/node_genesis.go
@@ -57,7 +57,7 @@ func (gi *genesisInitializer) InitChainDB(db ethdb.Database, shardID uint32) err
 func (node *Node) SetupGenesisBlock(db ethdb.Database, shardID uint32, myShardState types.ShardState) {
 	utils.GetLogger().Info("setting up a brand new chain database",
 		"shardID", shardID)
-	if shardID == node.Consensus.ShardID {
+	if shardID == node.NodeConfig.ShardID {
 		node.isFirstTime = true
 	}
 
@@ -93,7 +93,7 @@ func (node *Node) SetupGenesisBlock(db ethdb.Database, shardID uint32, myShardSt
 
 	// Initialize shard state
 	// TODO: add ShardID into chainconfig and change ChainID to NetworkID
-	//chainConfig.ChainID = big.NewInt(int64(shardID)) // Use ChainID as piggybacked ShardID
+	chainConfig.ChainID = big.NewInt(int64(shardID)) // Use ChainID as piggybacked ShardID
 
 	gspec := core.Genesis{
 		Config:         &chainConfig,

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	// MaxNumberOfTransactionsPerBlock is the max number of transaction per a block.
-	MaxNumberOfTransactionsPerBlock = 8000 // Disable tx processing
+	MaxNumberOfTransactionsPerBlock = 8000
 	consensusTimeout                = 30 * time.Second
 )
 

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	// MaxNumberOfTransactionsPerBlock is the max number of transaction per a block.
-	MaxNumberOfTransactionsPerBlock = 8000
+	MaxNumberOfTransactionsPerBlock = 8000 // Disable tx processing
 	consensusTimeout                = 30 * time.Second
 )
 
@@ -565,7 +565,7 @@ func (node *Node) pingMessageHandler(msgPayload []byte, sender libp2p_peer.ID) i
 			"genesisMemberIndex", genesisNode.MemberIndex,
 			"genesisStakingAccount", common2.MustAddressToBech32(genesisNode.NodeID.EcdsaAddress))
 	} else {
-		logger.Info("cannot find genesis node", "k", hex.EncodeToString(k[:]))
+		logger.Info("cannot find genesis node", "BlsPubKey", peer.ConsensusPubKey)
 	}
 	getLogger().Info("received ping message")
 

--- a/node/node_handler_test.go
+++ b/node/node_handler_test.go
@@ -27,8 +27,8 @@ func TestAddNewBlock(t *testing.T) {
 	}
 	node := New(host, consensus, testDBFactory, false)
 
-	selectedTxs := node.getTransactionsForNewBlock(MaxNumberOfTransactionsPerBlock)
-	node.Worker.CommitTransactions(selectedTxs)
+	selectedTxs := node.getTransactionsForNewBlock(MaxNumberOfTransactionsPerBlock, common.Address{})
+	node.Worker.CommitTransactions(selectedTxs, common.Address{})
 	block, _ := node.Worker.Commit([]byte{}, []byte{}, 0, common.Address{})
 
 	node.AddNewBlock(block)
@@ -53,8 +53,8 @@ func TestVerifyNewBlock(t *testing.T) {
 	}
 	node := New(host, consensus, testDBFactory, false)
 
-	selectedTxs := node.getTransactionsForNewBlock(MaxNumberOfTransactionsPerBlock)
-	node.Worker.CommitTransactions(selectedTxs)
+	selectedTxs := node.getTransactionsForNewBlock(MaxNumberOfTransactionsPerBlock, common.Address{})
+	node.Worker.CommitTransactions(selectedTxs, common.Address{})
 	block, _ := node.Worker.Commit([]byte{}, []byte{}, 0, common.Address{})
 
 	if err := node.VerifyNewBlock(block); err != nil {

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/core/types"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/ctxerror"
 	"github.com/harmony-one/harmony/internal/utils"
 )
@@ -74,7 +75,10 @@ func (node *Node) WaitForConsensusReadyv2(readySignal chan struct{}, stopChan ch
 
 					coinbase := node.Consensus.SelfAddress
 					// Normal tx block consensus
-					selectedTxs := node.getTransactionsForNewBlock(MaxNumberOfTransactionsPerBlock, coinbase)
+					selectedTxs := types.Transactions{} // Empty transaction list
+					if node.NodeConfig.GetNetworkType() != nodeconfig.Mainnet {
+						selectedTxs = node.getTransactionsForNewBlock(MaxNumberOfTransactionsPerBlock, coinbase)
+					}
 					utils.GetLogInstance().Info("PROPOSING NEW BLOCK ------------------------------------------------", "blockNum", node.Blockchain().CurrentBlock().NumberU64()+1, "threshold", threshold, "selectedTxs", len(selectedTxs))
 					if err := node.Worker.CommitTransactions(selectedTxs, coinbase); err != nil {
 						ctxerror.Log15(utils.GetLogger().Error,

--- a/node/staking_test.go
+++ b/node/staking_test.go
@@ -38,8 +38,8 @@ func TestUpdateStakingList(t *testing.T) {
 	node := New(host, consensus, testDBFactory, false)
 
 	for i := 0; i < 5; i++ {
-		selectedTxs := node.getTransactionsForNewBlock(MaxNumberOfTransactionsPerBlock)
-		node.Worker.CommitTransactions(selectedTxs)
+		selectedTxs := node.getTransactionsForNewBlock(MaxNumberOfTransactionsPerBlock, common.Address{})
+		node.Worker.CommitTransactions(selectedTxs, common.Address{})
 		block, _ := node.Worker.Commit([]byte{}, []byte{}, 0, common.Address{})
 
 		node.AddNewBlock(block)

--- a/node/worker/worker.go
+++ b/node/worker/worker.go
@@ -33,8 +33,7 @@ type Worker struct {
 	chain   *core.BlockChain
 	current *environment // An environment for current running cycle.
 
-	coinbase common.Address
-	engine   consensus_engine.Engine
+	engine consensus_engine.Engine
 
 	gasFloor uint64
 	gasCeil  uint64
@@ -43,7 +42,7 @@ type Worker struct {
 }
 
 // SelectTransactionsForNewBlock selects transactions for new block.
-func (w *Worker) SelectTransactionsForNewBlock(txs types.Transactions, maxNumTxs int) (types.Transactions, types.Transactions, types.Transactions) {
+func (w *Worker) SelectTransactionsForNewBlock(txs types.Transactions, maxNumTxs int, coinbase common.Address) (types.Transactions, types.Transactions, types.Transactions) {
 	if w.current.gasPool == nil {
 		w.current.gasPool = new(core.GasPool).AddGas(w.current.header.GasLimit)
 	}
@@ -55,7 +54,7 @@ func (w *Worker) SelectTransactionsForNewBlock(txs types.Transactions, maxNumTxs
 			invalid = append(invalid, tx)
 		}
 		snap := w.current.state.Snapshot()
-		_, err := w.commitTransaction(tx, w.coinbase)
+		_, err := w.commitTransaction(tx, coinbase)
 		if len(selected) > maxNumTxs {
 			unselected = append(unselected, tx)
 		} else {
@@ -68,7 +67,7 @@ func (w *Worker) SelectTransactionsForNewBlock(txs types.Transactions, maxNumTxs
 			}
 		}
 	}
-	err := w.UpdateCurrent()
+	err := w.UpdateCurrent(coinbase)
 	if err != nil {
 		log.Debug("Failed updating worker's state", "Error", err)
 	}
@@ -90,13 +89,13 @@ func (w *Worker) commitTransaction(tx *types.Transaction, coinbase common.Addres
 }
 
 // CommitTransactions commits transactions.
-func (w *Worker) CommitTransactions(txs types.Transactions) error {
+func (w *Worker) CommitTransactions(txs types.Transactions, coinbase common.Address) error {
 	if w.current.gasPool == nil {
 		w.current.gasPool = new(core.GasPool).AddGas(w.current.header.GasLimit)
 	}
 	for _, tx := range txs {
 		snap := w.current.state.Snapshot()
-		_, err := w.commitTransaction(tx, w.coinbase)
+		_, err := w.commitTransaction(tx, coinbase)
 		if err != nil {
 			w.current.state.RevertToSnapshot(snap)
 			return err
@@ -107,7 +106,7 @@ func (w *Worker) CommitTransactions(txs types.Transactions) error {
 }
 
 // UpdateCurrent updates the current environment with the current state and header.
-func (w *Worker) UpdateCurrent() error {
+func (w *Worker) UpdateCurrent(coinbase common.Address) error {
 	parent := w.chain.CurrentBlock()
 	num := parent.Number()
 	timestamp := time.Now().Unix()
@@ -126,6 +125,7 @@ func (w *Worker) UpdateCurrent() error {
 		Time:       big.NewInt(timestamp),
 		Epoch:      epoch,
 		ShardID:    w.chain.ShardID(),
+		Coinbase:   coinbase,
 	}
 	return w.makeCurrent(parent, header)
 }
@@ -156,16 +156,17 @@ func (w *Worker) GetCurrentReceipts() []*types.Receipt {
 }
 
 // Commit generate a new block for the new txs.
-func (w *Worker) Commit(sig []byte, signers []byte, viewID uint64, addr common.Address) (*types.Block, error) {
+func (w *Worker) Commit(sig []byte, signers []byte, viewID uint64, coinbase common.Address) (*types.Block, error) {
 	if len(sig) > 0 && len(signers) > 0 {
 		copy(w.current.header.LastCommitSignature[:], sig[:])
 		w.current.header.LastCommitBitmap = append(signers[:0:0], signers...)
 	}
-	w.current.header.Coinbase = addr
+	w.current.header.Coinbase = coinbase
 	w.current.header.ViewID = new(big.Int)
 	w.current.header.ViewID.SetUint64(viewID)
 
 	s := w.current.state.Copy()
+
 	block, err := w.engine.Finalize(w.chain, w.current.header, s, w.current.txs, w.current.receipts)
 	if err != nil {
 		return nil, ctxerror.New("cannot finalize block").WithCause(err)
@@ -174,7 +175,7 @@ func (w *Worker) Commit(sig []byte, signers []byte, viewID uint64, addr common.A
 }
 
 // New create a new worker object.
-func New(config *params.ChainConfig, chain *core.BlockChain, engine consensus_engine.Engine, coinbase common.Address, shardID uint32) *Worker {
+func New(config *params.ChainConfig, chain *core.BlockChain, engine consensus_engine.Engine, shardID uint32) *Worker {
 	worker := &Worker{
 		config: config,
 		chain:  chain,
@@ -182,7 +183,6 @@ func New(config *params.ChainConfig, chain *core.BlockChain, engine consensus_en
 	}
 	worker.gasFloor = 500000000000000000
 	worker.gasCeil = 1000000000000000000
-	worker.coinbase = coinbase
 	worker.shardID = shardID
 
 	parent := worker.chain.CurrentBlock()

--- a/node/worker/worker.go
+++ b/node/worker/worker.go
@@ -167,7 +167,8 @@ func (w *Worker) Commit(sig []byte, signers []byte, viewID uint64, coinbase comm
 
 	s := w.current.state.Copy()
 
-	block, err := w.engine.Finalize(w.chain, w.current.header, s, w.current.txs, w.current.receipts)
+	copyHeader := types.CopyHeader(w.current.header)
+	block, err := w.engine.Finalize(w.chain, copyHeader, s, w.current.txs, w.current.receipts)
 	if err != nil {
 		return nil, ctxerror.New("cannot finalize block").WithCause(err)
 	}

--- a/node/worker/worker_test.go
+++ b/node/worker/worker_test.go
@@ -40,7 +40,7 @@ func TestNewWorker(t *testing.T) {
 	chain, _ := core.NewBlockChain(database, nil, gspec.Config, consensus.NewFaker(), vm.Config{}, nil)
 
 	// Create a new worker
-	worker := New(params.TestChainConfig, chain, consensus.NewFaker(), testBankAddress, 0)
+	worker := New(params.TestChainConfig, chain, consensus.NewFaker(), 0)
 
 	if worker.GetCurrentState().GetBalance(crypto.PubkeyToAddress(testBankKey.PublicKey)).Cmp(testBankFunds) != 0 {
 		t.Error("Worker state is not setup correctly")
@@ -62,7 +62,7 @@ func TestCommitTransactions(t *testing.T) {
 	chain, _ := core.NewBlockChain(database, nil, gspec.Config, consensus.NewFaker(), vm.Config{}, nil)
 
 	// Create a new worker
-	worker := New(params.TestChainConfig, chain, consensus.NewFaker(), testBankAddress, 0)
+	worker := New(params.TestChainConfig, chain, consensus.NewFaker(), 0)
 
 	// Generate a test tx
 	baseNonce := worker.GetCurrentState().GetNonce(crypto.PubkeyToAddress(testBankKey.PublicKey))
@@ -70,7 +70,7 @@ func TestCommitTransactions(t *testing.T) {
 	tx, _ := types.SignTx(types.NewTransaction(baseNonce, testBankAddress, uint32(0), big.NewInt(int64(denominations.One*randAmount)), params.TxGas, nil, nil), types.HomesteadSigner{}, testBankKey)
 
 	// Commit the tx to the worker
-	err := worker.CommitTransactions(types.Transactions{tx})
+	err := worker.CommitTransactions(types.Transactions{tx}, testBankAddress)
 	if err != nil {
 		t.Error(err)
 	}

--- a/test/chain/main.go
+++ b/test/chain/main.go
@@ -105,7 +105,7 @@ func fundFaucetContract(chain *core.BlockChain) {
 	fmt.Println("--------- Funding addresses for Faucet Contract Call ---------")
 	fmt.Println()
 
-	contractworker = pkgworker.New(params.TestChainConfig, chain, consensus.NewFaker(), crypto.PubkeyToAddress(FaucetPriKey.PublicKey), 0)
+	contractworker = pkgworker.New(params.TestChainConfig, chain, consensus.NewFaker(), 0)
 	nonce = contractworker.GetCurrentState().GetNonce(crypto.PubkeyToAddress(FaucetPriKey.PublicKey))
 	dataEnc = common.FromHex(FaucetContractBinary)
 	ftx, _ := types.SignTx(types.NewContractCreation(nonce, 0, big.NewInt(7000000000000000000), params.TxGasContractCreation*10, nil, dataEnc), types.HomesteadSigner{}, FaucetPriKey)
@@ -125,7 +125,7 @@ func fundFaucetContract(chain *core.BlockChain) {
 	amount := 720000
 	tx, _ := types.SignTx(types.NewTransaction(nonce+uint64(4), StakingAddress, 0, big.NewInt(int64(amount)), params.TxGas, nil, nil), types.HomesteadSigner{}, FaucetPriKey)
 	txs = append(txs, tx)
-	err := contractworker.CommitTransactions(txs)
+	err := contractworker.CommitTransactions(txs, testUserAddress)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -163,7 +163,7 @@ func callFaucetContractToFundAnAddress(chain *core.BlockChain) {
 	callEnc = append(callEnc, paddedAddress...)
 	callfaucettx, _ := types.SignTx(types.NewTransaction(nonce+uint64(5), faucetContractAddress, 0, big.NewInt(0), params.TxGasContractCreation*10, nil, callEnc), types.HomesteadSigner{}, FaucetPriKey)
 
-	err = contractworker.CommitTransactions(types.Transactions{callfaucettx})
+	err = contractworker.CommitTransactions(types.Transactions{callfaucettx}, testUserAddress)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -241,7 +241,7 @@ func playStaking(chain *core.BlockChain) {
 		tx, _ := types.SignTx(types.NewTransaction(0, stakeContractAddress, 0, big.NewInt(int64(stake)), params.TxGas*5, nil, callEncl), types.HomesteadSigner{}, allRandomUserKey[i])
 		stakingtxns = append(stakingtxns, tx)
 	}
-	err = contractworker.CommitTransactions(stakingtxns)
+	err = contractworker.CommitTransactions(stakingtxns, common.Address{})
 
 	if err != nil {
 		fmt.Println(err)
@@ -299,7 +299,7 @@ func playWithdrawStaking(chain *core.BlockChain) {
 		withdrawstakingtxns = append(withdrawstakingtxns, tx)
 	}
 
-	err = contractworker.CommitTransactions(withdrawstakingtxns)
+	err = contractworker.CommitTransactions(withdrawstakingtxns, common.Address{})
 	if err != nil {
 		fmt.Println("error:")
 		fmt.Println(err)


### PR DESCRIPTION
Fix empty coinbase address during transaction validation; It caused mismatching receipt issue and not able to validate block on validators.
Populate coinbase with current leader's ECDSA address
  -remove BLSAddress utility to avoid confusion
Fix missing ViewID issue.
Update EVM to latest constantinople version to avoid invalid opcode issue.
Separate mainnet genesis allocation from testnet setup so mainnet have 12.6B only on shard 0.
Disable faceut/staking rpcs for mainnet.

Tested locally with both mainnet and testnet network. Tried wallet balances/transfer/getFreeToken too.