### PR TITLE
[cleanup] remove IsLeader of nodeConfig

### DIFF
--- a/api/service/config.go
+++ b/api/service/config.go
@@ -16,7 +16,6 @@ type NodeConfig struct {
 	Client       p2p.GroupID                    // the client group ID of the shard
 	IsClient     bool                           // whether this node is a client node, such as wallet/txgen
 	IsBeacon     bool                           // whether this node is a beacon node or not
-	IsLeader     bool                           // whether this node is a leader or not
 	ShardID      uint32                         // shardID of this node
 	Actions      map[p2p.GroupID]p2p.ActionType // actions on the groups
 }

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -333,28 +333,23 @@ func setUpConsensusAndNode(nodeConfig *nodeconfig.ConfigType) *node.Node {
 			nodeConfig.SetIsBeacon(true)
 			if nodeConfig.StringRole == "leader" {
 				currentNode.NodeConfig.SetRole(nodeconfig.BeaconLeader)
-				currentNode.NodeConfig.SetIsLeader(true)
 			} else {
 				currentNode.NodeConfig.SetRole(nodeconfig.BeaconValidator)
-				currentNode.NodeConfig.SetIsLeader(false)
 			}
 			currentNode.NodeConfig.SetShardGroupID(p2p.GroupIDBeacon)
 			currentNode.NodeConfig.SetClientGroupID(p2p.GroupIDBeaconClient)
 		} else {
 			if nodeConfig.StringRole == "leader" {
 				currentNode.NodeConfig.SetRole(nodeconfig.ShardLeader)
-				currentNode.NodeConfig.SetIsLeader(true)
 			} else {
 				currentNode.NodeConfig.SetRole(nodeconfig.ShardValidator)
-				currentNode.NodeConfig.SetIsLeader(false)
 			}
 			currentNode.NodeConfig.SetShardGroupID(p2p.NewGroupIDByShardID(p2p.ShardID(nodeConfig.ShardID)))
 			currentNode.NodeConfig.SetClientGroupID(p2p.NewClientGroupIDByShardID(p2p.ShardID(nodeConfig.ShardID)))
 		}
 	} else {
 		if *isNewNode {
-			currentNode.NodeConfig.SetIsLeader(false) // newnode can't be the leader
-			if nodeConfig.ShardID == 0 {              // Beacon chain
+			if nodeConfig.ShardID == 0 { // Beacon chain
 				nodeConfig.SetIsBeacon(true)
 				currentNode.NodeConfig.SetRole(nodeconfig.BeaconValidator)
 				currentNode.NodeConfig.SetShardGroupID(p2p.GroupIDBeacon)
@@ -367,7 +362,6 @@ func setUpConsensusAndNode(nodeConfig *nodeconfig.ConfigType) *node.Node {
 		}
 		if *isExplorer {
 			currentNode.NodeConfig.SetRole(nodeconfig.ExplorerNode)
-			currentNode.NodeConfig.SetIsLeader(false)
 			currentNode.NodeConfig.SetShardGroupID(p2p.NewGroupIDByShardID(p2p.ShardID(*shardID)))
 			currentNode.NodeConfig.SetClientGroupID(p2p.NewClientGroupIDByShardID(p2p.ShardID(*shardID)))
 		}

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -18,7 +18,6 @@ import (
 	"github.com/harmony-one/harmony/core/types"
 	bls_cosi "github.com/harmony-one/harmony/crypto/bls"
 	common2 "github.com/harmony-one/harmony/internal/common"
-	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/ctxerror"
 	"github.com/harmony-one/harmony/internal/genesis"
 	"github.com/harmony-one/harmony/internal/memprofiling"
@@ -240,13 +239,6 @@ func New(host p2p.Host, ShardID uint32, leader p2p.Peer, blsPriKey *bls.SecretKe
 	consensus.mode = PbftMode{mode: Normal}
 	// pbft timeout
 	consensus.consensusTimeout = createTimeout()
-
-	selfPeer := host.GetSelfPeer()
-	if leader.Port == selfPeer.Port && leader.IP == selfPeer.IP {
-		nodeconfig.GetDefaultConfig().SetIsLeader(true)
-	} else {
-		nodeconfig.GetDefaultConfig().SetIsLeader(false)
-	}
 
 	consensus.prepareSigs = map[string]*bls.Sign{}
 	consensus.commitSigs = map[string]*bls.Sign{}

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -22,7 +22,6 @@ import (
 	"github.com/harmony-one/harmony/core/state"
 	"github.com/harmony-one/harmony/core/types"
 	bls_cosi "github.com/harmony-one/harmony/crypto/bls"
-	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/ctxerror"
 	"github.com/harmony-one/harmony/internal/profiler"
 	"github.com/harmony-one/harmony/internal/utils"
@@ -398,7 +397,7 @@ func (consensus *Consensus) ResetState() {
 // Returns a string representation of this consensus
 func (consensus *Consensus) String() string {
 	var duty string
-	if nodeconfig.GetDefaultConfig().IsLeader() {
+	if consensus.IsLeader() {
 		duty = "LDR" // leader
 	} else {
 		duty = "VLD" // validator
@@ -666,4 +665,13 @@ func (consensus *Consensus) updateConsensusInformation() {
 			Msg("[SYNC] Most Recent LeaderPubKey Updated Based on BlockChain")
 		consensus.LeaderPubKey = leaderPubKey
 	}
+}
+
+// IsLeader check if the node is a leader or not by comparing the public key of
+// the node with the leader public key
+func (consensus *Consensus) IsLeader() bool {
+	if consensus.PubKey != nil && consensus.LeaderPubKey != nil {
+		return consensus.PubKey.IsEqual(consensus.LeaderPubKey)
+	}
+	return false
 }

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/harmony-one/harmony/crypto/bls"
-	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/p2p/p2pimpl"
@@ -23,10 +22,6 @@ func TestNew(test *testing.T) {
 	}
 	if consensus.viewID != 0 {
 		test.Errorf("Consensus Id is initialized to the wrong value: %d", consensus.viewID)
-	}
-
-	if !nodeconfig.GetDefaultConfig().IsLeader() {
-		test.Error("Consensus should belong to a leader")
 	}
 
 	if consensus.ReadySignal == nil {

--- a/internal/configs/node/config.go
+++ b/internal/configs/node/config.go
@@ -84,7 +84,6 @@ type ConfigType struct {
 	group    p2p.GroupID // the group ID of the shard (note: for beacon chain node, the beacon and shard group are the same)
 	client   p2p.GroupID // the client group ID of the shard
 	isClient bool        // whether this node is a client node, such as wallet/txgen
-	isLeader bool        // whether this node is a leader or not
 	isBeacon bool        // whether this node is beacon node doing consensus or not
 	ShardID  uint32      // ShardID of this node
 	role     Role        // Role of the node
@@ -146,7 +145,7 @@ func GetDefaultConfig() *ConfigType {
 }
 
 func (conf *ConfigType) String() string {
-	return fmt.Sprintf("%s/%s/%s:%v,%v,%v:%v", conf.beacon, conf.group, conf.client, conf.isClient, conf.IsBeacon(), conf.isLeader, conf.ShardID)
+	return fmt.Sprintf("%s/%s/%s:%v,%v,%v", conf.beacon, conf.group, conf.client, conf.isClient, conf.IsBeacon(), conf.ShardID)
 }
 
 // SetBeaconGroupID set the groupID for beacon group
@@ -167,11 +166,6 @@ func (conf *ConfigType) SetClientGroupID(g p2p.GroupID) {
 // SetIsClient set the isClient configuration
 func (conf *ConfigType) SetIsClient(b bool) {
 	conf.isClient = b
-}
-
-// SetIsLeader set the isLeader configuration
-func (conf *ConfigType) SetIsLeader(b bool) {
-	conf.isLeader = b
 }
 
 // SetIsBeacon sets the isBeacon configuration
@@ -212,11 +206,6 @@ func (conf *ConfigType) IsClient() bool {
 // IsBeacon returns the isBeacon configuration
 func (conf *ConfigType) IsBeacon() bool {
 	return conf.isBeacon
-}
-
-// IsLeader returns the isLeader configuration
-func (conf *ConfigType) IsLeader() bool {
-	return conf.isLeader
 }
 
 // Role returns the role

--- a/internal/configs/node/config_test.go
+++ b/internal/configs/node/config_test.go
@@ -13,19 +13,9 @@ func TestNodeConfigSingleton(t *testing.T) {
 	// get the singleton variable
 	c := GetShardConfig(Global)
 
-	c.SetIsLeader(true)
-
-	if !c.IsLeader() {
-		t.Errorf("IsLeader = %v, expected = %v", c.IsLeader(), true)
-	}
-
 	c.SetBeaconGroupID(p2p.GroupIDBeacon)
 
 	d := GetShardConfig(Global)
-
-	if !d.IsLeader() {
-		t.Errorf("IsLeader = %v, expected = %v", d.IsLeader(), true)
-	}
 
 	g := d.GetBeaconGroupID()
 

--- a/node/node.go
+++ b/node/node.go
@@ -270,7 +270,7 @@ func (node *Node) getTransactionsForNewBlock(maxNumTxs int, coinbase common.Addr
 
 // MaybeKeepSendingPongMessage keeps sending pong message if the current node is a leader.
 func (node *Node) MaybeKeepSendingPongMessage() {
-	if nodeconfig.GetDefaultConfig().IsLeader() {
+	if node.Consensus.IsLeader() {
 		go node.SendPongMessage()
 	}
 }
@@ -371,11 +371,6 @@ func New(host p2p.Host, consensusObj *consensus.Consensus, chainDBFactory shardc
 	}
 
 	utils.GetLogInstance().Info("Genesis block hash", "genesis block header", node.Blockchain().GetBlockByNumber(0).Header())
-	if consensusObj != nil && nodeconfig.GetDefaultConfig().IsLeader() {
-		node.State = NodeLeader
-	} else {
-		node.State = NodeInit
-	}
 
 	// start the goroutine to receive client message
 	// client messages are sent by clients, like txgen, wallet
@@ -459,8 +454,6 @@ func (node *Node) AddPeers(peers []*p2p.Peer) int {
 	// Only leader needs to add the peer info into consensus
 	// Validators will receive the updated peer info from Leader via pong message
 	// TODO: remove this after fully migrating to beacon chain-based committee membership
-	//if count > 0 && node.NodeConfig.IsLeader() {
-	//	node.Consensus.AddPeers(peers)
 	//	// TODO: make peers into a context object shared by consensus and drand
 	//	node.DRand.AddPeers(peers)
 	//}

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -759,7 +759,7 @@ func (node *Node) epochShardStateMessageHandler(msgPayload []byte) error {
 	receivedEpoch := big.NewInt(int64(epochShardState.Epoch))
 	getLogger().Info("received new shard state", "epoch", receivedEpoch)
 	node.nextShardState.master = epochShardState
-	if node.NodeConfig.IsLeader() {
+	if node.Consensus.IsLeader() {
 		// Wait a bit to allow the master table to reach other validators.
 		node.nextShardState.proposeTime = time.Now().Add(5 * time.Second)
 	} else {
@@ -785,7 +785,7 @@ func (node *Node) transitionIntoNextEpoch(shardState types.ShardState) {
 	logger = logger.New(
 		"blsPubKey", hex.EncodeToString(node.Consensus.PubKey.Serialize()),
 		"curShard", node.Blockchain().ShardID(),
-		"curLeader", node.NodeConfig.IsLeader())
+		"curLeader", node.Consensus.IsLeader())
 	for _, c := range shardState {
 		logger.Debug("new shard information",
 			"shardID", c.ShardID,


### PR DESCRIPTION
use consensus.IsLeader to replace the static nodeConfig
by checking the public key of the leader with the consensus public key

Signed-off-by: Leo Chen <leo@harmony.one>
