### PR TITLE
Fix networkinfo context handling

### DIFF
--- a/api/service/networkinfo/service.go
+++ b/api/service/networkinfo/service.go
@@ -189,6 +189,7 @@ func (s *Service) Run() {
 // DoService does network info.
 func (s *Service) DoService() {
 	tick := time.NewTicker(dhtTicker)
+	defer tick.Stop()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	for {

--- a/api/service/networkinfo/service.go
+++ b/api/service/networkinfo/service.go
@@ -43,9 +43,6 @@ type Service struct {
 var (
 	// retry for 30s and give up then
 	ConnectionRetry = 15
-
-	// context
-	ctx context.Context
 )
 
 const (
@@ -65,8 +62,7 @@ func New(
 	h p2p.Host, rendezvous nodeconfig.GroupID, peerChan chan p2p.Peer,
 	bootnodes utils.AddrList, dataStorePath string,
 ) (*Service, error) {
-	var cancel context.CancelFunc
-	ctx, cancel = context.WithTimeout(context.Background(), connectionTimeout)
+	ctx, cancel := context.WithCancel(context.Background())
 	var dhtOpts []libp2pdhtopts.Option
 	if dataStorePath != "" {
 		dataStore, err := badger.NewDatastore(dataStorePath, nil)
@@ -124,6 +120,8 @@ func (s *Service) StartService() {
 
 // Init initializes role conversion service.
 func (s *Service) Init() error {
+	ctx, cancel := context.WithTimeout(context.Background(), connectionTimeout)
+	defer cancel()
 	utils.Logger().Info().Msg("Init networkinfo service")
 
 	// Bootstrap the DHT. In the default configuration, this spawns a Background
@@ -191,6 +189,8 @@ func (s *Service) Run() {
 // DoService does network info.
 func (s *Service) DoService() {
 	tick := time.NewTicker(dhtTicker)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	for {
 		select {
 		case <-s.stopChan:
@@ -208,13 +208,13 @@ func (s *Service) DoService() {
 				return
 			}
 
-			s.findPeers()
+			s.findPeers(ctx)
 			time.Sleep(findPeerInterval)
 		}
 	}
 }
 
-func (s *Service) findPeers() {
+func (s *Service) findPeers(ctx context.Context) {
 	_, cgnPrefix, err := net.ParseCIDR("100.64.0.0/10")
 	if err != nil {
 		utils.Logger().Error().Err(err).Msg("can't parse CIDR")


### PR DESCRIPTION
## Issue

Previously, `networkinfo` used a global context was being used with a 3-minute timeout.  This caused all `networkinfo` discovery/advertisement activities to stop working 3 minutes after the node startup.
    
Fix this by eliminating the global 3-minute context and making its consumers use locally created contexts:
    
* `New` uses a context that does not time out;
* `(*Service).Init` uses a context that times out in 3 minutes;
* `(*Service).DoService`—the service “body”—uses a context that does not time out;
* `(*Service).findPeers` accept a context from its caller, `DoService`.

## Test

### Unit Test Coverage

Before:

```
ok      github.com/harmony-one/harmony/api/service/networkinfo  2.417s  coverage: 25.0% of statements
```

After:

```
ok      github.com/harmony-one/harmony/api/service/networkinfo  2.262s  coverage: 25.0% of statements
```

### Test/Run Logs

Local test still bootstraps and finds peer nodes correctly.

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

2. ~~Describe the migration plan.  For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.~~

3. ~~Describe how the plan was tested.~~

4. ~~How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?~~

5. ~~What are the planned flag epoch numbers and their ETAs on Pangaea?~~

6. ~~What are the planned flag epoch numbers and their ETAs on mainnet?~~

    ~~Note that this must be enough to cover baking period on Pangaea.~~

7. ~~What should node operators know about this planned change?~~

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

9. ~~Does the existing `node.sh` continue to work with this change?~~

10. ~~What should node operators know about this change?~~

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**
