### PR TITLE
Add target to "Register failed" error to help debug issue #1336

### DIFF
--- a/api/service/syncing/downloader/client.go
+++ b/api/service/syncing/downloader/client.go
@@ -49,7 +49,7 @@ func (client *Client) GetBlockHashes(startHash []byte, size uint32, ip, port str
 	request.Port = port
 	response, err := client.dlClient.Query(ctx, request)
 	if err != nil {
-		utils.Logger().Error().Err(err).Msg("[SYNC] GetBlockHashes query failed")
+		utils.Logger().Error().Err(err).Str("target", client.conn.Target()).Msg("[SYNC] GetBlockHashes query failed")
 	}
 	return response
 }
@@ -66,7 +66,7 @@ func (client *Client) GetBlocks(hashes [][]byte) *pb.DownloaderResponse {
 	}
 	response, err := client.dlClient.Query(ctx, request)
 	if err != nil {
-		utils.Logger().Error().Err(err).Msg("[SYNC] downloader/client.go:GetBlocks query failed")
+		utils.Logger().Error().Err(err).Str("target", client.conn.Target()).Msg("[SYNC] downloader/client.go:GetBlocks query failed")
 	}
 	return response
 }
@@ -83,7 +83,7 @@ func (client *Client) Register(hash []byte, ip, port string) *pb.DownloaderRespo
 	request.Port = port
 	response, err := client.dlClient.Query(ctx, request)
 	if err != nil || response == nil {
-		utils.Logger().Error().Err(err).Interface("response", response).Msg("[SYNC] client.go:Register failed")
+		utils.Logger().Error().Err(err).Str("target", client.conn.Target()).Interface("response", response).Msg("[SYNC] client.go:Register failed")
 	}
 	return response
 }
@@ -105,7 +105,7 @@ func (client *Client) PushNewBlock(selfPeerHash [20]byte, blockHash []byte, time
 
 	response, err := client.dlClient.Query(ctx, request)
 	if err != nil {
-		utils.Logger().Error().Err(err).Msg("[SYNC] unable to send new block to unsync node")
+		utils.Logger().Error().Err(err).Str("target", client.conn.Target()).Msg("[SYNC] unable to send new block to unsync node")
 	}
 	return response
 }


### PR DESCRIPTION
It is helpful to know who the misbehaving endpoint is when download registration fails.