### PR TITLE
add hmy getTransactionsHistory

### DIFF
--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -207,6 +207,12 @@ func (b *APIBackend) GetBalance(address common.Address) (*hexutil.Big, error) {
 	return (*hexutil.Big)(balance), err
 }
 
+// GetTransactionsHistory returns list of transactions hashes of address.
+func (b *APIBackend) GetTransactionsHistory(address string) ([]common.Hash, error) {
+	hashes, err := b.hmy.nodeAPI.GetTransactionsHistory(address)
+	return hashes, err
+}
+
 // NetVersion returns net version
 func (b *APIBackend) NetVersion() uint64 {
 	return b.hmy.NetVersion()

--- a/hmy/backend.go
+++ b/hmy/backend.go
@@ -48,6 +48,7 @@ type NodeAPI interface {
 	AccountManager() *accounts.Manager
 	GetBalanceOfAddress(address common.Address) (*big.Int, error)
 	GetNonceOfAddress(address common.Address) uint64
+	GetTransactionsHistory(address string) ([]common.Hash, error)
 }
 
 // New creates a new Harmony object (including the

--- a/internal/hmyapi/backend.go
+++ b/internal/hmyapi/backend.go
@@ -67,7 +67,8 @@ type Backend interface {
 	// Get committee for a particular epoch
 	GetCommittee(epoch *big.Int) (*shard.Committee, error)
 	GetShardID() uint32
-
+	// Get transactions history for an address
+	GetTransactionsHistory(address string) ([]common.Hash, error)
 	// retrieve the blockHash using txID and add blockHash to CxPool for resending
 	ResendCx(ctx context.Context, txID common.Hash) (uint64, bool)
 }

--- a/internal/hmyapi/transactionpool.go
+++ b/internal/hmyapi/transactionpool.go
@@ -2,6 +2,7 @@ package hmyapi
 
 import (
 	"context"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -22,6 +23,19 @@ type PublicTransactionPoolAPI struct {
 // NewPublicTransactionPoolAPI creates a new RPC service with methods specific for the transaction pool.
 func NewPublicTransactionPoolAPI(b Backend, nonceLock *AddrLocker) *PublicTransactionPoolAPI {
 	return &PublicTransactionPoolAPI{b, nonceLock}
+}
+
+// GetTransactionsHistory returns the list of transactions hashes that involve a particular address.
+func (s *PublicTransactionPoolAPI) GetTransactionsHistory(ctx context.Context, address string) ([]common.Hash, error) {
+	if strings.HasPrefix(address, "one1") {
+		return s.b.GetTransactionsHistory(address)
+	}
+	addr := internal_common.ParseAddr(address)
+	oneAddress, err := internal_common.AddressToBech32(addr)
+	if err != nil {
+		return nil, err
+	}
+	return s.b.GetTransactionsHistory(oneAddress)
 }
 
 // GetBlockTransactionCountByNumber returns the number of transactions in the block with the given block number.

--- a/internal/hmyapi/types.go
+++ b/internal/hmyapi/types.go
@@ -15,34 +15,34 @@ import (
 
 // RPCTransaction represents a transaction that will serialize to the RPC representation of a transaction
 type RPCTransaction struct {
-	BlockHash        common.Hash     `json:"blockHash"`
-	BlockNumber      *hexutil.Big    `json:"blockNumber"`
-	From             string          `json:"from"`
-	Gas              hexutil.Uint64  `json:"gas"`
-	GasPrice         *hexutil.Big    `json:"gasPrice"`
-	Hash             common.Hash     `json:"hash"`
-	Input            hexutil.Bytes   `json:"input"`
-	Nonce            hexutil.Uint64  `json:"nonce"`
-	To               string          `json:"to"`
-	TransactionIndex hexutil.Uint    `json:"transactionIndex"`
-	Value            *hexutil.Big    `json:"value"`
-	ShardID          uint32          `json:"shardID"`
-	ToShardID        uint32          `json:"toShardID"`
-	V                *hexutil.Big    `json:"v"`
-	R                *hexutil.Big    `json:"r"`
-	S                *hexutil.Big    `json:"s"`
+	BlockHash        common.Hash    `json:"blockHash"`
+	BlockNumber      *hexutil.Big   `json:"blockNumber"`
+	From             string         `json:"from"`
+	Gas              hexutil.Uint64 `json:"gas"`
+	GasPrice         *hexutil.Big   `json:"gasPrice"`
+	Hash             common.Hash    `json:"hash"`
+	Input            hexutil.Bytes  `json:"input"`
+	Nonce            hexutil.Uint64 `json:"nonce"`
+	To               string         `json:"to"`
+	TransactionIndex hexutil.Uint   `json:"transactionIndex"`
+	Value            *hexutil.Big   `json:"value"`
+	ShardID          uint32         `json:"shardID"`
+	ToShardID        uint32         `json:"toShardID"`
+	V                *hexutil.Big   `json:"v"`
+	R                *hexutil.Big   `json:"r"`
+	S                *hexutil.Big   `json:"s"`
 }
 
 // RPCCXReceipt represents a CXReceipt that will serialize to the RPC representation of a CXReceipt
 type RPCCXReceipt struct {
-	BlockHash   common.Hash     `json:"blockHash"`
-	BlockNumber *hexutil.Big    `json:"blockNumber"`
-	TxHash      common.Hash     `json:"hash"`
-	From        string          `json:"from"`
-	To          string          `json:"to"`
-	ShardID     uint32          `json:"shardID"`
-	ToShardID   uint32          `json:"toShardID"`
-	Amount      *hexutil.Big    `json:"value"`
+	BlockHash   common.Hash  `json:"blockHash"`
+	BlockNumber *hexutil.Big `json:"blockNumber"`
+	TxHash      common.Hash  `json:"hash"`
+	From        string       `json:"from"`
+	To          string       `json:"to"`
+	ShardID     uint32       `json:"shardID"`
+	ToShardID   uint32       `json:"toShardID"`
+	Amount      *hexutil.Big `json:"value"`
 }
 
 // HeaderInformation represents the latest consensus information

--- a/internal/hmyapi/types.go
+++ b/internal/hmyapi/types.go
@@ -17,13 +17,13 @@ import (
 type RPCTransaction struct {
 	BlockHash        common.Hash     `json:"blockHash"`
 	BlockNumber      *hexutil.Big    `json:"blockNumber"`
-	From             common.Address  `json:"from"`
+	From             string          `json:"from"`
 	Gas              hexutil.Uint64  `json:"gas"`
 	GasPrice         *hexutil.Big    `json:"gasPrice"`
 	Hash             common.Hash     `json:"hash"`
 	Input            hexutil.Bytes   `json:"input"`
 	Nonce            hexutil.Uint64  `json:"nonce"`
-	To               *common.Address `json:"to"`
+	To               string          `json:"to"`
 	TransactionIndex hexutil.Uint    `json:"transactionIndex"`
 	Value            *hexutil.Big    `json:"value"`
 	ShardID          uint32          `json:"shardID"`
@@ -38,8 +38,8 @@ type RPCCXReceipt struct {
 	BlockHash   common.Hash     `json:"blockHash"`
 	BlockNumber *hexutil.Big    `json:"blockNumber"`
 	TxHash      common.Hash     `json:"hash"`
-	From        common.Address  `json:"from"`
-	To          *common.Address `json:"to"`
+	From        string          `json:"from"`
+	To          string          `json:"to"`
 	ShardID     uint32          `json:"shardID"`
 	ToShardID   uint32          `json:"toShardID"`
 	Amount      *hexutil.Big    `json:"value"`
@@ -84,8 +84,8 @@ func newRPCCXReceipt(cx *types.CXReceipt, blockHash common.Hash, blockNumber uin
 	result := &RPCCXReceipt{
 		BlockHash: blockHash,
 		TxHash:    cx.TxHash,
-		From:      cx.From,
-		To:        cx.To,
+		From:      common2.MustAddressToBech32(cx.From),
+		To:        common2.MustAddressToBech32(*cx.To),
 		Amount:    (*hexutil.Big)(cx.Amount),
 		ShardID:   cx.ShardID,
 		ToShardID: cx.ToShardID,
@@ -108,13 +108,13 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 	v, r, s := tx.RawSignatureValues()
 
 	result := &RPCTransaction{
-		From:      from,
+		From:      common2.MustAddressToBech32(from),
 		Gas:       hexutil.Uint64(tx.Gas()),
 		GasPrice:  (*hexutil.Big)(tx.GasPrice()),
 		Hash:      tx.Hash(),
 		Input:     hexutil.Bytes(tx.Data()),
 		Nonce:     hexutil.Uint64(tx.Nonce()),
-		To:        tx.To(),
+		To:        common2.MustAddressToBech32(*tx.To()),
 		Value:     (*hexutil.Big)(tx.Value()),
 		ShardID:   tx.ShardID(),
 		ToShardID: tx.ToShardID(),

--- a/internal/hmyapi/util.go
+++ b/internal/hmyapi/util.go
@@ -11,6 +11,24 @@ import (
 	"github.com/harmony-one/harmony/internal/utils"
 )
 
+// defaultOffset is to have default pagination.
+const (
+	defaultOffset = 100
+)
+
+// ReturnWithPagination returns result with pagination (offset, page in TxHistoryArgs).
+func ReturnWithPagination(hashes []common.Hash, args TxHistoryArgs) []common.Hash {
+	offset := defaultOffset
+	page := args.Page
+	if args.Offset > 0 {
+		offset = args.Offset
+	}
+	if offset*page+offset > len(hashes) {
+		return hashes[offset*page:]
+	}
+	return hashes[offset*page : offset*page+offset]
+}
+
 // SubmitTransaction is a helper function that submits tx to txPool and logs a message.
 func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (common.Hash, error) {
 	if err := b.SendTx(ctx, tx); err != nil {


### PR DESCRIPTION
## Issue

https://github.com/harmony-one/harmony/issues/1633

## Test

<img width="1362" alt="Screenshot 2019-09-24 at 00 07 29" src="https://user-images.githubusercontent.com/52401354/65463046-ac91b380-de5f-11e9-81d2-7dea7e9dc2bf.png">


#### Test Coverage Data

<!-- run 'go test -cover' in the directory you made change -->

* Before
* After

#### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## TODO

Make adjustments on explorer frontend. GetTransactionsHistory returns list of hashes, then query each tx by hash by GetTransactionByHash and its receipt by GetTransactionReceipt and show on explorer. Such design makes all methods atomic.