### PR TITLE
fix block signers

### DIFF
--- a/api/service/explorer/service.go
+++ b/api/service/explorer/service.go
@@ -206,7 +206,6 @@ func (s *Service) GetExplorerBlocks(w http.ResponseWriter, r *http.Request) {
 		if id == 0 || id == len(accountBlocks)-1 || accountBlock == nil {
 			continue
 		}
-		utils.Logger().Info().Msgf("Block %d", id+fromInt-1)
 		block := NewBlock(accountBlock, id+fromInt-1)
 		if int64(block.Epoch) > curEpoch {
 			if bytes, err := db.Get([]byte(GetCommitteeKey(uint32(s.ShardID), block.Epoch))); err == nil {
@@ -238,7 +237,6 @@ func (s *Service) GetExplorerBlocks(w http.ResponseWriter, r *http.Request) {
 			if err == nil {
 				for _, validator := range committee.NodeList {
 					oneAddress, err := common2.AddressToBech32(validator.EcdsaAddress)
-					utils.Logger().Info().Msgf("Validator address %s", oneAddress)
 					if err != nil {
 						continue
 					}

--- a/api/service/explorer/structs.go
+++ b/api/service/explorer/structs.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/harmony-one/harmony/core/types"
-	"github.com/harmony-one/harmony/internal/common"
 	"github.com/harmony-one/harmony/internal/utils"
 )
 
@@ -88,7 +87,7 @@ type Shard struct {
 func NewBlock(block *types.Block, height int) *Block {
 	// TODO(ricl): use block.Header().CommitBitmap and GetPubKeyFromMask
 	signers := []string{}
-	state, err := block.Header().GetShardState()
+	/*state, err := block.Header().GetShardState()
 	if err == nil {
 		for _, committee := range state {
 			if committee.ShardID == block.ShardID() {
@@ -101,7 +100,7 @@ func NewBlock(block *types.Block, height int) *Block {
 				}
 			}
 		}
-	}
+	}*/
 	return &Block{
 		Height:     strconv.Itoa(height),
 		ID:         block.Hash().Hex(),

--- a/api/service/explorer/structs.go
+++ b/api/service/explorer/structs.go
@@ -92,17 +92,15 @@ func NewBlock(block *types.Block, height int) *Block {
 	if err == nil {
 		for _, committee := range state {
 			if committee.ShardID == block.ShardID() {
-				for _, validator := range committee.NodeList {
+				for i, validator := range committee.NodeList {
 					oneAddress, err := common.AddressToBech32(validator.EcdsaAddress)
-					if err != nil {
+					if err != nil && block.Header().LastCommitBitmap[i] != 0x0 {
 						continue
 					}
 					signers = append(signers, oneAddress)
 				}
 			}
 		}
-	} else {
-		utils.Logger().Warn().Err(err).Msgf("bad state block %d", block.NumberU64())
 	}
 	return &Block{
 		Height:     strconv.Itoa(height),


### PR DESCRIPTION
## Issue

Mechanism of adding block signers to block in explorer api was little incorrect as it returned whole list of validators instead of only signers. Need review of block signers mechanism from @chaosma at api/service/explorer/service.go L#208. I use LastCommitBitmap and if i-th validator from committee list LastCommitBitmap[i] not 0 then he signed the block.

## Test

Tested on localnet with postman.
