### PR TITLE
VRF integration step 1 

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -149,6 +149,12 @@ type Consensus struct {
 
 	// If true, this consensus will not propose view change.
 	disableViewChange bool
+
+	// If true, the leader will generate a new VRF
+	generateNewVrf    bool
+
+	// A list of pending VRFs received in this epoch
+	pendingVrfs        [][32]byte
 }
 
 // SetCommitDelay sets the commit message delay.  If set to non-zero,
@@ -269,6 +275,9 @@ func New(host p2p.Host, ShardID uint32, leader p2p.Peer, blsPriKey *bls.SecretKe
 	consensus.ReadySignal = make(chan struct{})
 
 	consensus.uniqueIDInstance = utils.GetUniqueValidatorIDInstance()
+
+	// enable the VRF generation flag for the first master
+	consensus.generateNewVrf = true
 
 	memprofiling.GetMemProfiling().Add("consensus.pbftLog", consensus.PbftLog)
 	return &consensus, nil

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -151,10 +151,10 @@ type Consensus struct {
 	disableViewChange bool
 
 	// If true, the leader will generate a new VRF
-	generateNewVrf    bool
+	generateNewVrf bool
 
 	// A list of pending VRFs received in this epoch
-	pendingVrfs        [][32]byte
+	pendingVrfs [][32]byte
 }
 
 // SetCommitDelay sets the commit message delay.  If set to non-zero,

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -14,12 +14,12 @@ import (
 	msg_pb "github.com/harmony-one/harmony/api/proto/message"
 	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/core/types"
+	vrf_bls "github.com/harmony-one/harmony/crypto/vrf/bls"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/ctxerror"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/p2p/host"
-	vrf_bls "github.com/harmony-one/harmony/crypto/vrf/bls"
 )
 
 // handleMessageUpdate will update the consensus state according to received message
@@ -1061,12 +1061,12 @@ func (consensus *Consensus) Start(blockChannel chan *types.Block, stopChan chan 
 						consensus.pendingVrfs = nil
 					}
 
-					if (consensus.generateNewVrf) {
+					if consensus.generateNewVrf {
 						sk := vrf_bls.NewVRFSigner(consensus.priKey)
 
 						var blockHash [32]byte
 						previousHeader := consensus.ChainReader.GetHeaderByNumber(newBlock.NumberU64() - 1)
-						previousHash   := previousHeader.Hash()
+						previousHash := previousHeader.Hash()
 						copy(blockHash[:], previousHash[:])
 
 						vrf, proof := sk.Evaluate(blockHash[:])

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -228,7 +228,7 @@ func (consensus *Consensus) onAnnounce(msg *msg_pb.Message) {
 			}
 
 			consensus.pendingVrfs = append(consensus.pendingVrfs, headerObj.Vrf)
-			consensus.getLogger().Warn().
+			consensus.getLogger().Info().
 				Uint64("MsgBlockNum", headerObj.Number.Uint64()).
 				Int("VRF numbers", len(consensus.pendingVrfs)).
 				Msg("[OnAnnounce] validated the new VRF")
@@ -1077,7 +1077,7 @@ func (consensus *Consensus) Start(blockChannel chan *types.Block, stopChan chan 
 						newBlock.AddVrfProof(vrfProof)
 
 						consensus.pendingVrfs = append(consensus.pendingVrfs, vrf)
-						consensus.getLogger().Debug().
+						consensus.getLogger().Info().
 							Uint64("MsgBlockNum", newBlock.NumberU64()).
 							Int("VRF numbers", len(consensus.pendingVrfs)).
 							Msg("[ConsensusMainLoop] Leader generated a VRF")

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -442,6 +442,7 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 			Uint64("viewID", consensus.viewID).
 			Uint64("block", consensus.blockNum).
 			Msg("[onViewChange] I am the New Leader")
+		consensus.generateNewVrf = true
 	}
 }
 

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -90,6 +90,10 @@ type Header struct {
 	LastCommitSignature [96]byte    `json:"lastCommitSignature"  gencodec:"required"`
 	LastCommitBitmap    []byte      `json:"lastCommitBitmap"     gencodec:"required"` // Contains which validator signed
 	ShardStateHash      common.Hash `json:"shardStateRoot"`
+	Vrf                 [32]byte    `json:"vrf"`
+	VrfProof            [96]byte    `json:"vrfProof"`
+	Vdf                 [258]byte   `json:"vdf"`
+	VdfProof            [258]byte   `json:"vdfProof"`
 	ShardState          []byte      `json:"shardState"`
 }
 
@@ -485,15 +489,25 @@ func Number(b1, b2 *Block) bool {
 	return b1.header.Number.Cmp(b2.header.Number) < 0
 }
 
-//// AddVdf add vdf into block header
-//func (b *Block) AddVdf(vdf [258]byte) {
-//	b.header.Vdf = vdf
-//}
-//
-//// AddVrf add vrf into block header
-//func (b *Block) AddVrf(vrf [32]byte) {
-//	b.header.Vrf = vrf
-//}
+// AddVrf add vrf into block header
+func (b *Block) AddVrf(vrf [32]byte) {
+	b.header.Vrf = vrf
+}
+
+// AddVrfProof add vrf into block header
+func (b *Block) AddVrfProof(proof [96]byte) {
+	b.header.VrfProof = proof
+}
+
+// AddVdf add vdf into block header
+func (b *Block) AddVdf(vdf [258]byte) {
+	b.header.Vdf = vdf
+}
+
+// AddVdfProof add vdf proof into block header
+func (b *Block) AddVdfProof(proof [258]byte) {
+	b.header.VdfProof = proof
+}
 
 // AddShardState add shardState into block header
 func (b *Block) AddShardState(shardState ShardState) error {


### PR DESCRIPTION
Design doc: https://docs.google.com/document/d/1JCcA7pM84q_wI1QAeRjbBXbkTjwcU6In9xHZ15NJJlo/edit

Summary

1)VRF is issued by the current beacon shard leader when a new block is announced.
2) The leader gets the hash of previous block (block( newBlock.number() - 1). hash() ) , use it to generate VRF and Proof through BLS_VRF algorithm. The generated VRF/Proof is put to block header fields: Vrf[32], VrfProof[96]
3)The new block is announced and all validators check the new Vrf and VrfProof in the onAnnounce(...) phase. Validate that Vrf/VrfProof is correct using the consensus leader's public BLS key
4)The new VRF is added to a VRF list for the current consensus.
5)All nodes wait for leader change
6)Leader changed
7)The new leader puts a new VRF to the block chain same as in 1)
8)The new leader checks the current VRF list, if the total number of VRFs >= 2/3 shard nodes, it xor all VRF and start VDF process. If not, go to 4)

