### PR TITLE
Check md5sum after download

### DIFF
--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -241,11 +241,6 @@ if [ "$OS" == "Linux" ]; then
    BIN=( harmony libbls384_256.so libcrypto.so.10 libgmp.so.10 libgmpxx.so.4 libmcl.so md5sum.txt )
 fi
 
-# clean up old files
-for bin in "${BIN[@]}"; do
-   ${do_not_download} || rm -f ${bin}
-done
-
 any_new_binaries() {
    local outdir
    ${do_not_download} && return 0

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -246,9 +246,14 @@ any_new_binaries() {
    ${do_not_download} && return 0
    outdir="${1:-.}"
    mkdir -p "${outdir}"
-   curl http://${BUCKET}.s3.amazonaws.com/${FOLDER}md5sum.txt -o "${outdir}/md5sum.txt" || return $?
-   diff $outdir/md5sum.txt md5sum.txt
-   return $?
+   curl http://${BUCKET}.s3.amazonaws.com/${FOLDER}md5sum.txt -o "${outdir}/md5sum.txt.new" || return $?
+   if diff $outdir/md5sum.txt.new md5sum.txt
+   then
+      rm "${outdir}/md5sum.txt.new"
+   else
+      mv "${outdir}/md5sum.txt.new" "${outdir}/md5sum.txt"
+      return 1
+   fi
 }
 
 download_binaries() {

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -306,7 +306,7 @@ download_binaries() {
    (cd "${outdir}" && exec openssl sha256 "${BIN[@]}") > "${outdir}/harmony-checksums.txt"
 }
 
-if any_new_binaries staging
+if any_new_binaries
 then
    msg "binaries did not change"
 else


### PR DESCRIPTION
This is a preventive action for the 8/30/2019 mainnet deployment failure.

## Test Results

**Note:** the tests below were run with #1480 applied as well.

### When run initially
```
$ sudo ./node.sh
node.sh: autodetected BLS key file: faf143c9891a323ef2f780adb578c34d4687c986786ec4931d9e96970dd08629fcdce1b7b6dc74a9d53cac4e7da06401.key
diff: md5sum.txt: No such file or directory
node.sh: downloaded harmony
node.sh: downloaded libbls384_256.so
node.sh: downloaded libcrypto.so.10
node.sh: downloaded libgmp.so.10
node.sh: downloaded libgmpxx.so.4
node.sh: downloaded libmcl.so
node.sh: downloaded md5sum.txt
net.core.somaxconn = 1024
net.core.netdev_max_backlog = 65536
net.ipv4.tcp_tw_reuse = 1
net.ipv4.tcp_rmem = 4096 65536 16777216
net.ipv4.tcp_wmem = 4096 65536 16777216
net.ipv4.tcp_mem = 65536 131072 262144
node.sh: public IP address autodetected: 34.211.29.122
```
### When run again
Next time, it just verifies md5sum.txt to note that the binaries does not change (introduced by @LeoHChen's recent md5sum verification PR #1468; my PR fixes a few bugs that prevented the initial check from working properly):
```
$ sudo ./node.sh
node.sh: autodetected BLS key file: faf143c9891a323ef2f780adb578c34d4687c986786ec4931d9e96970dd08629fcdce1b7b6dc74a9d53cac4e7da06401.key
node.sh: binaries did not change
net.core.somaxconn = 1024
net.core.netdev_max_backlog = 65536
net.ipv4.tcp_tw_reuse = 1
net.ipv4.tcp_rmem = 4096 65536 16777216
net.ipv4.tcp_wmem = 4096 65536 16777216
net.ipv4.tcp_mem = 65536 131072 262144
node.sh: public IP address autodetected: 34.211.29.122
```
### Wrong bucket
If I change the bucket to a non-existent one:
```diff
--- node.sh.orig	2019-08-31 20:17:19.623723240 +0000
+++ node.sh	2019-08-31 20:20:37.721190174 +0000
@@ -229,7 +229,7 @@
    ;;
 esac

-BUCKET=pub.harmony.one
+BUCKET=omgwtfbbq
 OS=$(uname -s)

 if [ "$OS" == "Darwin" ]; then
```
It fails to fetch the md5sum and exits:
```
$ sudo ./node.sh
node.sh: autodetected BLS key file: faf143c9891a323ef2f780adb578c34d4687c986786ec4931d9e96970dd08629fcdce1b7b6dc74a9d53cac4e7da06401.key
curl: (22) The requested URL returned error: 403 Forbidden
curl: (22) The requested URL returned error: 403 Forbidden
node.sh: initial node software update failed
$ 
```
### When checksum mismatches
With a test patch to force-corrupt downloaded files:
```diff
--- node.sh.orig	2019-08-31 20:17:19.623723240 +0000
+++ node.sh	2019-08-31 20:21:36.696436346 +0000
@@ -299,6 +299,7 @@
    mkdir -p "${outdir}"
    for bin in "${BIN[@]}"; do
       curl -sSf http://${BUCKET}.s3.amazonaws.com/${FOLDER}${bin} -o "${outdir}/${bin}" || return $?
+      echo OMG >> "${outdir}/${bin}" # append one line to the downloaded file to force checksum mismatch
       verify_checksum "${outdir}" "${bin}" md5sum.txt || return $?
       msg "downloaded ${bin}"
    done
```
The checksum validation fails (md5sum.txt was removed to force download):
```
$ rm -f md5sum.txt
$ sudo ./node.sh
node.sh: autodetected BLS key file: faf143c9891a323ef2f780adb578c34d4687c986786ec4931d9e96970dd08629fcdce1b7b6dc74a9d53cac4e7da06401.key
diff: md5sum.txt: No such file or directory
node.sh: checksum FAILED for harmony
node.sh: initial node software update failed
$ 
```