### PR TITLE
Include chain ID in DHT cache database directory name

### DIFF
--- a/api/service/networkinfo/service.go
+++ b/api/service/networkinfo/service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	manet "github.com/multiformats/go-multiaddr-net"
+	"github.com/pkg/errors"
 
 	"github.com/ethereum/go-ethereum/rpc"
 	msg_pb "github.com/harmony-one/harmony/api/proto/message"
@@ -17,6 +18,7 @@ import (
 	coredis "github.com/libp2p/go-libp2p-core/discovery"
 	libp2pdis "github.com/libp2p/go-libp2p-discovery"
 	libp2pdht "github.com/libp2p/go-libp2p-kad-dht"
+	libp2pdhtopts "github.com/libp2p/go-libp2p-kad-dht/opts"
 	peerstore "github.com/libp2p/go-libp2p-peerstore"
 )
 
@@ -57,15 +59,22 @@ const (
 )
 
 // New returns role conversion service.
-func New(h p2p.Host, rendezvous p2p.GroupID, peerChan chan p2p.Peer, bootnodes utils.AddrList) *Service {
+func New(
+	h p2p.Host, rendezvous p2p.GroupID, peerChan chan p2p.Peer,
+	bootnodes utils.AddrList,
+) (*Service, error) {
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithTimeout(context.Background(), connectionTimeout)
 	dataStore, err := badger.NewDatastore(fmt.Sprintf(".dht-%s-%s", h.GetSelfPeer().IP, h.GetSelfPeer().Port), nil)
 	if err != nil {
-		panic(err)
+		return nil, errors.Wrapf(err,
+			"cannot open Badger datastore at %s", dataStorePath)
 	}
 
-	dht := libp2pdht.NewDHT(ctx, h.GetP2PHost(), dataStore)
+	dht, err := libp2pdht.New(ctx, h.GetP2PHost(), libp2pdhtopts.Datastore(dataStore))
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot create DHT")
+	}
 
 	return &Service{
 		Host:        h,
@@ -78,7 +87,19 @@ func New(h p2p.Host, rendezvous p2p.GroupID, peerChan chan p2p.Peer, bootnodes u
 		bootnodes:   bootnodes,
 		discovery:   nil,
 		started:     false,
+	}, nil
+}
+
+// MustNew is a panic-on-error version of New.
+func MustNew(
+	h p2p.Host, rendezvous p2p.GroupID, peerChan chan p2p.Peer,
+	bootnodes utils.AddrList,
+) *Service {
+	service, err := New(h, rendezvous, peerChan, bootnodes)
+	if err != nil {
+		panic(err)
 	}
+	return service
 }
 
 // StartService starts network info service.

--- a/api/service/networkinfo/service.go
+++ b/api/service/networkinfo/service.go
@@ -71,6 +71,9 @@ func New(
 		return nil, errors.Wrapf(err,
 			"cannot open Badger datastore at %s", dataStorePath)
 	}
+	utils.Logger().Info().
+		Str("dataStorePath", dataStorePath).
+		Msg("backing DHT with Badger datastore")
 
 	dht, err := libp2pdht.New(ctx, h.GetP2PHost(), libp2pdhtopts.Datastore(dataStore))
 	if err != nil {

--- a/api/service/networkinfo/service.go
+++ b/api/service/networkinfo/service.go
@@ -58,14 +58,15 @@ const (
 	discoveryLimit = 32
 )
 
-// New returns role conversion service.
+// New returns role conversion service.  datastorePath points to a persistent
+// database directory to use.
 func New(
 	h p2p.Host, rendezvous p2p.GroupID, peerChan chan p2p.Peer,
-	bootnodes utils.AddrList,
+	bootnodes utils.AddrList, dataStorePath string,
 ) (*Service, error) {
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithTimeout(context.Background(), connectionTimeout)
-	dataStore, err := badger.NewDatastore(fmt.Sprintf(".dht-%s-%s", h.GetSelfPeer().IP, h.GetSelfPeer().Port), nil)
+	dataStore, err := badger.NewDatastore(dataStorePath, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err,
 			"cannot open Badger datastore at %s", dataStorePath)
@@ -93,9 +94,9 @@ func New(
 // MustNew is a panic-on-error version of New.
 func MustNew(
 	h p2p.Host, rendezvous p2p.GroupID, peerChan chan p2p.Peer,
-	bootnodes utils.AddrList,
+	bootnodes utils.AddrList, dataStorePath string,
 ) *Service {
-	service, err := New(h, rendezvous, peerChan, bootnodes)
+	service, err := New(h, rendezvous, peerChan, bootnodes, dataStorePath)
 	if err != nil {
 		panic(err)
 	}

--- a/api/service/networkinfo/service_test.go
+++ b/api/service/networkinfo/service_test.go
@@ -28,7 +28,10 @@ func TestService(t *testing.T) {
 		t.Fatal("unable to new host in harmony")
 	}
 
-	s := New(host, p2p.GroupIDBeaconClient, nil, nil)
+	s, err := New(host, p2p.GroupIDBeaconClient, nil, nil, "")
+	if err != nil {
+		t.Fatalf("New() failed: %s", err)
+	}
 
 	s.StartService()
 

--- a/node/node.go
+++ b/node/node.go
@@ -192,6 +192,9 @@ type Node struct {
 	// node configuration, including group ID, shard ID, etc
 	NodeConfig *nodeconfig.ConfigType
 
+	// Chain configuration.
+	chainConfig params.ChainConfig
+
 	// map of service type to its message channel.
 	serviceMessageChan map[service.Type]chan *msg_pb.Message
 
@@ -373,6 +376,7 @@ func New(host p2p.Host, consensusObj *consensus.Consensus, chainDBFactory shardc
 	case nodeconfig.Pangaea:
 		chainConfig = *params.PangaeaChainConfig
 	}
+	node.chainConfig = chainConfig
 
 	collection := shardchain.NewCollection(
 		chainDBFactory, &genesisInitializer{&node}, chain.Engine, &chainConfig)

--- a/node/service_setup.go
+++ b/node/service_setup.go
@@ -22,7 +22,7 @@ func (node *Node) setupForValidator() {
 	// Register peer discovery service. No need to do staking for beacon chain node.
 	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, node.AddBeaconPeer))
 	// Register networkinfo service. "0" is the beacon shard ID
-	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, node.NodeConfig.GetShardGroupID(), chanPeer, nil))
+	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.MustNew(node.host, node.NodeConfig.GetShardGroupID(), chanPeer, nil))
 	// Register consensus service.
 	node.serviceManager.RegisterService(service.Consensus, consensus.New(node.BlockChannel, node.Consensus, node.startConsensus))
 	// Register new block service.
@@ -51,7 +51,7 @@ func (node *Node) setupForNewNode() {
 	// Register peer discovery service. "0" is the beacon shard ID
 	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, node.AddBeaconPeer))
 	// Register networkinfo service. "0" is the beacon shard ID
-	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, node.NodeConfig.GetBeaconGroupID(), chanPeer, nil))
+	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.MustNew(node.host, node.NodeConfig.GetBeaconGroupID(), chanPeer, nil))
 	// Register new metrics service
 	if node.NodeConfig.GetMetricsFlag() {
 		node.serviceManager.RegisterService(service.Metrics, metrics.New(&node.SelfPeer, node.NodeConfig.ConsensusPubKey.SerializeToHexStr(), node.NodeConfig.GetPushgatewayIP(), node.NodeConfig.GetPushgatewayPort()))
@@ -60,7 +60,7 @@ func (node *Node) setupForNewNode() {
 
 func (node *Node) setupForClientNode() {
 	// Register networkinfo service. "0" is the beacon shard ID
-	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, p2p.GroupIDBeacon, nil, nil))
+	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.MustNew(node.host, p2p.GroupIDBeacon, nil, nil))
 }
 
 func (node *Node) setupForExplorerNode() {
@@ -69,7 +69,7 @@ func (node *Node) setupForExplorerNode() {
 	// Register peer discovery service.
 	node.serviceManager.RegisterService(service.PeerDiscovery, discovery.New(node.host, nodeConfig, chanPeer, nil))
 	// Register networkinfo service.
-	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.New(node.host, node.NodeConfig.GetShardGroupID(), chanPeer, nil))
+	node.serviceManager.RegisterService(service.NetworkInfo, networkinfo.MustNew(node.host, node.NodeConfig.GetShardGroupID(), chanPeer, nil))
 	// Register explorer service.
 	node.serviceManager.RegisterService(service.SupportExplorer, explorer.New(&node.SelfPeer, node.NodeConfig.GetShardID(), node.Consensus.GetNodeIDs, node.GetBalanceOfAddress))
 	// Register explorer service.


### PR DESCRIPTION
## Issue

DHT directory is of the form `.dht-<IP>-<port>`, e.g. `.dht-12.34.56.78-9000` in the current directory.  If a node is restarted in the current directory for a different network, e.g. from Mainnet to Pangaea due to misconfiguration, then in the new invocation (Pangaea) the node still connects to old cached nodes (on Mainnet).  Segregate cache by having chain ID embedded in the DHT cache directory name.

## Test
![image](https://user-images.githubusercontent.com/42688919/65379900-fc685300-dc84-11e9-9e71-f8aa4cf348b6.png)

(19876 is bootnode, which is inherently network agnostic, so its directory name does not have the chain ID embedded.)