### PR TITLE
[unit-testing] Add test for schedule.go

### DIFF
--- a/consensus/reward/schedule.go
+++ b/consensus/reward/schedule.go
@@ -96,7 +96,7 @@ var (
 		mustParse("2025-Feb-28"): numeric.MustNewDecFromStr("0.9941"),
 		mustParse("2025-Mar-31"): numeric.MustNewDecFromStr("0.9961"),
 		mustParse("2025-Apr-30"): numeric.MustNewDecFromStr("0.9980"),
-		mustParse("2025-May-30"): numeric.MustNewDecFromStr("1.0000"),
+		mustParse("2025-May-31"): numeric.MustNewDecFromStr("1.0000"),
 	}
 	sorted = func() []pair {
 		s := []pair{}
@@ -126,8 +126,12 @@ func PercentageForTimeStamp(ts int64) numeric.Dec {
 	i, j := 0, 1
 
 	for range sorted {
-		if i == len(sorted) {
-			bucket = sorted[i-1]
+		if i == (len(sorted) - 1) {
+			if ts < sorted[0].ts {
+				bucket = sorted[0]
+			} else {
+				bucket = sorted[i]
+			}
 			break
 		}
 		if ts >= sorted[i].ts && ts < sorted[j].ts {

--- a/consensus/reward/schedule_test.go
+++ b/consensus/reward/schedule_test.go
@@ -1,0 +1,31 @@
+package reward
+
+import (
+	"testing"
+
+	"github.com/harmony-one/harmony/numeric"
+)
+
+func TestPercentageForTimeStamp(t *testing.T) {
+	testCases := []struct {
+		time     string
+		expected string
+	}{
+		{"2019-Jan-01", "0.2429"},
+		{"2019-May-31", "0.2429"},
+		{"2021-Nov-30", "0.8561"},
+		{"2023-Apr-29", "0.9488"},
+		{"2023-Apr-30", "0.9507"},
+		{"2025-May-31", "1.0000"},
+		{"2026-Jan-01", "1.0000"},
+	}
+
+	for _, tc := range testCases {
+		result := PercentageForTimeStamp(mustParse(tc.time))
+		expect := numeric.MustNewDecFromStr(tc.expected)
+		if !result.Equal(expect) {
+			t.Errorf("Time: %s, Chosen bucket percent: %s, Expected: %s",
+				tc.time, result, expect)
+		}
+	}
+}


### PR DESCRIPTION
* Fix wrong date in release schedule map
* Fix panic when PercentageForTimeStamp receives time before first bucket & time after last bucket

## Issue

#1860 

## Test

### Unit Test Coverage
```
$ go test -v -count=1 github.com/harmony-one/harmony/consensus/reward/...
=== RUN   TestPercentageForTimeStamp
--- PASS: TestPercentageForTimeStamp (0.00s)
PASS
ok  	github.com/harmony-one/harmony/consensus/reward	0.051s
```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**

## TODO
