### PR TITLE
close peer sync config connections to prevent duplicate peer sync config creation

### DIFF
--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -217,6 +217,9 @@ func (ss *StateSync) CreateSyncConfig(peers []p2p.Peer, isBeacon bool) error {
 	if len(peers) == 0 {
 		return ctxerror.New("[SYNC] no peers to connect to")
 	}
+	if ss.syncConfig != nil {
+		ss.syncConfig.CloseConnections()
+	}
 	ss.syncConfig = &SyncConfig{}
 	var wg sync.WaitGroup
 	for _, peer := range peers {


### PR DESCRIPTION
close peer sync config connections to prevent duplicate peer sync config creation, causing inifinite memory leak, causing wallet to not function.

## Issue

https://github.com/harmony-one/harmony/issues/1460

## Test

#### Test Coverage Data

dennis.won@jongs-mbp:~/harmony/api/service/syncing (fix_socket_too_many_open) $ go test -cover
PASS
coverage: 3.8% of statements
ok  	github.com/harmony-one/harmony/api/service/syncing	0.066s

#### Test/Run Logs

wallet balance runs fine. Do not see any more "Too many socket connections open" error on log.