### PR TITLE
[wallet] Add colored output in balance flag after doing transaction

### DIFF
--- a/cmd/client/wallet/main.go
+++ b/cmd/client/wallet/main.go
@@ -13,10 +13,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/harmony-one/harmony/internal/params"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
+	color "github.com/fatih/color"
 	ffi_bls "github.com/harmony-one/bls/ffi/go/bls"
 	"github.com/harmony-one/harmony/accounts"
 	"github.com/harmony-one/harmony/accounts/keystore"
@@ -30,6 +29,7 @@ import (
 	common2 "github.com/harmony-one/harmony/internal/common"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/ctxerror"
+	"github.com/harmony-one/harmony/internal/params"
 	"github.com/harmony-one/harmony/internal/shardchain"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/node"
@@ -98,6 +98,7 @@ var (
 	transferToShardIDPtr  = transferCommand.Int("toShardID", -1, "Specify the destination shard ID for the transfer")
 	transferInputDataPtr  = transferCommand.String("inputData", "", "Base64-encoded input data to embed in the transaction")
 	transferSenderPassPtr = transferCommand.String("pass", "", "Passphrase of the sender's private key")
+	waitForColoredBalance = transferCommand.Bool("waitThenBal", false, "")
 
 	freeTokenCommand    = flag.NewFlagSet("getFreeToken", flag.ExitOnError)
 	freeTokenAddressPtr = freeTokenCommand.String("address", "", "Specify the account address to receive the free token")
@@ -167,6 +168,7 @@ func main() {
 		fmt.Println("        --toShardID      - The destination shard Id for the transfer")
 		fmt.Println("        --inputData      - Base64-encoded input data to embed in the transaction")
 		fmt.Println("        --pass           - Passphrase of sender's private key")
+		fmt.Println("        --waitThenBal    - Wait after the transfer with colored balances output")
 		fmt.Println("    8. export        - Export account key to a new file")
 		fmt.Println("        --account        - Specify the account to export. Empty will export every key.")
 		fmt.Println("    9. exportPriKey  - Export account private key")
@@ -491,25 +493,43 @@ func processImportCommnad() {
 	fmt.Printf("Private key imported for account: %s\n", common2.MustAddressToBech32(account.Address))
 }
 
+func showAllBalances(sender, receiver string, fromS, toS int) {
+	allAccounts := ks.Accounts()
+	for i, account := range allAccounts {
+		asBech32 := common2.MustAddressToBech32(account.Address)
+		fmt.Printf("Account %d:\n", i)
+		if asBech32 == sender {
+			color.Yellow("    Address: %s\n", asBech32)
+		} else if asBech32 == receiver {
+			color.Cyan("    Address: %s\n", asBech32)
+		} else {
+			fmt.Printf("    Address: %s\n", asBech32)
+		}
+		for shardID, balanceNonce := range FetchBalance(account.Address) {
+			if balanceNonce != nil {
+				if shardID == fromS && asBech32 == sender {
+					color.Yellow("    Balance in Shard %d:  %s, nonce: %v \n", shardID, convertBalanceIntoReadableFormat(balanceNonce.balance), balanceNonce.nonce)
+				} else if shardID == toS && asBech32 == receiver {
+					color.Cyan("    Balance in Shard %d:  %s, nonce: %v \n", shardID, convertBalanceIntoReadableFormat(balanceNonce.balance), balanceNonce.nonce)
+				} else {
+					fmt.Printf("    Balance in Shard %d:  %s, nonce: %v \n", shardID, convertBalanceIntoReadableFormat(balanceNonce.balance), balanceNonce.nonce)
+				}
+
+			} else {
+				fmt.Printf("    Balance in Shard %d:  connection failed", shardID)
+			}
+		}
+	}
+
+}
+
 func processBalancesCommand() {
 	if err := balanceCommand.Parse(os.Args[2:]); err != nil {
 		fmt.Println(ctxerror.New("failed to parse flags").WithCause(err))
 		return
 	}
-
 	if *balanceAddressPtr == "" {
-		allAccounts := ks.Accounts()
-		for i, account := range allAccounts {
-			fmt.Printf("Account %d:\n", i)
-			fmt.Printf("    Address: %s\n", common2.MustAddressToBech32(account.Address))
-			for shardID, balanceNonce := range FetchBalance(account.Address) {
-				if balanceNonce != nil {
-					fmt.Printf("    Balance in Shard %d:  %s, nonce: %v \n", shardID, convertBalanceIntoReadableFormat(balanceNonce.balance), balanceNonce.nonce)
-				} else {
-					fmt.Printf("    Balance in Shard %d:  connection failed", shardID)
-				}
-			}
-		}
+		showAllBalances("", "", -1, -1)
 	} else {
 		address := common2.ParseAddr(*balanceAddressPtr)
 		fmt.Printf("Account: %s:\n", common2.MustAddressToBech32(address))
@@ -925,5 +945,13 @@ func submitTransaction(tx *types.Transaction, walletNode *node.Node, shardID uin
 	// FIXME (leo): how to we know the tx was successful sent to the network
 	// this is a hacky way to wait for sometime
 	time.Sleep(3 * time.Second)
+	if *waitForColoredBalance {
+		sender := *transferSenderPtr
+		receiver := *transferReceiverPtr
+		shardID := *transferShardIDPtr
+		toShardID := *transferToShardIDPtr
+		showAllBalances(sender, receiver, shardID, toShardID)
+	}
+
 	return nil
 }

--- a/cmd/client/wallet/main.go
+++ b/cmd/client/wallet/main.go
@@ -942,9 +942,6 @@ func submitTransaction(tx *types.Transaction, walletNode *node.Node, shardID uin
 		return err
 	}
 	fmt.Printf("Transaction Id for shard %d: %s\n", int(shardID), tx.Hash().Hex())
-	// FIXME (leo): how to we know the tx was successful sent to the network
-	// this is a hacky way to wait for sometime
-	time.Sleep(3 * time.Second)
 	if *waitForColoredBalance {
 		sender := *transferSenderPtr
 		receiver := *transferReceiverPtr

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/deckarep/golang-set v1.7.1
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/ethereum/go-ethereum v1.8.27
+	github.com/fatih/color v1.7.0
 	github.com/fjl/memsize v0.0.0-20180929194037-2a09253e352a
 	github.com/garslo/gogen v0.0.0-20170307003452-d6ebae628c7c // indirect
 	github.com/golang/mock v1.3.1


### PR DESCRIPTION
Since checking balance is so commonly done after a transaction with wallet, I added a flag that will do a balance check after a transaction and show a colored highlight of the sender's address and shard and the receiver's address and shard. See picture which corresponds to 
![Screen Shot 2019-09-05 at 7 30 46 PM](https://user-images.githubusercontent.com/3036816/64397074-c1271c80-d014-11e9-9011-f85981c4621e.png)

```
./bin/wallet -p local transfer --from one129r9pj3sk0re76f7zs3qz92rggmdgjhtwge62k --to one1d2rngmem4x2c6zxsjjz29dlah0jzkr0k2n88wc --amount 5.5 --shardID 1 --toShardID 0 --pass pass:'' --waitThenBal
```