### PR TITLE
[Pangaea] Change to functional DNS server

### DIFF
--- a/.hmy/wallet.ini
+++ b/.hmy/wallet.ini
@@ -55,17 +55,17 @@ bootnode = /ip4/52.40.84.2/tcp/9867/p2p/QmZJJx6AdaoEkGLrYG4JeLCKeCKDjnFz2wfHNHxA
 shards = 4
 
 [pangaea.shard0.rpc]
-rpc = l0.p.hmny.io:14555
-rpc = s0.p.hmny.io:14555
+rpc = l0.n.hmny.io:14555
+rpc = s0.n.hmny.io:14555
 
 [pangaea.shard1.rpc]
-rpc = l1.p.hmny.io:14555
-rpc = s1.p.hmny.io:14555
+rpc = l1.n.hmny.io:14555
+rpc = s1.n.hmny.io:14555
 
 [pangaea.shard2.rpc]
-rpc = l2.p.hmny.io:14555
-rpc = s2.p.hmny.io:14555
+rpc = l2.n.hmny.io:14555
+rpc = s2.n.hmny.io:14555
 
 [pangaea.shard3.rpc]
-rpc = l3.p.hmny.io:14555
-rpc = s3.p.hmny.io:14555
+rpc = l3.n.hmny.io:14555
+rpc = s3.n.hmny.io:14555

--- a/cmd/client/wallet/generated_wallet.ini.go
+++ b/cmd/client/wallet/generated_wallet.ini.go
@@ -58,19 +58,19 @@ bootnode = /ip4/52.40.84.2/tcp/9867/p2p/QmZJJx6AdaoEkGLrYG4JeLCKeCKDjnFz2wfHNHxA
 shards = 4
 
 [pangaea.shard0.rpc]
-rpc = l0.p.hmny.io:14555
-rpc = s0.p.hmny.io:14555
+rpc = l0.n.hmny.io:14555
+rpc = s0.n.hmny.io:14555
 
 [pangaea.shard1.rpc]
-rpc = l1.p.hmny.io:14555
-rpc = s1.p.hmny.io:14555
+rpc = l1.n.hmny.io:14555
+rpc = s1.n.hmny.io:14555
 
 [pangaea.shard2.rpc]
-rpc = l2.p.hmny.io:14555
-rpc = s2.p.hmny.io:14555
+rpc = l2.n.hmny.io:14555
+rpc = s2.n.hmny.io:14555
 
 [pangaea.shard3.rpc]
-rpc = l3.p.hmny.io:14555
-rpc = s3.p.hmny.io:14555
+rpc = l3.n.hmny.io:14555
+rpc = s3.n.hmny.io:14555
 `
 )

--- a/cmd/client/wallet_stress_test/generated_wallet.ini.go
+++ b/cmd/client/wallet_stress_test/generated_wallet.ini.go
@@ -58,19 +58,19 @@ bootnode = /ip4/52.40.84.2/tcp/9867/p2p/QmZJJx6AdaoEkGLrYG4JeLCKeCKDjnFz2wfHNHxA
 shards = 4
 
 [pangaea.shard0.rpc]
-rpc = l0.p.hmny.io:14555
-rpc = s0.p.hmny.io:14555
+rpc = l0.n.hmny.io:14555
+rpc = s0.n.hmny.io:14555
 
 [pangaea.shard1.rpc]
-rpc = l1.p.hmny.io:14555
-rpc = s1.p.hmny.io:14555
+rpc = l1.n.hmny.io:14555
+rpc = s1.n.hmny.io:14555
 
 [pangaea.shard2.rpc]
-rpc = l2.p.hmny.io:14555
-rpc = s2.p.hmny.io:14555
+rpc = l2.n.hmny.io:14555
+rpc = s2.n.hmny.io:14555
 
 [pangaea.shard3.rpc]
-rpc = l3.p.hmny.io:14555
-rpc = s3.p.hmny.io:14555
+rpc = l3.n.hmny.io:14555
+rpc = s3.n.hmny.io:14555
 `
 )

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -182,7 +182,7 @@ pangaea)
   )
   REL=master
   network_type=pangaea
-  dns_zone=p.hmny.io
+  dns_zone=n.hmny.io
   ;;
 *)
   err 64 "${network}: invalid network"


### PR DESCRIPTION
I messed up p.hmny.io and I don't want to use pga.hmny.io as there are old nodes connecting to it. Using n as it's close to p and is the second consonant in Pa**n**gaea.