### PR TITLE
[unit-testing] Finish one-node-staked-vote tests

### DIFF
--- a/consensus/quorum/one-node-staked-vote_test.go
+++ b/consensus/quorum/one-node-staked-vote_test.go
@@ -3,23 +3,21 @@ package quorum
 import (
 	"math/big"
 	"math/rand"
+	"strconv"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/bls/ffi/go/bls"
-	"github.com/harmony-one/harmony/consensus/votepower"
 	"github.com/harmony-one/harmony/numeric"
 	"github.com/harmony-one/harmony/shard"
 )
 
 var (
-	secretKeyMap  map[shard.BlsPublicKey]bls.SecretKey
-	slotList      shard.SlotList
-	roster        *votepower.Roster
-	stakedVote    Decider
-	result        *TallyResult
-	harmonyNodes  = 33
-	stakedNodes   = 33
+	quorumNodes   = 100
+	msg           = "Testing"
+	hmy           = "Harmony"
+	reg           = "Stakers"
+	basicDecider  Decider
 	maxAccountGen = int64(98765654323123134)
 	accountGen    = rand.New(rand.NewSource(1337))
 	maxKeyGen     = int64(98765654323123134)
@@ -28,29 +26,10 @@ var (
 	stakeGen      = rand.New(rand.NewSource(541))
 )
 
+type secretKeyMap map[shard.BlsPublicKey]bls.SecretKey
+
 func init() {
-	slotList = shard.SlotList{}
-	secretKeyMap = make(map[shard.BlsPublicKey]bls.SecretKey)
-	for i := 0; i < harmonyNodes; i++ {
-		newSlot, sKey := generateRandomSlot()
-		newSlot.TotalStake = nil
-		slotList = append(slotList, newSlot)
-		secretKeyMap[newSlot.BlsPublicKey] = sKey
-	}
-
-	for j := 0; j < stakedNodes; j++ {
-		newSlot, sKey := generateRandomSlot()
-		slotList = append(slotList, newSlot)
-		secretKeyMap[newSlot.BlsPublicKey] = sKey
-	}
-
-	stakedVote = NewDecider(SuperMajorityStake)
-	stakedVote.SetShardIDProvider(func() (uint32, error) { return 0, nil })
-	r, err := stakedVote.SetVoters(slotList)
-	if err != nil {
-		panic("Unable to SetVoters")
-	}
-	result = r
+	basicDecider = NewDecider(SuperMajorityStake)
 }
 
 func generateRandomSlot() (shard.Slot, bls.SecretKey) {
@@ -64,39 +43,188 @@ func generateRandomSlot() (shard.Slot, bls.SecretKey) {
 	return shard.Slot{addr, key, &stake}, secretKey
 }
 
-func Test33(t *testing.T) {
-	sum := result.ourPercent.Add(result.theirPercent)
-	if !sum.Equal(numeric.OneDec()) {
-		t.Errorf("Total voting power does not equal 1. Harmony voting power: %s, Staked voting power: %s, Sum: %s",
-			result.ourPercent, result.theirPercent, sum)
+// 50 Harmony Nodes, 50 Staked Nodes
+func setupBaseCase() (Decider, *TallyResult, shard.SlotList, map[string]secretKeyMap) {
+	slotList := shard.SlotList{}
+	sKeys := make(map[string]secretKeyMap)
+	sKeys[hmy] = make(secretKeyMap)
+	sKeys[reg] = make(secretKeyMap)
+	pubKeys := []*bls.PublicKey{}
+
+	for i := 0; i < quorumNodes; i++ {
+		newSlot, sKey := generateRandomSlot()
+		if i < 50 {
+			newSlot.TotalStake = nil
+			sKeys[hmy][newSlot.BlsPublicKey] = sKey
+		} else {
+			sKeys[reg][newSlot.BlsPublicKey] = sKey
+		}
+		slotList = append(slotList, newSlot)
+		pubKeys = append(pubKeys, sKey.GetPublicKey())
+	}
+
+	decider := NewDecider(SuperMajorityStake)
+	decider.SetShardIDProvider(func() (uint32, error) { return 0, nil })
+	decider.UpdateParticipants(pubKeys)
+	tally, err := decider.SetVoters(slotList)
+	if err != nil {
+		panic("Unable to SetVoters for Base Case")
+	}
+	return decider, tally, slotList, sKeys
+}
+
+// 33 Harmony Nodes, 67 Staked Nodes
+func setupEdgeCase() (Decider, *TallyResult, shard.SlotList, secretKeyMap) {
+	slotList := shard.SlotList{}
+	sKeys := make(secretKeyMap)
+	pubKeys := []*bls.PublicKey{}
+
+	for i := 0; i < quorumNodes; i++ {
+		newSlot, sKey := generateRandomSlot()
+		if i < 33 {
+			newSlot.TotalStake = nil
+			sKeys[newSlot.BlsPublicKey] = sKey
+		}
+		slotList = append(slotList, newSlot)
+		pubKeys = append(pubKeys, sKey.GetPublicKey())
+	}
+
+	decider := NewDecider(SuperMajorityStake)
+	decider.SetShardIDProvider(func() (uint32, error) { return 0, nil })
+	decider.UpdateParticipants(pubKeys)
+	tally, err := decider.SetVoters(slotList)
+	if err != nil {
+		panic("Unable to SetVoters for Edge Case")
+	}
+	return decider, tally, slotList, sKeys
+}
+
+func sign(d Decider, k secretKeyMap, p Phase) {
+	for _, v := range k {
+		pubKey := v.GetPublicKey()
+		sig := v.Sign(msg)
+		d.AddSignature(p, pubKey, sig)
 	}
 }
 
 func TestPolicy(t *testing.T) {
 	expectedPolicy := SuperMajorityStake
-	policy := stakedVote.Policy()
+	policy := basicDecider.Policy()
 	if expectedPolicy != policy {
 		t.Errorf("Expected: %s, Got: %s", expectedPolicy.String(), policy.String())
 	}
 }
 
-func TestIsQuorumAchieved(t *testing.T) {
-	//
-}
-
 func TestQuorumThreshold(t *testing.T) {
 	expectedThreshold := numeric.NewDec(2).Quo(numeric.NewDec(3))
-	quorumThreshold := stakedVote.QuorumThreshold()
+	quorumThreshold := basicDecider.QuorumThreshold()
 	if !expectedThreshold.Equal(quorumThreshold) {
 		t.Errorf("Expected: %s, Got: %s", expectedThreshold.String(), quorumThreshold.String())
 	}
 }
 
-func TestIsRewardThresholdAchieved(t *testing.T) {
-	//
+func TestEvenNodes(t *testing.T) {
+	stakedVote, result, _, sKeys := setupBaseCase()
+	// Check HarmonyPercent + StakePercent == 1
+	sum := result.ourPercent.Add(result.theirPercent)
+	if !sum.Equal(numeric.OneDec()) {
+		t.Errorf("Total voting power does not equal 1. Harmony voting power: %s, Staked voting power: %s, Sum: %s",
+			result.ourPercent, result.theirPercent, sum)
+		t.FailNow()
+	}
+	// Sign all Staker nodes
+	// Prepare
+	sign(stakedVote, sKeys[reg], Prepare)
+	achieved := stakedVote.IsQuorumAchieved(Prepare)
+	if achieved {
+		t.Errorf("[IsQuorumAchieved] Phase: %s, QuorumAchieved: %s, Expected: false (All Staker nodes = 32%%)",
+			Prepare, strconv.FormatBool(achieved))
+	}
+	// Commit
+	sign(stakedVote, sKeys[reg], Commit)
+	achieved = stakedVote.IsQuorumAchieved(Commit)
+	if achieved {
+		t.Errorf("[IsQuorumAchieved] Phase: %s, QuorumAchieved: %s, Expected: false (All Staker nodes = 32%%)",
+			Commit, strconv.FormatBool(achieved))
+	}
+	// ViewChange
+	sign(stakedVote, sKeys[reg], ViewChange)
+	achieved = stakedVote.IsQuorumAchieved(ViewChange)
+	if achieved {
+		t.Errorf("[IsQuorumAchieved] Phase: %s, Got: %s, Expected: false (All Staker nodes = 32%%)",
+			ViewChange, strconv.FormatBool(achieved))
+	}
+	// RewardThreshold
+	rewarded := stakedVote.IsRewardThresholdAchieved()
+	if rewarded {
+		t.Errorf("[IsRewardThresholdAchieved] Got: %s, Expected: false (All Staker nodes = 32%%)",
+			strconv.FormatBool(rewarded))
+	}
+
+	// Sign all Harmony Nodes
+	sign(stakedVote, sKeys[hmy], Prepare)
+	achieved = stakedVote.IsQuorumAchieved(Prepare)
+	if !achieved {
+		t.Errorf("[IsQuorumAchieved] Phase: %s, QuorumAchieved: %s, Expected: true (All nodes = 100%%)",
+			Prepare, strconv.FormatBool(achieved))
+	}
+	// Commit
+	sign(stakedVote, sKeys[hmy], Commit)
+	achieved = stakedVote.IsQuorumAchieved(Commit)
+	if !achieved {
+		t.Errorf("[IsQuorumAchieved] Phase: %s, QuorumAchieved: %s, Expected: true (All nodes = 100%%)",
+			Commit, strconv.FormatBool(achieved))
+	}
+	// ViewChange
+	sign(stakedVote, sKeys[hmy], ViewChange)
+	achieved = stakedVote.IsQuorumAchieved(ViewChange)
+	if !achieved {
+		t.Errorf("[IsQuorumAchieved] Phase: %s, Got: %s, Expected: true (All nodes = 100%%)",
+			ViewChange, strconv.FormatBool(achieved))
+	}
+	// RewardThreshold
+	rewarded = stakedVote.IsRewardThresholdAchieved()
+	if !rewarded {
+		t.Errorf("[IsRewardThresholdAchieved] Got: %s, Expected: true (All nodes = 100%%)",
+			strconv.FormatBool(rewarded))
+	}
 }
 
-// ????
-func TestShouldSlash(t *testing.T) {
-	//
+func Test33HarmonyNodes(t *testing.T) {
+	stakedVote, result, _, sKeys := setupEdgeCase()
+	// Check HarmonyPercent + StakePercent == 1
+	sum := result.ourPercent.Add(result.theirPercent)
+	if !sum.Equal(numeric.OneDec()) {
+		t.Errorf("Total voting power does not equal 1. Harmony voting power: %s, Staked voting power: %s, Sum: %s",
+			result.ourPercent, result.theirPercent, sum)
+		t.FailNow()
+	}
+	// Sign all Harmony Nodes, 0 Staker Nodes
+	// Prepare
+	sign(stakedVote, sKeys, Prepare)
+	achieved := stakedVote.IsQuorumAchieved(Prepare)
+	if !achieved {
+		t.Errorf("[IsQuorumAchieved] Phase: %s, QuorumAchieved: %s, Expected: true (All Harmony nodes = 68%%)",
+			Prepare, strconv.FormatBool(achieved))
+	}
+	// Commit
+	sign(stakedVote, sKeys, Commit)
+	achieved = stakedVote.IsQuorumAchieved(Commit)
+	if !achieved {
+		t.Errorf("[IsQuorumAchieved] Phase: %s, QuorumAchieved: %s, Expected: true (All Harmony nodes = 68%%)",
+			Commit, strconv.FormatBool(achieved))
+	}
+	// ViewChange
+	sign(stakedVote, sKeys, ViewChange)
+	achieved = stakedVote.IsQuorumAchieved(ViewChange)
+	if !achieved {
+		t.Errorf("[IsQuorumAchieved] Phase: %s, Got: %s, Expected: true (All Harmony nodes = 68%%)",
+			ViewChange, strconv.FormatBool(achieved))
+	}
+	// RewardThreshold
+	rewarded := stakedVote.IsRewardThresholdAchieved()
+	if rewarded {
+		t.Errorf("[IsRewardThresholdAchieved] Got: %s, Expected: false (All Harmony nodes = 68%%)",
+			strconv.FormatBool(rewarded))
+	}
 }


### PR DESCRIPTION
* Generate Decider for base case of 50/50 nodes
* Add Quorum Achieved tests for all Staker nodes & all nodes signed
* Add QuorumAchieved tests for all Harmony nodes signed
* Add RewardThreshold tests for all above cases

## Issue

#1860 

## Test

### Unit Test Coverage

```
$ go test -v -count=1 github.com/harmony-one/harmony/consensus/quorum/...
=== RUN   TestPolicy
--- PASS: TestPolicy (0.00s)
=== RUN   TestQuorumThreshold
--- PASS: TestQuorumThreshold (0.00s)
=== RUN   TestEvenNodes
--- PASS: TestEvenNodes (0.19s)
=== RUN   Test33HarmonyNodes
--- PASS: Test33HarmonyNodes (0.08s)
PASS
ok  	github.com/harmony-one/harmony/consensus/quorum	0.320s
```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**

## TODO