### PR TITLE
Replace all logs in p2p module to use zerolog

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -65,7 +65,7 @@ func main() {
 		panic(err)
 	}
 
-	log.Info("bootnode", "BN_MA", fmt.Sprintf("/ip4/%s/tcp/%s/p2p/%s", *ip, *port, host.GetID().Pretty()))
+	fmt.Printf("bootnode BN_MA=%s", fmt.Sprintf("/ip4/%s/tcp/%s/p2p/%s", *ip, *port, host.GetID().Pretty()))
 
 	if *logConn {
 		host.GetP2PHost().Network().Notify(utils.NewConnLogger(utils.GetLogInstance()))

--- a/p2p/host/hostv2/util.go
+++ b/p2p/host/hostv2/util.go
@@ -4,7 +4,6 @@ import "github.com/harmony-one/harmony/internal/utils"
 
 func catchError(err error) {
 	if err != nil {
-		utils.GetLogger().Error("catchError", "err", err)
-		panic(err)
+		utils.Logger().Panic().Err(err).Msg("catchError")
 	}
 }

--- a/p2p/p2pimpl/p2pimpl.go
+++ b/p2p/p2pimpl/p2pimpl.go
@@ -16,7 +16,10 @@ import (
 func NewHost(self *p2p.Peer, key libp2p_crypto.PrivKey) (p2p.Host, error) {
 	h := hostv2.New(self, key)
 
-	utils.GetLogInstance().Info("NewHost", "self", net.JoinHostPort(self.IP, self.Port), "PeerID", self.PeerID)
+	utils.Logger().Info().
+		Str("self", net.JoinHostPort(self.IP, self.Port)).
+		Interface("PeerID", self.PeerID).
+		Msg("NewHost")
 
 	return h, nil
 }


### PR DESCRIPTION
## Issue
#1171 

Verified that `.Panic()` log event calls `panic(msg)` (instead of `panic(err)`) after logging.

## Test
N/A, ran `./test/test_before_submit.sh`