### PR TITLE
Change endpoints to support for https and wss

### DIFF
--- a/internal/configs/sharding/mainnet.go
+++ b/internal/configs/sharding/mainnet.go
@@ -34,9 +34,9 @@ const (
 	mainnetEnableTxnThrottling            = true
 
 	// MainNetHTTPPattern is the http pattern for mainnet.
-	MainNetHTTPPattern = "http://s%d.t.hmny.io:9500"
+	MainNetHTTPPattern = "https://api.s%d.t.hmny.io"
 	// MainNetWSPattern is the websocket pattern for mainnet.
-	MainNetWSPattern = "ws://s%d.t.hmny.io:9800"
+	MainNetWSPattern = "wss://api.s%d.t.hmny.io"
 )
 
 // MainnetSchedule is the mainnet sharding configuration schedule.

--- a/internal/configs/sharding/pangaea.go
+++ b/internal/configs/sharding/pangaea.go
@@ -12,9 +12,9 @@ import (
 
 const (
 	// PangaeaHTTPPattern is the http pattern for pangaea.
-	PangaeaHTTPPattern = "http://s%d.pga.hmny.io:9500"
+	PangaeaHTTPPattern = "https://api.s%d.pga.hmny.io"
 	// PangaeaWSPattern is the websocket pattern for pangaea.
-	PangaeaWSPattern = "ws://s%d.pga.hmny.io:9800"
+	PangaeaWSPattern = "wss://api.s%d.pga.hmny.io"
 	// transaction throttling disabled on pangaea network
 	pangaeaEnableTxnThrottling = false
 )

--- a/internal/configs/sharding/testnet.go
+++ b/internal/configs/sharding/testnet.go
@@ -31,9 +31,9 @@ const (
 	testnetEnableTxnThrottling            = true
 
 	// TestNetHTTPPattern is the http pattern for testnet.
-	TestNetHTTPPattern = "http://s%d.b.hmny.io:9500"
+	TestNetHTTPPattern = "https://api.s%d.b.hmny.io"
 	// TestNetWSPattern is the websocket pattern for testnet.
-	TestNetWSPattern = "ws://s%d.b.hmny.io:9800"
+	TestNetWSPattern = "wss://api.s%d.b.hmny.io"
 )
 
 func (testnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {


### PR DESCRIPTION
## Issue

Support https and wss as part of the mainnet v1 checklist https://github.com/harmony-one/harmony/issues/1556
This is needed for the SDK which is being used by math wallet.
As such math wallet cross shard transactions should be tested to verify this (from shard0 to shard 1)

## Test

#### Test Coverage Data

This needs to be tested against betanet, pangea and mainnet.
math wallet cross shard transactions should be tested to verify this (from shard0 to shard 1)

* Before
* After

#### Test/Run Logs


## TODO
Merge and validate against betanet, pangaea and mainnet
