### PR TITLE
Add epoch number in shard state for use of beacon epoch sync

### DIFF
--- a/api/proto/node/node.go
+++ b/api/proto/node/node.go
@@ -174,6 +174,9 @@ func ConstructCrossLinkMessage(bc engine.ChainReader, headers []*block.Header) [
 
 	crosslinks := []types.CrossLink{}
 	for _, header := range headers {
+		if header.Number().Uint64() <= 1 || !bc.Config().IsCrossLink(header.Epoch()) {
+			continue
+		}
 		parentHeader := bc.GetHeaderByHash(header.ParentHash())
 		if parentHeader == nil {
 			continue

--- a/api/service/explorer/service.go
+++ b/api/service/explorer/service.go
@@ -269,7 +269,7 @@ func (s *Service) GetExplorerBlocks(w http.ResponseWriter, r *http.Request) {
 			if accountBlocks[id-1] != nil {
 				state, err := accountBlocks[id-1].Header().GetShardState()
 				if err == nil {
-					for _, shardCommittee := range state {
+					for _, shardCommittee := range state.Shards {
 						if shardCommittee.ShardID == accountBlock.ShardID() {
 							committee = &shardCommittee
 							break
@@ -392,7 +392,7 @@ func (s *ServiceAPI) GetExplorerBlocks(ctx context.Context, from, to, page, offs
 			if accountBlocks[id-1] != nil {
 				state, err := accountBlocks[id-1].Header().GetShardState()
 				if err == nil {
-					for _, shardCommittee := range state {
+					for _, shardCommittee := range state.Shards {
 						if shardCommittee.ShardID == accountBlock.ShardID() {
 							committee = &shardCommittee
 							break

--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -114,10 +114,14 @@ type StateSync struct {
 }
 
 func (ss *StateSync) purgeAllBlocksFromCache() {
+	ss.lastMileMux.Lock()
+	ss.lastMileBlocks = nil
+	ss.lastMileMux.Unlock()
+
 	ss.syncMux.Lock()
 	defer ss.syncMux.Unlock()
 	ss.commonBlocks = make(map[int]*types.Block)
-	ss.lastMileBlocks = nil
+
 	ss.syncConfig.ForEachPeer(func(configPeer *SyncPeerConfig) (brk bool) {
 		configPeer.blockHashes = nil
 		configPeer.newBlocks = nil

--- a/block/v0/header.go
+++ b/block/v0/header.go
@@ -418,7 +418,11 @@ func (h *Header) Logger(logger *zerolog.Logger) *zerolog.Logger {
 
 // GetShardState returns the deserialized shard state object.
 func (h *Header) GetShardState() (shard.State, error) {
-	return shard.DecodeWrapper(h.ShardState())
+	state, err := shard.DecodeWrapper(h.ShardState())
+	if err != nil {
+		return shard.State{}, err
+	}
+	return *state, nil
 }
 
 // Copy returns a copy of the given header.

--- a/block/v1/header.go
+++ b/block/v1/header.go
@@ -406,7 +406,11 @@ func (h *Header) Logger(logger *zerolog.Logger) *zerolog.Logger {
 
 // GetShardState returns the deserialized shard state object.
 func (h *Header) GetShardState() (shard.State, error) {
-	return shard.DecodeWrapper(h.ShardState())
+	state, err := shard.DecodeWrapper(h.ShardState())
+	if err != nil {
+		return shard.State{}, err
+	}
+	return *state, nil
 }
 
 // Copy returns a copy of the given header.

--- a/block/v2/header.go
+++ b/block/v2/header.go
@@ -402,7 +402,11 @@ func (h *Header) Logger(logger *zerolog.Logger) *zerolog.Logger {
 
 // GetShardState returns the deserialized shard state object.
 func (h *Header) GetShardState() (shard.State, error) {
-	return shard.DecodeWrapper(h.ShardState())
+	state, err := shard.DecodeWrapper(h.ShardState())
+	if err != nil {
+		return shard.State{}, err
+	}
+	return *state, nil
 }
 
 // Copy returns a copy of the given header.

--- a/block/v3/header.go
+++ b/block/v3/header.go
@@ -406,7 +406,11 @@ func (h *Header) Logger(logger *zerolog.Logger) *zerolog.Logger {
 
 // GetShardState returns the deserialized shard state object.
 func (h *Header) GetShardState() (shard.State, error) {
-	return shard.DecodeWrapper(h.ShardState())
+	state, err := shard.DecodeWrapper(h.ShardState())
+	if err != nil {
+		return shard.State{}, err
+	}
+	return *state, nil
 }
 
 // Copy returns a copy of the given header.

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -215,8 +215,8 @@ func (consensus *Consensus) onAnnounce(msg *msg_pb.Message) {
 	if recvMsg.BlockNum < consensus.blockNum || recvMsg.BlockNum != header.Number().Uint64() {
 		utils.Logger().Debug().
 			Uint64("MsgBlockNum", recvMsg.BlockNum).
-			Uint64("blockNum", consensus.blockNum).
 			Uint64("hdrBlockNum", header.Number().Uint64()).
+			Uint64("consensuBlockNum", consensus.blockNum).
 			Msg("[OnAnnounce] BlockNum does not match")
 		return
 	}
@@ -790,10 +790,11 @@ func (consensus *Consensus) finalizeCommits() {
 	consensus.ChainReader.WriteLastCommits(pbftMsg.Payload)
 
 	// find correct block content
-	block := consensus.FBFTLog.GetBlockByHash(consensus.blockHash)
+	curBlockHash := consensus.blockHash
+	block := consensus.FBFTLog.GetBlockByHash(curBlockHash)
 	if block == nil {
 		utils.Logger().Warn().
-			Str("blockHash", hex.EncodeToString(consensus.blockHash[:])).
+			Str("blockHash", hex.EncodeToString(curBlockHash[:])).
 			Msg("[FinalizeCommits] Cannot find block by hash")
 		return
 	}
@@ -815,7 +816,7 @@ func (consensus *Consensus) finalizeCommits() {
 		utils.Logger().Warn().Err(err).Msg("[Finalizing] Cannot send committed message")
 	} else {
 		utils.Logger().Info().
-			Hex("blockHash", consensus.blockHash[:]).
+			Hex("blockHash", curBlockHash[:]).
 			Uint64("blockNum", consensus.blockNum).
 			Msg("[Finalizing] Sent Committed Message")
 	}

--- a/consensus/engine/consensus_engine.go
+++ b/consensus/engine/consensus_engine.go
@@ -40,7 +40,7 @@ type ChainReader interface {
 	// ReadShardState retrieves sharding state given the epoch number.
 	// This api reads the shard state cached or saved on the chaindb.
 	// Thus, only should be used to read the shard state of the current chain.
-	ReadShardState(epoch *big.Int) (shard.State, error)
+	ReadShardState(epoch *big.Int) (*shard.State, error)
 
 	// ReadActiveValidatorList retrieves the list of active validators
 	ReadActiveValidatorList() ([]common.Address, error)

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -269,7 +269,7 @@ func (cr *fakeChainReader) GetHeaderByNumber(number uint64) *block.Header       
 func (cr *fakeChainReader) GetHeaderByHash(hash common.Hash) *block.Header          { return nil }
 func (cr *fakeChainReader) GetHeader(hash common.Hash, number uint64) *block.Header { return nil }
 func (cr *fakeChainReader) GetBlock(hash common.Hash, number uint64) *types.Block   { return nil }
-func (cr *fakeChainReader) ReadShardState(epoch *big.Int) (shard.State, error)      { return nil, nil }
+func (cr *fakeChainReader) ReadShardState(epoch *big.Int) (*shard.State, error)     { return nil, nil }
 func (cr *fakeChainReader) ReadActiveValidatorList() ([]common.Address, error)      { return nil, nil }
 func (cr *fakeChainReader) ValidatorCandidates() []common.Address                   { return nil }
 func (cr *fakeChainReader) ReadValidatorInformation(addr common.Address) (*staking.ValidatorWrapper, error) {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -29,8 +29,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/ethereum/go-ethereum/rlp"
-
 	blockfactory "github.com/harmony-one/harmony/block/factory"
 	"github.com/harmony-one/harmony/internal/params"
 
@@ -249,7 +247,7 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 		}
 	}
 	root := statedb.IntermediateRoot(false)
-	shardStateBytes, err := rlp.EncodeToBytes(g.ShardState)
+	shardStateBytes, err := shard.EncodeWrapper(g.ShardState, false)
 	if err != nil {
 		utils.Logger().Error().Msg("failed to rlp-serialize genesis shard state")
 		os.Exit(1)

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -417,7 +417,7 @@ func FindCommonAncestor(db DatabaseReader, a, b *block.Header) *block.Header {
 // ReadShardState retrieves sharding state.
 func ReadShardState(
 	db DatabaseReader, epoch *big.Int,
-) (shard.State, error) {
+) (*shard.State, error) {
 	data, err := db.Get(shardStateKey(epoch))
 	if err != nil {
 		return nil, ctxerror.New(MsgNoShardStateFromDB,
@@ -431,20 +431,6 @@ func ReadShardState(
 		).WithCause(err)
 	}
 	return ss, nil
-}
-
-// WriteShardState stores sharding state into database.
-func WriteShardState(
-	db DatabaseWriter, epoch *big.Int,
-	shardState shard.State, isStaking bool,
-) error {
-	data, err := shard.EncodeWrapper(shardState, isStaking)
-	if err != nil {
-		return ctxerror.New("cannot encode sharding state",
-			"epoch", epoch,
-		).WithCause(err)
-	}
-	return WriteShardStateBytes(db, epoch, data)
 }
 
 // WriteShardStateBytes stores sharding state into database.
@@ -767,7 +753,7 @@ func ReadDelegationsByDelegator(db DatabaseReader, delegator common.Address) ([]
 	return addrs, nil
 }
 
-// writeDelegationsByDelegator stores the list of validators delegated by a delegator
+// WriteDelegationsByDelegator stores the list of validators delegated by a delegator
 func WriteDelegationsByDelegator(db DatabaseWriter, delegator common.Address, indices []staking.DelegationIndex) error {
 	bytes, err := rlp.EncodeToBytes(indices)
 	if err != nil {

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -767,14 +767,14 @@ func ReadDelegationsByDelegator(db DatabaseReader, delegator common.Address) ([]
 	return addrs, nil
 }
 
-// WriteDelegationsByDelegator stores the list of validators delegated by a delegator
+// writeDelegationsByDelegator stores the list of validators delegated by a delegator
 func WriteDelegationsByDelegator(db DatabaseWriter, delegator common.Address, indices []staking.DelegationIndex) error {
 	bytes, err := rlp.EncodeToBytes(indices)
 	if err != nil {
-		utils.Logger().Error().Msg("[WriteDelegationsByDelegator] Failed to encode")
+		utils.Logger().Error().Msg("[writeDelegationsByDelegator] Failed to encode")
 	}
 	if err := db.Put(delegatorValidatorListKey(delegator), bytes); err != nil {
-		utils.Logger().Error().Msg("[WriteDelegationsByDelegator] Failed to store to database")
+		utils.Logger().Error().Msg("[writeDelegationsByDelegator] Failed to store to database")
 	}
 	return err
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -419,7 +419,7 @@ func (st *StateTransition) applyEditValidatorTx(editValidator *staking.EditValid
 		return errCommissionRateChangeTooHigh
 	}
 
-	if err := st.state.UpdateStakingInfo(editValidator.ValidatorAddress, wrapper); err != nil {
+	if err := st.state.UpdateStakingInfo(wrapper.Address, wrapper); err != nil {
 		return err
 	}
 	return nil

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -38,7 +38,6 @@ import (
 	v3 "github.com/harmony-one/harmony/block/v3"
 	"github.com/harmony-one/harmony/crypto/hash"
 	"github.com/harmony-one/harmony/internal/utils"
-	"github.com/harmony-one/harmony/shard"
 	staking "github.com/harmony-one/harmony/staking/types"
 	"github.com/harmony-one/taggedrlp"
 	"github.com/pkg/errors"
@@ -591,20 +590,6 @@ func (b *Block) AddVrf(vrf []byte) {
 // AddVdf add vdf into block header
 func (b *Block) AddVdf(vdf []byte) {
 	b.header.SetVdf(vdf)
-}
-
-// AddShardState add shardState into block header
-func (b *Block) AddShardState(shardState shard.State) error {
-	// Make a copy because State.Hash() internally sorts entries.
-	// Store the sorted copy.
-	shardState = append(shardState[:0:0], shardState...)
-	b.header.SetShardStateHash(shardState.Hash())
-	data, err := rlp.EncodeToBytes(shardState)
-	if err != nil {
-		return err
-	}
-	b.header.SetShardState(data)
-	return nil
 }
 
 // Logger returns a sub-logger with block contexts added.

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -247,7 +247,7 @@ func (b *APIBackend) GetValidators(epoch *big.Int) (*shard.Committee, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, committee := range state {
+	for _, committee := range state.Shards {
 		if committee.ShardID == b.GetShardID() {
 			return &committee, nil
 		}
@@ -364,10 +364,6 @@ func (b *APIBackend) GetValidatorSelfDelegation(addr common.Address) *big.Int {
 }
 
 // GetShardState ...
-func (b *APIBackend) GetShardState() (shard.State, error) {
-	state, err := b.hmy.BlockChain().ReadShardState(b.hmy.BlockChain().CurrentHeader().Epoch())
-	if err != nil {
-		return nil, err
-	}
-	return state, nil
+func (b *APIBackend) GetShardState() (*shard.State, error) {
+	return b.hmy.BlockChain().ReadShardState(b.hmy.BlockChain().CurrentHeader().Epoch())
 }

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -235,7 +235,7 @@ func (e *engineImpl) Finalize(
 func QuorumForBlock(
 	chain engine.ChainReader, h *block.Header, reCalculate bool,
 ) (quorum int, err error) {
-	var ss shard.State
+	ss := new(shard.State)
 	if reCalculate {
 		ss, _ = committee.WithStakingEnabled.Compute(h.Epoch(), chain)
 	} else {
@@ -297,7 +297,7 @@ func (e *engineImpl) VerifyHeaderWithSignature(chain engine.ChainReader, header 
 
 // GetPublicKeys finds the public keys of the committee that signed the block header
 func GetPublicKeys(chain engine.ChainReader, header *block.Header, reCalculate bool) ([]*bls.PublicKey, error) {
-	var shardState shard.State
+	shardState := new(shard.State)
 	var err error
 	if reCalculate {
 		shardState, _ = committee.WithStakingEnabled.Compute(header.Epoch(), chain)

--- a/internal/chain/reward.go
+++ b/internal/chain/reward.go
@@ -4,8 +4,6 @@ import (
 	"math/big"
 	"sort"
 
-	"github.com/harmony-one/harmony/shard/committee"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/harmony-one/bls/ffi/go/bls"
@@ -258,9 +256,6 @@ func AccumulateRewards(
 			for i := range crossLinks {
 				cxLink := crossLinks[i]
 				shardState, err := bc.ReadShardState(cxLink.Epoch())
-				if !bc.Config().IsStaking(cxLink.Epoch()) {
-					shardState, err = committee.WithStakingEnabled.Compute(cxLink.Epoch(), bc)
-				}
 
 				if err != nil {
 					return err

--- a/internal/hmyapi/backend.go
+++ b/internal/hmyapi/backend.go
@@ -80,7 +80,7 @@ type Backend interface {
 	GetDelegationsByValidator(validator common.Address) []*staking.Delegation
 	GetDelegationsByDelegator(delegator common.Address) ([]common.Address, []*staking.Delegation)
 	GetValidatorSelfDelegation(addr common.Address) *big.Int
-	GetShardState() (shard.State, error)
+	GetShardState() (*shard.State, error)
 }
 
 // GetAPIs returns all the APIs.

--- a/internal/hmyapi/blockchain.go
+++ b/internal/hmyapi/blockchain.go
@@ -523,7 +523,7 @@ func (s *PublicBlockChainAPI) GetValidatorInformation(ctx context.Context, addre
 	if err == nil {
 		blsKeyToShardID := make(map[shard.BlsPublicKey]uint32)
 
-		for _, committee := range shardState {
+		for _, committee := range shardState.Shards {
 			for _, slot := range committee.Slots {
 				blsKeyToShardID[slot.BlsPublicKey] = committee.ShardID
 			}

--- a/node/node_cross_shard.go
+++ b/node/node_cross_shard.go
@@ -167,16 +167,10 @@ func (node *Node) ProcessCrossLinkMessage(msgPayload []byte) {
 
 			if err = node.VerifyCrossLink(cl); err != nil {
 				utils.Logger().Debug().
-					Msgf("[ProcessingCrossLink] Crosslink blockNum %d epochNum %d shard %d skipped: %v", cl.BlockNum(), cl.Epoch().Uint64(), cl.ShardID(), cl)
+					Msgf("[ProcessingCrossLink] Failed to verify new cross link for blockNum %d epochNum %d shard %d skipped: %v", cl.BlockNum(), cl.Epoch().Uint64(), cl.ShardID(), cl)
 				continue
 			}
 
-			if err != nil {
-				utils.Logger().Error().
-					Err(err).
-					Msgf("[ProcessingCrossLink] Failed to verify new cross link for shardID %d, blockNum %d", cl.ShardID(), cl.Number())
-				continue
-			}
 			candidates = append(candidates, cl)
 			utils.Logger().Debug().
 				Msgf("[ProcessingCrossLink] committing for shardID %d, blockNum %d", cl.ShardID(), cl.Number().Uint64())

--- a/node/node_explorer.go
+++ b/node/node_explorer.go
@@ -192,7 +192,7 @@ func (node *Node) CommitCommittee() {
 			utils.Logger().Error().Err(err).Msg("[Explorer] Error reading shard state")
 			continue
 		}
-		for _, committee := range state {
+		for _, committee := range state.Shards {
 			if committee.ShardID == curBlock.ShardID() {
 				utils.Logger().Debug().Msg("[Explorer] Dumping committee")
 				err := explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port, false).DumpCommittee(curBlock.ShardID(), curBlock.Epoch().Uint64(), committee)

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -346,7 +346,7 @@ func (node *Node) PostConsensusProcessing(newBlock *types.Block, commitSigAndBit
 		if node.NodeConfig.ShardID == 0 {
 			node.BroadcastNewBlock(newBlock)
 		}
-		if node.NodeConfig.ShardID != shard.BeaconChainShardID && newBlock.Epoch().Cmp(node.Blockchain().Config().CrossLinkEpoch) >= 0 {
+		if node.NodeConfig.ShardID != shard.BeaconChainShardID && node.Blockchain().Config().IsCrossLink(newBlock.Epoch()) {
 			node.BroadcastCrossLink(newBlock)
 		}
 		node.BroadcastCXReceipts(newBlock, commitSigAndBitmap)

--- a/node/node_resharding.go
+++ b/node/node_resharding.go
@@ -69,7 +69,7 @@ func findRoleInShardState(
 	key *bls.PublicKey, state shard.State,
 ) (shardID uint32, isLeader bool) {
 	keyBytes := key.Serialize()
-	for idx, shard := range state {
+	for idx, shard := range state.Shards {
 		for nodeIdx, nodeID := range shard.Slots {
 			if bytes.Compare(nodeID.BlsPublicKey[:], keyBytes) == 0 {
 				return uint32(idx), nodeIdx == 0

--- a/node/worker/worker.go
+++ b/node/worker/worker.go
@@ -262,10 +262,15 @@ func (w *Worker) GetNewEpoch() *big.Int {
 	parent := w.chain.CurrentBlock()
 	epoch := new(big.Int).Set(parent.Header().Epoch())
 
-	// TODO: Don't depend on sharding state for epoch change.
-	if len(parent.Header().ShardState()) > 0 && parent.NumberU64() != 0 {
-		// ... except if parent has a resharding assignment it increases by 1.
-		epoch = epoch.Add(epoch, common.Big1)
+	shardState, err := parent.Header().GetShardState()
+	if err == nil && shardState.Epoch != nil {
+		// For shard state of staking epochs, the shard state will have an epoch and it will decide the next epoch for following blocks
+		epoch = new(big.Int).Set(shardState.Epoch)
+	} else {
+		if len(parent.Header().ShardState()) > 0 && parent.NumberU64() != 0 {
+			// if parent has proposed a new shard state it increases by 1, except for genesis block.
+			epoch = epoch.Add(epoch, common.Big1)
+		}
 	}
 	return epoch
 }
@@ -315,15 +320,11 @@ func (w *Worker) SuperCommitteeForNextEpoch(
 					beaconEpoch, beacon,
 				)
 
-				// Set this block's epoch to be beaconEpoch - 1, so the next block will have beaconEpoch
-				// This shouldn't be exactly beaconEpoch because the next block will have beaconEpoch + 1
-				blockEpoch := big.NewInt(0).Set(beaconEpoch).Sub(beaconEpoch, big.NewInt(1))
 				utils.Logger().Debug().
 					Uint64("blockNum", w.current.header.Number().Uint64()).
-					Uint64("myPrevEpoch", w.current.header.Epoch().Uint64()).
-					Uint64("myCurEpoch", blockEpoch.Uint64()).
+					Uint64("myCurEpoch", w.current.header.Epoch().Uint64()).
+					Uint64("beaconEpoch", beaconEpoch.Uint64()).
 					Msg("Propose new epoch as beacon chain's epoch")
-				w.current.header.SetEpoch(blockEpoch)
 			case 0:
 				// If it's same epoch, no need to propose new shard state (new epoch change)
 			case -1:
@@ -337,20 +338,17 @@ func (w *Worker) SuperCommitteeForNextEpoch(
 					beaconEpoch, beacon,
 				)
 
-				blockEpoch := big.NewInt(0).Set(beaconEpoch).Sub(beaconEpoch, big.NewInt(1))
 				utils.Logger().Debug().
 					Uint64("blockNum", w.current.header.Number().Uint64()).
-					Uint64("myPrevEpoch", w.current.header.Epoch().Uint64()).
-					Uint64("myCurEpoch", blockEpoch.Uint64()).
-					Msg("Propose one-time catch up with beacon chain's epoch")
-				// Set this block's epoch to be beaconEpoch - 1, so the next block will have beaconEpoch
-				w.current.header.SetEpoch(blockEpoch)
+					Uint64("myCurEpoch", w.current.header.Epoch().Uint64()).
+					Uint64("beaconEpoch", beaconEpoch.Uint64()).
+					Msg("Propose entering staking along with beacon chain's epoch")
 			} else {
 				// If I are not in staking nor has beacon chain proposed a staking-based shard state,
 				// do pre-staking committee calculation
 				if shard.Schedule.IsLastBlock(w.current.header.Number().Uint64()) {
 					nextCommittee, err = committee.WithStakingEnabled.Compute(
-						new(big.Int).Add(w.current.header.Epoch(), common.Big1),
+						nextEpoch,
 						w.chain,
 					)
 				}

--- a/shard/committee/assignment.go
+++ b/shard/committee/assignment.go
@@ -19,8 +19,8 @@ import (
 type ValidatorListProvider interface {
 	Compute(
 		epoch *big.Int, reader DataProvider,
-	) (shard.State, error)
-	ReadFromDB(epoch *big.Int, reader DataProvider) (shard.State, error)
+	) (*shard.State, error)
+	ReadFromDB(epoch *big.Int, reader DataProvider) (*shard.State, error)
 	GetCommitteePublicKeys(committee *shard.Committee) []*bls.PublicKey
 }
 
@@ -41,7 +41,7 @@ type ChainReader interface {
 	// ReadShardState retrieves sharding state given the epoch number.
 	// This api reads the shard state cached or saved on the chaindb.
 	// Thus, only should be used to read the shard state of the current chain.
-	ReadShardState(epoch *big.Int) (shard.State, error)
+	ReadShardState(epoch *big.Int) (*shard.State, error)
 	// GetHeader retrieves a block header from the database by hash and number.
 	GetHeaderByHash(common.Hash) *block.Header
 	// Config retrieves the blockchain's chain configuration.
@@ -61,13 +61,13 @@ var (
 	WithStakingEnabled Reader = partialStakingEnabled{}
 )
 
-func preStakingEnabledCommittee(s shardingconfig.Instance) shard.State {
+func preStakingEnabledCommittee(s shardingconfig.Instance) *shard.State {
 	shardNum := int(s.NumShards())
 	shardHarmonyNodes := s.NumHarmonyOperatedNodesPerShard()
 	shardSize := s.NumNodesPerShard()
 	hmyAccounts := s.HmyAccounts()
 	fnAccounts := s.FnAccounts()
-	shardState := shard.State{}
+	shardState := &shard.State{}
 	// Shard state needs to be sorted by shard ID
 	for i := 0; i < shardNum; i++ {
 		com := shard.Committee{ShardID: uint32(i)}
@@ -100,14 +100,14 @@ func preStakingEnabledCommittee(s shardingconfig.Instance) shard.State {
 			}
 			com.Slots = append(com.Slots, curNodeID)
 		}
-		shardState = append(shardState, com)
+		shardState.Shards = append(shardState.Shards, com)
 	}
 	return shardState
 }
 
 func eposStakedCommittee(
 	s shardingconfig.Instance, stakerReader DataProvider, stakedSlotsCount int,
-) (shard.State, error) {
+) (*shard.State, error) {
 	// TODO Nervous about this because overtime the list will become quite large
 	candidates := stakerReader.ValidatorCandidates()
 	essentials := map[common.Address]effective.SlotOrder{}
@@ -134,21 +134,23 @@ func eposStakedCommittee(
 	}
 
 	shardCount := int(s.NumShards())
-	superComm := make(shard.State, shardCount)
+
+	shardState := &shard.State{}
+	shardState.Shards = make([]shard.Committee, shardCount)
 	hAccounts := s.HmyAccounts()
 
 	// Shard state needs to be sorted by shard ID
 	for i := 0; i < shardCount; i++ {
-		superComm[i] = shard.Committee{uint32(i), shard.SlotList{}}
+		shardState.Shards[i] = shard.Committee{uint32(i), shard.SlotList{}}
 	}
 
 	for i := range hAccounts {
-		spot := i % shardCount
+		shardID := i % shardCount
 		pub := &bls.PublicKey{}
 		pub.DeserializeHexStr(hAccounts[i].BlsPublicKey)
 		pubKey := shard.BlsPublicKey{}
 		pubKey.FromLibBLSPublicKey(pub)
-		superComm[spot].Slots = append(superComm[spot].Slots, shard.Slot{
+		shardState.Shards[shardID].Slots = append(shardState.Shards[shardID].Slots, shard.Slot{
 			common2.ParseAddr(hAccounts[i].Address),
 			pubKey,
 			nil,
@@ -158,7 +160,7 @@ func eposStakedCommittee(
 	if stakedSlotsCount == 0 {
 		utils.Logger().Info().Int("slots-for-epos", stakedSlotsCount).
 			Msg("committe composed only of harmony node")
-		return superComm, nil
+		return shardState, nil
 	}
 
 	staked := effective.Apply(essentials, stakedSlotsCount)
@@ -170,9 +172,9 @@ func eposStakedCommittee(
 	}
 
 	for i := 0; i < stakedSlotsCount; i++ {
-		bucket := int(new(big.Int).Mod(staked[i].BlsPublicKey.Big(), shardBig).Int64())
+		shardID := int(new(big.Int).Mod(staked[i].BlsPublicKey.Big(), shardBig).Int64())
 		slot := staked[i]
-		superComm[bucket].Slots = append(superComm[bucket].Slots, shard.Slot{
+		shardState.Shards[shardID].Slots = append(shardState.Shards[shardID].Slots, shard.Slot{
 			slot.Address,
 			staked[i].BlsPublicKey,
 			&slot.Dec,
@@ -180,10 +182,10 @@ func eposStakedCommittee(
 	}
 	if c := len(candidates); c != 0 {
 		utils.Logger().Info().Int("staked-candidates", c).
-			RawJSON("staked-super-committee", []byte(superComm.JSON())).
+			RawJSON("staked-super-committee", []byte(shardState.JSON())).
 			Msg("EPoS based super-committe")
 	}
-	return superComm, nil
+	return shardState, nil
 }
 
 // GetCommitteePublicKeys returns the public keys of a shard
@@ -201,14 +203,14 @@ func (def partialStakingEnabled) GetCommitteePublicKeys(committee *shard.Committ
 
 func (def partialStakingEnabled) ReadFromDB(
 	epoch *big.Int, reader DataProvider,
-) (newSuperComm shard.State, err error) {
+) (newSuperComm *shard.State, err error) {
 	return reader.ReadShardState(epoch)
 }
 
 // ReadFromComputation is single entry point for reading the State of the network
 func (def partialStakingEnabled) Compute(
 	epoch *big.Int, stakerReader DataProvider,
-) (newSuperComm shard.State, err error) {
+) (newSuperComm *shard.State, err error) {
 	preStaking := true
 	if stakerReader != nil {
 		config := stakerReader.Config()

--- a/shard/shard_state.go
+++ b/shard/shard_state.go
@@ -96,6 +96,7 @@ func DecodeWrapper(shardState []byte) (*State, error) {
 				})
 			}
 		}
+		newSS.Epoch = nil // Make sure for legacy state, the epoch is nil
 		return &newSS, nil
 	}
 	return nil, err2

--- a/shard/shard_state_test.go
+++ b/shard/shard_state_test.go
@@ -73,7 +73,7 @@ func TestHash(t *testing.T) {
 			{common.Address{0x66}, blsPubKey6, nil},
 		},
 	}
-	shardState1 := State{com1, com2}
+	shardState1 := State{nil, []Committee{com1, com2}}
 	h1 := shardState1.Hash()
 
 	com3 := Committee{
@@ -93,7 +93,7 @@ func TestHash(t *testing.T) {
 		},
 	}
 
-	shardState2 := State{com3, com4}
+	shardState2 := State{nil, []Committee{com3, com4}}
 	h2 := shardState2.Hash()
 
 	if bytes.Compare(h1[:], h2[:]) != 0 {
@@ -120,7 +120,7 @@ func TestCompatibilityOldShardStateIntoNew(t *testing.T) {
 		}},
 	}
 
-	postStakingState := State{
+	postStakingState := State{nil, []Committee{
 		Committee{ShardID: 0, Slots: SlotList{
 			Slot{junkA, blsPubKey1, nil},
 			Slot{junkA, blsPubKey2, nil},
@@ -134,7 +134,7 @@ func TestCompatibilityOldShardStateIntoNew(t *testing.T) {
 			Slot{junkA, blsPubKey4, nil},
 			Slot{junkA, blsPubKey5, &stake2},
 		}},
-	}
+	}}
 
 	preStakingStateBytes, _ := rlp.EncodeToBytes(preStakingState)
 	postStakingStateBytes, _ := rlp.EncodeToBytes(postStakingState)

--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -271,19 +271,6 @@ func UpdateValidatorFromEditMsg(validator *Validator, edit *EditValidator) error
 		validator.MaxTotalDelegation = edit.MaxTotalDelegation
 	}
 
-	if edit.SlotKeyToAdd != nil {
-		found := false
-		for _, key := range validator.SlotPubKeys {
-			if key == *edit.SlotKeyToAdd {
-				found = true
-				break
-			}
-		}
-		if !found {
-			validator.SlotPubKeys = append(validator.SlotPubKeys, *edit.SlotKeyToAdd)
-		}
-	}
-
 	if edit.SlotKeyToRemove != nil {
 		index := -1
 		for i, key := range validator.SlotPubKeys {
@@ -295,6 +282,19 @@ func UpdateValidatorFromEditMsg(validator *Validator, edit *EditValidator) error
 		// we found key to be removed
 		if index >= 0 {
 			validator.SlotPubKeys = append(validator.SlotPubKeys[:index], validator.SlotPubKeys[index+1:]...)
+		}
+	}
+
+	if edit.SlotKeyToAdd != nil {
+		found := false
+		for _, key := range validator.SlotPubKeys {
+			if key == *edit.SlotKeyToAdd {
+				found = true
+				break
+			}
+		}
+		if !found {
+			validator.SlotPubKeys = append(validator.SlotPubKeys, *edit.SlotKeyToAdd)
 		}
 	}
 	return nil


### PR DESCRIPTION
Add epoch number in the new shard state. It's necessary because with beacon epoch sync, we have to mark explicitly which epoch the new shard state is for.

Also fix cross link block proposal conditions.

Tested locally, will deploy to devnet.