### PR TITLE
Revert "[log] filter out debug log by default"

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -129,7 +129,7 @@ var (
 	accountIndex   int
 
 	// logging verbosity
-	verbosity = flag.Int("verbosity", 3, "Logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail (default: 5)")
+	verbosity = flag.Int("verbosity", 5, "Logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail (default: 5)")
 
 	// dbDir is the database directory.
 	dbDir = flag.String("db_dir", "", "blockchain database directory")


### PR DESCRIPTION
Reverts harmony-one/harmony#1128

we still want to enable debug log at the v0 stage.