### PR TITLE
Fix the beacon committee check

### DIFF
--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -165,9 +165,7 @@ func (node *Node) messageHandler(content []byte, sender libp2p_peer.ID) {
 						Msg("block sync")
 				} else {
 					// for non-beaconchain node, subscribe to beacon block broadcast
-					role := node.NodeConfig.Role()
-					if role == nodeconfig.Validator {
-
+					if node.Blockchain().ShardID() != 0 {
 						for _, block := range blocks {
 							if block.ShardID() == 0 {
 								utils.Logger().Info().


### PR DESCRIPTION
`nodeconfig.Role` no longer differentiates `Leader` from `Validator`, and at one point `Leader` role was removed.  When we made that change, existing comparisons against `Validator` started holding true for leaders as well.  This caused received beacon block broadcasts to be processed by beacon nodes themselves as well.  However, the beaconchain syncing was disabled on beacon nodes, so attempts to send blocks over `node.BeaconBlockChannel` blocked, leading to leaks of goroutines created for processing incoming messages, then eventually to out-of-memory crashes.