### PR TITLE
Make ProcessStateSync to return error

### DIFF
--- a/api/service/syncing/errors.go
+++ b/api/service/syncing/errors.go
@@ -4,7 +4,13 @@ import "errors"
 
 // Errors ...
 var (
-	ErrRegistrationFail = errors.New("[SYNC]: registration failed")
-	ErrGetBlock         = errors.New("[SYNC]: get block failed")
-	ErrGetBlockHash     = errors.New("[SYNC]: get blockhash failed")
+	ErrRegistrationFail      = errors.New("[SYNC]: registration failed")
+	ErrGetBlock              = errors.New("[SYNC]: get block failed")
+	ErrGetBlockHash          = errors.New("[SYNC]: get blockhash failed")
+	ErrProcessStateSync      = errors.New("[SYNC]: get blockhash failed")
+	ErrGetConsensusHashes    = errors.New("[SYNC]: get consensus hashes failed")
+	ErrGenStateSyncTaskQueue = errors.New("[SYNC]: generate state sync task queue failed")
+	ErrDownloadBlocks        = errors.New("[SYNC]: get download blocks failed")
+	ErrUpdateBlockAndStatus  = errors.New("[SYNC]: update block and status failed")
+	ErrGenerateNewState      = errors.New("[SYNC]: get generate new state failed")
 )

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -332,7 +332,7 @@ func (node *Node) CalculateResponse(request *downloader_pb.DownloaderRequest, in
 		if request.BlockHash == nil {
 			return response, fmt.Errorf("[SYNC] GetBlockHashes Request BlockHash is NIL")
 		}
-		if request.Size == 0 || request.Size > syncing.BatchSize {
+		if request.Size == 0 || request.Size > syncing.SyncLoopBatchSize {
 			return response, fmt.Errorf("[SYNC] GetBlockHashes Request contains invalid Size %v", request.Size)
 		}
 		size := uint64(request.Size)


### PR DESCRIPTION
## Issue

This PR is a prep pr for the following the "robust new node state sync design" work.
Proper error handling is needed to gracefully handle state sync failures and take action more robustly.
Includes some minor naming, changes, and logging.

## Test
Ran local network, and confirm that consensus is reached.
```
 BINGO !!! Reached Consensus
```
and also check that errors are logged properly.

#### Test Coverage Data

```
ubuntu@ip-172-31-16-131:~/harmony-one/harmony/node (robust_state_sync) $ go test -cover
PASS
coverage: 14.6% of statements
ok  	github.com/harmony-one/harmony/node	2.485s

ubuntu@ip-172-31-16-131:~/harmony-one/harmony/node/worker (robust_state_sync) $ go test -cover
PASS
coverage: 24.3% of statements
ok  	github.com/harmony-one/harmony/node/worker	0.113s
```