### PR TITLE
nit: fix error log consensus:marshaling error: json: unsupported type: chan []uint8

### DIFF
--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -412,13 +412,12 @@ func (consensus *Consensus) reportMetrics(block types.Block) {
 	timeElapsed := endTime.Sub(startTime)
 	numOfTxs := len(block.Transactions())
 	tps := float64(numOfTxs) / timeElapsed.Seconds()
-	utils.Logger().Info().
+	consensus.getLogger().Info().
 		Int("numOfTXs", numOfTxs).
 		Time("startTime", startTime).
 		Time("endTime", endTime).
 		Dur("timeElapsed", endTime.Sub(startTime)).
 		Float64("TPS", tps).
-		Interface("consensus", consensus).
 		Msg("TPS Report")
 
 	// Post metrics

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -33,7 +33,7 @@ func (consensus *Consensus) handleMessageUpdate(payload []byte) {
 	msg := &msg_pb.Message{}
 	err := protobuf.Unmarshal(payload, msg)
 	if err != nil {
-		utils.Logger().Error().Err(err).Interface("consensus", consensus).Msg("Failed to unmarshal message payload.")
+		consensus.getLogger().Error().Err(err).Msg("Failed to unmarshal message payload.")
 		return
 	}
 
@@ -1161,7 +1161,6 @@ func (consensus *Consensus) Start(blockChannel chan *types.Block, stopChan chan 
 
 				consensus.getLogger().Debug().
 					Int("numTxs", len(newBlock.Transactions())).
-					Interface("consensus", consensus).
 					Time("startTime", startTime).
 					Int("publicKeys", len(consensus.PublicKeys)).
 					Msg("[ConsensusMainLoop] STARTING CONSENSUS")


### PR DESCRIPTION
migrate to zerologger removes this error log.
```
// getLogger returns logger for consensus contexts added
func (consensus *Consensus) getLogger() *zerolog.Logger {
	logger := utils.Logger().With().
		Uint64("myEpoch", consensus.epoch).
		Uint64("myBlock", consensus.blockNum).
		Uint64("myViewID", consensus.viewID).
		Interface("phase", consensus.phase).
		Str("mode", consensus.mode.Mode().String()).
		Logger()
	return &logger
}
```
