### PR TITLE
Make "No ReadCXReceipts found" Info() not Warn()

### DIFF
--- a/node/node_cross_shard.go
+++ b/node/node_cross_shard.go
@@ -58,7 +58,7 @@ func (node *Node) BroadcastCXReceiptsWithShardID(block *types.Block, commitSig [
 
 	cxReceipts, err := node.Blockchain().ReadCXReceipts(toShardID, block.NumberU64(), block.Hash(), false)
 	if err != nil || len(cxReceipts) == 0 {
-		utils.Logger().Warn().Err(err).Uint32("ToShardID", toShardID).Int("numCXReceipts", len(cxReceipts)).Msg("[BroadcastCXReceiptsWithShardID] No ReadCXReceipts found")
+		utils.Logger().Info().Err(err).Uint32("ToShardID", toShardID).Int("numCXReceipts", len(cxReceipts)).Msg("[BroadcastCXReceiptsWithShardID] No ReadCXReceipts found")
 		return
 	}
 	merkleProof, err := node.Blockchain().CXMerkleProof(toShardID, block)


### PR DESCRIPTION
We  have monitoring that sends alerts on warning/error messages after a  certain threshold. This warning is setting off our alerts.

See also https://github.com/harmony-one/harmony/pull/1566

>[12:28 AM] Chris | Harmony: That probably should be info
[12:28 AM] Chris | Harmony: That happens whenever there's no cross shard transactions
[12:28 AM] Chris | Harmony: Which is probably pretty common
[12:28 AM] Chris | Harmony: Also for all 3 shards