### PR TITLE
Make sharding configuration flexible

### DIFF
--- a/cmd/client/txgen/main.go
+++ b/cmd/client/txgen/main.go
@@ -106,8 +106,9 @@ func setUpTXGen() *node.Node {
 	consensusObj.SetStakeInfoFinder(gsif)
 	consensusObj.ChainReader = txGen.Blockchain()
 	consensusObj.PublicKeys = nil
+	genesisShardingConfig := core.ShardingSchedule.InstanceForEpoch(big.NewInt(core.GenesisEpoch))
 	startIdx := 0
-	endIdx := startIdx + core.GenesisShardSize
+	endIdx := startIdx + genesisShardingConfig.NumNodesPerShard()
 	for _, acct := range genesis.HarmonyAccounts[startIdx:endIdx] {
 		pub := &bls2.PublicKey{}
 		if err := pub.DeserializeHexStr(acct.BlsPublicKey); err != nil {
@@ -128,6 +129,7 @@ func setUpTXGen() *node.Node {
 
 	return txGen
 }
+
 func main() {
 	flag.Var(&utils.BootNodes, "bootnodes", "a list of bootnode multiaddress")
 	flag.Parse()

--- a/internal/configs/sharding/fixedschedule.go
+++ b/internal/configs/sharding/fixedschedule.go
@@ -1,0 +1,21 @@
+package shardingconfig
+
+import (
+	"math/big"
+)
+
+type fixedSchedule struct {
+	instance Instance
+}
+
+// InstanceForEpoch returns the fixed sharding configuration instance regardless
+// the given epoch.
+func (s fixedSchedule) InstanceForEpoch(epoch *big.Int) Instance {
+	return s.instance
+}
+
+// NewFixedSchedule returns a sharding configuration schedule that uses the
+// given config instance for all epochs.  Useful for testing.
+func NewFixedSchedule(instance Instance) Schedule {
+	return fixedSchedule{instance: instance}
+}

--- a/internal/configs/sharding/instance.go
+++ b/internal/configs/sharding/instance.go
@@ -1,0 +1,70 @@
+package shardingconfig
+
+import "github.com/harmony-one/harmony/internal/ctxerror"
+
+type instance struct {
+	numShards                       uint32
+	numNodesPerShard                int
+	numHarmonyOperatedNodesPerShard int
+}
+
+// NewInstance creates and validates a new sharding configuration based
+// upon given parameters.
+func NewInstance(
+	numShards uint32, numNodesPerShard, numHarmonyOperatedNodesPerShard int,
+) (Instance, error) {
+	if numShards < 1 {
+		return nil, ctxerror.New("sharding config must have at least one shard",
+			"numShards", numShards)
+	}
+	if numNodesPerShard < 1 {
+		return nil, ctxerror.New("each shard must have at least one node",
+			"numNodesPerShard", numNodesPerShard)
+	}
+	if numHarmonyOperatedNodesPerShard < 0 {
+		return nil, ctxerror.New("Harmony-operated nodes cannot be negative",
+			"numHarmonyOperatedNodesPerShard", numHarmonyOperatedNodesPerShard)
+	}
+	if numHarmonyOperatedNodesPerShard > numNodesPerShard {
+		return nil, ctxerror.New(""+
+			"number of Harmony-operated nodes cannot exceed "+
+			"overall number of nodes per shard",
+			"numHarmonyOperatedNodesPerShard", numHarmonyOperatedNodesPerShard,
+			"numNodesPerShard", numNodesPerShard)
+	}
+	return instance{
+		numShards:                       numShards,
+		numNodesPerShard:                numNodesPerShard,
+		numHarmonyOperatedNodesPerShard: numHarmonyOperatedNodesPerShard,
+	}, nil
+}
+
+// MustNewInstance creates a new sharding configuration based upon
+// given parameters.  It panics if parameter validation fails.
+// It is intended to be used for static initialization.
+func MustNewInstance(
+	numShards uint32, numNodesPerShard, numHarmonyOperatedNodesPerShard int,
+) Instance {
+	sc, err := NewInstance(
+		numShards, numNodesPerShard, numHarmonyOperatedNodesPerShard)
+	if err != nil {
+		panic(err)
+	}
+	return sc
+}
+
+// NumShards returns the number of shards in the network.
+func (sc instance) NumShards() uint32 {
+	return sc.numShards
+}
+
+// NumNodesPerShard returns number of nodes in each shard.
+func (sc instance) NumNodesPerShard() int {
+	return sc.numNodesPerShard
+}
+
+// NumHarmonyOperatedNodesPerShard returns number of nodes in each shard
+// that are operated by Harmony.
+func (sc instance) NumHarmonyOperatedNodesPerShard() int {
+	return sc.numHarmonyOperatedNodesPerShard
+}

--- a/internal/configs/sharding/mainnet.go
+++ b/internal/configs/sharding/mainnet.go
@@ -1,0 +1,24 @@
+package shardingconfig
+
+import "math/big"
+
+// MainnetSchedule is the mainnet sharding configuration schedule.
+var MainnetSchedule mainnetSchedule
+
+type mainnetSchedule struct{}
+
+func (mainnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
+	switch {
+	//case epoch.Cmp(big.NewInt(1000)) >= 0:
+	//	return mainnet6400
+	//case epoch.Cmp(big.NewInt(100)) >= 0:
+	//	return mainnetV2
+	default: // genesis
+		return mainnetV0
+	}
+}
+
+var mainnetV0 = MustNewInstance(4, 150, 112)
+
+//var mainnetV2 = MustNewInstance(8, 200, 100)
+//var mainnet6400 = MustNewInstance(16, 400, 50)

--- a/internal/configs/sharding/shardingconfig.go
+++ b/internal/configs/sharding/shardingconfig.go
@@ -1,0 +1,26 @@
+// Package shardingconfig defines types and utilities that deal with Harmony
+// sharding configuration schedule.
+package shardingconfig
+
+import (
+	"math/big"
+)
+
+// Schedule returns the sharding configuration instance for the given
+// epoch.
+type Schedule interface {
+	InstanceForEpoch(epoch *big.Int) Instance
+}
+
+// Instance is one sharding configuration instance.
+type Instance interface {
+	// NumShards returns the number of shards in the network.
+	NumShards() uint32
+
+	// NumNodesPerShard returns number of nodes in each shard.
+	NumNodesPerShard() int
+
+	// NumHarmonyOperatedNodesPerShard returns number of nodes in each shard
+	// that are operated by Harmony.
+	NumHarmonyOperatedNodesPerShard() int
+}

--- a/internal/configs/sharding/testnet.go
+++ b/internal/configs/sharding/testnet.go
@@ -1,0 +1,18 @@
+package shardingconfig
+
+import "math/big"
+
+// TestnetSchedule is the long-running public testnet sharding
+// configuration schedule.
+var TestnetSchedule testnetSchedule
+
+type testnetSchedule struct{}
+
+func (testnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
+	switch {
+	default: // genesis
+		return testnetV0
+	}
+}
+
+var testnetV0 = MustNewInstance(2, 150, 150)


### PR DESCRIPTION
This is done by introducing two concepts: sharding configuration instance and sharding configuration schedule.

A *sharding configuration instance* is a particular set of sharding parameters in effect, namely:

  - Number of shards;
  - Number of nodes/shard; and
  - Number of Harmony-operated nodes per shard.

A *sharding configuration schedule* is a mapping from an epoch to the corresponding sharding configuration for that epoch.

Two schedules are provided and to be maintained in the long term: Mainnet sharding schedule (4 shards, 150 nodes/shard, 112 Harmony-operated nodes/shard) and public testnet sharding schedule (2 shards, 150 nodes/shard, 150 Harmony-operated nodes/shard).

Harmony node binary uses one of these for `-network_type=mainnet` and `-network_type=testnet` respectively.

In addition, for `-network_type=devnet`, a fixed sharding schedule can be specified with direct control over all three parameters (`-dn_num_shards`, `-dn_shard_size`, and `-dn_hmy_size`).

The mainnet schedule code includes a commented-out example schedule.