### PR TITLE
Update Pangaea/testnet epoch/feature schedule

### DIFF
--- a/core/core_test.go
+++ b/core/core_test.go
@@ -10,13 +10,12 @@ import (
 )
 
 func TestIsEpochBlock(t *testing.T) {
-	block1 := types.NewBlock(blockfactory.NewTestHeader().With().Number(big.NewInt(10)).Header(), nil, nil, nil, nil, nil)
-	block2 := types.NewBlock(blockfactory.NewTestHeader().With().Number(big.NewInt(0)).Header(), nil, nil, nil, nil, nil)
-	block3 := types.NewBlock(blockfactory.NewTestHeader().With().Number(big.NewInt(344064)).Header(), nil, nil, nil, nil, nil)
-	block4 := types.NewBlock(blockfactory.NewTestHeader().With().Number(big.NewInt(77)).Header(), nil, nil, nil, nil, nil)
-	block5 := types.NewBlock(blockfactory.NewTestHeader().With().Number(big.NewInt(78)).Header(), nil, nil, nil, nil, nil)
-	block6 := types.NewBlock(blockfactory.NewTestHeader().With().Number(big.NewInt(188)).Header(), nil, nil, nil, nil, nil)
-	block7 := types.NewBlock(blockfactory.NewTestHeader().With().Number(big.NewInt(189)).Header(), nil, nil, nil, nil, nil)
+	blockNumbered := func(n int64) *types.Block {
+		return types.NewBlock(
+			blockfactory.NewTestHeader().With().Number(big.NewInt(n)).Header(),
+			nil, nil, nil, nil, nil,
+		)
+	}
 	tests := []struct {
 		schedule shardingconfig.Schedule
 		block    *types.Block
@@ -24,37 +23,37 @@ func TestIsEpochBlock(t *testing.T) {
 	}{
 		{
 			shardingconfig.MainnetSchedule,
-			block1,
+			blockNumbered(10),
 			false,
 		},
 		{
 			shardingconfig.MainnetSchedule,
-			block2,
+			blockNumbered(0),
 			true,
 		},
 		{
 			shardingconfig.MainnetSchedule,
-			block3,
+			blockNumbered(344064),
 			true,
 		},
 		{
 			shardingconfig.TestnetSchedule,
-			block4,
+			blockNumbered(74),
 			false,
 		},
 		{
 			shardingconfig.TestnetSchedule,
-			block5,
+			blockNumbered(75),
 			true,
 		},
 		{
 			shardingconfig.TestnetSchedule,
-			block6,
+			blockNumbered(149),
 			false,
 		},
 		{
 			shardingconfig.TestnetSchedule,
-			block7,
+			blockNumbered(150),
 			true,
 		},
 	}

--- a/internal/configs/sharding/testnet.go
+++ b/internal/configs/sharding/testnet.go
@@ -15,9 +15,6 @@ var TestnetSchedule testnetSchedule
 type testnetSchedule struct{}
 
 const (
-	testnetV1Epoch = 1
-	testnetV2Epoch = 2
-
 	// 10 minutes per epoch (at 8s/block)
 	testnetBlocksPerEpoch = 75
 
@@ -38,10 +35,6 @@ const (
 
 func (testnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	switch {
-	case epoch.Cmp(big.NewInt(testnetV2Epoch)) >= 0:
-		return testnetV2
-	case epoch.Cmp(big.NewInt(testnetV1Epoch)) >= 0:
-		return testnetV1
 	default: // genesis
 		return testnetV0
 	}
@@ -125,8 +118,8 @@ func (ts testnetSchedule) GetShardingStructure(numShard, shardID int) []map[stri
 	return genShardingStructure(numShard, shardID, TestNetHTTPPattern, TestNetWSPattern)
 }
 
-var testnetReshardingEpoch = []*big.Int{big.NewInt(0), big.NewInt(testnetV1Epoch), big.NewInt(testnetV2Epoch)}
+var testnetReshardingEpoch = []*big.Int{
+	big.NewInt(0),
+}
 
-var testnetV0 = MustNewInstance(2, 150, 150, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch)
-var testnetV1 = MustNewInstance(2, 160, 150, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch)
-var testnetV2 = MustNewInstance(2, 170, 150, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch)
+var testnetV0 = MustNewInstance(3, 100, 80, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch)

--- a/internal/configs/sharding/testnet.go
+++ b/internal/configs/sharding/testnet.go
@@ -54,7 +54,7 @@ func (ts testnetSchedule) IsLastBlock(blockNum uint64) bool {
 }
 
 func (ts testnetSchedule) EpochLastBlock(epochNum uint64) uint64 {
-	return (ts.BlocksPerEpoch()+1)*epochNum - 1
+	return ts.BlocksPerEpoch()*(epochNum+1) - 1
 }
 
 func (ts testnetSchedule) VdfDifficulty() int {

--- a/internal/configs/sharding/testnet.go
+++ b/internal/configs/sharding/testnet.go
@@ -18,8 +18,8 @@ const (
 	testnetV1Epoch = 1
 	testnetV2Epoch = 2
 
-	testnetEpochBlock1 = 78
-	threeOne           = 111
+	// 10 minutes per epoch (at 8s/block)
+	testnetBlocksPerEpoch = 75
 
 	testnetVdfDifficulty = 10000 // This takes about 20s to finish the vdf
 
@@ -48,40 +48,20 @@ func (testnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 }
 
 func (testnetSchedule) BlocksPerEpoch() uint64 {
-	// 8 seconds per block, roughly 86400 blocks, around one day
-	return threeOne
+	return testnetBlocksPerEpoch
 }
 
 func (ts testnetSchedule) CalcEpochNumber(blockNum uint64) *big.Int {
-	blocks := ts.BlocksPerEpoch()
-	switch {
-	case blockNum >= testnetEpochBlock1:
-		return big.NewInt(int64((blockNum-testnetEpochBlock1)/blocks) + 1)
-	default:
-		return big.NewInt(0)
-	}
+	epoch := blockNum % ts.BlocksPerEpoch()
+	return big.NewInt(int64(epoch))
 }
 
 func (ts testnetSchedule) IsLastBlock(blockNum uint64) bool {
-	blocks := ts.BlocksPerEpoch()
-	switch {
-	case blockNum < testnetEpochBlock1-1:
-		return false
-	case blockNum == testnetEpochBlock1-1:
-		return true
-	default:
-		return ((blockNum-testnetEpochBlock1)%blocks == blocks-1)
-	}
+	return (blockNum+1)%ts.BlocksPerEpoch() == 0
 }
 
 func (ts testnetSchedule) EpochLastBlock(epochNum uint64) uint64 {
-	blocks := ts.BlocksPerEpoch()
-	switch {
-	case epochNum == 0:
-		return testnetEpochBlock1 - 1
-	default:
-		return testnetEpochBlock1 - 1 + blocks*epochNum
-	}
+	return (ts.BlocksPerEpoch()+1)*epochNum - 1
 }
 
 func (ts testnetSchedule) VdfDifficulty() int {

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -35,8 +35,8 @@ var (
 	TestnetChainConfig = &ChainConfig{
 		ChainID:        TestnetChainID,
 		CrossTxEpoch:   big.NewInt(0),
-		CrossLinkEpoch: big.NewInt(2),
-		StakingEpoch:   big.NewInt(3),
+		CrossLinkEpoch: EpochTBD,
+		StakingEpoch:   EpochTBD,
 		EIP155Epoch:    big.NewInt(0),
 		S3Epoch:        big.NewInt(0),
 	}

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -34,7 +34,7 @@ var (
 	// TestnetChainConfig contains the chain parameters to run a node on the harmony test network.
 	TestnetChainConfig = &ChainConfig{
 		ChainID:        TestnetChainID,
-		CrossTxEpoch:   big.NewInt(1),
+		CrossTxEpoch:   big.NewInt(0),
 		CrossLinkEpoch: big.NewInt(2),
 		StakingEpoch:   big.NewInt(3),
 		EIP155Epoch:    big.NewInt(0),


### PR DESCRIPTION
Now it's 75 blocks/epoch, without epoch-0 exception.  At 8 seconds/block, it amounts to 10 minutes/epoch.

Resize testnet to 100 nodes/shard * 3 shards = 300 nodes.  Shard 0/1 are Harmony-operated for now; shard 2 is operated/managed by P-OPS.

Also disable crosslinks and staking transactions because they are not used yet, and enable cross-shard transaction at genesis.

We reuse existing testnet keys.