### PR TITLE
improve cross shard tx receipts verification design and logic

### DIFF
--- a/api/proto/node/node.go
+++ b/api/proto/node/node.go
@@ -189,9 +189,10 @@ func DeserializeEpochShardStateFromMessage(payload []byte) (*shard.EpochShardSta
 	return epochShardState, nil
 }
 
-// ConstructCXReceiptsProof constructs cross shard receipts and merkle proof
-func ConstructCXReceiptsProof(cxs types.CXReceipts, mkp *types.CXMerkleProof) []byte {
-	msg := &types.CXReceiptsProof{Receipts: cxs, MerkleProof: mkp}
+// ConstructCXReceiptsProof constructs cross shard receipts and related proof including
+// merkle proof, blockHeader and  commitSignatures
+func ConstructCXReceiptsProof(cxs types.CXReceipts, mkp *types.CXMerkleProof, header *block.Header, commitSig [96]byte, CommitBitmap []byte) []byte {
+	msg := &types.CXReceiptsProof{Receipts: cxs, MerkleProof: mkp, Header: header, CommitSig: commitSig, CommitBitmap: commitBitmap}
 
 	byteBuffer := bytes.NewBuffer([]byte{byte(proto.Node)})
 	byteBuffer.WriteByte(byte(Block))

--- a/api/proto/node/node.go
+++ b/api/proto/node/node.go
@@ -191,7 +191,7 @@ func DeserializeEpochShardStateFromMessage(payload []byte) (*shard.EpochShardSta
 
 // ConstructCXReceiptsProof constructs cross shard receipts and related proof including
 // merkle proof, blockHeader and  commitSignatures
-func ConstructCXReceiptsProof(cxs types.CXReceipts, mkp *types.CXMerkleProof, header *block.Header, commitSig [96]byte, CommitBitmap []byte) []byte {
+func ConstructCXReceiptsProof(cxs types.CXReceipts, mkp *types.CXMerkleProof, header *block.Header, commitSig []byte, commitBitmap []byte) []byte {
 	msg := &types.CXReceiptsProof{Receipts: cxs, MerkleProof: mkp, Header: header, CommitSig: commitSig, CommitBitmap: commitBitmap}
 
 	byteBuffer := bytes.NewBuffer([]byte{byte(proto.Node)})

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -127,7 +127,7 @@ type Consensus struct {
 	ReadySignal chan struct{}
 	// The post-consensus processing func passed from Node object
 	// Called when consensus on a new block is done
-	OnConsensusDone func(*types.Block)
+	OnConsensusDone func(*types.Block, []byte)
 	// The verifier func passed from Node object
 	BlockVerifier func(*types.Block) error
 

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -985,7 +985,7 @@ func (consensus *Consensus) tryCatchup() {
 		consensus.LeaderPubKey = msgs[0].SenderPubkey
 
 		consensus.getLogger().Info().Msg("[TryCatchup] Adding block to chain")
-		consensus.OnConsensusDone(block)
+		consensus.OnConsensusDone(block, msgs[0].Payload)
 		consensus.ResetState()
 
 		select {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2166,39 +2166,38 @@ func (bc *BlockChain) NextCXReceiptsCheckpoint(currentNum uint64, shardID uint32
 
 	// the new checkpoint will not exceed currentNum+1
 	for num := lastCheckpoint; num <= currentNum+1; num++ {
+		newCheckpoint = num
 		by, _ := rawdb.ReadCXReceiptsProofSpent(bc.db, shardID, num)
 		if by == rawdb.NAByte {
 			// TODO chao: check if there is IncompingReceiptsHash in crosslink header
 			// if the rootHash is non-empty, it means incomingReceipts are not delivered
 			// otherwise, it means there is no cross-shard transactions for this block
-			newCheckpoint = num
 			continue
 		}
 		if by == rawdb.SpentByte {
-			newCheckpoint = num
 			continue
 		}
 		// the first unspent blockHash found, break the loop
-		newCheckpoint = num
 		break
 	}
 	return newCheckpoint
 }
 
-// cleanCXReceiptsCheckpoints will update the checkpoint and clean spent receipts upto checkpoint
-func (bc *BlockChain) cleanCXReceiptsCheckpoints(shardID uint32, currentNum uint64) {
+// updateCXReceiptsCheckpoints will update the checkpoint and clean spent receipts upto checkpoint
+func (bc *BlockChain) updateCXReceiptsCheckpoints(shardID uint32, currentNum uint64) {
 	lastCheckpoint, err := rawdb.ReadCXReceiptsProofUnspentCheckpoint(bc.db, shardID)
 	if err != nil {
-		utils.Logger().Warn().Msg("[cleanCXReceiptsCheckpoints] Cannot get lastCheckpoint")
+		utils.Logger().Warn().Msg("[updateCXReceiptsCheckpoints] Cannot get lastCheckpoint")
 	}
 	newCheckpoint := bc.NextCXReceiptsCheckpoint(currentNum, shardID)
 	if lastCheckpoint == newCheckpoint {
 		return
 	}
-	utils.Logger().Debug().Uint64("lastCheckpoint", lastCheckpoint).Uint64("newCheckpont", newCheckpoint).Msg("[CleanCXReceiptsCheckpoints]")
+	utils.Logger().Debug().Uint64("lastCheckpoint", lastCheckpoint).Uint64("newCheckpont", newCheckpoint).Msg("[updateCXReceiptsCheckpoints]")
 	for num := lastCheckpoint; num < newCheckpoint; num++ {
 		rawdb.DeleteCXReceiptsProofSpent(bc.db, shardID, num)
 	}
+	rawdb.WriteCXReceiptsProofUnspentCheckpoint(bc.db, shardID, newCheckpoint)
 }
 
 // WriteCXReceiptsProofSpent mark the CXReceiptsProof list with given unspent status
@@ -2220,8 +2219,8 @@ func (bc *BlockChain) IsSpent(cxp *types.CXReceiptsProof) bool {
 	return false
 }
 
-// CleanCXReceiptsCheckpointsByBlock cleans checkpoints based on incomingReceipts of the given block
-func (bc *BlockChain) CleanCXReceiptsCheckpointsByBlock(block *types.Block) {
+// UpdateCXReceiptsCheckpointsByBlock cleans checkpoints and update latest checkpoint based on incomingReceipts of the given block
+func (bc *BlockChain) UpdateCXReceiptsCheckpointsByBlock(block *types.Block) {
 	m := make(map[uint32]uint64)
 	for _, cxp := range block.IncomingReceipts() {
 		shardID := cxp.MerkleProof.ShardID
@@ -2235,6 +2234,6 @@ func (bc *BlockChain) CleanCXReceiptsCheckpointsByBlock(block *types.Block) {
 
 	for k, v := range m {
 		utils.Logger().Debug().Uint32("shardID", k).Uint64("blockNum", v).Msg("[CleanCXReceiptsCheckpoints] Cleaning CXReceiptsProof upto")
-		bc.cleanCXReceiptsCheckpoints(k, v)
+		bc.updateCXReceiptsCheckpoints(k, v)
 	}
 }

--- a/core/types/cx_receipt.go
+++ b/core/types/cx_receipt.go
@@ -1,16 +1,12 @@
 package types
 
 import (
-	"bytes"
-	"encoding/binary"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/harmony-one/harmony/block"
-	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/internal/ctxerror"
 )
 
@@ -79,7 +75,7 @@ type CXReceiptsProof struct {
 	Receipts     CXReceipts
 	MerkleProof  *CXMerkleProof
 	Header       *block.Header
-	CommitSig    [96]byte
+	CommitSig    []byte
 	CommitBitmap []byte
 }
 

--- a/node/node_cross_shard.go
+++ b/node/node_cross_shard.go
@@ -99,7 +99,7 @@ func (node *Node) verifyIncomingReceipts(block *types.Block) error {
 	m := make(map[common.Hash]bool)
 	cxps := block.IncomingReceipts()
 	for _, cxp := range cxps {
-		if err := cxp.IsValidCXReceiptsProof(); err != nil {
+		if err := core.IsValidCXReceiptsProof(cxp, node.Blockchain()); err != nil {
 			return ctxerror.New("[verifyIncomingReceipts] verification failed").WithCause(err)
 		}
 		if node.Blockchain().IsSpent(cxp) {
@@ -285,7 +285,7 @@ func (node *Node) ProcessReceiptMessage(msgPayload []byte) {
 		return
 	}
 
-	if err := cxp.IsValidCXReceiptsProof(); err != nil {
+	if err := core.IsValidCXReceiptsProof(cxp, node.Blockchain()); err != nil {
 		utils.Logger().Error().Err(err).Msg("[ProcessReceiptMessage] Invalid CXReceiptsProof")
 		return
 	}

--- a/node/node_cross_shard.go
+++ b/node/node_cross_shard.go
@@ -365,12 +365,6 @@ func (node *Node) ProcessReceiptMessage(msgPayload []byte) {
 		utils.Logger().Error().Err(err).Msg("[ProcessReceiptMessage] Unable to Decode message Payload")
 		return
 	}
-
-	if err := core.IsValidCXReceiptsProof(&cxp); err != nil {
-		utils.Logger().Error().Err(err).Msg("[ProcessReceiptMessage] Invalid CXReceiptsProof")
-		return
-	}
-
 	utils.Logger().Debug().Interface("cxp", cxp).Msg("[ProcessReceiptMessage] Add CXReceiptsProof to pending Receipts")
 	// TODO: integrate with txpool
 	node.AddPendingReceipts(&cxp)

--- a/node/node_cross_shard.go
+++ b/node/node_cross_shard.go
@@ -99,7 +99,7 @@ func (node *Node) verifyIncomingReceipts(block *types.Block) error {
 	m := make(map[common.Hash]bool)
 	cxps := block.IncomingReceipts()
 	for _, cxp := range cxps {
-		if err := core.IsValidCXReceiptsProof(cxp, node.Blockchain()); err != nil {
+		if err := core.IsValidCXReceiptsProof(cxp); err != nil {
 			return ctxerror.New("[verifyIncomingReceipts] verification failed").WithCause(err)
 		}
 		if node.Blockchain().IsSpent(cxp) {
@@ -285,7 +285,7 @@ func (node *Node) ProcessReceiptMessage(msgPayload []byte) {
 		return
 	}
 
-	if err := core.IsValidCXReceiptsProof(cxp, node.Blockchain()); err != nil {
+	if err := core.IsValidCXReceiptsProof(&cxp); err != nil {
 		utils.Logger().Error().Err(err).Msg("[ProcessReceiptMessage] Invalid CXReceiptsProof")
 		return
 	}

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -304,7 +304,7 @@ func (node *Node) BroadcastCrossLinkHeader(newBlock *types.Block) {
 
 // BroadcastCXReceipts broadcasts cross shard receipts to correspoding
 // destination shards
-func (node *Node) BroadcastCXReceipts(newBlock *types.Block) {
+func (node *Node) BroadcastCXReceipts(newBlock *types.Block, commitSig [96]byte, commitBitmap []byte) {
 	epoch := newBlock.Header().Epoch()
 	shardingConfig := core.ShardingSchedule.InstanceForEpoch(epoch)
 	shardNum := int(shardingConfig.NumShards())
@@ -328,7 +328,7 @@ func (node *Node) BroadcastCXReceipts(newBlock *types.Block) {
 		utils.Logger().Info().Uint32("ToShardID", uint32(i)).Msg("[BroadcastCXReceipts] ReadCXReceipts and MerkleProof Found")
 
 		groupID := p2p.ShardID(i)
-		go node.host.SendMessageToGroups([]p2p.GroupID{p2p.NewGroupIDByShardID(groupID)}, host.ConstructP2pMessage(byte(0), proto_node.ConstructCXReceiptsProof(cxReceipts, merkleProof)))
+		go node.host.SendMessageToGroups([]p2p.GroupID{p2p.NewGroupIDByShardID(groupID)}, host.ConstructP2pMessage(byte(0), proto_node.ConstructCXReceiptsProof(cxReceipts, merkleProof, commitSig, commitBitmap)))
 	}
 }
 
@@ -578,7 +578,7 @@ func (node *Node) PostConsensusProcessing(newBlock *types.Block) {
 		} else {
 			node.BroadcastCrossLinkHeader(newBlock)
 		}
-		node.BroadcastCXReceipts(newBlock)
+		node.BroadcastCXReceipts(newBlock) //hehe
 	} else {
 		utils.Logger().Info().
 			Uint64("ViewID", node.Consensus.GetViewID()).

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -598,8 +598,8 @@ func (node *Node) PostConsensusProcessing(newBlock *types.Block, commitSigAndBit
 			Msg("BINGO !!! Reached Consensus")
 	}
 
-	// TODO chao: Write New checkpoint after clean
-	node.Blockchain().CleanCXReceiptsCheckpointsByBlock(newBlock)
+	// TODO chao: uncomment this after beacon syncing is stable
+	// node.Blockchain().UpdateCXReceiptsCheckpointsByBlock(newBlock)
 
 	if node.NodeConfig.GetNetworkType() != nodeconfig.Mainnet {
 		// Update contract deployer's nonce so default contract like faucet can issue transaction with current nonce

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -195,7 +195,6 @@ func (node *Node) proposeLocalShardState(block *types.Block) {
 
 func (node *Node) proposeReceiptsProof() []*types.CXReceiptsProof {
 	validReceiptsList := []*types.CXReceiptsProof{}
-	pendingReceiptsList := []*types.CXReceiptsProof{}
 	node.pendingCXMutex.Lock()
 
 	sort.Slice(node.pendingCXReceipts, func(i, j int) bool {
@@ -218,18 +217,13 @@ func (node *Node) proposeReceiptsProof() []*types.CXReceiptsProof {
 			m[hash] = true
 		}
 
-		if err := node.compareCrosslinkWithReceipts(cxp); err != nil {
-			utils.Logger().Debug().Err(err).Interface("cxp", cxp).Msg("[proposeReceiptsProof] CrossLink Verify Fail")
-			if err != ErrCrosslinkVerificationFail {
-				pendingReceiptsList = append(pendingReceiptsList, cxp)
-			}
-		} else {
-			utils.Logger().Debug().Interface("cxp", cxp).Msg("[proposeReceiptsProof] CXReceipts Added")
-			validReceiptsList = append(validReceiptsList, cxp)
-		}
+		utils.Logger().Debug().Interface("cxp", cxp).Msg("[proposeReceiptsProof] CXReceipts Added")
+		validReceiptsList = append(validReceiptsList, cxp)
 	}
-	node.pendingCXReceipts = pendingReceiptsList
+
+	node.pendingCXReceipts = nil
 	node.pendingCXMutex.Unlock()
-	utils.Logger().Debug().Msgf("[proposeReceiptsProof] number of validReceipts %d, pendingReceipts %d", len(validReceiptsList), len(pendingReceiptsList))
+
+	utils.Logger().Debug().Msgf("[proposeReceiptsProof] number of validReceipts %d", len(validReceiptsList))
 	return validReceiptsList
 }

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -14,9 +14,10 @@ import (
 	"github.com/harmony-one/harmony/shard"
 )
 
-// Constants of lower bound limit of a new block.
+// Constants of proposing a new block
 const (
-	PeriodicBlock = 200 * time.Millisecond
+	PeriodicBlock         = 200 * time.Millisecond
+	IncomingReceiptsLimit = 6000 // 2000 * (numShards - 1)
 )
 
 // WaitForConsensusReadyV2 listen for the readiness signal from consensus and generate new block for consensus.
@@ -194,7 +195,10 @@ func (node *Node) proposeLocalShardState(block *types.Block) {
 }
 
 func (node *Node) proposeReceiptsProof() []*types.CXReceiptsProof {
+	numProposed := 0
 	validReceiptsList := []*types.CXReceiptsProof{}
+	pendingReceiptsList := []*types.CXReceiptsProof{}
+
 	node.pendingCXMutex.Lock()
 
 	sort.Slice(node.pendingCXReceipts, func(i, j int) bool {
@@ -204,6 +208,10 @@ func (node *Node) proposeReceiptsProof() []*types.CXReceiptsProof {
 	m := make(map[common.Hash]bool)
 
 	for _, cxp := range node.pendingCXReceipts {
+		if numProposed > IncomingReceiptsLimit {
+			pendingReceiptsList = append(pendingReceiptsList, cxp)
+			continue
+		}
 		// check double spent
 		if node.Blockchain().IsSpent(cxp) {
 			utils.Logger().Debug().Interface("cxp", cxp).Msg("[proposeReceiptsProof] CXReceipt is spent")
@@ -217,11 +225,17 @@ func (node *Node) proposeReceiptsProof() []*types.CXReceiptsProof {
 			m[hash] = true
 		}
 
+		if err := core.IsValidCXReceiptsProof(cxp); err != nil {
+			utils.Logger().Error().Err(err).Msg("[proposeReceiptsProof] Invalid CXReceiptsProof")
+			continue
+		}
+
 		utils.Logger().Debug().Interface("cxp", cxp).Msg("[proposeReceiptsProof] CXReceipts Added")
 		validReceiptsList = append(validReceiptsList, cxp)
+		numProposed = numProposed + len(cxp.Receipts)
 	}
 
-	node.pendingCXReceipts = nil
+	node.pendingCXReceipts = pendingReceiptsList
 	node.pendingCXMutex.Unlock()
 
 	utils.Logger().Debug().Msgf("[proposeReceiptsProof] number of validReceipts %d", len(validReceiptsList))


### PR DESCRIPTION
- add header and signature information when broadcasting cxreceipts
- avoid crosslink verification to speedup cross shard tx finalization by around 1 block time.