### PR TITLE
[local] fix local test no balances issue

### DIFF
--- a/internal/configs/sharding/localnet.go
+++ b/internal/configs/sharding/localnet.go
@@ -27,11 +27,11 @@ const (
 	localnetFirstCrossLinkBlock     = 3
 	localnetRandomnessStartingEpoch = 0
 
-	localnetMaxTxAmountLimit               = 1e2 // unit is in One
-	localnetMaxNumRecentTxsPerAccountLimit = 2
+	localnetMaxTxAmountLimit               = 1e3 // unit is in One
+	localnetMaxNumRecentTxsPerAccountLimit = 1e2
 	localnetMaxTxPoolSizeLimit             = 8000
 	localnetMaxNumTxsPerBlockLimit         = 1000
-	localnetRecentTxDuration               = 10 * time.Second
+	localnetRecentTxDuration               = time.Hour
 )
 
 func (localnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {


### PR DESCRIPTION
the local net configuration was strictly throttled

the wallet -p local balances was very slow and won't even get the
balance

lifted the throttle on localnet to the same as mainnet and it works.

Signed-off-by: Leo Chen <leo@harmony.one>