### PR TITLE
[RPC] Expose node metadata

### DIFF
--- a/internal/hmyapi/README.md
+++ b/internal/hmyapi/README.md
@@ -10,6 +10,7 @@
 * [x] hmy_protocolVersion - check protocol version
 * [ ] net_version - get network id
 * [ ] net_peerCount - peer count
+* [x] hmy_getNodeMetadata - get node's version, bls key
 
 ### BlockChain info related
 * [ ] hmy_gasPrice - return min-gas-price

--- a/internal/hmyapi/harmony.go
+++ b/internal/hmyapi/harmony.go
@@ -43,17 +43,21 @@ func (s *PublicHarmonyAPI) GasPrice(ctx context.Context) (*hexutil.Big, error) {
 	return (*hexutil.Big)(big.NewInt(1)), nil
 }
 
+// NodeMetadata captures select metadata of the RPC answering node
 type NodeMetadata struct {
 	BLSPublicKey string `json:"blskey"`
 	Version      string `json:"version"`
 	NetworkType  string `json:"network"`
+	ChainID      string `json:"chainid"`
 }
 
+// GetNodeMetadata produces a NodeMetadata record. Note the data is from the answering RPC
 func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
 	cfg := nodeconfig.GetDefaultConfig()
 	return NodeMetadata{
 		cfg.ConsensusPubKey.SerializeToHexStr(),
 		nodeconfig.GetVersion(),
 		string(cfg.GetNetworkType()),
+		s.b.ChainConfig().ChainID.String(),
 	}
 }

--- a/internal/hmyapi/harmony.go
+++ b/internal/hmyapi/harmony.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/harmony-one/harmony/api/proto"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 )
 
 // PublicHarmonyAPI provides an API to access Harmony related information.
@@ -40,4 +41,19 @@ func (s *PublicHarmonyAPI) Syncing() (interface{}, error) {
 func (s *PublicHarmonyAPI) GasPrice(ctx context.Context) (*hexutil.Big, error) {
 	// TODO(ricl): add SuggestPrice API
 	return (*hexutil.Big)(big.NewInt(1)), nil
+}
+
+type NodeMetadata struct {
+	BLSPublicKey string `json:"blskey"`
+	Version      string `json:"version"`
+	NetworkType  string `json:"network"`
+}
+
+func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
+	cfg := nodeconfig.GetDefaultConfig()
+	return NodeMetadata{
+		cfg.ConsensusPubKey.SerializeToHexStr(),
+		nodeconfig.GetVersion(),
+		string(cfg.GetNetworkType()),
+	}
 }


### PR DESCRIPTION
Add node meta data RPC so that we can build monitoring services. 

Tested with:

```
test/debug.sh
curl -X POST -H 'content-type:application/json' localhost:9500  \
     -d  '{"id":"1","jsonrpc":"2.0","method":"hmy_getNodeMetadata","params":[]}' | json_pp
{
   "id" : "1",
   "jsonrpc" : "2.0",
   "result" : {
      "network" : "",
      "version" : "Harmony (C) 2019. harmony, version - ( )",
      "blskey" : "65f55eb3052f9e9f632b2923be594ba77c55543f5c58ee1454b9cfd658d25e06373b0f7d42a19c84768139ea294f6204"
   }
}
```

Note:

1. network is empty, this is to be investigated as possible bug in existing code
2. version is empty, this is because of how local build of harmony binary proceeds. 
3. blskey is the public key used in consensus
