### PR TITLE
Limit concurrency

### DIFF
--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -1269,6 +1269,7 @@ func (consensus *Consensus) GenerateVdfAndProof(newBlock *types.Block, vrfBlockN
 		Int("Num of VRF", len(vrfBlockNumbers)).
 		Msg("[ConsensusMainLoop] VDF computation started")
 
+	// TODO ek – limit concurrency
 	go func() {
 		vdf := vdf_go.New(core.ShardingSchedule.VdfDifficulty(), seed)
 		outputChannel := vdf.GetOutputChannel()

--- a/crypto/vdf/vdf.go
+++ b/crypto/vdf/vdf.go
@@ -37,6 +37,7 @@ func (vdf *VDF) Execute() {
 		tempResult = sha3.Sum256(tempResult[:])
 	}
 	vdf.output = tempResult
+	// TODO ek – limit concurrency
 	go func() {
 		vdf.outputChan <- vdf.output
 	}()

--- a/drand/drand_leader.go
+++ b/drand/drand_leader.go
@@ -38,6 +38,7 @@ func (dRand *DRand) WaitForEpochBlock(blockChannel chan *types.Block, stopChan c
 				zeros := [32]byte{}
 				if core.IsEpochBlock(newBlock) && !bytes.Equal(pRnd[:], zeros[:]) {
 					// The epoch block should contain the randomness preimage pRnd
+					// TODO ek – limit concurrency
 					go func() {
 						vdf := vdf.New(vdfDifficulty, pRnd)
 						outputChannel := vdf.GetOutputChannel()

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,6 @@ require (
 	golang.org/x/lint v0.0.0-20190409202823-959b441ac422
 	golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3 // indirect
 	golang.org/x/tools v0.0.0-20190924052046-3ac2a5bbd98a
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/grpc v1.22.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
 	gopkg.in/ini.v1 v1.42.0

--- a/internal/hmyapi/filters/api.go
+++ b/internal/hmyapi/filters/api.go
@@ -60,6 +60,7 @@ func NewPublicFilterAPI(backend Backend, lightMode bool) *PublicFilterAPI {
 // timeoutLoop runs every 5 minutes and deletes filters that have not been recently used.
 // Tt is started when the api is created.
 func (api *PublicFilterAPI) timeoutLoop() {
+	// TODO ek – infinite loop; add shutdown/cleanup logic
 	ticker := time.NewTicker(5 * time.Minute)
 	for {
 		<-ticker.C

--- a/internal/memprofiling/lib.go
+++ b/internal/memprofiling/lib.go
@@ -79,6 +79,7 @@ func (m *MemProfiling) Stop() {
 // PeriodicallyScanMemSize scans memsize of the observed objects every 30 seconds.
 func (m *MemProfiling) PeriodicallyScanMemSize() {
 	go func() {
+		// TODO ek – infinite loop; add shutdown/cleanup logic
 		for {
 			select {
 			case <-time.After(memSizeScanTime):
@@ -98,6 +99,7 @@ func (m *MemProfiling) PeriodicallyScanMemSize() {
 // MaybeCallGCPeriodically runs GC manually every gcTime minutes. This is one of the options to mitigate the OOM issue.
 func MaybeCallGCPeriodically() {
 	go func() {
+		// TODO ek – infinite loop; add shutdown/cleanup logic
 		for {
 			select {
 			case <-time.After(gcTime):
@@ -108,6 +110,7 @@ func MaybeCallGCPeriodically() {
 		}
 	}()
 	go func() {
+		// TODO ek – infinite loop; add shutdown/cleanup logic
 		for {
 			select {
 			case <-time.After(memStatTime):

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -43,6 +43,7 @@ func (profiler *Profiler) Config(shardID uint32, metricsReportURL string) {
 
 // LogMemory logs memory.
 func (profiler *Profiler) LogMemory() {
+	// TODO ek – infinite loop; add shutdown/cleanup logic
 	for {
 		// log mem usage
 		info, _ := profiler.proc.MemoryInfo()
@@ -63,6 +64,7 @@ func (profiler *Profiler) LogMemory() {
 
 // LogCPU logs CPU metrics.
 func (profiler *Profiler) LogCPU() {
+	// TODO ek – infinite loop; add shutdown/cleanup logic
 	for {
 		// log cpu usage
 		percent, _ := profiler.proc.CPUPercent()

--- a/msgq/msgq.go
+++ b/msgq/msgq.go
@@ -47,5 +47,11 @@ func (q *Queue) HandleMessages(h MessageHandler) {
 	}
 }
 
+// Close closes the given queue.
+func (q *Queue) Close() error {
+	close(q.ch)
+	return nil
+}
+
 // ErrRxOverrun signals that a receive queue has been overrun.
 var ErrRxOverrun = errors.New("rx overrun")

--- a/msgq/msgq.go
+++ b/msgq/msgq.go
@@ -1,0 +1,51 @@
+// Package msgq implements a simple, finite-sized message queue.  It can be used
+// as a building block for a message processor pool.
+package msgq
+
+import (
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/pkg/errors"
+)
+
+type message struct {
+	content []byte
+	sender  peer.ID
+}
+
+// MessageHandler is a message handler.
+type MessageHandler interface {
+	HandleMessage(content []byte, sender peer.ID)
+}
+
+// Queue is a finite-sized message queue.
+type Queue struct {
+	ch chan message
+}
+
+// New returns a new message queue of the given size.
+func New(size int) *Queue {
+	return &Queue{ch: make(chan message, size)}
+}
+
+// AddMessage enqueues a received message for processing.  It returns without
+// blocking, and may return a queue overrun error.
+func (q *Queue) AddMessage(content []byte, sender peer.ID) error {
+	select {
+	case q.ch <- message{content, sender}:
+	default:
+		return ErrRxOverrun
+	}
+	return nil
+}
+
+// HandleMessages dequeues and dispatches incoming messages using the given
+// message handler, until the message queue is closed.  This function can be
+// spawned as a background goroutine, potentially multiple times for a pool.
+func (q *Queue) HandleMessages(h MessageHandler) {
+	for msg := range q.ch {
+		h.HandleMessage(msg.content, msg.sender)
+	}
+}
+
+// ErrRxOverrun signals that a receive queue has been overrun.
+var ErrRxOverrun = errors.New("rx overrun")

--- a/msgq/msgq_test.go
+++ b/msgq/msgq_test.go
@@ -1,0 +1,94 @@
+package msgq
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name string
+		cap  int
+	}{
+		{"unbuffered", 0},
+		{"buffered10", 10},
+		{"buffered100", 100},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := New(tt.cap)
+			if cap(got.ch) != tt.cap {
+				t.Errorf("New() ch cap %d, want %d", cap(got.ch), tt.cap)
+			}
+		})
+	}
+}
+
+func TestQueue_AddMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		cap  int
+	}{
+		{"unbuffered", 0},
+		{"buffered", 100},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := &Queue{ch: make(chan message, tt.cap)}
+			for i := 0; i < tt.cap+10; i++ {
+				var wantErr error
+				if i >= tt.cap {
+					wantErr = ErrRxOverrun
+				} else {
+					wantErr = nil
+				}
+				err := q.AddMessage([]byte{}, peer.ID(""))
+				if err != wantErr {
+					t.Fatalf("AddMessage() iter %d, error = %v, want %v",
+						i, err, wantErr)
+				}
+			}
+		})
+	}
+}
+
+type testMessageHandler struct {
+	t   *testing.T
+	seq int
+}
+
+func (h *testMessageHandler) HandleMessage(content []byte, sender peer.ID) {
+	got, want := string(content), fmt.Sprint(h.seq)
+	if got != want {
+		h.t.Errorf("out-of-sequence message %v, want %v", got, want)
+	}
+	h.seq++
+}
+
+func TestQueue_HandleMessages(t *testing.T) {
+	ch := make(chan message, 500)
+	for seq := 0; seq < cap(ch); seq++ {
+		ch <- message{content: []byte(fmt.Sprint(seq))}
+	}
+	close(ch)
+	q := &Queue{ch: ch}
+	q.HandleMessages(&testMessageHandler{t: t})
+}
+
+func TestQueue_Close(t *testing.T) {
+	q := &Queue{ch: make(chan message, 100)}
+	err := q.Close()
+	if err != nil {
+		t.Errorf("Close() error = %v, want nil", err)
+	}
+	select {
+	case m, ok := <-q.ch:
+		if ok {
+			t.Errorf("unexpected message %v", m)
+		}
+	default:
+		t.Error("channel closed but not ready")
+	}
+}

--- a/node/node.go
+++ b/node/node.go
@@ -419,14 +419,14 @@ func (node *Node) StartServer() {
 
 	// start the goroutine to receive client message
 	// client messages are sent by clients, like txgen, wallet
-	go node.ReceiveGroupMessage(node.clientReceiver)
+	go node.receiveGroupMessage(node.clientReceiver)
 
 	// start the goroutine to receive group message
-	go node.ReceiveGroupMessage(node.shardGroupReceiver)
+	go node.receiveGroupMessage(node.shardGroupReceiver)
 
 	// start the goroutine to receive global message, used for cross-shard TX
 	// FIXME (leo): we use beacon client topic as the global topic for now
-	go node.ReceiveGroupMessage(node.globalGroupReceiver)
+	go node.receiveGroupMessage(node.globalGroupReceiver)
 
 	select {}
 }

--- a/node/node.go
+++ b/node/node.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/harmony-one/harmony/accounts"
 	"github.com/harmony-one/harmony/api/client"
 	clientService "github.com/harmony-one/harmony/api/client/service"

--- a/node/node.go
+++ b/node/node.go
@@ -419,14 +419,14 @@ func (node *Node) StartServer() {
 
 	// start the goroutine to receive client message
 	// client messages are sent by clients, like txgen, wallet
-	go node.ReceiveClientGroupMessage()
+	go node.ReceiveGroupMessage(node.clientReceiver)
 
 	// start the goroutine to receive group message
-	go node.ReceiveGroupMessage()
+	go node.ReceiveGroupMessage(node.shardGroupReceiver)
 
 	// start the goroutine to receive global message, used for cross-shard TX
 	// FIXME (leo): we use beacon client topic as the global topic for now
-	go node.ReceiveGlobalMessage()
+	go node.ReceiveGroupMessage(node.globalGroupReceiver)
 
 	select {}
 }

--- a/node/node_cross_shard.go
+++ b/node/node_cross_shard.go
@@ -69,6 +69,7 @@ func (node *Node) BroadcastCXReceiptsWithShardID(block *types.Block, commitSig [
 	utils.Logger().Info().Uint32("ToShardID", toShardID).Msg("[BroadcastCXReceiptsWithShardID] ReadCXReceipts and MerkleProof Found")
 
 	groupID := nodeconfig.ShardID(toShardID)
+	// TODO ek – limit concurrency
 	go node.host.SendMessageToGroups([]nodeconfig.GroupID{nodeconfig.NewGroupIDByShardID(groupID)}, host.ConstructP2pMessage(byte(0), proto_node.ConstructCXReceiptsProof(cxReceipts, merkleProof, block.Header(), commitSig, commitBitmap)))
 }
 

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -36,61 +36,21 @@ const (
 	crossLinkBatchSize = 7
 )
 
-// ReceiveGlobalMessage use libp2p pubsub mechanism to receive global broadcast messages
-func (node *Node) ReceiveGlobalMessage() {
-	ctx := context.Background()
-	for {
-		// TODO ek – infinite loop; add shutdown/cleanup logic
-		msg, sender, err := node.globalGroupReceiver.Receive(ctx)
-		if err != nil {
-			utils.Logger().Warn().Err(err).
-				Msg("cannot receive from global group")
-			continue
-		}
-		if sender == node.host.GetID() {
-			continue
-		}
-		//utils.Logger().Info("[PUBSUB]", "received global msg", len(msg), "sender", sender)
-		// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
-		node.enqueueIncomingMessage(msg[5:], sender)
-	}
-}
-
 // ReceiveGroupMessage use libp2p pubsub mechanism to receive broadcast messages
-func (node *Node) ReceiveGroupMessage() {
+func (node *Node) ReceiveGroupMessage(receiver p2p.GroupReceiver) {
 	ctx := context.Background()
 	// TODO ek – infinite loop; add shutdown/cleanup logic
 	for {
-		msg, sender, err := node.shardGroupReceiver.Receive(ctx)
+		msg, sender, err := receiver.Receive(ctx)
 		if err != nil {
 			utils.Logger().Warn().Err(err).
-				Msg("cannot receive from shard group")
+				Msg("cannot receive from group")
 			continue
 		}
 		if sender == node.host.GetID() {
 			continue
 		}
 		//utils.Logger().Info("[PUBSUB]", "received group msg", len(msg), "sender", sender)
-		// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
-		node.enqueueIncomingMessage(msg[5:], sender)
-	}
-}
-
-// ReceiveClientGroupMessage use libp2p pubsub mechanism to receive broadcast messages for client
-func (node *Node) ReceiveClientGroupMessage() {
-	ctx := context.Background()
-	// TODO ek – infinite loop; add shutdown/cleanup logic
-	for {
-		msg, sender, err := node.clientReceiver.Receive(ctx)
-		if err != nil {
-			utils.Logger().Warn().Err(err).
-				Msg("cannot receive from client group")
-			continue
-		}
-		if sender == node.host.GetID() {
-			continue
-		}
-		// utils.Logger().Info("[CLIENT]", "received group msg", len(msg), "sender", sender, "error", err)
 		// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
 		node.enqueueIncomingMessage(msg[5:], sender)
 	}

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -78,17 +78,17 @@ func (node *Node) handleIncomingMessages() {
 	for {
 		// TODO ek – infinite loop; add shutdown/cleanup logic
 		msg := <-node.incomingMessages
-		node.messageHandler(msg.content, msg.sender)
+		node.handleMessage(msg.content, msg.sender)
 	}
 }
 
-// messageHandler parses the message and dispatch the actions
-func (node *Node) messageHandler(content []byte, sender libp2p_peer.ID) {
+// handleMessage parses the message and dispatch the actions
+func (node *Node) handleMessage(content []byte, sender libp2p_peer.ID) {
 	msgCategory, err := proto.GetMessageCategory(content)
 	if err != nil {
 		utils.Logger().Error().
 			Err(err).
-			Msg("messageHandler get message category failed")
+			Msg("handleMessage get message category failed")
 		return
 	}
 
@@ -96,7 +96,7 @@ func (node *Node) messageHandler(content []byte, sender libp2p_peer.ID) {
 	if err != nil {
 		utils.Logger().Error().
 			Err(err).
-			Msg("messageHandler get message type failed")
+			Msg("handleMessage get message type failed")
 		return
 	}
 
@@ -104,7 +104,7 @@ func (node *Node) messageHandler(content []byte, sender libp2p_peer.ID) {
 	if err != nil {
 		utils.Logger().Error().
 			Err(err).
-			Msg("messageHandler get message payload failed")
+			Msg("handleMessage get message payload failed")
 		return
 	}
 

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -41,10 +41,6 @@ func (node *Node) ReceiveGlobalMessage() {
 	ctx := context.Background()
 	for {
 		// TODO ek – infinite loop; add shutdown/cleanup logic
-		if node.globalGroupReceiver == nil {
-			time.Sleep(100 * time.Millisecond)
-			continue
-		}
 		msg, sender, err := node.globalGroupReceiver.Receive(ctx)
 		if err != nil {
 			utils.Logger().Warn().Err(err).
@@ -65,10 +61,6 @@ func (node *Node) ReceiveGroupMessage() {
 	ctx := context.Background()
 	// TODO ek – infinite loop; add shutdown/cleanup logic
 	for {
-		if node.shardGroupReceiver == nil {
-			time.Sleep(100 * time.Millisecond)
-			continue
-		}
 		msg, sender, err := node.shardGroupReceiver.Receive(ctx)
 		if err != nil {
 			utils.Logger().Warn().Err(err).
@@ -89,11 +81,6 @@ func (node *Node) ReceiveClientGroupMessage() {
 	ctx := context.Background()
 	// TODO ek – infinite loop; add shutdown/cleanup logic
 	for {
-		if node.clientReceiver == nil {
-			// check less frequent on client messages
-			time.Sleep(100 * time.Millisecond)
-			continue
-		}
 		msg, sender, err := node.clientReceiver.Receive(ctx)
 		if err != nil {
 			utils.Logger().Warn().Err(err).

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -28,7 +28,7 @@ import (
 	"github.com/harmony-one/harmony/p2p/host"
 	"github.com/harmony-one/harmony/shard"
 	staking "github.com/harmony-one/harmony/staking/types"
-	libp2p_peer "github.com/libp2p/go-libp2p-peer"
+	libp2p_peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
 const (

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -49,6 +49,7 @@ func (node *Node) ReceiveGlobalMessage() {
 			//utils.Logger().Info("[PUBSUB]", "received global msg", len(msg), "sender", sender)
 			if err == nil {
 				// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
+				// TODO ek – limit concurrency
 				go node.messageHandler(msg[5:], sender)
 			}
 		}
@@ -68,6 +69,7 @@ func (node *Node) ReceiveGroupMessage() {
 			//utils.Logger().Info("[PUBSUB]", "received group msg", len(msg), "sender", sender)
 			if err == nil {
 				// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
+				// TODO ek – limit concurrency
 				go node.messageHandler(msg[5:], sender)
 			}
 		}
@@ -88,6 +90,7 @@ func (node *Node) ReceiveClientGroupMessage() {
 			// utils.Logger().Info("[CLIENT]", "received group msg", len(msg), "sender", sender, "error", err)
 			if err == nil {
 				// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
+				// TODO ek – limit concurrency
 				go node.messageHandler(msg[5:], sender)
 			}
 		}

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -51,11 +51,12 @@ func (node *Node) ReceiveGlobalMessage() {
 				Msg("cannot receive from global group")
 			continue
 		}
-		if sender != node.host.GetID() {
-			//utils.Logger().Info("[PUBSUB]", "received global msg", len(msg), "sender", sender)
-			// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
-			node.enqueueIncomingMessage(msg[5:], sender)
+		if sender == node.host.GetID() {
+			continue
 		}
+		//utils.Logger().Info("[PUBSUB]", "received global msg", len(msg), "sender", sender)
+		// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
+		node.enqueueIncomingMessage(msg[5:], sender)
 	}
 }
 
@@ -74,11 +75,12 @@ func (node *Node) ReceiveGroupMessage() {
 				Msg("cannot receive from shard group")
 			continue
 		}
-		if sender != node.host.GetID() {
-			//utils.Logger().Info("[PUBSUB]", "received group msg", len(msg), "sender", sender)
-			// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
-			node.enqueueIncomingMessage(msg[5:], sender)
+		if sender == node.host.GetID() {
+			continue
 		}
+		//utils.Logger().Info("[PUBSUB]", "received group msg", len(msg), "sender", sender)
+		// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
+		node.enqueueIncomingMessage(msg[5:], sender)
 	}
 }
 
@@ -98,11 +100,12 @@ func (node *Node) ReceiveClientGroupMessage() {
 				Msg("cannot receive from client group")
 			continue
 		}
-		if sender != node.host.GetID() {
-			// utils.Logger().Info("[CLIENT]", "received group msg", len(msg), "sender", sender, "error", err)
-			// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
-			node.enqueueIncomingMessage(msg[5:], sender)
+		if sender == node.host.GetID() {
+			continue
 		}
+		// utils.Logger().Info("[CLIENT]", "received group msg", len(msg), "sender", sender, "error", err)
+		// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
+		node.enqueueIncomingMessage(msg[5:], sender)
 	}
 }
 

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -36,8 +36,8 @@ const (
 	crossLinkBatchSize = 7
 )
 
-// ReceiveGroupMessage use libp2p pubsub mechanism to receive broadcast messages
-func (node *Node) ReceiveGroupMessage(receiver p2p.GroupReceiver) {
+// receiveGroupMessage use libp2p pubsub mechanism to receive broadcast messages
+func (node *Node) receiveGroupMessage(receiver p2p.GroupReceiver) {
 	ctx := context.Background()
 	// TODO ek – infinite loop; add shutdown/cleanup logic
 	for {

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -46,12 +46,15 @@ func (node *Node) ReceiveGlobalMessage() {
 			continue
 		}
 		msg, sender, err := node.globalGroupReceiver.Receive(ctx)
+		if err != nil {
+			utils.Logger().Warn().Err(err).
+				Msg("cannot receive from global group")
+			continue
+		}
 		if sender != node.host.GetID() {
 			//utils.Logger().Info("[PUBSUB]", "received global msg", len(msg), "sender", sender)
-			if err == nil {
-				// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
-				node.enqueueIncomingMessage(msg[5:], sender)
-			}
+			// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
+			node.enqueueIncomingMessage(msg[5:], sender)
 		}
 	}
 }
@@ -66,12 +69,15 @@ func (node *Node) ReceiveGroupMessage() {
 			continue
 		}
 		msg, sender, err := node.shardGroupReceiver.Receive(ctx)
+		if err != nil {
+			utils.Logger().Warn().Err(err).
+				Msg("cannot receive from shard group")
+			continue
+		}
 		if sender != node.host.GetID() {
 			//utils.Logger().Info("[PUBSUB]", "received group msg", len(msg), "sender", sender)
-			if err == nil {
-				// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
-				node.enqueueIncomingMessage(msg[5:], sender)
-			}
+			// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
+			node.enqueueIncomingMessage(msg[5:], sender)
 		}
 	}
 }
@@ -87,12 +93,15 @@ func (node *Node) ReceiveClientGroupMessage() {
 			continue
 		}
 		msg, sender, err := node.clientReceiver.Receive(ctx)
+		if err != nil {
+			utils.Logger().Warn().Err(err).
+				Msg("cannot receive from client group")
+			continue
+		}
 		if sender != node.host.GetID() {
 			// utils.Logger().Info("[CLIENT]", "received group msg", len(msg), "sender", sender, "error", err)
-			if err == nil {
-				// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
-				node.enqueueIncomingMessage(msg[5:], sender)
-			}
+			// skip the first 5 bytes, 1 byte is p2p type, 4 bytes are message size
+			node.enqueueIncomingMessage(msg[5:], sender)
 		}
 	}
 }

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -40,6 +40,7 @@ const (
 func (node *Node) ReceiveGlobalMessage() {
 	ctx := context.Background()
 	for {
+		// TODO ek – infinite loop; add shutdown/cleanup logic
 		if node.globalGroupReceiver == nil {
 			time.Sleep(100 * time.Millisecond)
 			continue
@@ -59,6 +60,7 @@ func (node *Node) ReceiveGlobalMessage() {
 // ReceiveGroupMessage use libp2p pubsub mechanism to receive broadcast messages
 func (node *Node) ReceiveGroupMessage() {
 	ctx := context.Background()
+	// TODO ek – infinite loop; add shutdown/cleanup logic
 	for {
 		if node.shardGroupReceiver == nil {
 			time.Sleep(100 * time.Millisecond)
@@ -79,6 +81,7 @@ func (node *Node) ReceiveGroupMessage() {
 // ReceiveClientGroupMessage use libp2p pubsub mechanism to receive broadcast messages for client
 func (node *Node) ReceiveClientGroupMessage() {
 	ctx := context.Background()
+	// TODO ek – infinite loop; add shutdown/cleanup logic
 	for {
 		if node.clientReceiver == nil {
 			// check less frequent on client messages

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -162,6 +162,7 @@ func (p *LocalSyncingPeerProvider) SyncingPeers(shardID uint32) (peers []p2p.Pee
 // DoBeaconSyncing update received beaconchain blocks and downloads missing beacon chain blocks
 func (node *Node) DoBeaconSyncing() {
 	go func(node *Node) {
+		// TODO ek – infinite loop; add shutdown/cleanup logic
 		for {
 			select {
 			case beaconBlock := <-node.BeaconBlockChannel:
@@ -170,6 +171,7 @@ func (node *Node) DoBeaconSyncing() {
 		}
 	}(node)
 
+	// TODO ek – infinite loop; add shutdown/cleanup logic
 	for {
 		if node.beaconSync == nil {
 			utils.Logger().Info().Msg("initializing beacon sync")
@@ -198,6 +200,7 @@ func (node *Node) DoBeaconSyncing() {
 // DoSyncing keep the node in sync with other peers, willJoinConsensus means the node will try to join consensus after catch up
 func (node *Node) DoSyncing(bc *core.BlockChain, worker *worker.Worker, willJoinConsensus bool) {
 
+	// TODO ek – infinite loop; add shutdown/cleanup logic
 SyncingLoop:
 	for {
 		if node.stateSync == nil {


### PR DESCRIPTION
Do not spawn unbounded number of goroutines for parallel message processing.  Instead, use a worker pool of 32 goroutines sharing the same intake queue.  Log (`"rx overrun"`) and tail-drop messages if the queue is full.

## Tests

Local test pass; 100% coverage of the newly added core code (`./msgq`):

```sh
git checkout harmony-one/master
go test -count=1 -cover ./... > coverage-before.txt
git checkout limit_concurrency 
go test -count=1 -cover ./... > coverage-after.txt
sed -i.bak -E 's/  [0-9]+(\.[0-9]*)?s      /       /' coverage-*.txt
diff -U0 coverage-before.txt coverage-after.txt
```
```diff
--- coverage-before.txt 2019-10-08 16:13:42.000000000 -0700
+++ coverage-after.txt  2019-10-08 16:13:42.000000000 -0700
@@ -86 +86,2 @@
-ok     github.com/harmony-one/harmony/node     coverage: 15.4% of statements
+ok     github.com/harmony-one/harmony/msgq     coverage: 100.0% of statements
+ok     github.com/harmony-one/harmony/node     coverage: 14.3% of statements
```

## TODO

* [x] Add UTs