### PR TITLE
Fix CrossTxEpoch handling

### DIFF
--- a/block/factory/factory.go
+++ b/block/factory/factory.go
@@ -34,7 +34,7 @@ func (f *factory) NewHeader(epoch *big.Int) *block.Header {
 		impl = v3.NewHeader()
 	case f.chainConfig.IsCrossLink(epoch):
 		impl = v2.NewHeader()
-	case f.chainConfig.IsCrossTx(epoch):
+	case f.chainConfig.HasCrossTxFields(epoch):
 		impl = v1.NewHeader()
 	default:
 		impl = v0.NewHeader()

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -100,7 +100,7 @@ func (v *BlockValidator) ValidateState(block, parent *types.Block, statedb *stat
 		return fmt.Errorf("invalid receipt root hash (remote: %x local: %x)", header.ReceiptHash(), receiptSha)
 	}
 
-	if v.config.IsCrossTx(block.Epoch()) {
+	if v.config.AcceptsCrossTx(block.Epoch()) {
 		cxsSha := types.DeriveMultipleShardsSha(cxReceipts)
 		if cxsSha != header.OutgoingReceiptHash() {
 			return fmt.Errorf("invalid cross shard receipt root hash (remote: %x local: %x)", header.OutgoingReceiptHash(), cxsSha)
@@ -175,7 +175,7 @@ func CalcGasLimit(parent *types.Block, gasFloor, gasCeil uint64) uint64 {
 
 // ValidateCXReceiptsProof checks whether the given CXReceiptsProof is consistency with itself
 func (v *BlockValidator) ValidateCXReceiptsProof(cxp *types.CXReceiptsProof) error {
-	if !v.config.IsCrossTx(cxp.Header.Epoch()) {
+	if !v.config.AcceptsCrossTx(cxp.Header.Epoch()) {
 		return ctxerror.New("[ValidateCXReceiptsProof] cross shard receipt received before cx fork")
 	}
 

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -100,7 +100,7 @@ func (v *BlockValidator) ValidateState(block, parent *types.Block, statedb *stat
 		return fmt.Errorf("invalid receipt root hash (remote: %x local: %x)", header.ReceiptHash(), receiptSha)
 	}
 
-	if v.config.AcceptsCrossTx(block.Epoch()) {
+	if v.config.HasCrossTxFields(block.Epoch()) {
 		cxsSha := types.DeriveMultipleShardsSha(cxReceipts)
 		if cxsSha != header.OutgoingReceiptHash() {
 			return fmt.Errorf("invalid cross shard receipt root hash (remote: %x local: %x)", header.OutgoingReceiptHash(), cxsSha)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1102,7 +1102,7 @@ func (bc *BlockChain) WriteBlockWithState(
 
 	//// Cross-shard txns
 	epoch := block.Header().Epoch()
-	if bc.chainConfig.IsCrossTx(block.Epoch()) {
+	if bc.chainConfig.AcceptsCrossTx(block.Epoch()) {
 		shardingConfig := shard.Schedule.InstanceForEpoch(epoch)
 		shardNum := int(shardingConfig.NumShards())
 		for i := 0; i < shardNum; i++ {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1102,7 +1102,7 @@ func (bc *BlockChain) WriteBlockWithState(
 
 	//// Cross-shard txns
 	epoch := block.Header().Epoch()
-	if bc.chainConfig.AcceptsCrossTx(block.Epoch()) {
+	if bc.chainConfig.HasCrossTxFields(block.Epoch()) {
 		shardingConfig := shard.Schedule.InstanceForEpoch(epoch)
 		shardNum := int(shardingConfig.NumShards())
 		for i := 0; i < shardNum; i++ {

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -122,7 +122,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.DB, cfg vm.C
 
 // return true if it is valid
 func getTransactionType(config *params.ChainConfig, header *block.Header, tx *types.Transaction) types.TransactionType {
-	if header.ShardID() == tx.ShardID() && (!config.IsCrossTx(header.Epoch()) || tx.ShardID() == tx.ToShardID()) {
+	if header.ShardID() == tx.ShardID() && (!config.AcceptsCrossTx(header.Epoch()) || tx.ShardID() == tx.ToShardID()) {
 		return types.SameShardTx
 	}
 	numShards := shard.Schedule.InstanceForEpoch(header.Epoch()).NumShards()
@@ -143,7 +143,7 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 		return nil, nil, 0, fmt.Errorf("Invalid Transaction Type")
 	}
 
-	if txType != types.SameShardTx && !config.IsCrossTx(header.Epoch()) {
+	if txType != types.SameShardTx && !config.AcceptsCrossTx(header.Epoch()) {
 		return nil, nil, 0, fmt.Errorf(
 			"cannot handle cross-shard transaction until after epoch %v (now %v)",
 			config.CrossTxEpoch, header.Epoch())

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -139,19 +139,26 @@ func (c *ChainConfig) IsEIP155(epoch *big.Int) bool {
 	return isForked(c.EIP155Epoch, epoch)
 }
 
-// IsCrossTx returns whether cross-shard transaction is enabled in the given
+// IsCrossTx returns whether cross-shard transaction is accepted in the given
 // epoch.
 //
 // Note that this is different from comparing epoch against CrossTxEpoch.
-// Cross-shard transaction is enabled from CrossTxEpoch+1 and on, in order to
+// Cross-shard transaction is accepted from CrossTxEpoch+1 and on, in order to
 // allow for all shards to roll into CrossTxEpoch and become able to handle
 // ingress receipts.  In other words, cross-shard transaction fields are
-// introduced at CrossTxEpoch, but these fields are not used until
-// CrossTxEpoch+1, when cross-shard transactions are actually accepted by the
-// network.
+// introduced and ingress receipts are processed at CrossTxEpoch, but the shard
+// does not accept cross-shard transactions from clients until CrossTxEpoch+1.
+//
+// TODO ek – rename to AcceptsCrossTx to clarify
 func (c *ChainConfig) IsCrossTx(epoch *big.Int) bool {
 	crossTxEpoch := new(big.Int).Add(c.CrossTxEpoch, common.Big1)
 	return isForked(crossTxEpoch, epoch)
+}
+
+// HasCrossTxFields returns whether blocks in the given epoch includes
+// cross-shard transaction fields.
+func (c *ChainConfig) HasCrossTxFields(epoch *big.Int) bool {
+	return isForked(c.CrossTxEpoch, epoch)
 }
 
 // IsStaking determines whether it is staking epoch

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -139,8 +139,8 @@ func (c *ChainConfig) IsEIP155(epoch *big.Int) bool {
 	return isForked(c.EIP155Epoch, epoch)
 }
 
-// IsCrossTx returns whether cross-shard transaction is accepted in the given
-// epoch.
+// AcceptsCrossTx returns whether cross-shard transaction is accepted in the
+// given epoch.
 //
 // Note that this is different from comparing epoch against CrossTxEpoch.
 // Cross-shard transaction is accepted from CrossTxEpoch+1 and on, in order to
@@ -148,9 +148,7 @@ func (c *ChainConfig) IsEIP155(epoch *big.Int) bool {
 // ingress receipts.  In other words, cross-shard transaction fields are
 // introduced and ingress receipts are processed at CrossTxEpoch, but the shard
 // does not accept cross-shard transactions from clients until CrossTxEpoch+1.
-//
-// TODO ek – rename to AcceptsCrossTx to clarify
-func (c *ChainConfig) IsCrossTx(epoch *big.Int) bool {
+func (c *ChainConfig) AcceptsCrossTx(epoch *big.Int) bool {
 	crossTxEpoch := new(big.Int).Add(c.CrossTxEpoch, common.Big1)
 	return isForked(crossTxEpoch, epoch)
 }

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -167,7 +167,7 @@ func (node *Node) proposeNewBlock() (*types.Block, error) {
 }
 
 func (node *Node) proposeReceiptsProof() []*types.CXReceiptsProof {
-	if !node.Blockchain().Config().AcceptsCrossTx(node.Worker.GetCurrentHeader().Epoch()) {
+	if !node.Blockchain().Config().HasCrossTxFields(node.Worker.GetCurrentHeader().Epoch()) {
 		return []*types.CXReceiptsProof{}
 	}
 

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -167,7 +167,7 @@ func (node *Node) proposeNewBlock() (*types.Block, error) {
 }
 
 func (node *Node) proposeReceiptsProof() []*types.CXReceiptsProof {
-	if !node.Blockchain().Config().IsCrossTx(node.Worker.GetCurrentHeader().Epoch()) {
+	if !node.Blockchain().Config().AcceptsCrossTx(node.Worker.GetCurrentHeader().Epoch()) {
 		return []*types.CXReceiptsProof{}
 	}
 


### PR DESCRIPTION
## Issue

e79ba5fe880b56973a50a80d918b9145fce07cf0 introduced an off-by-one error which caused cross-shard-transaction-enabled header (v1) to be introduced one epoch later than expected, i.e. at `CrossTxEpoch+1`, where it should be introduced at `CrossTxEpoch`.  This was caused by a vague, confusing naming of `IsCrossTx(epoch)` function of `ChainConfig`: The name did not clarify whether it meant introduction of CX-enabled header and processing of ingress receipts (which occurs at `CrossTxEpoch`) or acceptance of cross-shard transactions (which occurs at `CrossTxEpoch+1`).
    
Introduce and use `params.(*ChainConfig).HasCrossTxFields` which handles the former case, and rename `params.(*ChainConfig).IsCrossTx` to `AcceptsCrossTx` to clarify its intention.

Also fix three cases where `IsCrossTx` was erroneously used:

* `core.(*BlockValidator).ValidateState` – validation was being handled at `CrossTxEpoch+1`, and CX receipts roots were unverified in `CrossTxEpoch`, creating a security hole.
* `core.(*BlockChain).WriteBlockWithState` – CX receipt storage was starting at `CrossTxEpoch+1`, causing incoming CX receipts in blocks in `CrossTxEpoch` to be lost.
* `node.(*Node).proposeReceiptsProof` – processing of ingress CX receipts began in `CrossTxEpoch+1`, causing processing of early-day CXs to be delayed up to a full epoch.

## Test

### Test/Run Logs

Without this fix, new Pangaea (testnet) nodes cannot start block syncing, because their genesis block would be using v0 header where v1 should be used (`TestnetChainConfig.CrossTxEpoch == 0`).  With this fix, block synchronization starts normally.

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**