### PR TITLE
One address support where its missing

### DIFF
--- a/internal/hmyapi/blockchain.go
+++ b/internal/hmyapi/blockchain.go
@@ -500,16 +500,17 @@ func (s *PublicBlockChainAPI) GetActiveValidatorAddresses() ([]common.Address, e
 	return s.b.GetActiveValidatorAddresses(), nil
 }
 
-// GetValidatorInfo returns information about a validator.
-func (s *PublicBlockChainAPI) GetValidatorInfo(ctx context.Context, address common.Address) (*RPCValidator, error) {
-	validator := s.b.GetValidatorInformation(address)
+// GetValidatorInformation returns information about a validator.
+func (s *PublicBlockChainAPI) GetValidatorInformation(ctx context.Context, address string) (*RPCValidator, error) {
+	validatorAddress := internal_common.ParseAddr(address)
+	validator := s.b.GetValidatorInformation(validatorAddress)
 	if validator == nil {
-		return nil, fmt.Errorf("validator not found: %s", address.Hex())
+		return nil, fmt.Errorf("validator not found: %s", validatorAddress.Hex())
 	}
 
 	rpcValidator := newRPCValidator(validator)
 
-	stats := s.b.GetValidatorStats(address)
+	stats := s.b.GetValidatorStats(validatorAddress)
 
 	if stats != nil {
 		rpcValidator.Uptime = numeric.NewDecFromBigInt(stats.NumBlocksSigned).Quo(numeric.NewDecFromBigInt(stats.NumBlocksToSign)).String()
@@ -518,8 +519,9 @@ func (s *PublicBlockChainAPI) GetValidatorInfo(ctx context.Context, address comm
 }
 
 // GetDelegationsByDelegator returns information about a validator.
-func (s *PublicBlockChainAPI) GetDelegationsByDelegator(ctx context.Context, address common.Address) ([]*RPCDelegation, error) {
-	validators, delegations := s.b.GetDelegationsByDelegator(address)
+func (s *PublicBlockChainAPI) GetDelegationsByDelegator(ctx context.Context, address string) ([]*RPCDelegation, error) {
+	validatorAddress := internal_common.ParseAddr(address)
+	validators, delegations := s.b.GetDelegationsByDelegator(validatorAddress)
 	result := []*RPCDelegation{}
 	for i := range delegations {
 		delegation := delegations[i]
@@ -534,13 +536,12 @@ func (s *PublicBlockChainAPI) GetDelegationsByDelegator(ctx context.Context, add
 		}
 		result = append(result, &RPCDelegation{
 			validators[i],
-			address,
+			validatorAddress,
 			delegation.Amount,
 			delegation.Reward,
 			undelegations,
 		})
 	}
-
 	return result, nil
 }
 


### PR DESCRIPTION
## Issue

Also change hmy_getValidatorInfo => hmy_getValidatorInformation to preserve compatibility as much as possible. Format for hmy_getValidatorInformation has changed. 


// RPCValidator represents a validator
type RPCValidator struct {
	Address            common.Address       `json:"address"`
	SlotPubKeys        []shard.BlsPublicKey `json:"slot_pub_keys"`
	Stake              *big.Int             `json:"stake" yaml:"stake"`
	UnbondingHeight    *big.Int             `json:"unbonding_height"`
	MinSelfDelegation  *big.Int             `json:"min_self_delegation"`
	MaxTotalDelegation *big.Int             `json:"max_total_delegation"`
	Active             bool                 `json:"active"`
	Commission         types2.Commission    `json:"commission"`
	Description        types2.Description   `json:"description"`
	CreationHeight     *big.Int             `json:"creation_height"`
	Uptime             string               `json:"uptime"`
}

// RPCDelegation represents a particular delegation to a validator
type RPCDelegation struct {
	ValidatorAddress common.Address    `json:"validator_address" yaml:"validator_address"`
	DelegatorAddress common.Address    `json:"delegator_address" yaml:"delegator_address"`
	Amount           *big.Int          `json:"amount" yaml:"amount"`
	Reward           *big.Int          `json:"reward" yaml:"reward"`
	Undelegations    []RPCUndelegation `json:"Undelegations" yaml:"Undelegations"`
}

## Test

#### Test Coverage Data

<!-- run 'go test -cover' in the directory you made change -->

* Before
* After

#### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## TODO
