### PR TITLE
Add non-zero exit to test/deploy.sh if Cx test failed

### DIFF
--- a/test/deploy.sh
+++ b/test/deploy.sh
@@ -193,19 +193,23 @@ done < $config
 
 if [ "$DOTEST" == "true" ]; then
    echo "waiting for some block rewards"
-   sleep 60
+   sleep 110
    i=1
    echo "launching wallet cross shard transfer test"
    while [ $i -le $NUM_TEST ]; do
       "${ROOT}/bin/wallet" -p local transfer --from $ACC1 --to $ACC3 --shardID 0 --toShardID 1 --amount 0.1 --pass pass:"" 2>&1 | tee -a "${LOG_FILE}"
       "${ROOT}/bin/wallet" -p local transfer --from $ACC2 --to $ACC3 --shardID 1 --toShardID 0 --amount 0.1 --pass pass:"" 2>&1 | tee -a "${LOG_FILE}"
-      sleep 20
+      sleep 45
       i=$((i+1))
    done
    echo "waiting for the result"
-   sleep 20
+   sleep 60
    check_result
    [ -e $RESULT_FILE ] && cat $RESULT_FILE
+   if [ "$err" == "true" ] ; then
+      cleanup_and_result
+      exit -1
+   fi
 fi
 
 sleep $DURATION


### PR DESCRIPTION
## Issue

Jenkins will not pick up a failure if script does not exit with a non-zero exit code. 
