### PR TITLE
Make Travis-CI see if binaries in ./cmd build fine

### DIFF
--- a/scripts/travis_checker.sh
+++ b/scripts/travis_checker.sh
@@ -79,6 +79,15 @@ else
 	ok=false
 fi
 
+echo "Building binaries in ./cmd/..."
+if go build ./cmd/...
+then
+	echo "go build succeeded."
+else
+	echo "go build FAILED!"
+	ok=false
+fi
+
 echo "Running go test..."
 if go test -v -count=1 ./...
 then


### PR DESCRIPTION
SSIA.  This is because the master branch needs to be deployable onto Pangaea/testnet at all times.

## Tests

Since the master branch is broken, the commit that introduces this change (a162c6f) fails Travis build.  Once the master branch builds again, I will merge from master then Travis should pass.