### PR TITLE
Comment out "Dumping block" message

### DIFF
--- a/api/service/explorer/storage.go
+++ b/api/service/explorer/storage.go
@@ -89,7 +89,7 @@ func (storage *Storage) GetDB() *ethdb.LDBDatabase {
 
 // Dump extracts information from block and index them into lvdb for explorer.
 func (storage *Storage) Dump(block *types.Block, height uint64) {
-	utils.Logger().Info().Uint64("block height", height).Msg("Dumping block")
+	//utils.Logger().Debug().Uint64("block height", height).Msg("Dumping block")
 	if block == nil {
 		return
 	}


### PR DESCRIPTION
When running explorer, every time we restart it, this dumps megabytes of
messages into zerolog, overwhelming logstash.