### PR TITLE
[state] Remove spurious call to .Bytes

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -209,7 +209,7 @@ func ApplyIncomingReceipt(config *params.ChainConfig, db *state.DB, header *bloc
 			db.CreateAccount(*cx.To)
 		}
 		db.AddBalance(*cx.To, cx.Amount)
-		db.IntermediateRoot(config.IsS3(header.Epoch())).Bytes()
+		db.IntermediateRoot(config.IsS3(header.Epoch()))
 	}
 	return nil
 }


### PR DESCRIPTION
Found needless call to `.Bytes` of a `common.Hash` object during out weekly code review at 10/8/19; no side effects in call to `.Bytes()` that would otherwise necessitate calling this method. 

