### PR TITLE
added support for building static binary on Linux platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,8 @@ exe:
 
 test:
 	./test/debug.sh
+
+linux_static:
+	make -C $(TOP)/mcl -j4
+	make -C $(TOP)/bls minimised_static BLS_SWAP_G=1 -j4
+	./scripts/go_executable_build.sh -s


### PR DESCRIPTION
 Build:

 a. git pull bls again to get the latest bls 
 b. make linux_static

 Limitation:  must build the binary under Ubuntu Linux (tested on 18.04 LTS)

 I tested the generated binary with different combinations
1) Mac:  can't build static link in Mac 
2) Linux:   build on ubuntu, run on ubuntu , this works
                    build on ubuntu, run on centos/ami,  doesn't work
                    build on  centos,  run on centos,  doesn't work
        
 NOTE:  Got some warning during linking process, which makes the static binary will have porting issue when libc is different. It is a Golang issue to me,  more information regarding this issue can be found here (https://jira.hyperledger.org/browse/FABC-313)

/tmp/go-link-996576825/000029.o: In function `mygetgrouplist':
getgrouplist_unix.cgo2.c:(.text+0x60): warning: Using 'getgrouplist' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-996576825/000028.o: In function `mygetgrgid_r':
cgo_lookup_unix.cgo2.c:(.text+0xe1): warning: Using 'getgrgid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-996576825/000028.o: In function `mygetgrnam_r':
cgo_lookup_unix.cgo2.c:(.text+0x11e): warning: Using 'getgrnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-996576825/000028.o: In function `mygetpwnam_r':
cgo_lookup_unix.cgo2.c:(.text+0xa7): warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-996576825/000028.o: In function `mygetpwuid_r':
cgo_lookup_unix.cgo2.c:(.text+0x6a): warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-996576825/000008.o: In function `_cgo_7e1b3c2abc8d_C2func_getaddrinfo':
cgo_unix.cgo2.c:(.text+0x81): warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
Harmony (C) 2019. harmony, version v${VERSION}-${COMMIT} (${BUILTBY} ${BUILTAT})
