### PR TITLE
Peg s3 at go 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - stable
+  - 1.12
 go_import_path: github.com/harmony-one/harmony
 install:
   - export GO111MODULE=on


### PR DESCRIPTION
Go 1.13 has been released and it is breaking a few backward compatibility, including a module version check that one of our upstream dependencies (golangci/golangci-lint) fails.  Peg our Travis check at Go 1.12 on s3 branch.  A separate PR will be opened for master as well.