### PR TITLE
Let 30% of the validator broadcast cx-receipts

### DIFF
--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -731,7 +731,7 @@ func (consensus *Consensus) finalizeCommits() {
 	consensus.getLogger().Info().Int("NumCommits", len(consensus.commitSigs)).Msg("[Finalizing] Finalizing Block")
 
 	beforeCatchupNum := consensus.blockNum
-	beforeCatchupViewID := consensus.viewID
+	//beforeCatchupViewID := consensus.viewID
 
 	// Construct committed message
 	msgToSend, aggSig := consensus.constructCommittedMessage()
@@ -792,11 +792,13 @@ func (consensus *Consensus) finalizeCommits() {
 	consensus.consensusTimeout[timeoutConsensus].Start()
 
 	consensus.getLogger().Info().
-		Uint64("blockNum", beforeCatchupNum).
-		Uint64("ViewId", beforeCatchupViewID).
+		Uint64("blockNum", block.NumberU64()).
+		Uint64("ViewId", block.Header().ViewID().Uint64()).
 		Str("blockHash", block.Hash().String()).
 		Int("index", consensus.getIndexOfPubKey(consensus.PubKey)).
 		Msg("HOORAY!!!!!!! CONSENSUS REACHED!!!!!!!")
+	// Print to normal log too
+	utils.GetLogInstance().Info("HOORAY!!!!!!! CONSENSUS REACHED!!!!!!!", "BlockNum", block.NumberU64())
 
 	// Send signal to Node so the new block can be added and new round of consensus can be triggered
 	consensus.ReadySignal <- struct{}{}

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -11,15 +11,15 @@ var (
 	// MainnetChainConfig is the chain parameters to run a node on the main network.
 	MainnetChainConfig = &ChainConfig{
 		ChainID:        big.NewInt(1),
-		CrossLinkEpoch: big.NewInt(21),
-		EIP155Epoch:    big.NewInt(20),
-		S3Epoch:        big.NewInt(20),
+		CrossLinkEpoch: big.NewInt(10000000), // Temporarily made very large until a exact number is decided.
+		EIP155Epoch:    big.NewInt(30),
+		S3Epoch:        big.NewInt(30),
 	}
 
 	// TestnetChainConfig contains the chain parameters to run a node on the harmony test network.
 	TestnetChainConfig = &ChainConfig{
 		ChainID:        big.NewInt(2),
-		CrossLinkEpoch: big.NewInt(0),
+		CrossLinkEpoch: big.NewInt(1),
 		EIP155Epoch:    big.NewInt(0),
 		S3Epoch:        big.NewInt(0),
 	}

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -387,6 +387,7 @@ func (node *Node) PostConsensusProcessing(newBlock *types.Block, commitSigAndBit
 		utils.GetLogInstance().Info("BINGO !!! Reached Consensus", "BlockNum", newBlock.NumberU64())
 
 		// 30% of the validator also need to do broadcasting
+		rand.Seed(time.Now().UTC().UnixNano())
 		rnd := rand.Intn(100)
 		if rnd < 30 {
 			node.BroadcastCXReceipts(newBlock, commitSigAndBitmap)

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"math/big"
+	"math/rand"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
 	pb "github.com/golang/protobuf/proto"
 	"github.com/harmony-one/bls/ffi/go/bls"
@@ -372,14 +374,23 @@ func (node *Node) PostConsensusProcessing(newBlock *types.Block, commitSigAndBit
 	if node.Consensus.PubKey.IsEqual(node.Consensus.LeaderPubKey) {
 		if node.NodeConfig.ShardID == 0 {
 			node.BroadcastNewBlock(newBlock)
-		} else {
+		}
+		if node.NodeConfig.ShardID != 0 && newBlock.Epoch().Cmp(node.Blockchain().Config().CrossLinkEpoch) >= 0 {
 			node.BroadcastCrossLinkHeader(newBlock)
 		}
 		node.BroadcastCXReceipts(newBlock, commitSigAndBitmap)
 	} else {
 		utils.Logger().Info().
-			Uint64("ViewID", node.Consensus.GetViewID()).
+			Uint64("BlockNum", newBlock.NumberU64()).
 			Msg("BINGO !!! Reached Consensus")
+		// Print to normal log too
+		utils.GetLogInstance().Info("BINGO !!! Reached Consensus", "BlockNum", newBlock.NumberU64())
+
+		// 30% of the validator also need to do broadcasting
+		rnd := rand.Intn(100)
+		if rnd < 30 {
+			node.BroadcastCXReceipts(newBlock, commitSigAndBitmap)
+		}
 	}
 
 	// TODO chao: uncomment this after beacon syncing is stable


### PR DESCRIPTION
desides, delay the cross-link function for later, and print consensus message on stdout.