### PR TITLE
node.sh devnet

### DIFF
--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -653,6 +653,15 @@ do
    fi
 # backward compatible with older harmony node software
    case "${node_type}" in
+   validator)
+      case "${shard_id}" in
+      ?*)
+	 args+=(
+	    -shard_id="${shard_id}"
+	 )
+	 ;;
+      esac
+      ;;
    explorer)
       args+=(
       -node_type="${node_type}"

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -656,10 +656,10 @@ do
    validator)
       case "${shard_id}" in
       ?*)
-	 args+=(
-	    -shard_id="${shard_id}"
-	 )
-	 ;;
+         args+=(
+            -shard_id="${shard_id}"
+         )
+         ;;
       esac
       ;;
    explorer)

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -106,7 +106,7 @@ usage: ${progname} [-1ch] [-k KEYFILE]
    -d             just download the Harmony binaries (default: off)
    -D             do not download Harmony binaries (default: download when start)
    -m             collect and upload node metrics to harmony prometheus + grafana
-   -N network     join the given network (main, beta, pangaea; default: main)
+   -N network     join the given network (main, beta, pangaea, dev; default: main)
    -t             equivalent to -N pangaea (deprecated)
    -T nodetype    specify the node type (validator, explorer; default: validator)
    -i shardid     specify the shard id (valid only with explorer node; default: 1)
@@ -230,6 +230,15 @@ beta|pangaea)
   REL=pangaea
   network_type=testnet
   dns_zone=p.hmny.io
+  ;;
+dev)
+  bootnodes=(
+    /ip4/52.40.84.2/tcp/9870/p2p/QmZJJx6AdaoEkGLrYG4JeLCKeCKDjnFz2wfHNHxAqFSGA9
+    /ip4/54.86.126.90/tcp/9870/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv
+  )
+  REL=devnet
+  network_type=pangaea
+  dns_zone=pga.hmny.io
   ;;
 *)
   err 64 "${network}: invalid network"


### PR DESCRIPTION
## Issue

This enables node.sh to connect to devnet.  It also includes manual override of shard ID, required for the time being when running a staking node with node.sh.

## Test

### Unit Test Coverage

Script-only change, no UT coverage.

### Test/Run Logs

`sudo ./node.sh -k XXXXXXXXXXXXXXXXX.key -N dev -i 1` connects to the devnet shard 1 and starts making consensus.

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 2.)

    NO

2. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    NO

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    NO

## TODO
