### PR TITLE
Schedule Pangaea staking epochs

### DIFF
--- a/internal/configs/sharding/testnet.go
+++ b/internal/configs/sharding/testnet.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/harmony-one/harmony/internal/genesis"
+	"github.com/harmony-one/harmony/internal/params"
 )
 
 // TestnetSchedule is the long-running public testnet sharding
@@ -26,6 +27,8 @@ const (
 
 func (testnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	switch {
+	case epoch.Cmp(params.PangaeaChainConfig.StakingEpoch) >= 0:
+		return testnetV1
 	default: // genesis
 		return testnetV0
 	}
@@ -74,6 +77,8 @@ func (ts testnetSchedule) GetShardingStructure(numShard, shardID int) []map[stri
 
 var testnetReshardingEpoch = []*big.Int{
 	big.NewInt(0),
+	params.PangaeaChainConfig.StakingEpoch,
 }
 
 var testnetV0 = MustNewInstance(3, 100, 80, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch)
+var testnetV1 = MustNewInstance(3, 100, 68, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch)

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -37,8 +37,8 @@ var (
 		ChainID:         TestnetChainID,
 		CrossTxEpoch:    big.NewInt(0),
 		CrossLinkEpoch:  big.NewInt(2),
-		StakingEpoch:    big.NewInt(3),
-		PreStakingEpoch: big.NewInt(0),
+		StakingEpoch:    big.NewInt(5328), // around 2019-12-06T05:46:17Z
+		PreStakingEpoch: big.NewInt(5256), // around 2019-12-05T17:46:17Z
 		EIP155Epoch:     big.NewInt(0),
 		S3Epoch:         big.NewInt(0),
 	}

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -36,7 +36,7 @@ var (
 	TestnetChainConfig = &ChainConfig{
 		ChainID:         TestnetChainID,
 		CrossTxEpoch:    big.NewInt(0),
-		CrossLinkEpoch:  big.NewInt(2),
+		CrossLinkEpoch:  big.NewInt(5256),
 		StakingEpoch:    big.NewInt(5328), // around 2019-12-06T05:46:17Z
 		PreStakingEpoch: big.NewInt(5256), // around 2019-12-05T17:46:17Z
 		EIP155Epoch:     big.NewInt(0),


### PR DESCRIPTION
- Pre-staking starts at epoch 5256, around 2019-12-05T17:46:17Z
- Staking starts at epoch 5328, around 2019-12-06T05:46:17Z

Calculation is based upon Pangaea shard 0 block height 391440 at 2019-12-05T11:38:17Z.