### PR TITLE
update README to making sure the local machine has md5 available

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Note : Some of our scripts require bash 4.x support, please [install bash 4.x](h
 
 You can run the script `./scripts/go_executable_build.sh` to build all the executables.
 
+Note : if you get error `md5: command not found`, please install md5sum by either using HomeBrew or MacPorts,
+- HomeBrew: `brew install md5sha1sum`
+- MacPorts: `sudo port install md5sha1sum`
+
 ### Build individual executables
 
 Harmony server / main node:

--- a/scripts/go_executable_build.sh
+++ b/scripts/go_executable_build.sh
@@ -33,7 +33,7 @@ esac
 declare -A LIB
 
 if [ "$(uname -s)" == "Darwin" ]; then
-   MD5='md5 -r'
+   MD5=md5sum
    GOOS=darwin
    LIB[libbls384_256.dylib]=${BLS_DIR}/lib/libbls384_256.dylib
    LIB[libmcl.dylib]=${MCL_DIR}/lib/libmcl.dylib


### PR DESCRIPTION
## Issue

after upgrading macox to Catalina (10.15), md5 was not available by default.
So our build script returned `md5: command not found` error.
Updated the readme to make sure md5sum is installed on the local machine, and set MD5 to always use md5sum executable instead of using not-available-by-default md5.

## Test

After installing and using md5sum directly,
```
dennis.won@jongs-mbp:~/harmony (build_md5) $ ./scripts/go_executable_build.sh 
building cmd/client/wallet/main.go cmd/client/wallet/generated_wallet.ini.go
Harmony (C) 2019. wallet, version v4858-testnet-20191013.0-23-g1d4de96f-dirty (dennis.won@ 2019-10-19T18:09:40-0700)
building cmd/bootnode/main.go
Harmony (C) 2019. bootnode, version v4858-testnet-20191013.0-23-g1d4de96f-dirty (dennis.won@ 2019-10-19T18:09:40-0700)
building cmd/harmony/main.go
Harmony (C) 2019. harmony, version v4858-testnet-20191013.0-23-g1d4de96f-dirty (dennis.won@ 2019-10-19T18:09:40-0700)
building cmd/staking/*.go
Harmony (C) 2019. staking-standalone, version v4858-testnet-20191013.0-23-g1d4de96f-dirty (dennis.won@ 2019-10-19T18:09:40-0700)
~/harmony/bin ~/harmony
~/harmony
```
