### PR TITLE
Error fix

### DIFF
--- a/api/service/explorer/service.go
+++ b/api/service/explorer/service.go
@@ -782,7 +782,7 @@ func (s *Service) GetExplorerAddress(w http.ResponseWriter, r *http.Request) {
 }
 
 // GetExplorerAddress rpc end-point.
-func (s *ServiceAPI) GetExplorerAddress(ctx context.Context, id, txView string, page, offset int) (*Address, error) {
+func (s *ServiceAPI) GetExplorerAddress(ctx context.Context, id, txView string, page, offset int, order string) (*Address, error) {
 	if strings.HasPrefix(id, "0x") {
 		parsedAddr := common2.ParseAddr(id)
 		oneAddr, err := common2.AddressToBech32(parsedAddr)


### PR DESCRIPTION
## Issue

http://18.236.136.215:5000/address?id=one1puj38zamhlu89enzcdjw6rlhlqtyp2c675hjg5 returns balance but http://35.171.21.32:5000/address?id=one1puj38zamhlu89enzcdjw6rlhlqtyp2c675hjg5 returns 500, should return status 200 for both, also change error message for address format parsing.

## Test

<img width="1370" alt="Screenshot 2019-09-24 at 23 55 12" src="https://user-images.githubusercontent.com/52401354/65549721-c3e7a400-df26-11e9-9fdd-465118661a00.png">
Shows OK status for address that is not a validator and didn't have any txs, which is the case in issue.

#### Test Coverage Data

<!-- run 'go test -cover' in the directory you made change -->

* Before
* After

#### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## TODO

Make adjustments on frontend.