### PR TITLE
Get syncing peers using DNS, part 1

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2107,7 +2107,7 @@ func (bc *BlockChain) CXMerkleProof(shardID uint32, block *types.Block) (*types.
 }
 
 // NextCXReceiptsProofUnspentCheckpoint returns the next checkpoint blockNum
-func (bc *BlockChain) NextCXReceiptsProofUnpentCheckpoint(currentNum uint64, shardID uint32) uint64 {
+func (bc *BlockChain) NextCXReceiptsProofUnspentCheckpoint(currentNum uint64, shardID uint32) uint64 {
 	lastCheckpoint, _ := rawdb.ReadCXReceiptsProofUnspentCheckpoint(bc.db, shardID)
 	newCheckpoint := lastCheckpoint
 
@@ -2138,7 +2138,7 @@ func (bc *BlockChain) UpdateCXReceiptsProofUnspentAndCheckpoint(currentNum uint6
 	if err != nil {
 		utils.Logger().Warn().Msg("[UpdateCXReceiptsProofUnspentAndCheckpoint] Canot get lastCheckpoint")
 	}
-	newCheckpoint := bc.NextCXReceiptsProofUnpentCheckpoint(currentNum, shardID)
+	newCheckpoint := bc.NextCXReceiptsProofUnspentCheckpoint(currentNum, shardID)
 	if lastCheckpoint == newCheckpoint {
 		return
 	}

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -32,8 +32,8 @@ import (
 // Indicate whether the receipts corresponding to a blockHash is unspent or not
 // use a default blockHash as indicator which should be collision resistent
 var (
-	SpentHash common.Hash = common.Hash{0x01}
-	EmptyHash common.Hash = common.Hash{}
+	SpentHash = common.Hash{0x01}
+	EmptyHash = common.Hash{}
 )
 
 // ReadCanonicalHash retrieves the hash assigned to a canonical block number.

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -207,9 +207,9 @@ type StorageBlock Block
 
 // "external" block encoding. used for eth protocol, etc.
 type extblock struct {
-	Header *Header
-	Txs    []*Transaction
-	Uncles []*Header
+	Header           *Header
+	Txs              []*Transaction
+	Uncles           []*Header
 	IncomingReceipts CXReceiptsProofs
 }
 
@@ -323,9 +323,9 @@ func (b *Block) DecodeRLP(s *rlp.Stream) error {
 // EncodeRLP serializes b into the Ethereum RLP block format.
 func (b *Block) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, extblock{
-		Header: b.header,
-		Txs:    b.transactions,
-		Uncles: b.uncles,
+		Header:           b.header,
+		Txs:              b.transactions,
+		Uncles:           b.uncles,
 		IncomingReceipts: b.incomingReceipts,
 	})
 }

--- a/node/node.go
+++ b/node/node.go
@@ -125,7 +125,7 @@ type Node struct {
 	stateSync              *syncing.StateSync
 	beaconSync             *syncing.StateSync
 	peerRegistrationRecord map[string]*syncConfig // record registration time (unixtime) of peers begin in syncing
-	dnsZone                string
+	SyncingPeerProvider    SyncingPeerProvider
 
 	// The p2p host used to send/receive p2p messages
 	host p2p.Host
@@ -519,10 +519,4 @@ func (node *Node) initNodeConfiguration() (service.NodeConfig, chan p2p.Peer) {
 // AccountManager ...
 func (node *Node) AccountManager() *accounts.Manager {
 	return node.accountManager
-}
-
-// SetDNSZone sets the DNS zone to use to get peer info for node syncing
-func (node *Node) SetDNSZone(zone string) {
-	utils.Logger().Info().Str("zone", zone).Msg("using DNS zone to get peers")
-	node.dnsZone = zone
 }

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/pkg/errors"
 
 	"github.com/harmony-one/harmony/api/service/syncing"
 	"github.com/harmony-one/harmony/api/service/syncing/downloader"
@@ -33,7 +33,7 @@ const (
 
 // getNeighborPeers is a helper function to return list of peers
 // based on different neightbor map
-func (node *Node) getNeighborPeers(neighbor *sync.Map) []p2p.Peer {
+func getNeighborPeers(neighbor *sync.Map) []p2p.Peer {
 	tmp := []p2p.Peer{}
 	neighbor.Range(func(k, v interface{}) bool {
 		p := v.(p2p.Peer)
@@ -47,7 +47,7 @@ func (node *Node) getNeighborPeers(neighbor *sync.Map) []p2p.Peer {
 
 // DoSyncWithoutConsensus gets sync-ed to blockchain without joining consensus
 func (node *Node) DoSyncWithoutConsensus() {
-	go node.DoSyncing(node.Blockchain(), node.Worker, node.GetSyncingPeers, false) //Don't join consensus
+	go node.DoSyncing(node.Blockchain(), node.Worker, false) //Don't join consensus
 }
 
 // IsSameHeight tells whether node is at same bc height as a peer
@@ -58,35 +58,69 @@ func (node *Node) IsSameHeight() (uint64, bool) {
 	return node.stateSync.IsSameBlockchainHeight(node.Blockchain())
 }
 
-// GetBeaconSyncingPeers returns a list of peers for beaconchain syncing
-func (node *Node) GetBeaconSyncingPeers() []p2p.Peer {
-	return node.getNeighborPeers(&node.BeaconNeighbors)
+// SyncingPeerProvider is an interface for getting the peers in the given shard.
+type SyncingPeerProvider interface {
+	SyncingPeers(shardID uint32) (peers []p2p.Peer, err error)
 }
 
-// GetSyncingPeers returns list of peers for regular shard syncing.
-func (node *Node) GetSyncingPeers() []p2p.Peer {
-	return node.getNeighborPeers(&node.Neighbors)
+// LegacySyncingPeerProvider uses neighbor lists stored in a Node to serve
+// syncing peer list query.
+type LegacySyncingPeerProvider struct {
+	node    *Node
+	shardID func() uint32
 }
 
-// GetPeersFromDNS get peers from our DNS server; TODO: temp fix for resolve node syncing
-// the GetSyncingPeers return a bunch of "new" peers, all of them are out of sync
-func (node *Node) GetPeersFromDNS() []p2p.Peer {
-	if node.dnsZone == "" {
-		return nil
+// NewLegacySyncingPeerProvider creates and returns a new node-based syncing
+// peer provider.
+func NewLegacySyncingPeerProvider(node *Node) *LegacySyncingPeerProvider {
+	var shardID func() uint32
+	if node.shardChains != nil {
+		shardID = node.Blockchain().ShardID
 	}
-	shardID := node.Consensus.ShardID
-	dns := fmt.Sprintf("s%d.%s", shardID, node.dnsZone)
-	addrs, err := net.LookupHost(dns)
+	return &LegacySyncingPeerProvider{node: node, shardID: shardID}
+}
+
+// SyncingPeers returns peers stored in neighbor maps in the node structure.
+func (p *LegacySyncingPeerProvider) SyncingPeers(shardID uint32) (peers []p2p.Peer, err error) {
+	switch shardID {
+	case p.shardID():
+		peers = getNeighborPeers(&p.node.Neighbors)
+	case 0:
+		peers = getNeighborPeers(&p.node.BeaconNeighbors)
+	default:
+		return nil, errors.Errorf("unsupported shard ID %v", shardID)
+	}
+	return peers, nil
+}
+
+// DNSSyncingPeerProvider uses the given DNS zone to resolve syncing peers.
+type DNSSyncingPeerProvider struct {
+	zone, port string
+	lookupHost func(name string) (addrs []string, err error)
+}
+
+// NewDNSSyncingPeerProvider returns a provider that uses given DNS name and
+// port number to resolve syncing peers.
+func NewDNSSyncingPeerProvider(zone, port string) *DNSSyncingPeerProvider {
+	return &DNSSyncingPeerProvider{
+		zone:       zone,
+		port:       port,
+		lookupHost: net.LookupHost,
+	}
+}
+
+// SyncingPeers resolves DNS name into peers and returns them.
+func (p *DNSSyncingPeerProvider) SyncingPeers(shardID uint32) (peers []p2p.Peer, err error) {
+	dns := fmt.Sprintf("s%d.%s", shardID, p.zone)
+	addrs, err := p.lookupHost(dns)
 	if err != nil {
-		utils.Logger().Debug().Msg("[SYNC] GetPeersFromDNS cannot find peers")
-		return nil
+		return nil, errors.Wrapf(err,
+			"[SYNC] cannot find peers using DNS name %#v", dns)
 	}
-	port := syncing.GetSyncingPort(node.SelfPeer.Port)
-	peers := []p2p.Peer{}
 	for _, addr := range addrs {
-		peers = append(peers, p2p.Peer{IP: addr, Port: port})
+		peers = append(peers, p2p.Peer{IP: addr, Port: p.port})
 	}
-	return peers
+	return peers, nil
 }
 
 // DoBeaconSyncing update received beaconchain blocks and downloads missing beacon chain blocks
@@ -98,7 +132,13 @@ func (node *Node) DoBeaconSyncing() {
 				node.beaconSync = syncing.CreateStateSync(node.SelfPeer.IP, node.SelfPeer.Port, node.GetSyncID())
 			}
 			if node.beaconSync.GetActivePeerNumber() == 0 {
-				peers := node.GetBeaconSyncingPeers()
+				peers, err := node.SyncingPeerProvider.SyncingPeers(0)
+				if err != nil {
+					utils.Logger().Warn().
+						Err(err).
+						Msg("cannot retrieve beacon syncing peers")
+					continue
+				}
 				if err := node.beaconSync.CreateSyncConfig(peers, true); err != nil {
 					ctxerror.Log15(utils.GetLogInstance().Debug, err)
 					continue
@@ -111,7 +151,7 @@ func (node *Node) DoBeaconSyncing() {
 }
 
 // DoSyncing keep the node in sync with other peers, willJoinConsensus means the node will try to join consensus after catch up
-func (node *Node) DoSyncing(bc *core.BlockChain, worker *worker.Worker, getPeers func() []p2p.Peer, willJoinConsensus bool) {
+func (node *Node) DoSyncing(bc *core.BlockChain, worker *worker.Worker, willJoinConsensus bool) {
 	ticker := time.NewTicker(SyncFrequency * time.Second)
 
 SyncingLoop:
@@ -124,9 +164,20 @@ SyncingLoop:
 				utils.Logger().Debug().Msg("[SYNC] initialized state sync")
 			}
 			if node.stateSync.GetActivePeerNumber() < MinConnectedPeers {
-				peers := getPeers()
+				shardID := bc.ShardID()
+				peers, err := node.SyncingPeerProvider.SyncingPeers(shardID)
+				if err != nil {
+					utils.Logger().Warn().
+						Err(err).
+						Uint32("shard_id", shardID).
+						Msg("cannot retrieve syncing peers")
+					continue SyncingLoop
+				}
 				if err := node.stateSync.CreateSyncConfig(peers, false); err != nil {
-					utils.Logger().Debug().Msg("[SYNC] create peers error")
+					utils.Logger().Warn().
+						Err(err).
+						Interface("peers", peers).
+						Msg("[SYNC] create peers error")
 					continue SyncingLoop
 				}
 				utils.Logger().Debug().Int("len", node.stateSync.GetActivePeerNumber()).Msg("[SYNC] Get Active Peers")
@@ -174,11 +225,7 @@ func (node *Node) SupportSyncing() {
 		go node.SendNewBlockToUnsync()
 	}
 
-	if node.dnsZone != "" {
-		go node.DoSyncing(node.Blockchain(), node.Worker, node.GetPeersFromDNS, !isExplorerNode)
-	} else {
-		go node.DoSyncing(node.Blockchain(), node.Worker, node.GetSyncingPeers, !isExplorerNode)
-	}
+	go node.DoSyncing(node.Blockchain(), node.Worker, !isExplorerNode)
 }
 
 // InitSyncingServer starts downloader server.

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -141,6 +141,40 @@ func TestDNSSyncingPeerProvider(t *testing.T) {
 	})
 }
 
+func TestLocalSyncingPeerProvider(t *testing.T) {
+	t.Run("BeaconChain", func(t *testing.T) {
+		p := makeLocalSyncingPeerProvider()
+		expectedBeaconPeers := []p2p.Peer{
+			{IP: "127.0.0.1", Port: "6000"},
+			{IP: "127.0.0.1", Port: "6002"},
+			{IP: "127.0.0.1", Port: "6004"},
+		}
+		if actualPeers, err := p.SyncingPeers(0); assert.NoError(t, err) {
+			assert.ElementsMatch(t, actualPeers, expectedBeaconPeers)
+		}
+	})
+	t.Run("Shard1Chain", func(t *testing.T) {
+		p := makeLocalSyncingPeerProvider()
+		expectedShard1Peers := []p2p.Peer{
+			// port 6001 omitted because self
+			{IP: "127.0.0.1", Port: "6003"},
+			{IP: "127.0.0.1", Port: "6005"},
+		}
+		if actualPeers, err := p.SyncingPeers(1); assert.NoError(t, err) {
+			assert.ElementsMatch(t, actualPeers, expectedShard1Peers)
+		}
+	})
+	t.Run("InvalidShard", func(t *testing.T) {
+		p := makeLocalSyncingPeerProvider()
+		_, err := p.SyncingPeers(999)
+		assert.Error(t, err)
+	})
+}
+
+func makeLocalSyncingPeerProvider() *LocalSyncingPeerProvider {
+	return NewLocalSyncingPeerProvider(6000, 6001, 2, 3)
+}
+
 func TestAddPeers(t *testing.T) {
 	pubKey1 := pki.GetBLSPrivateKeyFromInt(333).GetPublicKey()
 	pubKey2 := pki.GetBLSPrivateKeyFromInt(444).GetPublicKey()

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1,10 +1,14 @@
 package node
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	bls2 "github.com/harmony-one/harmony/crypto/bls"
 	"github.com/harmony-one/harmony/internal/shardchain"
@@ -50,32 +54,91 @@ func TestNewNode(t *testing.T) {
 	}
 }
 
-func TestGetSyncingPeers(t *testing.T) {
-	blsKey := bls2.RandPrivateKey()
-	pubKey := blsKey.GetPublicKey()
-	leader := p2p.Peer{IP: "127.0.0.1", Port: "8882", ConsensusPubKey: pubKey}
-	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "9902")
-	host, err := p2pimpl.NewHost(&leader, priKey)
-	if err != nil {
-		t.Fatalf("newhost failure: %v", err)
-	}
+func TestLegacySyncingPeerProvider(t *testing.T) {
+	t.Run("ShardChain", func(t *testing.T) {
+		p := makeLegacySyncingPeerProvider()
+		expectedPeers := []p2p.Peer{
+			{IP: "127.0.0.1", Port: "6001"},
+			{IP: "127.0.0.1", Port: "6003"},
+		}
+		actualPeers, err := p.SyncingPeers(1)
+		if assert.NoError(t, err) {
+			assert.ElementsMatch(t, actualPeers, expectedPeers)
+		}
+	})
+	t.Run("BeaconChain", func(t *testing.T) {
+		p := makeLegacySyncingPeerProvider()
+		expectedPeers := []p2p.Peer{
+			{IP: "127.0.0.1", Port: "6000"},
+			{IP: "127.0.0.1", Port: "6002"},
+		}
+		actualPeers, err := p.SyncingPeers(0)
+		if assert.NoError(t, err) {
+			assert.ElementsMatch(t, actualPeers, expectedPeers)
+		}
+	})
+	t.Run("NoMatch", func(t *testing.T) {
+		p := makeLegacySyncingPeerProvider()
+		_, err := p.SyncingPeers(999)
+		assert.Error(t, err)
+	})
+}
 
-	consensus, err := consensus.New(host, 0, leader, blsKey)
-	if err != nil {
-		t.Fatalf("Cannot craeate consensus: %v", err)
+func makeLegacySyncingPeerProvider() *LegacySyncingPeerProvider {
+	node := makeSyncOnlyNode()
+	p := NewLegacySyncingPeerProvider(node)
+	p.shardID = func() uint32 { return 1 }
+	return p
+}
+
+func makeSyncOnlyNode() *Node {
+	node := &Node{
+		Neighbors:       sync.Map{},
+		BeaconNeighbors: sync.Map{},
 	}
-	node := New(host, consensus, testDBFactory, false)
-	peer := p2p.Peer{IP: "127.0.0.1", Port: "8000"}
-	peer2 := p2p.Peer{IP: "127.0.0.1", Port: "8001"}
-	node.Neighbors.Store("minh", peer)
-	node.Neighbors.Store("mark", peer2)
-	res := node.GetSyncingPeers()
-	if len(res) == 0 || !(res[0].IP == peer.IP || res[0].IP == peer2.IP) {
-		t.Error("GetSyncingPeers should return list of {peer, peer2}")
-	}
-	if len(res) == 0 || (res[0].Port != "5000" && res[0].Port != "5001") {
-		t.Errorf("Syncing ports should be 5000, got %v", res[0].Port)
-	}
+	node.Neighbors.Store(
+		"127.0.0.1:9001:omg", p2p.Peer{IP: "127.0.0.1", Port: "9001"})
+	node.Neighbors.Store(
+		"127.0.0.1:9003:wtf", p2p.Peer{IP: "127.0.0.1", Port: "9003"})
+	node.BeaconNeighbors.Store(
+		"127.0.0.1:9000:bbq", p2p.Peer{IP: "127.0.0.1", Port: "9000"})
+	node.BeaconNeighbors.Store(
+		"127.0.0.1:9002:cakes", p2p.Peer{IP: "127.0.0.1", Port: "9002"})
+	return node
+}
+
+func TestDNSSyncingPeerProvider(t *testing.T) {
+	t.Run("Happy", func(t *testing.T) {
+		p := NewDNSSyncingPeerProvider("example.com", "1234")
+		lookupCount := 0
+		lookupName := ""
+		p.lookupHost = func(name string) (addrs []string, err error) {
+			lookupCount++
+			lookupName = name
+			return []string{"1.2.3.4", "5.6.7.8"}, nil
+		}
+		expectedPeers := []p2p.Peer{
+			{IP: "1.2.3.4", Port: "1234"},
+			{IP: "5.6.7.8", Port: "1234"},
+		}
+		actualPeers, err := p.SyncingPeers( /*shardID*/ 3)
+		if assert.NoError(t, err) {
+			assert.Equal(t, actualPeers, expectedPeers)
+		}
+		assert.Equal(t, lookupCount, 1)
+		assert.Equal(t, lookupName, "s3.example.com")
+		if err != nil {
+			t.Fatalf("SyncingPeers returned non-nil error %#v", err)
+		}
+	})
+	t.Run("LookupError", func(t *testing.T) {
+		p := NewDNSSyncingPeerProvider("example.com", "1234")
+		p.lookupHost = func(_ string) ([]string, error) {
+			return nil, errors.New("omg")
+		}
+		_, actualErr := p.SyncingPeers( /*shardID*/ 3)
+		assert.Error(t, actualErr)
+	})
 }
 
 func TestAddPeers(t *testing.T) {


### PR DESCRIPTION
This is the part 1 of beaconchain syncing.  It plumbs the machinery to get shard 0 syncing peers via DNS and localnet sharding config.  The non-DNS legacy method is still provided, but due to the way `Node.BeaconNeighbors` is filled (or lack thereof), the non-DNS method is still broken.