### PR TITLE
Implement Log File Rotation with GZIP

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -32,19 +32,6 @@ func printVersion(me string) {
 	os.Exit(0)
 }
 
-func initLogFile(logFolder, ip, port string, logMaxSize int) {
-	// Setup a logger to stdout and log file.
-	if err := os.MkdirAll(logFolder, 0755); err != nil {
-		panic(err)
-	}
-	utils.AddLogHandler(
-		log.StreamHandler(&lumberjack.Logger{
-			Filename: fmt.Sprintf("./%v/bootnode-%v-%v.log", logFolder, ip, port),
-			MaxSize:  logMaxSize,
-			Compress: true,
-		}, log.JSONFormat()))
-}
-
 func main() {
 	ip := flag.String("ip", "127.0.0.1", "IP of the node")
 	port := flag.String("port", "9876", "port of the node.")
@@ -64,7 +51,10 @@ func main() {
 	// Logging setup
 	utils.SetLogContext(*port, *ip)
 	utils.SetLogVerbosity(log.Lvl(*verbosity))
-	initLogFile(*logFolder, *ip, *port, *logMaxSize)
+	filename := fmt.Sprintf("%v/bootnode-%v-%v.log", *logFolder, *ip, *port)
+	if err := utils.AddLogFile(filename, *logMaxSize); err != nil {
+		panic(err)
+	}
 
 	privKey, _, err := utils.LoadKeyFromFile(*keyFile)
 	if err != nil {

--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -32,20 +32,24 @@ func printVersion(me string) {
 	os.Exit(0)
 }
 
-func initLogFile(logFolder, ip, port string) {
+func initLogFile(logFolder, ip, port string, logMaxSize int) {
 	// Setup a logger to stdout and log file.
 	if err := os.MkdirAll(logFolder, 0755); err != nil {
 		panic(err)
 	}
-	logFileName := fmt.Sprintf("./%v/bootnode-%v-%v.log", logFolder, ip, port)
-	fileHandler := log.Must.FileHandler(logFileName, log.JSONFormat()) // Log to file
-	utils.AddLogHandler(fileHandler)
+	utils.AddLogHandler(
+		log.StreamHandler(&lumberjack.Logger{
+			Filename: fmt.Sprintf("./%v/bootnode-%v-%v.log", logFolder, ip, port),
+			MaxSize:  logMaxSize,
+			Compress: true,
+		}, log.JSONFormat()))
 }
 
 func main() {
 	ip := flag.String("ip", "127.0.0.1", "IP of the node")
 	port := flag.String("port", "9876", "port of the node.")
 	logFolder := flag.String("log_folder", "latest", "the folder collecting the logs of this execution")
+	logMaxSize := flag.Int("log_max_size", 100, "the max size in megabytes of the log file before it gets rotated")
 	keyFile := flag.String("key", "./.bnkey", "the private key file of the bootnode")
 	versionFlag := flag.Bool("version", false, "Output version info")
 	verbosity := flag.Int("verbosity", 5, "Logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail (default: 5)")
@@ -60,7 +64,7 @@ func main() {
 	// Logging setup
 	utils.SetLogContext(*port, *ip)
 	utils.SetLogVerbosity(log.Lvl(*verbosity))
-	initLogFile(*logFolder, *ip, *port)
+	initLogFile(*logFolder, *ip, *port, *logMaxSize)
 
 	privKey, _, err := utils.LoadKeyFromFile(*keyFile)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/libp2p/go-libp2p-pubsub v0.1.0
 	github.com/multiformats/go-multiaddr v0.0.4
 	github.com/multiformats/go-multiaddr-net v0.0.1
+	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/errors v0.8.1
 	github.com/rjeczalik/notify v0.9.2

--- a/internal/utils/singleton.go
+++ b/internal/utils/singleton.go
@@ -5,10 +5,12 @@ package utils
 import (
 	"io"
 	"os"
+	"path"
 	"sync"
 	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/natefinch/lumberjack"
 )
 
 var (
@@ -39,6 +41,22 @@ func SetLogVerbosity(verbosity log.Lvl) {
 	if glogger != nil {
 		glogger.Verbosity(logVerbosity)
 	}
+}
+
+// AddLogFile creates a StreamHandler that outputs JSON logs
+// into rotating files with specified max file size
+func AddLogFile(filepath string, maxSize int) error {
+	if err := os.MkdirAll(path.Dir(filepath), 0755); err != nil {
+		return err
+	}
+
+	AddLogHandler(log.StreamHandler(&lumberjack.Logger{
+		Filename: filepath,
+		MaxSize:  maxSize,
+		Compress: true,
+	}, log.JSONFormat()))
+
+	return nil
 }
 
 // AddLogHandler add a log handler


### PR DESCRIPTION
## Issue
#1170 

## Test
N/A

#### Test Coverage Data
N/A

#### Test/Run Logs
Tested by launching a node with `-log_max_size 1` (1MB), waited for logs to generate and verified logs are GZIP compressed once it goes over set size:
<img width="775" alt="Screen Shot 2019-06-26 at 9 04 26 PM" src="https://user-images.githubusercontent.com/9807064/60233716-527c5480-9856-11e9-8cdd-3aac772fcc13.png">

## TODO
N/A