### PR TITLE
Cleanup state sync logic; fix explorer node sync wrong committee issue

### DIFF
--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -561,11 +561,6 @@ func (ss *StateSync) updateBlockAndStatus(block *types.Block, bc *core.BlockChai
 		bc.Rollback([]common.Hash{bc.CurrentBlock().Hash()})
 		return false
 	}
-	ss.syncMux.Lock()
-	if err := worker.UpdateCurrent(block.Header().Coinbase()); err != nil {
-		utils.Logger().Warn().Err(err).Msg("[SYNC] (*Worker).UpdateCurrent failed")
-	}
-	ss.syncMux.Unlock()
 	utils.Logger().Info().
 		Uint64("blockHeight", bc.CurrentBlock().NumberU64()).
 		Str("blockHex", bc.CurrentBlock().Hash().Hex()).
@@ -740,7 +735,7 @@ func (ss *StateSync) IsOutOfSync(bc *core.BlockChain) bool {
 }
 
 // SyncLoop will keep syncing with peers until catches up
-func (ss *StateSync) SyncLoop(bc *core.BlockChain, worker *worker.Worker, willJoinConsensus bool, isBeacon bool) {
+func (ss *StateSync) SyncLoop(bc *core.BlockChain, worker *worker.Worker, isBeacon bool) {
 	if !isBeacon {
 		ss.RegisterNodeInfo()
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -392,9 +392,9 @@ func New(host p2p.Host, consensusObj *consensus.Consensus, chainDBFactory shardc
 		node.recentTxsStats = make(types.RecentTxsStats)
 		node.TxPool = core.NewTxPool(core.DefaultTxPoolConfig, node.Blockchain().Config(), blockchain)
 		node.CxPool = core.NewCxPool(core.CxPoolSize)
-		node.Worker = worker.New(node.Blockchain().Config(), blockchain, chain.Engine, node.Consensus.ShardID)
+		node.Worker = worker.New(node.Blockchain().Config(), blockchain, chain.Engine)
 		if node.Blockchain().ShardID() != 0 {
-			node.BeaconWorker = worker.New(node.Beaconchain().Config(), beaconChain, chain.Engine, node.Consensus.ShardID)
+			node.BeaconWorker = worker.New(node.Beaconchain().Config(), beaconChain, chain.Engine)
 		}
 
 		node.Consensus.VerifiedNewBlock = make(chan *types.Block)

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -190,7 +190,7 @@ func (node *Node) DoBeaconSyncing() {
 				continue
 			}
 		}
-		node.beaconSync.SyncLoop(node.Beaconchain(), node.BeaconWorker, false, true)
+		node.beaconSync.SyncLoop(node.Beaconchain(), node.BeaconWorker, true)
 		time.Sleep(BeaconSyncFrequency * time.Second)
 	}
 }
@@ -230,7 +230,10 @@ SyncingLoop:
 			if willJoinConsensus {
 				node.Consensus.BlocksNotSynchronized()
 			}
-			node.stateSync.SyncLoop(bc, worker, willJoinConsensus, false)
+			node.stateSync.SyncLoop(bc, worker, false)
+			if node.NodeConfig.Role() == nodeconfig.ExplorerNode {
+				node.Consensus.UpdateConsensusInformation()
+			}
 			if willJoinConsensus {
 				node.stateMutex.Lock()
 				node.State = NodeReadyForConsensus

--- a/node/worker/worker.go
+++ b/node/worker/worker.go
@@ -50,8 +50,6 @@ type Worker struct {
 
 	gasFloor uint64
 	gasCeil  uint64
-
-	shardID uint32
 }
 
 // Returns a tuple where the first value is the txs sender account address,
@@ -114,7 +112,7 @@ func (w *Worker) SelectTransactionsForNewBlock(newBlockNum uint64, txs types.Tra
 	unselected := types.Transactions{}
 	invalid := types.Transactions{}
 	for _, tx := range txs {
-		if tx.ShardID() != w.shardID {
+		if tx.ShardID() != w.chain.ShardID() {
 			invalid = append(invalid, tx)
 			continue
 		}
@@ -353,7 +351,7 @@ func (w *Worker) FinalizeNewBlock(sig []byte, signers []byte, viewID uint64, coi
 }
 
 // New create a new worker object.
-func New(config *params.ChainConfig, chain *core.BlockChain, engine consensus_engine.Engine, shardID uint32) *Worker {
+func New(config *params.ChainConfig, chain *core.BlockChain, engine consensus_engine.Engine) *Worker {
 	worker := &Worker{
 		config:  config,
 		factory: blockfactory.NewFactory(config),
@@ -362,7 +360,6 @@ func New(config *params.ChainConfig, chain *core.BlockChain, engine consensus_en
 	}
 	worker.gasFloor = 500000000000000000
 	worker.gasCeil = 1000000000000000000
-	worker.shardID = shardID
 
 	parent := worker.chain.CurrentBlock()
 	num := parent.Number()

--- a/node/worker/worker_test.go
+++ b/node/worker/worker_test.go
@@ -44,7 +44,7 @@ func TestNewWorker(t *testing.T) {
 	chain, _ := core.NewBlockChain(database, nil, gspec.Config, chain2.Engine, vm.Config{}, nil)
 
 	// Create a new worker
-	worker := New(params.TestChainConfig, chain, chain2.Engine, 0)
+	worker := New(params.TestChainConfig, chain, chain2.Engine)
 
 	if worker.GetCurrentState().GetBalance(crypto.PubkeyToAddress(testBankKey.PublicKey)).Cmp(testBankFunds) != 0 {
 		t.Error("Worker state is not setup correctly")
@@ -67,7 +67,7 @@ func TestCommitTransactions(t *testing.T) {
 	chain, _ := core.NewBlockChain(database, nil, gspec.Config, chain2.Engine, vm.Config{}, nil)
 
 	// Create a new worker
-	worker := New(params.TestChainConfig, chain, chain2.Engine, 0)
+	worker := New(params.TestChainConfig, chain, chain2.Engine)
 
 	// Generate a test tx
 	baseNonce := worker.GetCurrentState().GetNonce(crypto.PubkeyToAddress(testBankKey.PublicKey))

--- a/test/chain/main.go
+++ b/test/chain/main.go
@@ -107,7 +107,7 @@ func fundFaucetContract(chain *core.BlockChain) {
 	fmt.Println("--------- Funding addresses for Faucet Contract Call ---------")
 	fmt.Println()
 
-	contractworker = pkgworker.New(params.TestChainConfig, chain, chain.Engine(), 0)
+	contractworker = pkgworker.New(params.TestChainConfig, chain, chain.Engine())
 	nonce = contractworker.GetCurrentState().GetNonce(crypto.PubkeyToAddress(FaucetPriKey.PublicKey))
 	dataEnc = common.FromHex(FaucetContractBinary)
 	ftx, _ := types.SignTx(types.NewContractCreation(nonce, 0, big.NewInt(7000000000000000000), params.TxGasContractCreation*10, nil, dataEnc), types.HomesteadSigner{}, FaucetPriKey)


### PR DESCRIPTION
Worker is not needed for state sync.
ShardID is not needed in worker.
Explorer node needs to update consensus info once sync'ed.

Tested locally on both normal and explorer node.