### PR TITLE
Reduce wait time for bootnode connection to 30s

### DIFF
--- a/api/service/networkinfo/service.go
+++ b/api/service/networkinfo/service.go
@@ -41,8 +41,8 @@ type Service struct {
 
 // ConnectionRetry set the number of retry of connection to bootnode in case the initial connection is failed
 var (
-	// retry for 1 minutes and give up then
-	ConnectionRetry = 30
+	// retry for 30s and give up then
+	ConnectionRetry = 15
 
 	// context
 	ctx context.Context

--- a/api/service/networkinfo/service.go
+++ b/api/service/networkinfo/service.go
@@ -41,8 +41,8 @@ type Service struct {
 
 // ConnectionRetry set the number of retry of connection to bootnode in case the initial connection is failed
 var (
-	// retry for 10 minutes and give up then
-	ConnectionRetry = 300
+	// retry for 1 minutes and give up then
+	ConnectionRetry = 30
 
 	// context
 	ctx context.Context


### PR DESCRIPTION
Previously the retry time is 10 mins and it will block the whole client process for 10 mins if a single bootnode fails to connect. Reduce the retry time to 30s, so it won't appear that the node is stuck for a long time.