### PR TITLE
Add transactions history api with full tx info

### DIFF
--- a/internal/hmyapi/transactionpool.go
+++ b/internal/hmyapi/transactionpool.go
@@ -55,6 +55,20 @@ func (s *PublicTransactionPoolAPI) GetTransactionsHistory(ctx context.Context, a
 	return ReturnWithPagination(result, args), nil
 }
 
+// GetTransactionsHistoryFull returns the list of transactions with full info that involve a particular address.
+func (s *PublicTransactionPoolAPI) GetTransactionsHistoryFull(ctx context.Context, args TxHistoryArgs) ([]*RPCTransaction, error) {
+	hashes, err := s.GetTransactionsHistory(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	result := []*RPCTransaction{}
+	for _, hash := range hashes {
+		tx := s.GetTransactionByHash(ctx, hash)
+		result = append(result, tx)
+	}
+	return result, nil
+}
+
 // GetBlockTransactionCountByNumber returns the number of transactions in the block with the given block number.
 func (s *PublicTransactionPoolAPI) GetBlockTransactionCountByNumber(ctx context.Context, blockNr rpc.BlockNumber) *hexutil.Uint {
 	if block, _ := s.b.BlockByNumber(ctx, blockNr); block != nil {

--- a/internal/hmyapi/util.go
+++ b/internal/hmyapi/util.go
@@ -23,6 +23,9 @@ func ReturnWithPagination(hashes []common.Hash, args TxHistoryArgs) []common.Has
 	if args.Offset > 0 {
 		offset = args.Offset
 	}
+	if offset*page >= len(hashes) {
+		return make([]common.Hash, 0)
+	}
 	if offset*page+offset > len(hashes) {
 		return hashes[offset*page:]
 	}


### PR DESCRIPTION
## Issue

Richard requested tx history to have full tx info. I made a separate method to call tx history with full info using method that returns just hashes.

## Test

Localnet, postman.
<img width="1349" alt="Screenshot 2019-09-30 at 01 32 54" src="https://user-images.githubusercontent.com/52401354/65840490-9fbf0500-e322-11e9-901e-f5dbb2eadce3.png">


#### Test Coverage Data

<!-- run 'go test -cover' in the directory you made change -->

* Before
* After

#### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## TODO

Make adjustments on explorer back/front.
