### PR TITLE
Make staking txs optional in blocks

### DIFF
--- a/internal/hmyapi/blockchain.go
+++ b/internal/hmyapi/blockchain.go
@@ -48,6 +48,7 @@ type BlockArgs struct {
 	InclTx      bool     `json:"inclTx"`
 	FullTx      bool     `json:"fullTx"`
 	Signers     []string `json:"signers"`
+	InclStaking bool     `json:"inclStaking"`
 }
 
 // GetBlockByNumber returns the requested block. When blockNr is -1 the chain head is returned. When fullTx is true all
@@ -55,7 +56,7 @@ type BlockArgs struct {
 func (s *PublicBlockChainAPI) GetBlockByNumber(ctx context.Context, blockNr rpc.BlockNumber, fullTx bool) (map[string]interface{}, error) {
 	block, err := s.b.BlockByNumber(ctx, blockNr)
 	if block != nil {
-		blockArgs := BlockArgs{WithSigners: false, InclTx: true, FullTx: fullTx}
+		blockArgs := BlockArgs{WithSigners: false, InclTx: true, FullTx: fullTx, InclStaking: false}
 		response, err := RPCMarshalBlock(block, blockArgs)
 		if err == nil && blockNr == rpc.PendingBlockNumber {
 			// Pending blocks need to nil out a few fields
@@ -73,7 +74,7 @@ func (s *PublicBlockChainAPI) GetBlockByNumber(ctx context.Context, blockNr rpc.
 func (s *PublicBlockChainAPI) GetBlockByHash(ctx context.Context, blockHash common.Hash, fullTx bool) (map[string]interface{}, error) {
 	block, err := s.b.GetBlock(ctx, blockHash)
 	if block != nil {
-		blockArgs := BlockArgs{WithSigners: false, InclTx: true, FullTx: fullTx}
+		blockArgs := BlockArgs{WithSigners: false, InclTx: true, FullTx: fullTx, InclStaking: false}
 		return RPCMarshalBlock(block, blockArgs)
 	}
 	return nil, err

--- a/internal/hmyapi/types.go
+++ b/internal/hmyapi/types.go
@@ -389,14 +389,6 @@ func RPCMarshalBlock(b *types.Block, blockArgs BlockArgs) (map[string]interface{
 				return newRPCTransactionFromBlockHash(b, tx.Hash()), nil
 			}
 		}
-		formatStakingTx := func(tx *types2.StakingTransaction) (interface{}, error) {
-			return tx.Hash(), nil
-		}
-		if blockArgs.FullTx {
-			formatStakingTx = func(tx *types2.StakingTransaction) (interface{}, error) {
-				return newRPCStakingTransactionFromBlockHash(b, tx.Hash()), nil
-			}
-		}
 		txs := b.Transactions()
 		transactions := make([]interface{}, len(txs))
 		var err error
@@ -407,14 +399,24 @@ func RPCMarshalBlock(b *types.Block, blockArgs BlockArgs) (map[string]interface{
 		}
 		fields["transactions"] = transactions
 
-		stakingTxs := b.StakingTransactions()
-		stakingTransactions := make([]interface{}, len(stakingTxs))
-		for i, tx := range stakingTxs {
-			if stakingTransactions[i], err = formatStakingTx(tx); err != nil {
-				return nil, err
+		if blockArgs.InclStaking {	
+			formatStakingTx := func(tx *types2.StakingTransaction) (interface{}, error) {
+				return tx.Hash(), nil
 			}
+			if blockArgs.FullTx {
+				formatStakingTx = func(tx *types2.StakingTransaction) (interface{}, error) {
+					return newRPCStakingTransactionFromBlockHash(b, tx.Hash()), nil
+				}
+			}
+			stakingTxs := b.StakingTransactions()
+			stakingTransactions := make([]interface{}, len(stakingTxs))
+			for i, tx := range stakingTxs {
+				if stakingTransactions[i], err = formatStakingTx(tx); err != nil {
+					return nil, err
+				}
+			}
+			fields["stakingTransactions"] = stakingTransactions
 		}
-		fields["stakingTransactions"] = stakingTransactions
 	}
 
 	uncles := b.Uncles()

--- a/internal/hmyapi/types.go
+++ b/internal/hmyapi/types.go
@@ -399,7 +399,7 @@ func RPCMarshalBlock(b *types.Block, blockArgs BlockArgs) (map[string]interface{
 		}
 		fields["transactions"] = transactions
 
-		if blockArgs.InclStaking {	
+		if blockArgs.InclStaking {
 			formatStakingTx := func(tx *types2.StakingTransaction) (interface{}, error) {
 				return tx.Hash(), nil
 			}


### PR DESCRIPTION
## Issue

Staking txs should be optional at least for now for view in blocks. Also added optional bool param inclStaking to blockArgs to not break hmy_getBlockByHash and hmy_getBlockByNumber. Those will need to have update on block explorer and other sides to support new input with blockArgs and not break anything. For them staking txs not included by default but can be set included by default.

## Test

Localnet, postman.

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**  NO

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?** That there are new staking tx methods.

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO** YES

9. **Does the existing `node.sh` continue to work with this change?** - YES

10. **What should node operators know about this change?** - That there are new staking tx methods.

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?** NO

## TODO
