### PR TITLE
Fix apis for contract tx

### DIFF
--- a/api/service/explorer/storage.go
+++ b/api/service/explorer/storage.go
@@ -112,10 +112,6 @@ func (storage *Storage) Dump(block *types.Block, height uint64) {
 
 	// Store txs
 	for _, tx := range block.Transactions() {
-		if tx.To() == nil {
-			continue
-		}
-
 		explorerTransaction := GetTransaction(tx, block)
 		storage.UpdateTXStorage(batch, explorerTransaction, tx)
 		storage.UpdateAddress(batch, explorerTransaction, tx)
@@ -158,7 +154,9 @@ func (storage *Storage) UpdateTXStorage(batch ethdb.Batch, explorerTransaction *
 // TODO: deprecate this logic
 func (storage *Storage) UpdateAddress(batch ethdb.Batch, explorerTransaction *Transaction, tx *types.Transaction) {
 	explorerTransaction.Type = Received
-	storage.UpdateAddressStorage(batch, explorerTransaction.To, explorerTransaction, tx)
+	if explorerTransaction.To != "" {
+		storage.UpdateAddressStorage(batch, explorerTransaction.To, explorerTransaction, tx)
+	}
 	explorerTransaction.Type = Sent
 	storage.UpdateAddressStorage(batch, explorerTransaction.From, explorerTransaction, tx)
 }

--- a/api/service/explorer/structs.go
+++ b/api/service/explorer/structs.go
@@ -121,7 +121,7 @@ func GetTransaction(tx *types.Transaction, addressBlock *types.Block) *Transacti
 	to := ""
 	if msg.To() != nil {
 		if to, err = common.AddressToBech32(*msg.To()); err != nil {
-			return nil			
+			return nil
 		}
 	}
 	from := ""

--- a/api/service/explorer/structs.go
+++ b/api/service/explorer/structs.go
@@ -5,10 +5,8 @@ import (
 	"math/big"
 	"strconv"
 
-	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/harmony-one/harmony/core/types"
-	common2 "github.com/harmony-one/harmony/internal/common"
+	"github.com/harmony-one/harmony/internal/common"
 	"github.com/harmony-one/harmony/internal/utils"
 )
 
@@ -114,20 +112,21 @@ func NewBlock(block *types.Block, height int) *Block {
 
 // GetTransaction ...
 func GetTransaction(tx *types.Transaction, addressBlock *types.Block) *Transaction {
-	if tx.To() == nil {
-		return nil
-	}
 	msg, err := tx.AsMessage(types.NewEIP155Signer(tx.ChainID()))
 	if err != nil {
 		utils.Logger().Error().Err(err).Msg("Error when parsing tx into message")
 	}
 	gasFee := big.NewInt(0)
 	gasFee = gasFee.Mul(tx.GasPrice(), new(big.Int).SetUint64(tx.Gas()))
+	to := ""
+	if msg.To() != nil {
+		to = common.MustAddressToBech32(*msg.To())
+	}
 	return &Transaction{
 		ID:        tx.Hash().Hex(),
 		Timestamp: strconv.Itoa(int(addressBlock.Time().Int64() * 1000)),
-		From:      common2.MustAddressToBech32(common.HexToAddress(msg.From().Hex())),
-		To:        common2.MustAddressToBech32(common.HexToAddress(msg.To().Hex())),
+		From:      common.MustAddressToBech32(msg.From()),
+		To:        to,
 		Value:     msg.Value(),
 		Bytes:     strconv.Itoa(int(tx.Size())),
 		Data:      hex.EncodeToString(tx.Data()),

--- a/api/service/explorer/structs.go
+++ b/api/service/explorer/structs.go
@@ -119,7 +119,6 @@ func GetTransaction(tx *types.Transaction, addressBlock *types.Block) *Transacti
 	gasFee := big.NewInt(0)
 	gasFee = gasFee.Mul(tx.GasPrice(), new(big.Int).SetUint64(tx.Gas()))
 	to := ""
-	var err error
 	if msg.To() != nil {
 		if to, err = common.AddressToBech32(*msg.To()); err != nil {
 			return nil			

--- a/api/service/explorer/structs.go
+++ b/api/service/explorer/structs.go
@@ -119,13 +119,20 @@ func GetTransaction(tx *types.Transaction, addressBlock *types.Block) *Transacti
 	gasFee := big.NewInt(0)
 	gasFee = gasFee.Mul(tx.GasPrice(), new(big.Int).SetUint64(tx.Gas()))
 	to := ""
+	var err error
 	if msg.To() != nil {
-		to = common.MustAddressToBech32(*msg.To())
+		if to, err = common.AddressToBech32(*msg.To()); err != nil {
+			return nil			
+		}
+	}
+	from := ""
+	if from, err = common.AddressToBech32(msg.From()); err != nil {
+		return nil
 	}
 	return &Transaction{
 		ID:        tx.Hash().Hex(),
 		Timestamp: strconv.Itoa(int(addressBlock.Time().Int64() * 1000)),
-		From:      common.MustAddressToBech32(msg.From()),
+		From:      from,
 		To:        to,
 		Value:     msg.Value(),
 		Bytes:     strconv.Itoa(int(tx.Size())),

--- a/internal/hmyapi/blockchain.go
+++ b/internal/hmyapi/blockchain.go
@@ -41,7 +41,6 @@ func NewPublicBlockChainAPI(b Backend) *PublicBlockChainAPI {
 func (s *PublicBlockChainAPI) GetBlockByNumber(ctx context.Context, blockNr rpc.BlockNumber, fullTx bool) (map[string]interface{}, error) {
 	block, err := s.b.BlockByNumber(ctx, blockNr)
 	if block != nil {
-		utils.Logger().Info().Msgf("HASH block %s", block.Hash().String())
 		response, err := RPCMarshalBlock(block, true, fullTx)
 		if err == nil && blockNr == rpc.PendingBlockNumber {
 			// Pending blocks need to nil out a few fields

--- a/internal/hmyapi/blockchain.go
+++ b/internal/hmyapi/blockchain.go
@@ -41,6 +41,7 @@ func NewPublicBlockChainAPI(b Backend) *PublicBlockChainAPI {
 func (s *PublicBlockChainAPI) GetBlockByNumber(ctx context.Context, blockNr rpc.BlockNumber, fullTx bool) (map[string]interface{}, error) {
 	block, err := s.b.BlockByNumber(ctx, blockNr)
 	if block != nil {
+		utils.Logger().Info().Msgf("HASH block %s", block.Hash().String())
 		response, err := RPCMarshalBlock(block, true, fullTx)
 		if err == nil && blockNr == rpc.PendingBlockNumber {
 			// Pending blocks need to nil out a few fields
@@ -58,7 +59,7 @@ func (s *PublicBlockChainAPI) GetBlockByNumber(ctx context.Context, blockNr rpc.
 func (s *PublicBlockChainAPI) GetBlockByHash(ctx context.Context, blockHash common.Hash, fullTx bool) (map[string]interface{}, error) {
 	block, err := s.b.GetBlock(ctx, blockHash)
 	if block != nil {
-		return RPCMarshalBlock(block, false, false)
+		return RPCMarshalBlock(block, true, fullTx)
 	}
 	return nil, err
 }

--- a/internal/hmyapi/transactionpool.go
+++ b/internal/hmyapi/transactionpool.go
@@ -13,7 +13,6 @@ import (
 	"github.com/harmony-one/harmony/core/rawdb"
 	"github.com/harmony-one/harmony/core/types"
 	internal_common "github.com/harmony-one/harmony/internal/common"
-	"github.com/harmony-one/harmony/internal/utils"
 )
 
 // TxHistoryArgs is struct to make GetTransactionsHistory request

--- a/internal/hmyapi/transactionpool.go
+++ b/internal/hmyapi/transactionpool.go
@@ -94,7 +94,6 @@ func (s *PublicTransactionPoolAPI) GetTransactionByBlockHashAndIndex(ctx context
 func (s *PublicTransactionPoolAPI) GetTransactionByHash(ctx context.Context, hash common.Hash) *RPCTransaction {
 	// Try to return an already finalized transaction
 	if tx, blockHash, blockNumber, index := rawdb.ReadTransaction(s.b.ChainDb(), hash); tx != nil {
-		utils.Logger().Info().Msgf("HASH %s", tx.Hash().String())
 		return newRPCTransaction(tx, blockHash, blockNumber, index)
 	}
 	// No finalized transaction, try to retrieve it from the pool
@@ -176,7 +175,6 @@ func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, ha
 	if tx == nil {
 		return nil, nil
 	}
-	utils.Logger().Info().Msgf("HASH %s", tx.Hash().String())
 	receipts, err := s.b.GetReceipts(ctx, blockHash)
 	if err != nil {
 		return nil, err
@@ -192,7 +190,6 @@ func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, ha
 	}
 	from, _ := types.Sender(signer, tx)
 	to := ""
-	utils.Logger().Info().Msgf("LOLOLO %s", internal_common.MustAddressToBech32(from))
 	if tx.To() != nil {
 		to = internal_common.MustAddressToBech32(*tx.To())
 	}

--- a/internal/hmyapi/types.go
+++ b/internal/hmyapi/types.go
@@ -3,6 +3,7 @@ package hmyapi
 import (
 	"encoding/hex"
 	"math/big"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -156,8 +157,10 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		if toAddr, err = internal_common.AddressToBech32(*tx.To()); err != nil {
 			return nil
 		}
+		result.From = fromAddr
+	} else {
+		result.From = strings.ToLower(from.Hex())
 	}
-	result.From = fromAddr
 	result.To = toAddr
 
 	return result

--- a/internal/hmyapi/types.go
+++ b/internal/hmyapi/types.go
@@ -10,7 +10,8 @@ import (
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/harmony-one/harmony/block"
 	"github.com/harmony-one/harmony/core/types"
-	common2 "github.com/harmony-one/harmony/internal/common"
+	internal_common "github.com/harmony-one/harmony/internal/common"
+	"github.com/harmony-one/harmony/internal/utils"
 )
 
 // RPCTransaction represents a transaction that will serialize to the RPC representation of a transaction
@@ -78,7 +79,7 @@ func newHeaderInformation(header *block.Header) *HeaderInformation {
 	sig := header.LastCommitSignature()
 	result.LastCommitSig = hex.EncodeToString(sig[:])
 
-	bechAddr, err := common2.AddressToBech32(header.Coinbase())
+	bechAddr, err := internal_common.AddressToBech32(header.Coinbase())
 	if err != nil {
 		bechAddr = header.Coinbase().Hex()
 	}
@@ -101,13 +102,15 @@ func newRPCCXReceipt(cx *types.CXReceipt, blockHash common.Hash, blockNumber uin
 		result.BlockNumber = (*hexutil.Big)(new(big.Int).SetUint64(blockNumber))
 	}
 
-	fromAddr, err := common2.AddressToBech32(cx.From)
+	fromAddr, err := internal_common.AddressToBech32(cx.From)
 	if err != nil {
-		fromAddr = cx.From.Hex()
+		return nil
 	}
-	toAddr, err := common2.AddressToBech32(*cx.To)
-	if err != nil {
-		toAddr = (*cx.To).Hex()
+	toAddr := ""
+	if cx.To != nil {
+		if toAddr, err = internal_common.AddressToBech32(*cx.To); err != nil {
+			return nil
+		}
 	}
 	result.From = fromAddr
 	result.To = toAddr
@@ -144,13 +147,17 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		result.TransactionIndex = hexutil.Uint(index)
 	}
 
-	fromAddr, err := common2.AddressToBech32(from)
+	fromAddr, err := internal_common.AddressToBech32(from)
 	if err != nil {
-		fromAddr = from.Hex()
+		return nil
 	}
-	toAddr, err := common2.AddressToBech32(*tx.To())
-	if err != nil {
-		toAddr = (*tx.To()).Hex()
+	toAddr := ""
+
+	utils.Logger().Info().Msgf("LOLOLO %s", fromAddr)
+	if tx.To() != nil {
+		if toAddr, err = internal_common.AddressToBech32(*tx.To()); err != nil {
+			return nil
+		}
 	}
 	result.From = fromAddr
 	result.To = toAddr

--- a/internal/hmyapi/types.go
+++ b/internal/hmyapi/types.go
@@ -11,7 +11,6 @@ import (
 	"github.com/harmony-one/harmony/block"
 	"github.com/harmony-one/harmony/core/types"
 	internal_common "github.com/harmony-one/harmony/internal/common"
-	"github.com/harmony-one/harmony/internal/utils"
 )
 
 // RPCTransaction represents a transaction that will serialize to the RPC representation of a transaction
@@ -153,7 +152,6 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 	}
 	toAddr := ""
 
-	utils.Logger().Info().Msgf("LOLOLO %s", fromAddr)
 	if tx.To() != nil {
 		if toAddr, err = internal_common.AddressToBech32(*tx.To()); err != nil {
 			return nil


### PR DESCRIPTION
## Issue

https://github.com/harmony-one/harmony/issues/1678. Also fixed explorer to support contract tx and added one1 address formatting at missing places.

## Test

Localnet, postman, truffle.
Block methods and tx methods for fetching txs
<img width="1370" alt="Screenshot 2019-09-28 at 18 24 26" src="https://user-images.githubusercontent.com/52401354/65825640-122bd880-e282-11e9-8027-63cb44881621.png">
<img width="1364" alt="Screenshot 2019-09-28 at 18 24 35" src="https://user-images.githubusercontent.com/52401354/65825641-12c46f00-e282-11e9-859c-ab9369b6e10f.png">
<img width="1375" alt="Screenshot 2019-09-28 at 18 24 43" src="https://user-images.githubusercontent.com/52401354/65825642-12c46f00-e282-11e9-9a51-1302b24a5a7c.png">
<img width="1363" alt="Screenshot 2019-09-28 at 18 24 56" src="https://user-images.githubusercontent.com/52401354/65825643-12c46f00-e282-11e9-92dd-22ae8b23e481.png">
Methods results for contract tx.
<img width="1359" alt="Screenshot 2019-09-29 at 06 25 09" src="https://user-images.githubusercontent.com/52401354/65825647-1d7f0400-e282-11e9-9937-5119bc01d397.png">
<img width="1354" alt="Screenshot 2019-09-29 at 06 25 41" src="https://user-images.githubusercontent.com/52401354/65825648-1d7f0400-e282-11e9-916b-9a93ee6fe649.png">



#### Test Coverage Data

<!-- run 'go test -cover' in the directory you made change -->

* Before
* After

#### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## TODO

Test on testnet.