### PR TITLE
Unit test DeployAccount tables

### DIFF
--- a/internal/genesis/foundational_test.go
+++ b/internal/genesis/foundational_test.go
@@ -1,0 +1,16 @@
+package genesis
+
+import "testing"
+
+func TestFoundationalNodeAccounts(t *testing.T) {
+	for name, accounts := range map[string][]DeployAccount{
+		"V0":   FoundationalNodeAccounts,
+		"V0_1": FoundationalNodeAccountsV0_1,
+		"V0_2": FoundationalNodeAccountsV0_2,
+		// V0_3 exempted due to historical mistakes (dups at 187/204 & 202/205)
+		//"V0_3": FoundationalNodeAccountsV0_3,
+		"V0_4": FoundationalNodeAccountsV0_4,
+	} {
+		t.Run(name, func(t *testing.T) { testDeployAccounts(t, accounts) })
+	}
+}

--- a/internal/genesis/genesis_test.go
+++ b/internal/genesis/genesis_test.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/btcsuite/btcutil/bech32"
+	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/bls/ffi/go/bls"
+
+	"github.com/harmony-one/harmony/internal/common"
 )
 
 func TestString(t *testing.T) {
@@ -49,35 +51,39 @@ func testGenesisccounts(t *testing.T) {
 	}
 }
 
