### PR TITLE
[StateSync] add retries to process state sync where failed peer config is excluded on the next try

### DIFF
--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -830,11 +830,13 @@ Loop:
 					Int("retryCount", retryCount).
 					Msg("[SYNC] ProcessStateSync failed. Retrying ...")
 
-				ss.syncConfig.ForEachPeer(func(configPeer *SyncPeerConfig) (brk bool) {
+				// Track the peer sync config(s) that failed node sync here to exclude it on successive retries
+				trackFailedPeer := func(configPeer *SyncPeerConfig) (brk bool) {
 					ss.syncConfig.failedPeers = append(ss.syncConfig.failedPeers, configPeer)
 					brk = true
 					return
-				})
+				}
+				ss.syncConfig.ForEachPeer(trackFailedPeer)
 				retryCount++
 			}
 

--- a/api/service/syncing/syncing_test.go
+++ b/api/service/syncing/syncing_test.go
@@ -16,7 +16,7 @@ func TestCreateTestSyncPeerConfig(t *testing.T) {
 }
 
 // Simple test for IncorrectResponse
-func TestCompareSyncPeerConfigByblockHashes(t *testing.T) {
+func TestCompareSyncPeerConfigByBlockHashes(t *testing.T) {
 	client := &downloader.Client{}
 	blockHashes1 := [][]byte{{1, 2, 3}}
 	syncPeerConfig1 := CreateTestSyncPeerConfig(client, blockHashes1)
@@ -24,19 +24,19 @@ func TestCompareSyncPeerConfigByblockHashes(t *testing.T) {
 	syncPeerConfig2 := CreateTestSyncPeerConfig(client, blockHashes2)
 
 	// syncPeerConfig1 is less than syncPeerConfig2
-	assert.Equal(t, CompareSyncPeerConfigByblockHashes(syncPeerConfig1, syncPeerConfig2), -1, "syncPeerConfig1 is less than syncPeerConfig2")
+	assert.Equal(t, CompareSyncPeerConfigByBlockHashes(syncPeerConfig1, syncPeerConfig2), -1, "syncPeerConfig1 is less than syncPeerConfig2")
 
 	// syncPeerConfig1 is greater than syncPeerConfig2
 	blockHashes1[0][2] = 5
-	assert.Equal(t, CompareSyncPeerConfigByblockHashes(syncPeerConfig1, syncPeerConfig2), 1, "syncPeerConfig1 is greater than syncPeerConfig2")
+	assert.Equal(t, CompareSyncPeerConfigByBlockHashes(syncPeerConfig1, syncPeerConfig2), 1, "syncPeerConfig1 is greater than syncPeerConfig2")
 
 	// syncPeerConfig1 is equal to syncPeerConfig2
 	blockHashes1[0][2] = 4
-	assert.Equal(t, CompareSyncPeerConfigByblockHashes(syncPeerConfig1, syncPeerConfig2), 0, "syncPeerConfig1 is equal to syncPeerConfig2")
+	assert.Equal(t, CompareSyncPeerConfigByBlockHashes(syncPeerConfig1, syncPeerConfig2), 0, "syncPeerConfig1 is equal to syncPeerConfig2")
 
 	// syncPeerConfig1 is less than syncPeerConfig2
 	blockHashes1 = blockHashes1[:1]
-	assert.Equal(t, CompareSyncPeerConfigByblockHashes(syncPeerConfig1, syncPeerConfig2), 0, "syncPeerConfig1 is less than syncPeerConfig2")
+	assert.Equal(t, CompareSyncPeerConfigByBlockHashes(syncPeerConfig1, syncPeerConfig2), 0, "syncPeerConfig1 is less than syncPeerConfig2")
 }
 
 func TestCreateStateSync(t *testing.T) {


### PR DESCRIPTION
## Issue

https://github.com/harmony-one/harmony/issues/1313

This PR makes the new node syncing process more robust with retries where for each try, the *previously failed sync peer config* selected as the max consensus hash (the most common block hashes of the header chain is in each sync batch) is excluded on the subsequent retries during sync peer config selection.

The updated logic, therefore, is that, if process state sync fails during chain insertion, the retry will then try with the next most common sync peer config as the source of state syncing for that batch.

## Test

artificially made the first try to fail by throwing an error from process state sync, and on the next try, subsequent sync peer config is used (which I again artificially made the 2nd common sync peer config to be the same as the actual max consensus), and saw that the state sync succeeds. Tested on the local-resharding config network.

#### Test Coverage Data

```
1914]
ubuntu@ip-172-31-16-131:~/go/src/github.com/harmony-one/harmony/node (retry_state_sync) $ go test -cover -v
=== RUN   TestAddNewBlock
--- PASS: TestAddNewBlock (0.47s)
=== RUN   TestVerifyNewBlock
--- PASS: TestVerifyNewBlock (0.51s)
=== RUN   TestNewNode
--- PASS: TestNewNode (0.51s)
=== RUN   TestLegacySyncingPeerProvider
=== RUN   TestLegacySyncingPeerProvider/ShardChain
=== RUN   TestLegacySyncingPeerProvider/BeaconChain
=== RUN   TestLegacySyncingPeerProvider/NoMatch
--- PASS: TestLegacySyncingPeerProvider (0.00s)
    --- PASS: TestLegacySyncingPeerProvider/ShardChain (0.00s)
    --- PASS: TestLegacySyncingPeerProvider/BeaconChain (0.00s)
    --- PASS: TestLegacySyncingPeerProvider/NoMatch (0.00s)
=== RUN   TestDNSSyncingPeerProvider
=== RUN   TestDNSSyncingPeerProvider/Happy
=== RUN   TestDNSSyncingPeerProvider/LookupError
--- PASS: TestDNSSyncingPeerProvider (0.00s)
    --- PASS: TestDNSSyncingPeerProvider/Happy (0.00s)
    --- PASS: TestDNSSyncingPeerProvider/LookupError (0.00s)
=== RUN   TestLocalSyncingPeerProvider
=== RUN   TestLocalSyncingPeerProvider/BeaconChain
=== RUN   TestLocalSyncingPeerProvider/Shard1Chain
=== RUN   TestLocalSyncingPeerProvider/InvalidShard
--- PASS: TestLocalSyncingPeerProvider (0.00s)
    --- PASS: TestLocalSyncingPeerProvider/BeaconChain (0.00s)
    --- PASS: TestLocalSyncingPeerProvider/Shard1Chain (0.00s)
    --- PASS: TestLocalSyncingPeerProvider/InvalidShard (0.00s)
=== RUN   TestAddPeers
--- PASS: TestAddPeers (0.52s)
=== RUN   TestAddBeaconPeer
--- PASS: TestAddBeaconPeer (0.51s)
PASS
coverage: 13.2% of statements
ok      github.com/harmony-one/harmony/node     2.620s
```

## TODO
https://github.com/harmony-one/harmony/issues/1752