### PR TITLE
Merklelize staking information  (WIP)

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -30,6 +30,7 @@ import (
 	"github.com/harmony-one/harmony/internal/ctxerror"
 	"github.com/harmony-one/harmony/internal/params"
 	"github.com/harmony-one/harmony/internal/utils"
+	types2 "github.com/harmony-one/harmony/staking/types"
 )
 
 // StateProcessor is a basic Processor, which takes care of transitioning
@@ -200,4 +201,14 @@ func ApplyIncomingReceipt(config *params.ChainConfig, db *state.DB, header *bloc
 		db.IntermediateRoot(config.IsS3(header.Epoch())).Bytes()
 	}
 	return nil
+}
+
+// ApplyStakingTransaction attempts to apply a staking transaction to the given state database
+// and uses the input parameters for its environment. It returns the receipt
+// for the staking transaction, gas used and an error if the transaction failed,
+// indicating the block was invalid.
+// staking transaction will use the code field in the account to store the staking information
+// TODO chao: Add receipts for staking tx
+func ApplyStakingTransaction(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.DB, header *block.Header, tx *types2.StakingTransaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, *types.CXReceipt, uint64, error) {
+	return nil, nil, 0, nil
 }

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -30,7 +30,7 @@ import (
 	"github.com/harmony-one/harmony/internal/ctxerror"
 	"github.com/harmony-one/harmony/internal/params"
 	"github.com/harmony-one/harmony/internal/utils"
-	types2 "github.com/harmony-one/harmony/staking/types"
+	staking "github.com/harmony-one/harmony/staking/types"
 )
 
 // StateProcessor is a basic Processor, which takes care of transitioning
