### PR TITLE
Fix consensus start issue.

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -268,13 +268,6 @@ func New(host p2p.Host, ShardID uint32, leader p2p.Peer, blsPriKey *bls.SecretKe
 	consensus.commitFinishChan = make(chan uint64)
 
 	consensus.ReadySignal = make(chan struct{})
-	if nodeconfig.GetDefaultConfig().IsLeader() {
-		// send a signal to indicate it's ready to run consensus
-		// this signal is consumed by node object to create a new block and in turn trigger a new consensus on it
-		go func() {
-			consensus.ReadySignal <- struct{}{}
-		}()
-	}
 
 	consensus.uniqueIDInstance = utils.GetUniqueValidatorIDInstance()
 

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -834,6 +834,14 @@ func (consensus *Consensus) Start(blockChannel chan *types.Block, stopChan chan 
 		if nodeconfig.GetDefaultConfig().IsLeader() {
 			consensus.getLogger().Info("[ConsensusMainLoop] Waiting for consensus start", "time", time.Now())
 			<-startChannel
+
+			if nodeconfig.GetDefaultConfig().IsLeader() {
+				// send a signal to indicate it's ready to run consensus
+				// this signal is consumed by node object to create a new block and in turn trigger a new consensus on it
+				go func() {
+					consensus.ReadySignal <- struct{}{}
+				}()
+			}
 		}
 		consensus.getLogger().Info("[ConsensusMainLoop] Consensus started", "time", time.Now())
 		defer close(stoppedChan)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1229,7 +1229,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 		}
 		switch status {
 		case CanonStatTy:
-			log.Debug("Inserted new block", "number", block.Number(), "hash", block.Hash(), "uncles", len(block.Uncles()),
+			log.Info("Inserted new block", "number", block.Number(), "hash", block.Hash(), "uncles", len(block.Uncles()),
 				"txs", len(block.Transactions()), "gas", block.GasUsed(), "elapsed", common.PrettyDuration(time.Since(bstart)))
 
 			coalescedLogs = append(coalescedLogs, logs...)

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -47,7 +47,7 @@ func (node *Node) WaitForConsensusReadyv2(readySignal chan struct{}, stopChan ch
 				return
 			case <-time.After(ConsensusTimeOut * time.Second):
 				if node.Consensus.PubKey.IsEqual(node.Consensus.LeaderPubKey) {
-					utils.GetLogInstance().Debug("Consensus timeout, retry!", "count", timeoutCount)
+					utils.GetLogInstance().Debug("Leader consensus timeout, retry!", "count", timeoutCount)
 					node.Consensus.ResetState()
 					timeoutCount++
 					if newBlock != nil {

--- a/test/cal_tps.sh
+++ b/test/cal_tps.sh
@@ -61,7 +61,7 @@ done
 FILES=$(cat $VALIDATORS) 
 for i in $FILES; do
     peer=`echo $i | cut -f 5 -d - | cut -f 1 -d .`
-    num=`grep "Inserted new block" $i | tail -n 1 | cut -f 6 -d , | grep -Eo [0-9]+`
+    num=`grep "Added New Block to Blockchain" $i | tail -n 1 | cut -f 6 -d , | grep -Eo [0-9]+`
     echo "peerID": $peer, "numOfConsensus": $num
 done
 

--- a/test/cal_tps.sh
+++ b/test/cal_tps.sh
@@ -61,7 +61,7 @@ done
 FILES=$(cat $VALIDATORS) 
 for i in $FILES; do
     peer=`echo $i | cut -f 5 -d - | cut -f 1 -d .`
-    num=`grep "Added New Block to Blockchain" $i | tail -n 1 | cut -f 6 -d , | grep -Eo [0-9]+`
+    num=`grep "HOORAY" $i | tail -n 1 | cut -f 6 -d , | grep -Eo [0-9]+`
     echo "peerID": $peer, "numOfConsensus": $num
 done
 

--- a/test/cal_tps.sh
+++ b/test/cal_tps.sh
@@ -61,7 +61,7 @@ done
 FILES=$(cat $VALIDATORS) 
 for i in $FILES; do
     peer=`echo $i | cut -f 5 -d - | cut -f 1 -d .`
-    num=`grep "HOORAY" $i | tail -n 1 | cut -f 6 -d , | grep -Eo [0-9]+`
+    num=`grep "Inserted new block" $i | tail -n 1 | cut -f 6 -d , | grep -Eo [0-9]+`
     echo "peerID": $peer, "numOfConsensus": $num
 done
 


### PR DESCRIPTION
The consensus readySignal should be given when the startConsensus signal is given, rather than when the consensus object is constructed.