### PR TITLE
Added wrapper for DRG generation based on epoch number

### DIFF
--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -5,7 +5,10 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/big"
 	"time"
+
+	"github.com/harmony-one/harmony/core"
 
 	"github.com/harmony-one/harmony/crypto/hash"
 
@@ -677,5 +680,14 @@ func (consensus *Consensus) IsLeader() bool {
 	if consensus.PubKey != nil && consensus.LeaderPubKey != nil {
 		return consensus.PubKey.IsEqual(consensus.LeaderPubKey)
 	}
+	return false
+}
+
+// NeedsRandomNumberGeneration returns true if the current epoch needs random number generation
+func (consensus *Consensus) NeedsRandomNumberGeneration(epoch *big.Int) bool {
+	if consensus.ShardID == 0 && epoch.Uint64() >= core.ShardingSchedule.RandomnessStartingEpoch() {
+		return true
+	}
+
 	return false
 }

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -210,7 +210,7 @@ func (consensus *Consensus) onAnnounce(msg *msg_pb.Message) {
 		}
 
 		//VRF/VDF is only generated in the beach chain
-		if consensus.ShardID == 0 {
+		if consensus.NeedsRandomNumberGeneration(headerObj.Epoch) {
 			//validate the VRF with proof if a non zero VRF is found in header
 			if len(headerObj.Vrf) > 0 {
 				if !consensus.ValidateVrfAndProof(headerObj) {
@@ -1104,13 +1104,14 @@ func (consensus *Consensus) Start(blockChannel chan *types.Block, stopChan chan 
 					Msg("[ConsensusMainLoop] Received Proposed New Block!")
 
 				//VRF/VDF is only generated in the beacon chain
-				if consensus.ShardID == 0 {
+				if consensus.NeedsRandomNumberGeneration(newBlock.Header().Epoch) {
 					// generate VRF if the current block has a new leader
 					if !consensus.ChainReader.IsSameLeaderAsPreviousBlock(newBlock) {
 						vrfBlockNumbers, err := consensus.ChainReader.ReadEpochVrfBlockNums(newBlock.Header().Epoch)
 						if err != nil {
 							consensus.getLogger().Info().
 								Uint64("MsgBlockNum", newBlock.NumberU64()).
+								Uint64("Epoch", newBlock.Header().Epoch.Uint64()).
 								Msg("[ConsensusMainLoop] no VRF block number from local db")
 						}
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1961,7 +1961,7 @@ func (bc *BlockChain) WriteEpochVdfBlockNum(epoch *big.Int, blockNum *big.Int) e
 
 // IsSameLeaderAsPreviousBlock retrieves a block from the database by number, caching it
 func (bc *BlockChain) IsSameLeaderAsPreviousBlock(block *types.Block) bool {
-	if block.NumberU64() == 0 {
+	if IsEpochBlock(block) {
 		return false
 	}
 

--- a/internal/configs/sharding/fixedschedule.go
+++ b/internal/configs/sharding/fixedschedule.go
@@ -41,6 +41,12 @@ func (s fixedSchedule) ConsensusRatio() float64 {
 	return mainnetConsensusRatio
 }
 
+// TODO: remove it after randomness feature turned on mainnet
+//RandonnessStartingEpoch returns starting epoch of randonness generation
+func (s fixedSchedule) RandomnessStartingEpoch() uint64 {
+	return mainnetRandomnessStartingEpoch
+}
+
 // NewFixedSchedule returns a sharding configuration schedule that uses the
 // given config instance for all epochs.  Useful for testing.
 func NewFixedSchedule(instance Instance) Schedule {

--- a/internal/configs/sharding/localnet.go
+++ b/internal/configs/sharding/localnet.go
@@ -21,6 +21,9 @@ const (
 
 	localnetVdfDifficulty  = 5000 // This takes about 10s to finish the vdf
 	localnetConsensusRatio = float64(0.1)
+
+	// TODO: remove it after randomness feature turned on mainnet
+	localnetRandomnessStartingEpoch = 0
 )
 
 func (localnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
@@ -67,6 +70,12 @@ func (ls localnetSchedule) VdfDifficulty() int {
 // ConsensusRatio ratio of new nodes vs consensus total nodes
 func (ls localnetSchedule) ConsensusRatio() float64 {
 	return localnetConsensusRatio
+}
+
+// TODO: remove it after randomness feature turned on mainnet
+//RandonnessStartingEpoch returns starting epoch of randonness generation
+func (ls localnetSchedule) RandomnessStartingEpoch() uint64 {
+	return localnetRandomnessStartingEpoch
 }
 
 var localnetReshardingEpoch = []*big.Int{big.NewInt(0), big.NewInt(localnetV1Epoch), big.NewInt(localnetV2Epoch)}

--- a/internal/configs/sharding/mainnet.go
+++ b/internal/configs/sharding/mainnet.go
@@ -14,6 +14,9 @@ const (
 
 	mainnetVdfDifficulty  = 50000 // This takes about 100s to finish the vdf
 	mainnetConsensusRatio = float64(0.66)
+
+	// TODO: remove it after randomness feature turned on mainnet
+	mainnetRandomnessStartingEpoch = 10
 )
 
 // MainnetSchedule is the mainnet sharding configuration schedule.
@@ -67,6 +70,12 @@ func (ms mainnetSchedule) VdfDifficulty() int {
 // ConsensusRatio ratio of new nodes vs consensus total nodes
 func (ms mainnetSchedule) ConsensusRatio() float64 {
 	return mainnetConsensusRatio
+}
+
+// TODO: remove it after randomness feature turned on mainnet
+//RandonnessStartingEpoch returns starting epoch of randonness generation
+func (ms mainnetSchedule) RandomnessStartingEpoch() uint64 {
+	return mainnetRandomnessStartingEpoch
 }
 
 var mainnetReshardingEpoch = []*big.Int{big.NewInt(0), big.NewInt(mainnetV1Epoch), big.NewInt(mainnetV2Epoch)}

--- a/internal/configs/sharding/mainnet.go
+++ b/internal/configs/sharding/mainnet.go
@@ -16,7 +16,7 @@ const (
 	mainnetConsensusRatio = float64(0.66)
 
 	// TODO: remove it after randomness feature turned on mainnet
-	mainnetRandomnessStartingEpoch = 10
+	mainnetRandomnessStartingEpoch = 100000
 )
 
 // MainnetSchedule is the mainnet sharding configuration schedule.

--- a/internal/configs/sharding/pangaea.go
+++ b/internal/configs/sharding/pangaea.go
@@ -41,3 +41,9 @@ var pangaeaReshardingEpoch = []*big.Int{common.Big0}
 
 var pangaeaV0 = MustNewInstance(
 	4, 200, 200, genesis.PangaeaAccounts, nil, pangaeaReshardingEpoch)
+
+// TODO: remove it after randomness feature turned on mainnet
+//RandonnessStartingEpoch returns starting epoch of randonness generation
+func (pangaeaSchedule) RandomnessStartingEpoch() uint64 {
+	return mainnetRandomnessStartingEpoch
+}

--- a/internal/configs/sharding/shardingconfig.go
+++ b/internal/configs/sharding/shardingconfig.go
@@ -27,6 +27,10 @@ type Schedule interface {
 
 	// ConsensusRatio ratio of new nodes vs consensus total nodes
 	ConsensusRatio() float64
+
+	// TODO: remove it after randomness feature turned on mainnet
+	//RandomnessStartingEpoch returns starting epoch of randonness generation
+	RandomnessStartingEpoch() uint64
 }
 
 // Instance is one sharding configuration instance.

--- a/internal/configs/sharding/testnet.go
+++ b/internal/configs/sharding/testnet.go
@@ -69,6 +69,12 @@ func (ts testnetSchedule) ConsensusRatio() float64 {
 	return mainnetConsensusRatio
 }
 
+// TODO: remove it after randomness feature turned on mainnet
+//RandonnessStartingEpoch returns starting epoch of randonness generation
+func (ts testnetSchedule) RandomnessStartingEpoch() uint64 {
+	return mainnetRandomnessStartingEpoch
+}
+
 var testnetReshardingEpoch = []*big.Int{big.NewInt(0), big.NewInt(testnetV1Epoch), big.NewInt(testnetV2Epoch)}
 
 var testnetV0 = MustNewInstance(2, 150, 150, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch)


### PR DESCRIPTION
## Issue
Need to adjust mainnet DRG feature on EPOCH

mainnetRandomnessStartingEpoch = 10

The code should be removed after DRG is on mainnet. 

## Test

#### Test Coverage Data

<!-- run 'go test -cover' in the directory you made change -->

* Before
* After

#### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## TODO
