### PR TITLE
Add -N (network) option to node.sh

### DIFF
--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -163,7 +163,13 @@ main)
   network_type=mainnet
   ;;
 beta)
-  err 69 "${network}: unsupported yet"
+  bootnodes=(
+    /ip4/54.213.43.194/tcp/9868/p2p/QmZJJx6AdaoEkGLrYG4JeLCKeCKDjnFz2wfHNHxAqFSGA9
+    /ip4/100.26.90.187/tcp/9868/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv
+    /ip4/13.113.101.219/tcp/12018/p2p/QmQayinFSgMMw5cSpDUiD9pQ2WeP6WNmGxpZ6ou3mdVFJX
+  )
+  REL=testnet
+  network_type=testnet
   ;;
 pangaea)
   bootnodes=(

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -406,11 +406,17 @@ do
       -port "${NODE_PORT}"
       -is_genesis
       -blskey_file "${BLSKEYFILE}"
-      -metrics "${metrics}"
-      -pushgateway_ip "${PUSHGATEWAY_IP}"
-      -pushgateway_port "${PUSHGATEWAY_PORT}"
       -network_type="${network_type}"
    )
+   case "${metrics}" in
+   true)
+      args+=(
+         -metrics "${metrics}"
+         -pushgateway_ip "${PUSHGATEWAY_IP}"
+         -pushgateway_port "${PUSHGATEWAY_PORT}"
+      )
+      ;;
+   esac
    case "$OS" in
    Darwin) ld_path_var=DYLD_FALLBACK_LIBRARY_PATH;;
    *) ld_path_var=LD_LIBRARY_PATH;;

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -104,6 +104,7 @@ usage: ${progname} [-1ch] [-k KEYFILE]
    -D             do not download Harmony binaries (default: download when start)
    -m             collect and upload node metrics to harmony prometheus + grafana
    -N network     join the given network (main, beta, pangaea; default: main)
+   -t             equivalent to -N pangaea (deprecated)
 
 example:
 
@@ -129,7 +130,7 @@ ${BLSKEYFILE=}
 
 unset OPTIND OPTARG opt
 OPTIND=1
-while getopts :1chk:sSp:DmN: opt
+while getopts :1chk:sSp:DmN:t opt
 do
    case "${opt}" in
    '?') usage "unrecognized option -${OPTARG}";;
@@ -144,6 +145,7 @@ do
    D) do_not_download=true;;
    m) metrics=true;;
    N) network="${OPTARG}";;
+   t) network=pangaea;;
    *) err 70 "unhandled option -${OPTARG}";;  # EX_SOFTWARE
    esac
 done

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -149,7 +149,7 @@ do
 done
 shift $((${OPTIND} - 1))
 
-unset -v bootnodes REL network_type
+unset -v bootnodes REL network_type dns_zone
 
 case "${network}" in
 main)
@@ -161,6 +161,7 @@ main)
   )
   REL=r3
   network_type=mainnet
+  dns_zone=t.hmny.io
   ;;
 beta)
   bootnodes=(
@@ -170,6 +171,7 @@ beta)
   )
   REL=testnet
   network_type=testnet
+  dns_zone=
   ;;
 pangaea)
   bootnodes=(
@@ -180,6 +182,7 @@ pangaea)
   )
   REL=master
   network_type=pangaea
+  dns_zone=p.hmny.io
   ;;
 *)
   err 64 "${network}: invalid network"
@@ -413,6 +416,7 @@ do
       -is_genesis
       -blskey_file "${BLSKEYFILE}"
       -network_type="${network_type}"
+      -dns_zone="${dns_zone}"
    )
    case "${metrics}" in
    true)

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -149,7 +149,7 @@ do
 done
 shift $((${OPTIND} - 1))
 
-unset -v bootnodes REL
+unset -v bootnodes REL network_type
 
 case "${network}" in
 main)
@@ -160,6 +160,7 @@ main)
     /ip4/99.81.170.167/tcp/12019/p2p/QmRVbTpEYup8dSaURZfF6ByrMTSKa4UyUzJhSjahFzRqNj
   )
   REL=r3
+  network_type=mainnet
   ;;
 beta)
   err 69 "${network}: unsupported yet"
@@ -172,6 +173,7 @@ pangaea)
     /ip4/99.81.170.167/tcp/9867/p2p/QmRVbTpEYup8dSaURZfF6ByrMTSKa4UyUzJhSjahFzRqNj
   )
   REL=master
+  network_type=pangaea
   ;;
 *)
   err 64 "${network}: invalid network"
@@ -407,6 +409,7 @@ do
       -metrics "${metrics}"
       -pushgateway_ip "${PUSHGATEWAY_IP}"
       -pushgateway_port "${PUSHGATEWAY_PORT}"
+      -network_type="${network_type}"
    )
    case "$OS" in
    Darwin) ld_path_var=DYLD_FALLBACK_LIBRARY_PATH;;


### PR DESCRIPTION
Valid networks are main (mainnet), beta (betanet), pangaea (Pangaea);
default is main.

Vary release channel (folder), bootnodes, and network type.

TODO @harmony-ek – replace hardcoded bootnode with DNS