@@ -209,6 +209,6 @@ func ApplyIncomingReceipt(config *params.ChainConfig, db *state.DB, header *bloc
 // indicating the block was invalid.
 // staking transaction will use the code field in the account to store the staking information
 // TODO chao: Add receipts for staking tx
-func ApplyStakingTransaction(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.DB, header *block.Header, tx *types2.StakingTransaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, *types.CXReceipt, uint64, error) {
+func ApplyStakingTransaction(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.DB, header *block.Header, tx *staking.StakingTransaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, *types.CXReceipt, uint64, error) {
 	return nil, nil, 0, nil
 }

--- a/node/node.go
+++ b/node/node.go
@@ -372,7 +372,7 @@ func (node *Node) getTransactionsForNewBlock(
 	}
 
 	selected, unselected, invalid := node.Worker.SelectTransactionsForNewBlock(newBlockNum, pendingTransactions, node.recentTxsStats, txsThrottleConfig, coinbase)
-	selectedStaking, unselectedStaking, invalidStaking := node.Worker.SelectStakingTransactionsForNewBlock(newBlockNum, pendingStakingTransactions, node.recentTxsStats, txsThrottleConfig, coinbase)
+	selectedStaking, unselectedStaking, invalidStaking := node.Worker.SelectStakingTransactionsForNewBlock(newBlockNum, pendingStakingTransactions, txsThrottleConfig, coinbase)
 
 	node.pendingTransactions = make(map[common.Hash]*types.Transaction)
 	for _, unselectedTx := range unselected {

--- a/node/worker/worker.go
+++ b/node/worker/worker.go
@@ -29,6 +29,7 @@ type environment struct {
 
 	header   *block.Header
 	txs      []*types.Transaction
+	stxs     []*types2.StakingTransaction
 	receipts []*types.Receipt
 	outcxs   []*types.CXReceipt       // cross shard transaction receipts (source shard)
 	incxs    []*types.CXReceiptsProof // cross shard receipts and its proof (desitinatin shard)
@@ -433,8 +434,7 @@ func (w *Worker) commitStakingTransaction(tx *types2.StakingTransaction, coinbas
 		utils.Logger().Warn().Interface("tx", tx).Interface("cx", cx).Msg("Receipt is Nil!")
 		return nil, fmt.Errorf("Receipt is Nil")
 	}
-	// TODO: chao
-	// w.current.txs = append(w.current.txs, tx)
-	// w.current.receipts = append(w.current.receipts, receipt)
+	w.current.stxs = append(w.current.stxs, tx)
+	w.current.receipts = append(w.current.receipts, receipt)
 	return receipt.Logs, nil
 }

--- a/staking/types/staking_transaction.go
+++ b/staking/types/staking_transaction.go
@@ -1,0 +1,44 @@
+package types
+
+import (
+	"bytes"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/harmony-one/harmony/crypto/hash"
+)
+
+// StakingTransaction struct.
+type StakingTransaction struct {
+	AccountNonce uint64         `json:"nonce"      gencodec:"required"`
+	Price        *big.Int       `json:"gasPrice"   gencodec:"required"`
+	GasLimit     uint64         `json:"gas"        gencodec:"required"`
+	Msg          StakingMessage `json:"msg"      gencodec:"required"`
+
+	// Signature values
+	V *big.Int `json:"v" gencodec:"required"`
+	R *big.Int `json:"r" gencodec:"required"`
+	S *big.Int `json:"s" gencodec:"required"`
+
+	// This is only used when marshaling to JSON.
+	hash *common.Hash `json:"hash" rlp:"-"`
+}
+
+// StakingTransactions is a Transaction slice type for basic sorting.
+type StakingTransactions []*StakingTransaction
+
+// Hash hashes the RLP encoding of tx.
+// It uniquely identifies the transaction.
+func (tx *StakingTransaction) Hash() common.Hash {
+	emptyHash := common.Hash{}
+	if bytes.Compare(tx.hash[:], emptyHash[:]) == 0 {
+		h := hash.FromRLP(tx)
+		tx.hash = &h
+	}
+	return *tx.hash
+}
+
+// Gas returns gaslimit of staking transaction
+func (tx *StakingTransaction) Gas() uint64 {
+	return tx.GasLimit
+}

--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -36,3 +36,91 @@ type Description struct {
 	SecurityContact string `json:"security_contact" yaml:"security_contact"` // optional security contact info
 	Details         string `json:"details" yaml:"details"`                   // optional details
 }
+
+// NewValidator - initialize a new validator
+func NewValidator(addr common.Address, pubKey bls.PublicKey, description Description, commission Commission, minAmt *big.Int) Validator {
+	return Validator{
+		Address:           addr,
+		ValidatingPubKey:  pubKey,
+		Active:            true,
+		Stake:             new(big.Int),
+		Description:       description,
+		UnbondingHeight:   new(big.Int),
+		Commission:        commission,
+		MinSelfDelegation: minAmt,
+	}
+}
+
+// MarshalValidator marshals the validator object
+func MarshalValidator(validator Validator) ([]byte, error) {
+	return rlp.EncodeToBytes(validator)
+}
+
+// UnmarshalValidator unmarshal binary into Validator object
+func UnmarshalValidator(by []byte) (*Validator, error) {
+	decoded := &Validator{}
+	err := rlp.DecodeBytes(by, decoded)
+	return decoded, err
+}
+
+// NewDescription returns a new Description with the provided values.
+func NewDescription(name, identity, website, securityContact, details string) Description {
+	return Description{
+		Name:            name,
+		Identity:        identity,
+		Website:         website,
+		SecurityContact: securityContact,
+		Details:         details,
+	}
+}
+
+// UpdateDescription updates the fields of a given description. An error is
+// returned if the resulting description contains an invalid length.
+func (d Description) UpdateDescription(d2 Description) (Description, error) {
+	return NewDescription(
+		d2.Name,
+		d2.Identity,
+		d2.Website,
+		d2.SecurityContact,
+		d2.Details,
+	).EnsureLength()
+}
+
+// EnsureLength ensures the length of a validator's description.
+func (d Description) EnsureLength() (Description, error) {
+	if len(d.Name) > MaxNameLength {
+		return d, ctxerror.New("[EnsureLength] Exceed Maximum Length", "have", len(d.Name), "maxNameLen", MaxNameLength)
+	}
+	if len(d.Identity) > MaxIdentityLength {
+		return d, ctxerror.New("[EnsureLength] Exceed Maximum Length", "have", len(d.Identity), "maxIdentityLen", MaxIdentityLength)
+	}
+	if len(d.Website) > MaxWebsiteLength {
+		return d, ctxerror.New("[EnsureLength] Exceed Maximum Length", "have", len(d.Website), "maxWebsiteLen", MaxWebsiteLength)
+	}
+	if len(d.SecurityContact) > MaxSecurityContactLength {
+		return d, ctxerror.New("[EnsureLength] Exceed Maximum Length", "have", len(d.SecurityContact), "maxSecurityContactLen", MaxSecurityContactLength)
+	}
+	if len(d.Details) > MaxDetailsLength {
+		return d, ctxerror.New("[EnsureLength] Exceed Maximum Length", "have", len(d.Details), "maxDetailsLen", MaxDetailsLength)
+	}
+
+	return d, nil
+}
+
+// GetAddress returns address
+func (v Validator) GetAddress() common.Address { return v.Address }
+
+// IsActive checks whether validator is active
+func (v Validator) IsActive() bool { return v.Active }
+
+// GetName returns the name of validator in the description
+func (v Validator) GetName() string { return v.Description.Name }
+
+// GetStake returns the total staking amount
+func (v Validator) GetStake() *big.Int { return v.Stake }
+
+// GetCommissionRate returns the commission rate of the validator
+func (v Validator) GetCommissionRate() Dec { return v.Commission.Rate }
+
+// GetMinSelfDelegation returns the minimum amount the validator must stake
+func (v Validator) GetMinSelfDelegation() *big.Int { return v.MinSelfDelegation }


### PR DESCRIPTION
Discussed with RJ and Edgar.  We use Storage field (core/state/state_object.go) to store all the staking information including validator and delegation. To do this, we need first make the fields of Validator flatten (staking/types/validator.go). Then whenever we create a new validator, we use a specific key for each of the field in Validator structure to store the value. For delegation, it's even simpler, the key will be the delegator's address, value will be the amount of delegation. The Root field in the Account structure (state_object.go) will be the merkle root of this validator and its delegations' information.