### PR TITLE
[rpc] Expose ShardID in NodeMetadata

### DIFF
--- a/internal/hmyapi/harmony.go
+++ b/internal/hmyapi/harmony.go
@@ -50,6 +50,7 @@ type NodeMetadata struct {
 	NetworkType  string `json:"network"`
 	ChainID      string `json:"chainid"`
 	IsLeader     bool   `json:"is-leader"`
+	ShardID      uint32 `json:"shard-id"`
 }
 
 // GetNodeMetadata produces a NodeMetadata record. Note the data is from the answering RPC
@@ -61,5 +62,6 @@ func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
 		string(cfg.GetNetworkType()),
 		s.b.ChainConfig().ChainID.String(),
 		s.b.IsLeader(),
+		cfg.GetShardID(),
 	}
 }


### PR DESCRIPTION
Exposed ShardID of answering RPC node. Note, this will have to be smarter once resharding takes place. 

Useful for downstream projects, namely `harmony-watchdogd` 