### PR TITLE
[staking-testing] Fix staking median logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,10 +58,14 @@ require (
 	github.com/stretchr/testify v1.3.0
 	github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965
 	github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc
-	golang.org/x/crypto v0.0.0-20190618222545-ea8f1a30c443
-	golang.org/x/lint v0.0.0-20190409202823-959b441ac422
-	golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3 // indirect
-	golang.org/x/tools v0.0.0-20190924052046-3ac2a5bbd98a
+	golang.org/x/crypto v0.0.0-20191117063200-497ca9f6d64f
+	golang.org/x/lint v0.0.0-20190930215403-16217165b5de
+	golang.org/x/net v0.0.0-20191118183410-d06c31c94cae // indirect
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
+	golang.org/x/sys v0.0.0-20191118133127-cf1e2d577169 // indirect
+	golang.org/x/text v0.3.2 // indirect
+	golang.org/x/tools v0.0.0-20191118222007-07fc4c7f2b98
+	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect
 	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/grpc v1.22.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,6 @@ require (
 	github.com/stretchr/testify v1.3.0
 	github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965
 	github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc
-	golang.org/x/crypto v0.0.0-20191117063200-497ca9f6d64f
 	golang.org/x/lint v0.0.0-20190930215403-16217165b5de
 	golang.org/x/net v0.0.0-20191118183410-d06c31c94cae // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect

--- a/go.mod
+++ b/go.mod
@@ -58,13 +58,10 @@ require (
 	github.com/stretchr/testify v1.3.0
 	github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965
 	github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc
-	golang.org/x/lint v0.0.0-20190930215403-16217165b5de
-	golang.org/x/net v0.0.0-20191118183410-d06c31c94cae // indirect
-	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
-	golang.org/x/sys v0.0.0-20191118133127-cf1e2d577169 // indirect
-	golang.org/x/text v0.3.2 // indirect
-	golang.org/x/tools v0.0.0-20191118222007-07fc4c7f2b98
-	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect
+	golang.org/x/crypto v0.0.0-20190618222545-ea8f1a30c443
+	golang.org/x/lint v0.0.0-20190409202823-959b441ac422
+	golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3 // indirect
+	golang.org/x/tools v0.0.0-20190924052046-3ac2a5bbd98a
 	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/grpc v1.22.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127

--- a/staking/effective/calculate.go
+++ b/staking/effective/calculate.go
@@ -6,10 +6,10 @@ import (
 	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
+	common2 "github.com/harmony-one/harmony/internal/common"
+	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/numeric"
 	"github.com/harmony-one/harmony/shard"
-	"github.com/harmony-one/harmony/internal/utils"
-	common2 "github.com/harmony-one/harmony/internal/common"
 )
 
 // medium.com/harmony-one/introducing-harmonys-effective-proof-of-stake-epos-2d39b4b8d58

--- a/staking/effective/calculate.go
+++ b/staking/effective/calculate.go
@@ -78,7 +78,7 @@ func median(stakes []SlotPurchase) numeric.Dec {
 		utils.Logger().Info().Int("left", left).Int("right", right)
 		return stakes[left].Dec.Add(stakes[right].Dec).Quo(two)
 	default:
-		utils.Logger().Info().Int("median index", l / 2)
+		utils.Logger().Info().Int("median index", l/2)
 		return stakes[l/2].Dec
 	}
 }

--- a/staking/effective/calculate.go
+++ b/staking/effective/calculate.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"math/big"
 	"sort"
-	"fmt"
-	"strconv"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/numeric"
@@ -63,7 +61,7 @@ func (s Slots) JSON() string {
 		}
 		data.Slots = append(data.Slots, newData)
 	}
-	b, _ := json.MarshalIndent(data, "", "\t")
+	b, _ := json.Marshal(data)
 	return string(b)
 }
 
