### PR TITLE
[staking] Set RawStake per voter when creating roster

### DIFF
--- a/consensus/votepower/roster.go
+++ b/consensus/votepower/roster.go
@@ -53,11 +53,13 @@ func Compute(staked shard.SlotList) *Roster {
 			IsHarmonyNode:    true,
 			EarningAccount:   staked[i].EcdsaAddress,
 			EffectivePercent: numeric.ZeroDec(),
+			RawStake:         numeric.ZeroDec(),
 		}
 
 		// Real Staker
 		if staked[i].TotalStake != nil {
 			member.IsHarmonyNode = false
+			member.RawStake = member.RawStake.Add(*staked[i].TotalStake)
 			member.EffectivePercent = staked[i].TotalStake.
 				Quo(roster.RawStakedTotal).
 				Mul(StakersShare)


### PR DESCRIPTION
## Issue

RawStake isn't being set for each StakedVoter when creating the Roster.

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**