### PR TITLE
Log common.Hash in hex instead of TerminalString/Bytes

### DIFF
--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -107,7 +107,7 @@ func (consensus *Consensus) announce(block *types.Block) {
 
 	consensus.PbftLog.AddMessage(pbftMsg)
 	consensus.getLogger().Debug().
-		Bytes("MsgblockHash", pbftMsg.BlockHash[:]).
+		Str("MsgblockHash", pbftMsg.BlockHash.Hex()).
 		Uint64("MsgViewID", pbftMsg.ViewID).
 		Uint64("MsgBlockNum", pbftMsg.BlockNum).
 		Msg("[Announce] Added Announce message in pbftLog")
@@ -127,7 +127,7 @@ func (consensus *Consensus) announce(block *types.Block) {
 			Msg("[Announce] Cannot send announce message")
 	} else {
 		consensus.getLogger().Info().
-			Bytes("BlockHash", block.Hash().Bytes()).
+			Str("BlockHash", block.Hash().Hex()).
 			Uint64("BlockNum", block.NumberU64()).
 			Msg("[Announce] Sent Announce Message!!")
 	}
@@ -470,7 +470,7 @@ func (consensus *Consensus) onPrepared(msg *msg_pb.Message) {
 		consensus.getLogger().Warn().
 			Uint64("MsgBlockNum", recvMsg.BlockNum).
 			Bytes("MsgBlockHash", recvMsg.BlockHash[:]).
-			Bytes("blockObjHash", blockObj.Header().Hash().Bytes()).
+			Str("blockObjHash", blockObj.Header().Hash().Hex()).
 			Msg("[OnPrepared] BlockHash not match")
 		return
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -267,7 +267,7 @@ func (bc *BlockChain) loadLastState() error {
 		// Dangling block without a state associated, init from scratch
 		utils.Logger().Warn().
 			Str("number", currentBlock.Number().String()).
-			Bytes("hash", currentBlock.Hash().Bytes()).
+			Str("hash", currentBlock.Hash().Hex()).
 			Msg("Head state missing, repairing chain")
 		if err := bc.repair(&currentBlock); err != nil {
 			return err
@@ -302,19 +302,19 @@ func (bc *BlockChain) loadLastState() error {
 
 	utils.Logger().Info().
 		Str("number", currentHeader.Number.String()).
-		Bytes("hash", currentHeader.Hash().Bytes()).
+		Str("hash", currentHeader.Hash().Hex()).
 		Str("td", headerTd.String()).
 		Str("age", common.PrettyAge(time.Unix(currentHeader.Time.Int64(), 0)).String()).
 		Msg("Loaded most recent local header")
 	utils.Logger().Info().
 		Str("number", currentBlock.Number().String()).
-		Bytes("hash", currentBlock.Hash().Bytes()).
+		Str("hash", currentBlock.Hash().Hex()).
 		Str("td", blockTd.String()).
 		Str("age", common.PrettyAge(time.Unix(currentBlock.Time().Int64(), 0)).String()).
 		Msg("Loaded most recent local full block")
 	utils.Logger().Info().
 		Str("number", currentFastBlock.Number().String()).
-		Bytes("hash", currentFastBlock.Hash().Bytes()).
+		Str("hash", currentFastBlock.Hash().Hex()).
 		Str("td", fastTd.String()).
 		Str("age", common.PrettyAge(time.Unix(currentFastBlock.Time().Int64(), 0)).String()).
 		Msg("Loaded most recent local fast block")
@@ -395,7 +395,7 @@ func (bc *BlockChain) FastSyncCommitHead(hash common.Hash) error {
 
 	utils.Logger().Info().
 		Str("number", block.Number().String()).
-		Bytes("hash", hash.Bytes()).
+		Str("hash", hash.Hex()).
 		Msg("Committed new head block")
 	return nil
 }
@@ -500,7 +500,7 @@ func (bc *BlockChain) repair(head **types.Block) error {
 		if _, err := state.New((*head).Root(), bc.stateCache); err == nil {
 			utils.Logger().Info().
 				Str("number", (*head).Number().String()).
-				Bytes("hash", (*head).Hash().Bytes()).
+				Str("hash", (*head).Hash().Hex()).
 				Msg("Rewound blockchain to past state")
 			return nil
 		}
@@ -755,8 +755,8 @@ func (bc *BlockChain) Stop() {
 
 				utils.Logger().Info().
 					Str("block", recent.Number().String()).
-					Bytes("hash", recent.Hash().Bytes()).
-					Bytes("root", recent.Root().Bytes()).
+					Str("hash", recent.Hash().Hex()).
+					Str("root", recent.Root().Hex()).
 					Msg("Writing cached state to disk")
 				if err := triedb.Commit(recent.Root(), true); err != nil {
 					utils.Logger().Error().Err(err).Msg("Failed to commit recent state trie")
@@ -875,10 +875,10 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 		if blockChain[i].NumberU64() != blockChain[i-1].NumberU64()+1 || blockChain[i].ParentHash() != blockChain[i-1].Hash() {
 			utils.Logger().Error().
 				Str("number", blockChain[i].Number().String()).
-				Bytes("hash", blockChain[i].Hash().Bytes()).
-				Bytes("parent", blockChain[i].ParentHash().Bytes()).
+				Str("hash", blockChain[i].Hash().Hex()).
+				Str("parent", blockChain[i].ParentHash().Hex()).
 				Str("prevnumber", blockChain[i-1].Number().String()).
-				Bytes("prevhash", blockChain[i-1].Hash().Bytes()).
+				Str("prevhash", blockChain[i-1].Hash().Hex()).
 				Msg("Non contiguous receipt insert")
 			return 0, fmt.Errorf("non contiguous insert: item %d is #%d [%x…], item %d is #%d [%x…] (parent [%x…])", i-1, blockChain[i-1].NumberU64(),
 				blockChain[i-1].Hash().Bytes()[:4], i, blockChain[i].NumberU64(), blockChain[i].Hash().Bytes()[:4], blockChain[i].ParentHash().Bytes()[:4])
@@ -949,7 +949,7 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 		Str("elapsed", common.PrettyDuration(time.Since(start)).String()).
 		Str("age", common.PrettyAge(time.Unix(head.Time().Int64(), 0)).String()).
 		Str("head", head.Number().String()).
-		Bytes("hash", head.Hash().Bytes()).
+		Str("hash", head.Hash().Hex()).
 		Str("size", common.StorageSize(bytes).String()).
 		Int32("ignored", stats.ignored).
 		Msg("Imported new block receipts")
@@ -1095,7 +1095,7 @@ func (bc *BlockChain) InsertChain(chain types.Blocks) (int, error) {
 			header := block.Header()
 			header.Logger(utils.Logger()).Info().
 				Int("segmentIndex", idx).
-				Bytes("parentHash", header.ParentHash.Bytes()).
+				Str("parentHash", header.ParentHash.Hex()).
 				Msg("added block to chain")
 
 			if header.ShardStateHash != (common.Hash{}) {
@@ -1124,10 +1124,10 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 			// Chain broke ancestry, log a message (programming error) and skip insertion
 			utils.Logger().Error().
 				Str("number", chain[i].Number().String()).
-				Bytes("hash", chain[i].Hash().Bytes()).
-				Bytes("parent", chain[i].ParentHash().Bytes()).
+				Str("hash", chain[i].Hash().Hex()).
+				Str("parent", chain[i].ParentHash().Hex()).
 				Str("prevnumber", chain[i-1].Number().String()).
-				Bytes("prevhash", chain[i-1].Hash().Bytes()).
+				Str("prevhash", chain[i-1].Hash().Hex()).
 				Msg("Non contiguous block insert")
 
 			return 0, nil, nil, fmt.Errorf("non contiguous insert: item %d is #%d [%x…], item %d is #%d [%x…] (parent [%x…])", i-1, chain[i-1].NumberU64(),
@@ -1274,7 +1274,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 		}
 		logger := utils.Logger().With().
 			Str("number", block.Number().String()).
-			Bytes("hash", block.Hash().Bytes()).
+			Str("hash", block.Hash().Hex()).
 			Int("uncles", len(block.Uncles())).
 			Int("txs", len(block.Transactions())).
 			Uint64("gas", block.GasUsed()).
@@ -1344,7 +1344,7 @@ func (st *insertStats) report(chain []*types.Block, index int, cache common.Stor
 			Str("elapsed", common.PrettyDuration(elapsed).String()).
 			Float64("mgasps", float64(st.usedGas)*1000/float64(elapsed)).
 			Str("number", end.Number().String()).
-			Bytes("hash", end.Hash().Bytes()).
+			Str("hash", end.Hash().Hex()).
 			Str("cache", cache.String())
 
 		if timestamp := time.Unix(end.Time().Int64(), 0); time.Since(timestamp) > time.Minute {
@@ -1451,18 +1451,18 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 		}
 		logEvent.
 			Str("number", commonBlock.Number().String()).
-			Bytes("hash", commonBlock.Hash().Bytes()).
+			Str("hash", commonBlock.Hash().Hex()).
 			Int("drop", len(oldChain)).
-			Bytes("dropfrom", oldChain[0].Hash().Bytes()).
+			Str("dropfrom", oldChain[0].Hash().Hex()).
 			Int("add", len(newChain)).
-			Bytes("addfrom", newChain[0].Hash().Bytes()).
+			Str("addfrom", newChain[0].Hash().Hex()).
 			Msg("Chain split detected")
 	} else {
 		utils.Logger().Error().
 			Str("oldnum", oldBlock.Number().String()).
-			Bytes("oldhash", oldBlock.Hash().Bytes()).
+			Str("oldhash", oldBlock.Hash().Hex()).
 			Str("newnum", newBlock.Number().String()).
-			Bytes("newhash", newBlock.Hash().Bytes()).
+			Str("newhash", newBlock.Hash().Hex()).
 			Msg("Impossible reorg, please file an issue")
 	}
 	// Insert the new chain, taking care of the proper incremental order

--- a/core/chain_indexer.go
+++ b/core/chain_indexer.go
@@ -286,8 +286,8 @@ func (c *ChainIndexer) newHead(head uint64, reorg bool) {
 				if syncedHead != c.checkpointHead {
 					c.log.Error().
 						Uint64("number", c.checkpointSections*c.sectionSize-1).
-						Str("expected", c.checkpointHead.TerminalString()).
-						Str("synced", syncedHead.TerminalString()).
+						Str("expected", c.checkpointHead.Hex()).
+						Str("synced", syncedHead.Hex()).
 						Msg("Synced chain does not match checkpoint")
 					return
 				}

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -209,10 +209,10 @@ func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int)
 			// Chain broke ancestry, log a message (programming error) and skip insertion
 			utils.Logger().Error().
 				Str("number", chain[i].Number.String()).
-				Str("hash", chain[i].Hash().TerminalString()).
-				Str("parent", chain[i].ParentHash.TerminalString()).
+				Str("hash", chain[i].Hash().Hex()).
+				Str("parent", chain[i].ParentHash.Hex()).
 				Str("prevnumber", chain[i-1].Number.String()).
-				Str("prevhash", chain[i-1].Hash().TerminalString()).
+				Str("prevhash", chain[i-1].Hash().Hex()).
 				Msg("Non contiguous header insert")
 
 			return 0, fmt.Errorf("non contiguous insert: item %d is #%d [%x…], item %d is #%d [%x…] (parent [%x…])", i-1, chain[i-1].Number,
@@ -286,7 +286,7 @@ func (hc *HeaderChain) InsertHeaderChain(chain []*types.Header, writeHeader WhCa
 		Int("count", stats.processed).
 		Str("elapsed", common.PrettyDuration(time.Since(start)).String()).
 		Str("number", last.Number.String()).
-		Str("hash", last.Hash().TerminalString())
+		Str("hash", last.Hash().Hex())
 
 	if timestamp := time.Unix(last.Time.Int64(), 0); time.Since(timestamp) > time.Minute {
 		context = context.Str("age", common.PrettyAge(timestamp).String())

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -150,7 +150,7 @@ func ReadHeader(db DatabaseReader, hash common.Hash, number uint64) *types.Heade
 	}
 	header := new(types.Header)
 	if err := rlp.Decode(bytes.NewReader(data), header); err != nil {
-		utils.Logger().Error().Err(err).Bytes("hash", hash.Bytes()).Msg("Invalid block header RLP")
+		utils.Logger().Error().Err(err).Str("hash", hash.Hex()).Msg("Invalid block header RLP")
 		return nil
 	}
 	return header
@@ -219,7 +219,7 @@ func ReadBody(db DatabaseReader, hash common.Hash, number uint64) *types.Body {
 	}
 	body := new(types.Body)
 	if err := rlp.Decode(bytes.NewReader(data), body); err != nil {
-		utils.Logger().Error().Err(err).Bytes("hash", hash.Bytes()).Msg("Invalid block body RLP")
+		utils.Logger().Error().Err(err).Str("hash", hash.Hex()).Msg("Invalid block body RLP")
 		return nil
 	}
 	return body
@@ -249,7 +249,7 @@ func ReadTd(db DatabaseReader, hash common.Hash, number uint64) *big.Int {
 	}
 	td := new(big.Int)
 	if err := rlp.Decode(bytes.NewReader(data), td); err != nil {
-		utils.Logger().Error().Err(err).Bytes("hash", hash.Bytes()).Msg("Invalid block total difficulty RLP")
+		utils.Logger().Error().Err(err).Str("hash", hash.Hex()).Msg("Invalid block total difficulty RLP")
 		return nil
 	}
 	return td
@@ -283,7 +283,7 @@ func ReadReceipts(db DatabaseReader, hash common.Hash, number uint64) types.Rece
 	// Convert the receipts from their storage form to their internal representation
 	storageReceipts := []*types.ReceiptForStorage{}
 	if err := rlp.DecodeBytes(data, &storageReceipts); err != nil {
-		utils.Logger().Error().Err(err).Bytes("hash", hash.Bytes()).Msg("Invalid receipt array RLP")
+		utils.Logger().Error().Err(err).Str("hash", hash.Hex()).Msg("Invalid receipt array RLP")
 		return nil
 	}
 	receipts := make(types.Receipts, len(storageReceipts))

--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -74,7 +74,7 @@ func ReadTransaction(db DatabaseReader, hash common.Hash) (*types.Transaction, c
 	if body == nil || len(body.Transactions) <= int(txIndex) {
 		utils.Logger().Error().
 			Uint64("number", blockNumber).
-			Bytes("hash", blockHash.Bytes()).
+			Str("hash", blockHash.Hex()).
 			Uint64("index", txIndex).
 			Msg("Transaction referenced missing")
 		return nil, common.Hash{}, 0, 0
@@ -93,7 +93,7 @@ func ReadReceipt(db DatabaseReader, hash common.Hash) (*types.Receipt, common.Ha
 	if len(receipts) <= int(receiptIndex) {
 		utils.Logger().Error().
 			Uint64("number", blockNumber).
-			Bytes("hash", blockHash.Bytes()).
+			Str("hash", blockHash.Hex()).
 			Uint64("index", receiptIndex).
 			Msg("Receipt refereced missing")
 		return nil, common.Hash{}, 0, 0

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -121,7 +121,7 @@ func (h *Header) Size() common.StorageSize {
 func (h *Header) Logger(logger *zerolog.Logger) *zerolog.Logger {
 	nlogger := logger.
 		With().
-		Bytes("blockHash", h.Hash().Bytes()).
+		Str("blockHash", h.Hash().Hex()).
 		Uint32("blockShard", h.ShardID).
 		Str("blockEpoch", h.Epoch.String()).
 		Str("blockNumber", h.Number.String()).


### PR DESCRIPTION
## Issue

#1171 

Before:
• Bytes: `\x02�\x1c\vT�g\x1a\x03uQ���u\vZ&7��\x02\x17��8�%���h`
• TerminalString: `c046f9…943e38`

After:
• Hex: `0x6a732f9f1e773540d67253ef618bea0f12c0c293dcb4cb663f186ef4b58a3f01`

## Test
N/A, ran `./test/test_before_submit.sh`.

## TODO
~Blocked on other relating PRs to be merged. For now, please only review commit: cd6e66
Will rebase branch after:~
• #1192 
• #1193 

Update: Rebased `master`