@@ -77,12 +75,10 @@ func median(stakes []SlotPurchase) numeric.Dec {
 	case isEven:
 		left := (l / 2) - 1
 		right := (l / 2)
-		msg := fmt.Sprintf("Len(stakes) is even. Left = %d. Right = %d.", left, right)
-		utils.Logger().Info().Str("median", strconv.FormatInt(int64(len(stakes)), 10)).Msg(msg)
+		utils.Logger().Info().Int("left", left).Int("right", right)
 		return stakes[left].Dec.Add(stakes[right].Dec).Quo(two)
 	default:
-		msg := fmt.Sprintf("Median index = %d", l / 2)
-		utils.Logger().Info().Str("median", strconv.FormatInt(int64(len(stakes)), 10)).Msg(msg)
+		utils.Logger().Info().Int("median index", l / 2)
 		return stakes[l/2].Dec
 	}
 }

--- a/staking/effective/calculate_test.go
+++ b/staking/effective/calculate_test.go
@@ -70,7 +70,7 @@ func generateRandomSlots(num int) Slots {
 func TestMedian(t *testing.T) {
 	copyPurchases := append([]SlotPurchase{}, testingPurchases...)
 	sort.SliceStable(copyPurchases,
-	        func(i, j int) bool { return copyPurchases[i].Dec.LTE(copyPurchases[j].Dec) })
+		func(i, j int) bool { return copyPurchases[i].Dec.LTE(copyPurchases[j].Dec) })
 	numPurchases := len(copyPurchases) / 2
 	expectedResult := numeric.ZeroDec()
 	if len(copyPurchases)%2 == 0 {

--- a/staking/effective/calculate_test.go
+++ b/staking/effective/calculate_test.go
@@ -5,12 +5,27 @@ import (
 	"fmt"
 	"io/ioutil"
 	"testing"
+	"math/rand"
+	"math/big"
+	"bytes"
+	"sort"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/harmony-one/harmony/numeric"
+	"github.com/harmony-one/harmony/shard"
 )
 
 const eposTestingFile = "epos.json"
+const slotTestingFile = "slots.json"
 
 var (
 	testingSlots slotsData
+	testingPurchases Slots
+	maxAccountGen = int64(98765654323123134)
+	accountGen    = rand.New(rand.NewSource(1337))
+	keyGen        = rand.New(rand.NewSource(42))
+	maxStakeGen   = int64(200)
+	stakeGen      = rand.New(rand.NewSource(541))
 )
 
 type slotsData struct {
@@ -33,10 +48,56 @@ func init() {
 		fmt.Println(oops.Error())
 		panic("Could not unmarshal slots data into memory")
 	}
+
+	// Generate random data, TODO maybe should test both even & odd number slots
+	testingPurchases = generateRandomSlots(21)
+}
+
+func generateRandomSlots(num int) Slots {
+	randomSlots := Slots{}
+	for i := 0; i < num; i++ {
+		addr := common.Address{}
+		addr.SetBytes(big.NewInt(int64(accountGen.Int63n(maxAccountGen))).Bytes())
+		key := shard.BlsPublicKey{}
+		copy(key[:], randomKey())
+		stake := numeric.NewDecFromBigInt(big.NewInt(int64(stakeGen.Int63n(maxStakeGen))))
+		randomSlots = append(randomSlots, SlotPurchase{ addr, key, stake })
+	}
+	return randomSlots
+}
+
+// Generates random valid bytes for BlsPublicKey
+func randomKey() []byte {
+	buf := bytes.Buffer{}
+	for i := 0; i < shard.PublicKeySizeInBytes; i++ {
+		invalid := true
+		newByte := 0
+		for invalid {
+			newByte = int(int64(48) + keyGen.Int63n(int64(43)))
+			if newByte <= int(57) || newByte >= int(65) {
+				invalid = false
+			}
+		}
+		buf.Write([]byte{byte(newByte)})
+	}
+	return buf.Bytes()
 }
 
 func TestMedian(t *testing.T) {
-	//
+	copyPurchases := append([]SlotPurchase{}, testingPurchases...)
+	sort.SliceStable(copyPurchases,
+									func(i, j int) bool { return copyPurchases[i].Dec.LTE(copyPurchases[j].Dec) })
+	numPurchases := len(copyPurchases) / 2
+	expectedResult := numeric.ZeroDec()
+	if len(copyPurchases) % 2 == 0 {
+		expectedResult = copyPurchases[numPurchases - 1].Dec.Add(copyPurchases[numPurchases].Dec).Quo(two)
+	} else {
+		expectedResult = copyPurchases[numPurchases].Dec
+	}
+	med := median(testingPurchases)
+	if !med.Equal(expectedResult) {
+		t.Error()
+	}
 }
 
 func TestEffectiveStake(t *testing.T) {

--- a/staking/effective/calculate_test.go
+++ b/staking/effective/calculate_test.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"testing"
-	"math/rand"
 	"math/big"
+	"math/rand"
 	"sort"
+	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/bls/ffi/go/bls"
@@ -19,14 +19,14 @@ const eposTestingFile = "epos.json"
 const slotTestingFile = "slots.json"
 
 var (
-	testingSlots slotsData
+	testingSlots     slotsData
 	testingPurchases Slots
-	maxAccountGen = int64(98765654323123134)
-	accountGen    = rand.New(rand.NewSource(1337))
-	maxKeyGen     = int64(98765654323123134)
-	keyGen        = rand.New(rand.NewSource(42))
-	maxStakeGen   = int64(200)
-	stakeGen      = rand.New(rand.NewSource(541))
+	maxAccountGen    = int64(98765654323123134)
+	accountGen       = rand.New(rand.NewSource(1337))
+	maxKeyGen        = int64(98765654323123134)
+	keyGen           = rand.New(rand.NewSource(42))
+	maxStakeGen      = int64(200)
+	stakeGen         = rand.New(rand.NewSource(541))
 )
 
 type slotsData struct {
@@ -64,7 +64,7 @@ func generateRandomSlots(num int) Slots {
 		key := shard.BlsPublicKey{}
 		key.FromLibBLSPublicKey(secretKey.GetPublicKey())
 		stake := numeric.NewDecFromBigInt(big.NewInt(int64(stakeGen.Int63n(maxStakeGen))))
-		randomSlots = append(randomSlots, SlotPurchase{ addr, key, stake })
+		randomSlots = append(randomSlots, SlotPurchase{addr, key, stake})
 	}
 	return randomSlots
 }
@@ -72,11 +72,11 @@ func generateRandomSlots(num int) Slots {
 func TestMedian(t *testing.T) {
 	copyPurchases := append([]SlotPurchase{}, testingPurchases...)
 	sort.SliceStable(copyPurchases,
-	                 func(i, j int) bool { return copyPurchases[i].Dec.LTE(copyPurchases[j].Dec) })
+	        func(i, j int) bool { return copyPurchases[i].Dec.LTE(copyPurchases[j].Dec) })
 	numPurchases := len(copyPurchases) / 2
 	expectedResult := numeric.ZeroDec()
-	if len(copyPurchases) % 2 == 0 {
-		expectedResult = copyPurchases[numPurchases - 1].Dec.Add(copyPurchases[numPurchases].Dec).Quo(two)
+	if len(copyPurchases)%2 == 0 {
+		expectedResult = copyPurchases[numPurchases-1].Dec.Add(copyPurchases[numPurchases].Dec).Quo(two)
 	} else {
 		expectedResult = copyPurchases[numPurchases].Dec
 	}

--- a/staking/effective/calculate_test.go
+++ b/staking/effective/calculate_test.go
@@ -57,8 +57,6 @@ func generateRandomSlots(num int) Slots {
 	for i := 0; i < num; i++ {
 		addr := common.Address{}
 		addr.SetBytes(big.NewInt(int64(accountGen.Int63n(maxAccountGen))).Bytes())
-		// key := shard.BlsPublicKey{}
-		// copy(key[:], randomKey())
 		secretKey := bls.SecretKey{}
 		secretKey.Deserialize(big.NewInt(int64(keyGen.Int63n(maxKeyGen))).Bytes())
 		key := shard.BlsPublicKey{}

--- a/staking/effective/calculate_test.go
+++ b/staking/effective/calculate_test.go
@@ -50,7 +50,7 @@ func init() {
 	}
 
 	// Generate random data, TODO maybe should test both even & odd number slots
-	testingPurchases = generateRandomSlots(21)
+	testingPurchases = generateRandomSlots(20)
 }
 
 func generateRandomSlots(num int) Slots {
@@ -96,7 +96,7 @@ func TestMedian(t *testing.T) {
 	}
 	med := median(testingPurchases)
 	if !med.Equal(expectedResult) {
-		t.Error()
+		t.Errorf("Expected: %s, Got: %s", expectedResult.String(), med.String())
 	}
 }
 


### PR DESCRIPTION
* Generate random purchase data to test calculate.go
* Add unit test for median function
* Update JSON to pretty print randomly generated data for debug

## Issue

In `median()`, in the case that `len(stakes)` is even, the median is being calculated from the `l / 2 - 1` and `l / 2 + 1` index of stakes.
If `len(stakes) = 20`, the left index will be `20 / 2 - 1 = 9` and the right index will be `20 / 2 + 1 = 11` and the median value will be `stakes[9] + stakes[11] / 2`, whereas the median value should be taken as `stakes[9] + stakes[10] / 2`.

Randomized testing data:
```json
{
	"slots": [
		{
			"slot-owner": "one1qqqqqqqqqqqqqqqqqqqqp7cu00grrnq6mfapw9",
			"bls-public-key": "364a33574556594c454e444242564f364b4b424648355951503338424858324b5845475844464c4753374237535a3456",
			"actual-stake": "105.000000000000000000"
		},
		{
			"slot-owner": "one1qqqqqqqqqqqqqqqqqqqqz5pec84jh52qwsrw5l",
			"bls-public-key": "4e474656465942433139323137384a4f595134354d5a4b415433325737455a4731543052525357555630505a53445432",
			"actual-stake": "97.000000000000000000"
		},
		{
			"slot-owner": "one1qqqqqqqqqqqqqqqqqqqqzk8t5fj46dnqpjrwew",
			"bls-public-key": "4d4946444b465144504833334d3854454f34344a465155515a4359533934315041445336344e39425056324d4f4b4f4e",
			"actual-stake": "111.000000000000000000"
		},
		{
			"slot-owner": "one1qqqqqqqqqqqqqqqqqqqqpmesnqtsp4t428v0tz",
			"bls-public-key": "57524959533657475a3933494b434b4d35375430344237353735383256464f505149454f564a524732373750334c5a39",
			"actual-stake": "39.000000000000000000"
		},
		{
			"slot-owner": "one1qqqqqqqqqqqqqqqqqqqqz4f0v9xsq305gwpq5v",
			"bls-public-key": "49413359324d3545425a324c3254443556503654334446385543474d3459465a4e48383753315a4d53344c43334a3147",
			"actual-stake": "89.000000000000000000"
		},
		{
			"slot-owner": "one1qqqqqqqqqqqqqqqqqqqqqgcsvfp62lefj03n0g",
			"bls-public-key": "54534a424c42444b42365844594a474b5744464f314b3637394135495936415949314a3146303141344e494a4b435433",
			"actual-stake": "152.000000000000000000"
		},
		{
			"slot-owner": "one1qqqqqqqqqqqqqqqqqqqqp9wsuf5kmshug5jgl2",
			"bls-public-key": "44594e3450414b36503241484e413859514935454f47443057584d3554504b455844584b51314b3957414a3730484759",
			"actual-stake": "182.000000000000000000"
		},
		{
			"slot-owner": "one1qqqqqqqqqqqqqqqqqqqqqffvu29t4rn9c4dfdq",
			"bls-public-key": "425148495a47324c534e424848374238444d4d51505752335536554e514f39355a343433314a555954414f5a48553442",
			"actual-stake": "59.000000000000000000"
		},
		{
			"slot-owner": "one1qqqqqqqqqqqqqqqqqqqqperu3y9xj2rqhtlxau",
			"bls-public-key": "4131364c523635474a5651424e47584c414343544a4d5749555a364d375132393145495638394d58383238374b474d34",
			"actual-stake": "157.000000000000000000"
		},
		{
			"slot-owner": "one1qqqqqqqqqqqqqqqqqqqqqgz72nwmclzm2adm93",
			"bls-public-key": "4146424534595a365556354237454c5655364d384f3735583657365953413657343441354152364c3256435051525549",
			"actual-stake": "101.000000000000000000"
		},
		{
			"slot-owner": "one1qqqqqqqqqqqqqqqqqqqqps55wyfatawjug502d",
			"bls-public-key": "55514f4c4651493348355144434b46534e52514c55485352495436584f4559544838504b44313844484d525353324634",
			"actual-stake": "67.000000000000000000"
		},
		{
			"slot-owner": "one1qqqqqqqqqqqqqqqqqqqqptrr5et7qcv4er247f",
			"bls-public-key": "54465646414e53344636374f49384d374243324a5a41555159414458514148535735584f345851423535423149384452",
			"actual-stake": "145.000000000000000000"
		},
		{
			"slot-owner": "one1qqqqqqqqqqqqqqqqqqqqpz0ukefscetuvme4yf",
			"bls-public-key": "54503837514a495335475353544650504d5850565632393739594b494f314e4135583158574b394f533939544a474e59",
			"actual-stake": "24.000000000000000000"
		},
		{
			"slot-owner": "one1qqqqqqqqqqqqqqqqqqqqqwjputftnrr4wc5pcs",
			"bls-public-key": "5232475735484e394a344a57424c3230315a514a56484e575443474b454942355335544a4e31323451414c57474a5431",
			"actual-stake": "170.000000000000000000"
		},
		{
			"slot-owner": "one1qqqqqqqqqqqqqqqqqqqqpm0070m2wsqzr6en39",
			"bls-public-key": "304e585a30525741495a46535348414835393346554d4c3555544a353130383954433041593143453238394c54544151",
			"actual-stake": "93.000000000000000000"
		},
		{
			"slot-owner": "one1qqqqqqqqqqqqqqqqqqqqphhy9mgp6n488fynv6",
			"bls-public-key": "5658514c504b5a52484735554b545437334332354656444d5539504859444e314e4d5a334857424a574358365332354f",
			"actual-stake": "182.000000000000000000"
		},
		{
			"slot-owner": "one1qqqqqqqqqqqqqqqqqqqqplpvqpd29hxutreys2",
			"bls-public-key": "4e50343859535a4e3247364f424658354a5539575a5352384e56344e595953583747474f3752354e54474c4f4d485151",
			"actual-stake": "183.000000000000000000"
		},
		{
			"slot-owner": "one1qqqqqqqqqqqqqqqqqqqqph0auws48ev48jfnl9",
			"bls-public-key": "4e38495657564336564e37544b534f4e385938415842324a36524d4e4c36544b4c375755384c4e584e344c4b544e4944",
			"actual-stake": "19.000000000000000000"
		},
		{
			"slot-owner": "one1qqqqqqqqqqqqqqqqqqqqp4s6usaxtcffz6yw7p",
			"bls-public-key": "44554f4238335a56414636414f464d393939593047325942434b5046515a495256415a5448314d4253333138464e5249",
			"actual-stake": "169.000000000000000000"
		},
		{
			"slot-owner": "one1qqqqqqqqqqqqqqqqqqqqzj0cfgtp9rfqj0jf9f",
			"bls-public-key": "465746334d304936535a303550544b57533746485834314c4e4b5739454d49395351584d42564a50525536384e59434a",
			"actual-stake": "171.000000000000000000"
		}
	]
}
```

Error:
```
$ go test -v -count=1 github.com/harmony-one/harmony/staking/effective/...
=== RUN   TestMedian
--- FAIL: TestMedian (0.00s)
    calculate_test.go:99: Expected: 108.000000000000000000, Got: 125.000000000000000000
=== RUN   TestEffectiveStake
--- PASS: TestEffectiveStake (0.00s)
=== RUN   TestApply
--- PASS: TestApply (0.00s)
FAIL
FAIL	github.com/harmony-one/harmony/staking/effective	0.048s
```
## TODO
 
Finish TestEffectiveStake & TestApply