### PR TITLE
Add pagerduty validation status script

### DIFF
--- a/scripts/pagerduty.sh
+++ b/scripts/pagerduty.sh
@@ -36,8 +36,8 @@ delay=60
 ### Pagerduty
 if [[ $(($curtime - $latest)) -gt $delay ]]; then
     # Trigger an alert
-    trigger=$(curl -X POST -H "$HEADER" -d "$TRIGGER" "$POSTURL")
+    trigger=$(curl -s -X POST -H "$HEADER" -d "$TRIGGER" "$POSTURL")
 else
     # Resolve an alert
-    resolve=$(curl -X POST -H "$HEADER" -d "$RESOLVE" "$POSTURL")
+    resolve=$(curl -s -X POST -H "$HEADER" -d "$RESOLVE" "$POSTURL")
 fi

--- a/scripts/pagerduty.sh
+++ b/scripts/pagerduty.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
-# Pagerduty constants
+### Log variables
 LOGFILE="/home/tmp_log/log-20190628.153354/*.log"
 LOG=$(tail -n 1000 $LOGFILE)
-SHARD_NUM=$(echo "$LOG" | grep -oE -m 1 "Shard\":.?" | rev | cut -c 1)
+
+### POST constants
 IP=$(dig -4 @resolver1.opendns.com ANY myip.opendns.com +short)
-KEY="5d11f6173899423689b6fc98691930de"
+SHARD_NUM=$(echo "$LOG" | grep -oE -m 1 "Shard\":.?" | rev | cut -c 1)
 TRIGGER="\
 {\
-  \"routing_key\": \"$KEY\",\
   \"event_action\": \"trigger\",\
   \"dedup_key\": \"$IP\",\
   \"payload\": {\
@@ -19,39 +19,25 @@ TRIGGER="\
 }"
 RESOLVE="\
 {\
-  \"routing_key\": \"$KEY\",\
   \"event_action\": \"resolve\",\
   \"dedup_key\": \"$IP\"\
 }"
-JSON_HEADER="Content-Type: application/json"
+KEY="${HMY_PAGERDUTY_KEY}"
+HEADER="X-Routing-Key: $KEY"
 POSTURL="https://events.pagerduty.com/v2/enqueue"
 
-# Validation check constants
-if [[ -f "triggered" ]]
-  then
-    triggered=$(< triggered)
-  else
-    triggered=false
-fi
+### Validation check variables
 validation=$(echo "$LOG" | tac | grep -ai -m 1 "bingo\|hooray")
 timestamp=$(echo $validation | cut -f 3 -d 't' | cut -c 4-22 | tr T \ )
 latest=$(date -d "$timestamp" +%s)
 curtime=$(date +%s)
 delay=60
 
-# Pagerduty alert
-if [[ $(($curtime - $latest)) -gt $delay ]]
-  then
-    cat "$TRIGGER"
-    curl -X POST -H "$JSON_HEADER" -d "$TRIGGER" "$POSTURL"
-    echo
-    triggered=true
-  else
-    if [[ $triggered = true ]]
-      then
-        curl -X POST -H "$JSON_HEADER" -d "$RESOLVE" "$POSTURL"
-	      echo
-       triggered=false
-    fi
+### Pagerduty
+if [[ $(($curtime - $latest)) -gt $delay ]]; then
+    # Trigger an alert
+    trigger=curl -X POST -H "$HEADER" -d "$TRIGGER" "$POSTURL"
+else
+    # Resolve an alert
+    resolve=curl -X POST -H "$HEADER" -d "$RESOLVE" "$POSTURL"
 fi
-echo "$triggered" > triggered

--- a/scripts/pagerduty.sh
+++ b/scripts/pagerduty.sh
@@ -36,8 +36,8 @@ delay=60
 ### Pagerduty
 if [[ $(($curtime - $latest)) -gt $delay ]]; then
     # Trigger an alert
-    trigger=curl -X POST -H "$HEADER" -d "$TRIGGER" "$POSTURL"
+    trigger=$(curl -X POST -H "$HEADER" -d "$TRIGGER" "$POSTURL")
 else
     # Resolve an alert
-    resolve=curl -X POST -H "$HEADER" -d "$RESOLVE" "$POSTURL"
+    resolve=$(curl -X POST -H "$HEADER" -d "$RESOLVE" "$POSTURL")
 fi

--- a/scripts/pagerduty.sh
+++ b/scripts/pagerduty.sh
@@ -2,8 +2,8 @@
 
 # Pagerduty constants
 LOGFILE="/home/tmp_log/log-20190628.153354/*.log"
