### PR TITLE
Fail if build fails so Makefile knows something went wrong

### DIFF
--- a/scripts/go_executable_build.sh
+++ b/scripts/go_executable_build.sh
@@ -94,6 +94,8 @@ function build_only
    BUILTBY=${USER}@
    local build=$1
 
+   set -e
+
    for bin in "${!SRC[@]}"; do
       if [[ -z "$build" || "$bin" == "$build" ]]; then
          rm -f $BINDIR/$bin


### PR DESCRIPTION
Currently the build script continues on no matter what error occurred.

This is problematic for three reasons:

1) the state of the build is in some indeterminate state (e.g bad m5sums wrong etc) since the script blindly moves on no matter what errors happened before

2) the `Makefile` is unaware something went wrong

3) it makes `git bisect run` impossible w/o a wrapper script.