### PR TITLE
Add old api compatibility back

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2345,25 +2345,25 @@ func (bc *BlockChain) UpdateValidatorMap(tx *staking.StakingTransaction) error {
 
 // CurrentValidatorAddresses returns the address of active validators for current epoch
 func (bc *BlockChain) CurrentValidatorAddresses() []common.Address {
-	return nil
+	return make([]common.Address, 0)
 }
 
 // ValidatorCandidates returns the up to date validator candidates for next epoch
 func (bc *BlockChain) ValidatorCandidates() []common.Address {
-	return nil
+	return make([]common.Address, 0)
 }
 
 // ValidatorInformation returns the information of validator
 func (bc *BlockChain) ValidatorInformation(addr common.Address) *staking.Validator {
-	return nil
+	return &staking.Validator{}
 }
 
 // DelegatorsInformation returns up to date information of delegators of a given validator address
 func (bc *BlockChain) DelegatorsInformation(addr common.Address) []*staking.Delegation {
-	return nil
+	return make([]*staking.Delegation, 0)
 }
 
 // ValidatorStakingWithDelegation returns the amount of staking after applying all delegated stakes
 func (bc *BlockChain) ValidatorStakingWithDelegation(addr common.Address) *big.Int {
-	return nil
+	return big.NewInt(0)
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -41,9 +41,11 @@ import (
 	"github.com/harmony-one/harmony/core/state"
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/core/vm"
+	internal_common "github.com/harmony-one/harmony/internal/common"
 	"github.com/harmony-one/harmony/internal/ctxerror"
 	"github.com/harmony-one/harmony/internal/params"
 	"github.com/harmony-one/harmony/internal/utils"
+	"github.com/harmony-one/harmony/numeric"
 	"github.com/harmony-one/harmony/shard"
 	staking "github.com/harmony-one/harmony/staking/types"
 	lru "github.com/hashicorp/golang-lru"
@@ -2355,7 +2357,31 @@ func (bc *BlockChain) ValidatorCandidates() []common.Address {
 
 // ValidatorInformation returns the information of validator
 func (bc *BlockChain) ValidatorInformation(addr common.Address) *staking.Validator {
-	return &staking.Validator{}
+	commission := staking.Commission{
+		UpdateHeight: big.NewInt(0),
+	}
+	commission.CommissionRates = staking.CommissionRates{
+		Rate:          numeric.Dec{Int: big.NewInt(0)},
+		MaxRate:       numeric.Dec{Int: big.NewInt(0)},
+		MaxChangeRate: numeric.Dec{Int: big.NewInt(0)},
+	}
+	validator := &staking.Validator{
+		Address:           internal_common.ParseAddr("0x0000000000000000000000000000000000000000000000000000000000000000"),
+		SlotPubKeys:       make([]shard.BlsPublicKey, 0),
+		Stake:             big.NewInt(0),
+		UnbondingHeight:   big.NewInt(0),
+		MinSelfDelegation: big.NewInt(0),
+		Active:            false,
+	}
+	validator.Commission = commission
+	validator.Description = staking.Description{
+		Name:            "lol",
+		Identity:        "lol",
+		Website:         "lol",
+		SecurityContact: "lol",
+		Details:         "lol",
+	}
+	return validator
 }
 
 // DelegatorsInformation returns up to date information of delegators of a given validator address


### PR DESCRIPTION
## Issue

Issue explained by Richard, quite lots of apps depend on hmy_getBlockByHash and hmy_getBlockByNumber and args formats needs to be fixed in all of them accordingly, which will take time. To not break those apps need to add compatibility back. Unfortunately it's not possible to merge methods as blockArgs struct can't be parsed to bool and missing args cause errors. So I brought back old methods and also renamed new ones by adding New in the end. They will be still available with hmy api.

Also small fix for hmy_getValidatorInformation api for slot pub keys.

## Test

Localnet, postman. New and old methods work okay.

#### Test Coverage Data

<!-- run 'go test -cover' in the directory you made change -->

* Before
* After

#### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## TODO