-LOG=$(tail -n 1000 $logfile)
-SHARD_NUM=$(echo "$log" | grep -oE -m 1 "Shard\":.?" | rev | cut -c 1)
+LOG=$(tail -n 1000 $LOGFILE)
+SHARD_NUM=$(echo "$LOG" | grep -oE -m 1 "Shard\":.?" | rev | cut -c 1)
 IP=$(dig -4 @resolver1.opendns.com ANY myip.opendns.com +short)
 KEY="5d11f6173899423689b6fc98691930de"
 TRIGGER="\
@@ -33,7 +33,7 @@ if [[ -f "triggered" ]]
   else
     triggered=false
 fi
-validation=$(tail -n 1000 $LOGFILE | tac | grep -ai -m 1 "bingo\|hooray")
+validation=$(echo "$LOG" | tac | grep -ai -m 1 "bingo\|hooray")
 timestamp=$(echo $validation | cut -f 3 -d 't' | cut -c 4-22 | tr T \ )
 latest=$(date -d "$timestamp" +%s)
 curtime=$(date +%s)

--- a/scripts/pagerduty.sh
+++ b/scripts/pagerduty.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Pagerduty constants
+LOGFILE="/home/tmp_log/log-20190628.153354/*.log"
+LOG=$(tail -n 1000 $logfile)
+SHARD_NUM=$(echo "$log" | grep -oE -m 1 "Shard\":.?" | rev | cut -c 1)
+IP=$(dig -4 @resolver1.opendns.com ANY myip.opendns.com +short)
+KEY="5d11f6173899423689b6fc98691930de"
+TRIGGER="\
+{\
+  \"routing_key\": \"$KEY\",\
+  \"event_action\": \"trigger\",\
+  \"dedup_key\": \"$IP\",\
+  \"payload\": {\
+    \"summary\": \"Node NOT validating: Shard-$SHARD_NUM: $IP\",\
+    \"source\": \"$IP\",\
+    \"severity\": \"critical\"\
+  }\
+}"
+RESOLVE="\
+{\
+  \"routing_key\": \"$KEY\",\
+  \"event_action\": \"resolve\",\
+  \"dedup_key\": \"$IP\"\
+}"
+JSON_HEADER="Content-Type: application/json"
+POSTURL="https://events.pagerduty.com/v2/enqueue"
+
+# Bingo check constants
+if [[ -f "triggered" ]]
+  then
+    triggered=$(< triggered)
+  else
+    triggered=false
+fi
+lastbingo=$(tail -n 1000 latest/*.log | tac | grep -ai -m 1 bingo)
+bingotime=$(echo $lastbingo | cut -f 2 -d 'r' | cut -c 16-34 | tr T \ )
+latest=$(date -d "$bingotime" +%s)
+curtime=$(date +%s)
+delay=60
+
+# Pagerduty alert
+if [[ $(($curtime - $latest)) -gt $delay ]]
+  then
+    cat "$TRIGGER"
+    curl -X POST -H "$JSON_HEADER" -d "$TRIGGER" "$POSTURL"
+    echo
+    triggered=true
+  else
+    if [[ $triggered = true ]]
+      then
+        curl -X POST -H "$JSON_HEADER" -d "$RESOLVE" "$POSTURL"
+	      echo
+       triggered=false
+    fi
+fi
+echo "$triggered" > triggered

--- a/scripts/pagerduty.sh
+++ b/scripts/pagerduty.sh
@@ -26,16 +26,16 @@ RESOLVE="\
 JSON_HEADER="Content-Type: application/json"
 POSTURL="https://events.pagerduty.com/v2/enqueue"
 
-# Bingo check constants
+# Validation check constants
 if [[ -f "triggered" ]]
   then
     triggered=$(< triggered)
   else
     triggered=false
 fi
-lastbingo=$(tail -n 1000 latest/*.log | tac | grep -ai -m 1 bingo)
-bingotime=$(echo $lastbingo | cut -f 2 -d 'r' | cut -c 16-34 | tr T \ )
-latest=$(date -d "$bingotime" +%s)
+validation=$(tail -n 1000 $LOGFILE | tac | grep -ai -m 1 "bingo\|hooray")
+timestamp=$(echo $validation | cut -f 3 -d 't' | cut -c 4-22 | tr T \ )
+latest=$(date -d "$timestamp" +%s)
 curtime=$(date +%s)
 delay=60
 


### PR DESCRIPTION
Script checks timestamp of last bingo in log and triggers an alert to Pagerduty if more than 60 seconds have passed since. The script should be used with crontab to be run every minute in order to constantly check for validation status.

> NOTE: If a Pagerduty has been triggered and node somehow starts validating again, the script will automatically send a resolve event to Pagerduty. This means that if the alert on Pagerduty is manually resolved (not simply acknowledged), the script will hang because it will try to post a resolve for an alert that doesn't exist. Not 100% sure if this functionality is wanted.

EDIT: Fixed