-func TestCommitteeAccounts(test *testing.T) {
-	testAccounts(test, FoundationalNodeAccounts)
-	testAccounts(test, FoundationalNodeAccountsV0_1)
-	testAccounts(test, FoundationalNodeAccountsV0_2)
-	testAccounts(test, FoundationalNodeAccountsV0_3)
-	testAccounts(test, FoundationalNodeAccountsV0_4)
-	testAccounts(test, HarmonyAccounts)
-	testAccounts(test, TNHarmonyAccounts)
-	testAccounts(test, TNFoundationalAccounts)
-}
-
-func testAccounts(test *testing.T, accounts []DeployAccount) {
-	index := 0
-	for _, account := range accounts {
-		accIndex, _ := strconv.Atoi(strings.Trim(account.Index, " "))
-		if accIndex != index {
-			test.Error("Account index", account.Index, "not in sequence")
+func testDeployAccounts(t *testing.T, accounts []DeployAccount) {
+	indicesByAddress := make(map[ethCommon.Address][]int)
+	indicesByKey := make(map[string][]int)
+	for index, account := range accounts {
+		if strings.TrimSpace(account.Index) != strconv.Itoa(index) {
+			t.Errorf("account %+v at index %v has wrong index string",
+				account, index)
 		}
-		index++
-
-		_, _, err := bech32.Decode(account.Address)
-		if err != nil {
-			test.Error("Account address", account.Address, "is not valid:", err)
+		if address, err := common.Bech32ToAddress(account.Address); err != nil {
+			t.Errorf("account %+v at index %v has invalid address (%s)",
+				account, index, err)
+		} else {
+			indicesByAddress[address] = append(indicesByAddress[address], index)
 		}
-
 		pubKey := bls.PublicKey{}
-		err = pubKey.DeserializeHexStr(account.BlsPublicKey)
-		if err != nil {
-			test.Error("Account bls public key", account.BlsPublicKey, "is not valid:", err)
+		if err := pubKey.DeserializeHexStr(account.BlsPublicKey); err != nil {
+			t.Errorf("account %+v at index %v has invalid public key (%s)",
+				account, index, err)
+		} else {
+			pubKeyStr := pubKey.SerializeToHexStr()
+			indicesByKey[pubKeyStr] = append(indicesByKey[pubKeyStr], index)
+		}
+	}
+	for address, indices := range indicesByAddress {
+		if len(indices) > 1 {
+			t.Errorf("account address %s appears in multiple rows: %v",
+				common.MustAddressToBech32(address), indices)
+		}
+	}
+	for pubKey, indices := range indicesByKey {
+		if len(indices) > 1 {
+			t.Errorf("BLS public key %s appears in multiple rows: %v",
+				pubKey, indices)
 		}
 	}
 }

--- a/internal/genesis/harmony_test.go
+++ b/internal/genesis/harmony_test.go
@@ -1,0 +1,7 @@
+package genesis
+
+import "testing"
+
+func TestHarmonyAccounts(t *testing.T) {
+	testDeployAccounts(t, HarmonyAccounts)
+}

--- a/internal/genesis/localnodes_test.go
+++ b/internal/genesis/localnodes_test.go
@@ -1,0 +1,16 @@
+package genesis
+
+import "testing"
+
+func TestLocalTestAccounts(t *testing.T) {
+	for name, accounts := range map[string][]DeployAccount{
+		"HarmonyV0":      LocalHarmonyAccounts,
+		"HarmonyV1":      LocalHarmonyAccountsV1,
+		"HarmonyV2":      LocalHarmonyAccountsV2,
+		"FoundationalV0": LocalFnAccounts,
+		"FoundationalV1": LocalFnAccountsV1,
+		"FoundationalV2": LocalFnAccountsV2,
+	} {
+		t.Run(name, func(t *testing.T) { testDeployAccounts(t, accounts) })
+	}
+}

--- a/internal/genesis/newnodes.go
+++ b/internal/genesis/newnodes.go
@@ -2,14 +2,14 @@ package genesis
 
 // NewNodeAccounts are the accounts for the new node
 var NewNodeAccounts = [...]DeployAccount{
-	{Index: "0", Address: "0x0e59b767D5E74cf7B29Ef9bEc3dA4c402d357C6C", BlsPublicKey: "92fa832056e71ea833e24a7e877e2f371ca645cf338a4cb93c2ced40d8d6676eaf15dac642f22c238d58fed279f34700"},
-	{Index: "1", Address: "0x0fAAda81c203C74CAc786786f7D428477a04bF9c", BlsPublicKey: "d1ac9bbf790e347cbe5e6fb9145f5ffd93e335452f94829df6376c6924fbceea4b96ac8c29778e7b06a92e25bd06f892"},
-	{Index: "2", Address: "0x0fd228bdFbe9ad0c898e9A0Fee2E6FB01f596F0d", BlsPublicKey: "0a4d8c3168072ac82604103b3ca5efd038ae38c6062f303b08a24152b8c58d1ff3b578521f80a386bcfa2ad6c680ba14"},
-	{Index: "3", Address: "0x123FF831333e2662D00c60A2C46f7196204506e9", BlsPublicKey: "a31b122157b1d6d958a184361299396b3b72a3cdcd20eb5e07e18bc03034fa1a8ddbd2e0f9e3ed68cd412b7b673c0094"},
-	{Index: "4", Address: "0x1240775288d0EE975583A2A7022006539dADb354", BlsPublicKey: "1aeaebce1a8a8aabb64877491a392f63682b3e2a223d1d3c7c5ef8d5b33e5e700543d5c9d8017c8520e6d7193f496f05"},
-	{Index: "5", Address: "0x127b8Cb71Fb78338d9EFFe47bB51c2EAd3995378", BlsPublicKey: "3ec3dd79bd1a8e27d0fa927bbf0f425ce564a962389a723924f071fc7802bc5924d848980595cd584e3588a6d3e0a191"},
-	{Index: "6", Address: "0x141B0e0f05739B7B784654E973e9b9146473aAb9", BlsPublicKey: "f2f085fb9258e47601db4c3b87f9d603b7557b57e1c4e0361f86f42070b45bca09d69276c4717846589b3a99481eed80"},
-	{Index: "7", Address: "0x1492ebD0EcfD54B4c211b37C8891bA3493c52100", BlsPublicKey: "01c91a20ec490e2e6663a3c5ce04e57b991998f8967453535360de66e14dca797aa5fd270cc6d3dbc31d684d2622af05"},
-	{Index: "8", Address: "0x1530A04592F9C3bF06aC6044525f08937ED38edB", BlsPublicKey: "fe3f52d068bb83211b3e804a29f27699f9388d2dd0fcbf91353e4dd68da69636046a24fd5912f8dd5e97388577fd388a"},
-	{Index: "9", Address: "0xE2ab78ecf325084485957B2599d53Bcf944Cbca8", BlsPublicKey: "c02e49e1395c6fbbabf0d619d872f74774d34ddec83553cf7f687da593253d072d5d050b3b4a3005304e504781847999"},
+	{Index: "0", Address: "one1pevmwe74uax00v57lxlv8kjvgqkn2lrv843nt9", BlsPublicKey: "92fa832056e71ea833e24a7e877e2f371ca645cf338a4cb93c2ced40d8d6676eaf15dac642f22c238d58fed279f34700"},
+	{Index: "1", Address: "one1p74d4qwzq0r5etrcv7r004pggaaqf0uu273jdl", BlsPublicKey: "d1ac9bbf790e347cbe5e6fb9145f5ffd93e335452f94829df6376c6924fbceea4b96ac8c29778e7b06a92e25bd06f892"},
+	{Index: "2", Address: "one1plfz300maxksezvwng87utn0kq04jmcd4jx4c8", BlsPublicKey: "0a4d8c3168072ac82604103b3ca5efd038ae38c6062f303b08a24152b8c58d1ff3b578521f80a386bcfa2ad6c680ba14"},
+	{Index: "3", Address: "one1zgllsvfn8cnx95qvvz3vgmm3jcsy2phf4wj7hm", BlsPublicKey: "a31b122157b1d6d958a184361299396b3b72a3cdcd20eb5e07e18bc03034fa1a8ddbd2e0f9e3ed68cd412b7b673c0094"},
+	{Index: "4", Address: "one1zfq8w55g6rhfw4vr52nsygqx2ww6mv658l4r5y", BlsPublicKey: "1aeaebce1a8a8aabb64877491a392f63682b3e2a223d1d3c7c5ef8d5b33e5e700543d5c9d8017c8520e6d7193f496f05"},
+	{Index: "5", Address: "one1zfacedclk7pn3k00lermk5wzatfej5mct4hh5r", BlsPublicKey: "3ec3dd79bd1a8e27d0fa927bbf0f425ce564a962389a723924f071fc7802bc5924d848980595cd584e3588a6d3e0a191"},
+	{Index: "6", Address: "one1zsdsurc9wwdhk7zx2n5h86dez3j8824ef59clr", BlsPublicKey: "f2f085fb9258e47601db4c3b87f9d603b7557b57e1c4e0361f86f42070b45bca09d69276c4717846589b3a99481eed80"},
+	{Index: "7", Address: "one1zjfwh58vl42tfss3kd7g3yd6xjfu2ggqsg2ecs", BlsPublicKey: "01c91a20ec490e2e6663a3c5ce04e57b991998f8967453535360de66e14dca797aa5fd270cc6d3dbc31d684d2622af05"},
+	{Index: "8", Address: "one1z5c2q3vjl8pm7p4vvpz9yhcgjdld8rkmu9uwdh", BlsPublicKey: "fe3f52d068bb83211b3e804a29f27699f9388d2dd0fcbf91353e4dd68da69636046a24fd5912f8dd5e97388577fd388a"},
+	{Index: "9", Address: "one1u24h3m8ny5yyfpv40vjen4fme72ye09gn5mr9q", BlsPublicKey: "c02e49e1395c6fbbabf0d619d872f74774d34ddec83553cf7f687da593253d072d5d050b3b4a3005304e504781847999"},
 }

--- a/internal/genesis/newnodes_test.go
+++ b/internal/genesis/newnodes_test.go
@@ -1,0 +1,7 @@
+package genesis
+
+import "testing"
+
+func TestNewNodeAccounts(t *testing.T) {
+	testDeployAccounts(t, NewNodeAccounts[:])
+}

--- a/internal/genesis/tn_harmony_test.go
+++ b/internal/genesis/tn_harmony_test.go
@@ -1,0 +1,11 @@
+package genesis
+
+import "testing"
+
+func TestTNHarmonyAccounts(t *testing.T) {
+	testDeployAccounts(t, TNHarmonyAccounts)
+}
+
+func TestTNFoundationalAccounts(t *testing.T) {
+	testDeployAccounts(t, TNFoundationalAccounts)
+}


### PR DESCRIPTION
## Issue

Introduce unit tests for `DeployAccount` tables which are often manually updated thus prone to errors.  Enforce the following:

* `Address` is a valid Bech32 address (guard against typo)
* `BlsPublicKey` is a valid BLS public key (guard against typo)
* `Address` and `BlsPublicKey` are unique within the table (common copy/paste glitch)

## Test

### Test Coverage Data

Before @LeoHChen's fix (#1273) and with a few intentional duplications:

```
$ go test ./internal/genesis
--- FAIL: TestFoundationalNodeAccountsV1 (0.03s)
    genesis_test.go:63: account one1pjn8zz5av5ddenaxmu6qrs381xuapygkeatxga/71c907378831009328f28db0e324848767b58e49eae1f2774e81276e25732bfea5ed8a567fed15afb010be05b9732b16:0 at index 158 has invalid address (cannot decode "one1pjn8zz5av5ddenaxmu6qrs381xuapygkeatxga" as bech32 address: decoding bech32 failed: checksum failed. Expected ecpqta, got eatxga.)
    genesis_test.go:79: account address one1s3dx73sa5dzrksmds5recptale8pxsa4d4hzt4 appears in multiple rows: [156 157]
    genesis_test.go:85: BLS public key 71c907378831009328f28db0e324848767b58e49eae1f2774e81276e25732bfea5ed8a567fed15afb010be05b9732b16 appears in multiple rows: [158 159]
FAIL
FAIL    github.com/harmony-one/harmony/internal/genesis 0.450s
```

After the fix:

```
$ go test ./internal/genesis
ok      github.com/harmony-one/harmony/internal/genesis 0.481s
```

Also, `FoundationalNodeAccountsV0_3` has two historical duplications, which this test detects:

```
--- FAIL: TestFoundationalNodeAccounts (0.19s)
    --- PASS: TestFoundationalNodeAccounts/V0_4 (0.05s)
    --- PASS: TestFoundationalNodeAccounts/V0 (0.03s)
    --- PASS: TestFoundationalNodeAccounts/V0_1 (0.03s)
    --- PASS: TestFoundationalNodeAccounts/V0_2 (0.04s)
    --- FAIL: TestFoundationalNodeAccounts/V0_3 (0.05s)
        genesis_test.go:79: account address one1g6l7xj9w8z3uxjud8da69twzvyccqam6k5xymd appears in multiple rows: [202 205]
        genesis_test.go:79: account address one1hyqkrvkad8kpttpglrl42rcthd6h0uqg2etgf4 appears in multiple rows: [187 204]
        genesis_test.go:85: BLS public key 1bc81f9fd333524032c5a8fbbd976b00ba8d5e0e2efe60fd8336abbaec1b5744ecef07b242efddf09bd42dbcbd2f5795 appears in multiple rows: [187 204]
        genesis_test.go:85: BLS public key a11451a324fffc50f33e934bcee1bd673b7e285c24817285cea8207212aad9951aa9b6c40a5b78a7fea7ed047c48d188 appears in multiple rows: [202 205]
```