### PR TITLE
increase number of min peers in state syncing from 5 to 10

### DIFF
--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -28,7 +28,7 @@ const (
 	lastMileThreshold = 4
 	inSyncThreshold   = 1  // unit in number of block
 	SyncFrequency     = 10 // unit in second
-	MinConnectedPeers = 5  // minimum number of peers connected to in node syncing
+	MinConnectedPeers = 10 // minimum number of peers connected to in node syncing
 )
 
 // getNeighborPeers is a helper function to return list of peers


### PR DESCRIPTION
*\[@harmony-ek: the following rationale is mine]*

Since our rolling upgrade procedure restarts a stride of 4 nodes at a time, a restarted node sees up to 3 stale copies.  Setting the minimum gRPC peer count to 10 (from 5) ensures that there will be a supermajority (≥7) reply from non-stale nodes, ensuring that their chain will be chosen.