### PR TITLE
[rpc] Fix mistake how nodemetadata gets ShardID, fix older networkTyp…

### DIFF
--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -236,7 +236,7 @@ func (b *APIBackend) RPCGasCap() *big.Int {
 	return b.hmy.RPCGasCap // TODO(ricl): should be hmy.config.RPCGasCap
 }
 
-// GetShardID returns the gas cap of rpc
+// GetShardID returns shardID of this node
 func (b *APIBackend) GetShardID() uint32 {
 	return b.hmy.shardID
 }

--- a/internal/configs/node/config.go
+++ b/internal/configs/node/config.go
@@ -224,6 +224,7 @@ func (conf *ConfigType) Role() Role {
 
 // SetNetworkType set the networkType
 func SetNetworkType(networkType NetworkType) {
+	defaultConfig.networkType = networkType
 	for i := range shardConfigs {
 		shardConfigs[i].networkType = networkType
 	}

--- a/internal/hmyapi/harmony.go
+++ b/internal/hmyapi/harmony.go
@@ -53,7 +53,7 @@ type NodeMetadata struct {
 	ShardID      uint32 `json:"shard-id"`
 }
 
-// GetNodeMetadata produces a NodeMetadata record. Note the data is from the answering RPC
+// GetNodeMetadata produces a NodeMetadata record, data is from the answering RPC node
 func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
 	cfg := nodeconfig.GetDefaultConfig()
 	return NodeMetadata{
@@ -62,6 +62,6 @@ func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
 		string(cfg.GetNetworkType()),
 		s.b.ChainConfig().ChainID.String(),
 		s.b.IsLeader(),
-		cfg.GetShardID(),
+		s.b.GetShardID(),
 	}
 }


### PR DESCRIPTION
Two lingering mistakes in RPC, downstream watchdog consumes this data