### PR TITLE
S3 merge conflict

### DIFF
--- a/cmd/client/wallet_stress_test/README.md
+++ b/cmd/client/wallet_stress_test/README.md
@@ -1,1 +1,1 @@
-The wallet program is the demo wallet which talks to Harmony devnet for various kinds of operations. For detail, please compile and execute ./bin/wallet.
+The wallet program is the demo wallet which talks to Harmony devnet for stress testing transactions operations. For detail, please compile and execute ./bin/wallet_stress test stressTest.

--- a/node/worker/worker.go
+++ b/node/worker/worker.go
@@ -92,6 +92,7 @@ func (w *Worker) SelectTransactionsForNewBlock(newBlockNum uint64, txs types.Tra
 	for _, tx := range txs {
 		if tx.ShardID() != w.shardID {
 			invalid = append(invalid, tx)
+			continue
 		}
 
 		sender, flag := w.throttleTxs(selected, recentTxsStats, txsThrottleConfig, tx)


### PR DESCRIPTION
## Issue

1 line of code unintentionally reverted in s3. Re-adding the bug fix line in worker.go.

impact: max amount transaction throttling will not work. After declaring the transaction to be over-the-limit of throttling max amount, it will still try to commit transaction and succeed in processing the transaction.

## Test

#### Test Coverage Data

dennis.won@jongs-mbp:~/harmony/node/worker (s3_merge_conflict) $ go test -cover
PASS
coverage: 31.1% of statements
ok  	github.com/harmony-one/harmony/node/worker	0.067s
