### PR TITLE
fix bug on undelegate and delegate

### DIFF
--- a/consensus/engine/consensus_engine.go
+++ b/consensus/engine/consensus_engine.go
@@ -45,6 +45,9 @@ type ChainReader interface {
 	// ReadActiveValidatorList retrieves the list of active validators
 	ReadActiveValidatorList() ([]common.Address, error)
 
+	// ReadValidatorList retrieves the list of all validators
+	ReadValidatorList() ([]common.Address, error)
+
 	// Methods needed for EPoS committee assignment calculation
 	committee.StakingCandidatesReader
 

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -271,7 +271,7 @@ func (cr *fakeChainReader) GetHeader(hash common.Hash, number uint64) *block.Hea
 func (cr *fakeChainReader) GetBlock(hash common.Hash, number uint64) *types.Block   { return nil }
 func (cr *fakeChainReader) ReadShardState(epoch *big.Int) (*shard.State, error)     { return nil, nil }
 func (cr *fakeChainReader) ReadActiveValidatorList() ([]common.Address, error)      { return nil, nil }
-func (cr *fakeChainReader) ReadValidatorList() ([]common.Address, error)      { return nil, nil }
+func (cr *fakeChainReader) ReadValidatorList() ([]common.Address, error)            { return nil, nil }
 func (cr *fakeChainReader) ValidatorCandidates() []common.Address                   { return nil }
 func (cr *fakeChainReader) ReadValidatorInformation(addr common.Address) (*staking.ValidatorWrapper, error) {
 	return nil, nil

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -271,6 +271,7 @@ func (cr *fakeChainReader) GetHeader(hash common.Hash, number uint64) *block.Hea
 func (cr *fakeChainReader) GetBlock(hash common.Hash, number uint64) *types.Block   { return nil }
 func (cr *fakeChainReader) ReadShardState(epoch *big.Int) (*shard.State, error)     { return nil, nil }
 func (cr *fakeChainReader) ReadActiveValidatorList() ([]common.Address, error)      { return nil, nil }
+func (cr *fakeChainReader) ReadValidatorList() ([]common.Address, error)      { return nil, nil }
 func (cr *fakeChainReader) ValidatorCandidates() []common.Address                   { return nil }
 func (cr *fakeChainReader) ReadValidatorInformation(addr common.Address) (*staking.ValidatorWrapper, error) {
 	return nil, nil

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -203,12 +203,10 @@ func (e *engineImpl) Finalize(
 		return nil, nil, ctxerror.New("cannot pay block reward").WithCause(err)
 	}
 
-	// TODO Shouldnt this logic only apply to beaconchain, right?
 	// Withdraw unlocked tokens to the delegators' accounts
 	// Only do such at the last block of an epoch
 	if header.ShardID() == shard.BeaconChainShardID && len(header.ShardState()) > 0 {
-		// TODO: make sure we are using the correct validator list
-		validators, err := chain.ReadActiveValidatorList()
+		validators, err := chain.ReadValidatorList()
 		if err != nil {
 			return nil, nil, ctxerror.New("failed to read active validators").WithCause(err)
 		}


### PR DESCRIPTION
Besides negative balances checks.

For delegate, the balance should be subtracted by the delegation leftover instead of the whole amount.

For undelegate, we should check against all the validators, rather than only the active ones.