### PR TITLE
[reward] Abstract out block-reward, use rewarder, check result correct 

### DIFF
--- a/consensus/consensus_leader_msg_test.go
+++ b/consensus/consensus_leader_msg_test.go
@@ -46,7 +46,7 @@ func TestConstructAnnounceMessage(test *testing.T) {
 func TestConstructPreparedMessage(test *testing.T) {
 	leaderPriKey := bls.RandPrivateKey()
 	leaderPubKey := leaderPriKey.GetPublicKey()
-	leader := p2p.Peer{IP: "127.0.0.1", Port: "6000", ConsensusPubKey: leaderPubKey}
+	leader := p2p.Peer{IP: "127.0.0.1", Port: "19999", ConsensusPubKey: leaderPubKey}
 
 	validatorPriKey := bls.RandPrivateKey()
 	validatorPubKey := leaderPriKey.GetPublicKey()

--- a/consensus/engine/consensus_engine.go
+++ b/consensus/engine/consensus_engine.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/block"
+	"github.com/harmony-one/harmony/consensus/reward"
 	"github.com/harmony-one/harmony/core/state"
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/internal/params"
@@ -72,6 +73,9 @@ type Engine interface {
 	// Prepare initializes the consensus fields of a block header according to the
 	// rules of a particular engine. The changes are executed inline.
 	Prepare(chain ChainReader, header *block.Header) error
+
+	// SetRewarder assigns the Distributor used in block reward
+	SetRewarder(reward.Distributor)
 
 	// Finalize runs any post-transaction state modifications (e.g. block rewards)
 	// and assembles the final block.

--- a/consensus/engine/consensus_engine.go
+++ b/consensus/engine/consensus_engine.go
@@ -74,6 +74,9 @@ type Engine interface {
 	// rules of a particular engine. The changes are executed inline.
 	Prepare(chain ChainReader, header *block.Header) error
 
+	// Rewarder handles the distribution of block rewards
+	Rewarder() reward.Distributor
+
 	// SetRewarder assigns the Distributor used in block reward
 	SetRewarder(reward.Distributor)
 

--- a/consensus/quorum/one-node-one-vote.go
+++ b/consensus/quorum/one-node-one-vote.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/bls/ffi/go/bls"
-	common2 "github.com/harmony-one/harmony/internal/common"
 	"github.com/harmony-one/harmony/internal/utils"
 	// "github.com/harmony-one/harmony/staking/effective"
 )
@@ -19,10 +18,6 @@ type uniformVoteWeight struct {
 func (v *uniformVoteWeight) Policy() Policy {
 	return SuperMajorityVote
 }
-
-// func (v *uniformVoteWeight) SetShardIDProvider(p func() (uint32, error)) {
-// 	v.p = p
-// }
 
 // IsQuorumAchieved ..
 func (v *uniformVoteWeight) IsQuorumAchieved(p Phase) bool {
@@ -59,7 +54,7 @@ func (v *uniformVoteWeight) ToggleActive(*bls.PublicKey) bool {
 func (v *uniformVoteWeight) Award(
 	// Here hook is the callback which gets the amount the earner is due in just reward
 	// up to the hook to do side-effects like write the statedb
-	Pie *big.Int, earners []common2.Address, hook func(earner common.Address, due *big.Int),
+	Pie *big.Int, earners []common.Address, hook func(earner common.Address, due *big.Int),
 ) *big.Int {
 	payout := big.NewInt(0)
 	last := big.NewInt(0)

--- a/consensus/quorum/one-node-staked-vote.go
+++ b/consensus/quorum/one-node-staked-vote.go
@@ -3,8 +3,8 @@ package quorum
 import (
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/bls/ffi/go/bls"
-	"github.com/harmony-one/harmony/internal/common"
 	"github.com/harmony-one/harmony/numeric"
 	"github.com/harmony-one/harmony/shard"
 )

--- a/consensus/reward/rewarder.go
+++ b/consensus/reward/rewarder.go
@@ -4,14 +4,13 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	common2 "github.com/harmony-one/harmony/internal/common"
 )
 
 // Distributor ..
 type Distributor interface {
 	Award(
 		Pie *big.Int,
-		earners []common2.Address,
+		earners []common.Address,
 		hook func(earner common.Address, due *big.Int),
 	) (payout *big.Int)
 }

--- a/consensus/reward/rewarder.go
+++ b/consensus/reward/rewarder.go
@@ -1,0 +1,17 @@
+package reward
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	common2 "github.com/harmony-one/harmony/internal/common"
+)
+
+// Distributor ..
+type Distributor interface {
+	Award(
+		Pie *big.Int,
+		earners []common2.Address,
+		hook func(earner common.Address, due *big.Int),
+	) (payout *big.Int)
+}

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -8,6 +8,7 @@ import (
 	"github.com/harmony-one/bls/ffi/go/bls"
 	"github.com/harmony-one/harmony/block"
 	"github.com/harmony-one/harmony/consensus/engine"
+	"github.com/harmony-one/harmony/consensus/reward"
 	"github.com/harmony-one/harmony/core/state"
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/internal/ctxerror"
@@ -19,10 +20,17 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
-type engineImpl struct{}
+type engineImpl struct {
+	d reward.Distributor
+}
 
 // Engine is an algorithm-agnostic consensus engine.
-var Engine = &engineImpl{}
+var Engine = &engineImpl{nil}
+
+// SetRewarder ..
+func (e *engineImpl) SetRewarder(d reward.Distributor) {
+	e.d = d
+}
 
 // SealHash returns the hash of a block prior to it being sealed.
 func (e *engineImpl) SealHash(header *block.Header) (hash common.Hash) {

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -27,6 +27,11 @@ type engineImpl struct {
 // Engine is an algorithm-agnostic consensus engine.
 var Engine = &engineImpl{nil}
 
+// Rewarder handles the distribution of block rewards
+func (e *engineImpl) Rewarder() reward.Distributor {
+	return e.d
+}
+
 // SetRewarder ..
 func (e *engineImpl) SetRewarder(d reward.Distributor) {
 	e.d = d
@@ -164,7 +169,7 @@ func (e *engineImpl) Finalize(
 	incxs []*types.CXReceiptsProof, stks []*staking.StakingTransaction) (*types.Block, error) {
 	// Accumulate any block and uncle rewards and commit the final state root
 	// Header seems complete, assemble into a block and return
-	if err := AccumulateRewards(chain, state, header); err != nil {
+	if err := AccumulateRewards(chain, state, header, e.Rewarder()); err != nil {
 		return nil, ctxerror.New("cannot pay block reward").WithCause(err)
 	}
 	header.SetRoot(state.IntermediateRoot(chain.Config().IsS3(header.Epoch())))

--- a/node/node.go
+++ b/node/node.go
@@ -17,6 +17,7 @@ import (
 	"github.com/harmony-one/harmony/api/service/syncing/downloader"
 	"github.com/harmony-one/harmony/block"
 	"github.com/harmony-one/harmony/consensus"
+	"github.com/harmony-one/harmony/consensus/reward"
 	"github.com/harmony-one/harmony/contracts"
 	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/core/types"
@@ -514,6 +515,7 @@ func New(host p2p.Host, consensusObj *consensus.Consensus, chainDBFactory shardc
 		node.pendingTransactions = make(map[common.Hash]*types.Transaction)
 		node.pendingStakingTransactions = make(map[common.Hash]*staking.StakingTransaction)
 		node.Consensus.VerifiedNewBlock = make(chan *types.Block)
+		chain.Engine.SetRewarder(node.Consensus.Decider.(reward.Distributor))
 		// the sequence number is the next block number to be added in consensus protocol, which is always one more than current chain header block
 		node.Consensus.SetBlockNum(blockchain.CurrentBlock().NumberU64() + 1)
 


### PR DESCRIPTION
This is PR #3 of breaking this PR #1762 into smaller PRs, assumes PR#1, PR#2 merged into master, then will rebase this one to reflect that.

1. Create package reward, has one interface, Distributor, reward.Distributor now a factored out block rewarder 
2. Use quorum type as the Awarder in engine/reward.go
3. Double checks that the paid out amount is indeed total amount as block-reward