### PR TITLE
[rpc] listen to localhost by default

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -66,6 +66,7 @@ func printVersion() {
 
 var (
 	ip               = flag.String("ip", "127.0.0.1", "ip of the node")
+	rcpIP            = flag.String("rpc_ip", "127.0.0.1", "listening ip of the node for rpc service")
 	port             = flag.String("port", "9000", "port of the node.")
 	logFolder        = flag.String("log_folder", "latest", "the folder collecting the logs of this execution")
 	logMaxSize       = flag.Int("log_max_size", 100, "the max size in megabytes of the log file before it gets rotated")
@@ -147,6 +148,7 @@ func initSetup() {
 	// Set port and ip to global config.
 	nodeconfig.GetDefaultConfig().Port = *port
 	nodeconfig.GetDefaultConfig().IP = *ip
+	nodeconfig.GetDefaultConfig().SetRPCIP(*ip)
 
 	// Setup mem profiling.
 	memprofiling.GetMemProfiling().Config()

--- a/internal/configs/node/config.go
+++ b/internal/configs/node/config.go
@@ -76,6 +76,7 @@ type ConfigType struct {
 	role     Role        // Role of the node
 	Port     string      // Port of the node.
 	IP       string      // IP of the node.
+	rpcIP    string      // IP of the node listen on RPC service
 
 	MetricsFlag     bool   // collect and upload metrics flag
 	PushgatewayIP   string // metrics pushgateway prometheus ip
@@ -236,6 +237,16 @@ func (conf *ConfigType) SetNetworkType(networkType NetworkType) {
 // GetNetworkType gets the networkType
 func (conf *ConfigType) GetNetworkType() NetworkType {
 	return conf.networkType
+}
+
+// SetRPCIP sets the IP of RPC service
+func (conf *ConfigType) SetRPCIP(ip string) {
+	conf.rpcIP = ip
+}
+
+// GetRPCIP gets the IP of the RPC srevice
+func (conf *ConfigType) GetRPCIP() string {
+	return conf.rpcIP
 }
 
 // SetVersion set the version of the node binary

--- a/node/rpc.go
+++ b/node/rpc.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/harmony-one/harmony/hmy"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/hmyapi"
 	"github.com/harmony-one/harmony/internal/hmyapi/filters"
 	"github.com/harmony-one/harmony/internal/utils"
@@ -56,12 +57,12 @@ func (node *Node) StartRPC(nodePort string) error {
 
 	port, _ := strconv.Atoi(nodePort)
 
-	httpEndpoint = fmt.Sprintf(":%v", port+rpcHTTPPortOffset)
+	httpEndpoint = fmt.Sprintf("%v:%v", nodeconfig.GetDefaultConfig().GetRPCIP(), port+rpcHTTPPortOffset)
 	if err := node.startHTTP(httpEndpoint, apis, httpModules, httpOrigins, httpVirtualHosts, httpTimeouts); err != nil {
 		return err
 	}
 
-	wsEndpoint = fmt.Sprintf(":%v", port+rpcWSPortOffset)
+	wsEndpoint = fmt.Sprintf("%v:%v", nodeconfig.GetDefaultConfig().GetRPCIP(), port+rpcWSPortOffset)
 	if err := node.startWS(wsEndpoint, apis, wsModules, wsOrigins, true); err != nil {
 		node.stopHTTP()
 		return err


### PR DESCRIPTION
for security reason, node program should only listen to localhost for rpc request by default.

-rpc_ip  option is introduced to listen to any port for rpc service

Signed-off-by: Leo Chen <leo@harmony.one>