### PR TITLE
enable transaction on mainnet/releasenet

### DIFF
--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/core/types"
-	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/ctxerror"
 	"github.com/harmony-one/harmony/internal/utils"
 )
@@ -74,15 +73,6 @@ func (node *Node) WaitForConsensusReadyv2(readySignal chan struct{}, stopChan ch
 					}
 					viewID := node.Consensus.GetViewID()
 					// add aggregated commit signatures from last block, except for the first two blocks
-
-					if node.NodeConfig.GetNetworkType() == nodeconfig.Mainnet {
-						if err = node.Worker.UpdateCurrent(coinbase); err != nil {
-							utils.Logger().Debug().
-								Err(err).
-								Msg("Failed updating worker's state")
-							continue
-						}
-					}
 
 					newBlock, err = node.Worker.Commit(sig, mask, viewID, coinbase)
 


### PR DESCRIPTION
## Issue

transaction not enabled on mainnet

## Test

#### Test Coverage Data

PASS
coverage: 17.2% of statements
ok  	github.com/harmony-one/harmony/node	2.452s

#### Test/Run Logs
Test on releasenet. Locally tested that if this if check takes into effect, transaction is not inserted into the pending transactions list.
<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->
