### PR TITLE
Revert signer change and add shard info in tx hash for eip155

### DIFF
--- a/cmd/client/wallet/main.go
+++ b/cmd/client/wallet/main.go
@@ -744,7 +744,7 @@ func processTransferCommand() {
 
 	fmt.Printf("Unlock account succeeded! '%v'\n", senderPass)
 
-	tx, err = ks.SignTx(account, tx, big.NewInt(1))
+	tx, err = ks.SignTx(account, tx, nil)
 	if err != nil {
 		fmt.Printf("SignTx Error: %v\n", err)
 		return

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -42,7 +42,14 @@ type sigCache struct {
 // MakeSigner returns a Signer based on the given chain config and block number.
 func MakeSigner(config *params.ChainConfig, blockNumber *big.Int) Signer {
 	var signer Signer
-	signer = NewEIP155Signer(config.ChainID)
+	switch {
+	case config.IsEIP155(blockNumber):
+		signer = NewEIP155Signer(config.ChainID)
+	case config.IsHomestead(blockNumber):
+		signer = HomesteadSigner{}
+	default:
+		signer = FrontierSigner{}
+	}
 	return signer
 }
 
@@ -154,6 +161,8 @@ func (s EIP155Signer) Hash(tx *Transaction) common.Hash {
 		tx.data.AccountNonce,
 		tx.data.Price,
 		tx.data.GasLimit,
+		tx.data.ShardID,
+		tx.data.ToShardID,
 		tx.data.Recipient,
 		tx.data.Amount,
 		tx.data.Payload,


### PR DESCRIPTION
We shouldn't change the signer without adding correct forking logic.