### PR TITLE
fix storage instance and 0x address case

### DIFF
--- a/node/node_explorer.go
+++ b/node/node_explorer.go
@@ -146,7 +146,10 @@ func (node *Node) commitBlockForExplorer(block *types.Block) {
 func (node *Node) GetTransactionsHistory(address string) ([]common.Hash, error) {
 	addressData := &explorer.Address{}
 	key := explorer.GetAddressKey(address)
-	bytes, err := explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port, true).GetDB().Get([]byte(key))
+	bytes, err := explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port, false).GetDB().Get([]byte(key))
+	if err != nil {
+		return make([]common.Hash, 0), nil
+	}
 	if err = rlp.DecodeBytes(bytes, &addressData); err != nil {
 		utils.Logger().Error().Err(err).Msg("[Explorer] Cannot convert address data from DB")
 		return nil, err


### PR DESCRIPTION
## Issue

Small fixes for tx transactions history api. Fixed 0x case (returned error if address wasn't in db), storage should be fetched with false flag.

## Test

Localnet, postman.

#### Test Coverage Data

<!-- run 'go test -cover' in the directory you made change -->

* Before
* After

#### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## TODO
