### PR TITLE
[rpc][staking] Quick way to add an staking transaction error sink for…

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -19,7 +19,6 @@ package core
 import (
 	"fmt"
 	"math/big"
-	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -33,19 +32,6 @@ import (
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/shard"
 	staking "github.com/harmony-one/harmony/staking/types"
-)
-
-// StakingTransactionError ..
-type StakingTransactionError struct {
-	TxHashID             string `json:"tx-hash-id"`
-	StakingDirective     string `json:"directive-kind"`
-	TimestampOfRejection int64  `json:"time-at-rejection"`
-	ErrMessage           string `json:"error-message"`
-}
-
-var (
-	// StakingTransactionErrorSink ..
-	StakingTransactionErrorSink = sync.Map{}
 )
 
 // StateProcessor is a basic Processor, which takes care of transitioning

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -19,6 +19,7 @@ package core
 import (
 	"fmt"
 	"math/big"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -32,6 +33,19 @@ import (
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/shard"
 	staking "github.com/harmony-one/harmony/staking/types"
+)
+
+// StakingTransactionError ..
+type StakingTransactionError struct {
+	TxHashID             string `json:"tx-hash-id"`
+	StakingDirective     string `json:"directive-kind"`
+	TimestampOfRejection int64  `json:"time-at-rejection"`
+	ErrMessage           string `json:"error-message"`
+}
+
+var (
+	// StakingTransactionErrorSink ..
+	StakingTransactionErrorSink = sync.Map{}
 )
 
 // StateProcessor is a basic Processor, which takes care of transitioning

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -367,3 +367,8 @@ func (b *APIBackend) GetValidatorSelfDelegation(addr common.Address) *big.Int {
 func (b *APIBackend) GetShardState() (*shard.State, error) {
 	return b.hmy.BlockChain().ReadShardState(b.hmy.BlockChain().CurrentHeader().Epoch())
 }
+
+// GetCurrentStakingTransactionErrorSink ..
+func (b *APIBackend) GetCurrentStakingTransactionErrorSink() []staking.RPCTransactionError {
+	return b.hmy.nodeAPI.ErroredStakingTransactionSink()
+}

--- a/hmy/backend.go
+++ b/hmy/backend.go
@@ -52,11 +52,15 @@ type NodeAPI interface {
 	GetNonceOfAddress(address common.Address) uint64
 	GetTransactionsHistory(address, txType, order string) ([]common.Hash, error)
 	IsCurrentlyLeader() bool
+	ErroredStakingTransactionSink() []staking.RPCTransactionError
 }
 
 // New creates a new Harmony object (including the
 // initialisation of the common Harmony object)
-func New(nodeAPI NodeAPI, txPool *core.TxPool, cxPool *core.CxPool, eventMux *event.TypeMux, shardID uint32) (*Harmony, error) {
+func New(
+	nodeAPI NodeAPI, txPool *core.TxPool,
+	cxPool *core.CxPool, eventMux *event.TypeMux, shardID uint32,
+) (*Harmony, error) {
 	chainDb := nodeAPI.Blockchain().ChainDB()
 	hmy := &Harmony{
 		shutdownChan:   make(chan bool),

--- a/internal/hmyapi/backend.go
+++ b/internal/hmyapi/backend.go
@@ -81,6 +81,7 @@ type Backend interface {
 	GetDelegationsByDelegator(delegator common.Address) ([]common.Address, []*staking.Delegation)
 	GetValidatorSelfDelegation(addr common.Address) *big.Int
 	GetShardState() (*shard.State, error)
+	GetCurrentStakingTransactionErrorSink() []staking.RPCTransactionError
 }
 
 // GetAPIs returns all the APIs.

--- a/internal/hmyapi/harmony.go
+++ b/internal/hmyapi/harmony.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/harmony-one/harmony/api/proto"
-	"github.com/harmony-one/harmony/core"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
+	staking "github.com/harmony-one/harmony/staking/types"
 )
 
 // PublicHarmonyAPI provides an API to access Harmony related information.
@@ -68,19 +68,6 @@ func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
 }
 
 // GetCurrentTransactionErrorSink ..
-func (s *PublicHarmonyAPI) GetCurrentTransactionErrorSink() []core.StakingTransactionError {
-	result := []core.StakingTransactionError{}
-	count := 0
-	core.StakingTransactionErrorSink.Range(func(key, value interface{}) bool {
-		count++
-		result = append(result, value.(core.StakingTransactionError))
-		return true
-	})
-	const maxMapSize = 1024
-	if count == maxMapSize {
-		for i := range result {
-			core.StakingTransactionErrorSink.Delete(result[i].TxHashID)
-		}
-	}
-	return result
+func (s *PublicHarmonyAPI) GetCurrentTransactionErrorSink() []staking.RPCTransactionError {
+	return s.b.GetCurrentStakingTransactionErrorSink()
 }

--- a/internal/hmyapi/harmony.go
+++ b/internal/hmyapi/harmony.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/harmony-one/harmony/api/proto"
+	"github.com/harmony-one/harmony/core"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 )
 
@@ -64,4 +65,22 @@ func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
 		s.b.IsLeader(),
 		s.b.GetShardID(),
 	}
+}
+
+// GetCurrentTransactionErrorSink ..
+func (s *PublicHarmonyAPI) GetCurrentTransactionErrorSink() []core.StakingTransactionError {
+	result := []core.StakingTransactionError{}
+	count := 0
+	core.StakingTransactionErrorSink.Range(func(key, value interface{}) bool {
+		count++
+		result = append(result, value.(core.StakingTransactionError))
+		return true
+	})
+	const maxMapSize = 1024
+	if count == maxMapSize {
+		for i := range result {
+			core.StakingTransactionErrorSink.Delete(result[i].TxHashID)
+		}
+	}
+	return result
 }

--- a/node/node.go
+++ b/node/node.go
@@ -216,6 +216,11 @@ type Node struct {
 
 	// last time consensus reached for metrics
 	lastConsensusTime int64
+	// Last 1024 staking transaction error, only in memory
+	errorSink struct {
+		sync.Mutex
+		failedTxns []staking.RPCTransactionError
+	}
 }
 
 // Blockchain returns the blockchain for the node's current shard.
@@ -390,6 +395,10 @@ func (node *Node) GetSyncID() [SyncIDLength]byte {
 func New(host p2p.Host, consensusObj *consensus.Consensus,
 	chainDBFactory shardchain.DBFactory, isArchival bool) *Node {
 	node := Node{}
+	node.errorSink = struct {
+		sync.Mutex
+		failedTxns []staking.RPCTransactionError
+	}{}
 
 	node.syncFreq = SyncFrequency
 	node.beaconSyncFreq = SyncFrequency

--- a/node/node_handler_test.go
+++ b/node/node_handler_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/consensus"
 	"github.com/harmony-one/harmony/consensus/quorum"
-	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/crypto/bls"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
@@ -14,7 +13,7 @@ import (
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/p2p/p2pimpl"
 	"github.com/harmony-one/harmony/shard"
-	types2 "github.com/harmony-one/harmony/staking/types"
+	staking "github.com/harmony-one/harmony/staking/types"
 )
 
 func TestAddNewBlock(t *testing.T) {
@@ -37,8 +36,8 @@ func TestAddNewBlock(t *testing.T) {
 	node := New(host, consensus, testDBFactory, false)
 
 	txs := make(map[common.Address]types.Transactions)
-	stks := types2.StakingTransactions{}
-	node.Worker.CommitTransactions(txs, stks, common.Address{}, func(core.StakingTransactionError) {})
+	stks := staking.StakingTransactions{}
+	node.Worker.CommitTransactions(txs, stks, common.Address{}, func(staking.RPCTransactionError) {})
 	block, _ := node.Worker.FinalizeNewBlock([]byte{}, []byte{}, 0, common.Address{}, nil, nil)
 
 	_, err = node.Blockchain().InsertChain([]*types.Block{block}, true)
@@ -70,8 +69,8 @@ func TestVerifyNewBlock(t *testing.T) {
 	node := New(host, consensus, testDBFactory, false)
 
 	txs := make(map[common.Address]types.Transactions)
-	stks := types2.StakingTransactions{}
-	node.Worker.CommitTransactions(txs, stks, common.Address{}, func(core.StakingTransactionError) {})
+	stks := staking.StakingTransactions{}
+	node.Worker.CommitTransactions(txs, stks, common.Address{}, func(staking.RPCTransactionError) {})
 	block, _ := node.Worker.FinalizeNewBlock([]byte{}, []byte{}, 0, common.Address{}, nil, nil)
 
 	if err := node.VerifyNewBlock(block); err != nil {

--- a/node/node_handler_test.go
+++ b/node/node_handler_test.go
@@ -3,18 +3,18 @@ package node
 import (
 	"testing"
 
-	"github.com/harmony-one/harmony/core/types"
-	types2 "github.com/harmony-one/harmony/staking/types"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/consensus"
 	"github.com/harmony-one/harmony/consensus/quorum"
+	"github.com/harmony-one/harmony/core"
+	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/crypto/bls"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/p2p/p2pimpl"
 	"github.com/harmony-one/harmony/shard"
+	types2 "github.com/harmony-one/harmony/staking/types"
 )
 
 func TestAddNewBlock(t *testing.T) {
@@ -38,7 +38,7 @@ func TestAddNewBlock(t *testing.T) {
 
 	txs := make(map[common.Address]types.Transactions)
 	stks := types2.StakingTransactions{}
-	node.Worker.CommitTransactions(txs, stks, common.Address{})
+	node.Worker.CommitTransactions(txs, stks, common.Address{}, func(core.StakingTransactionError) {})
 	block, _ := node.Worker.FinalizeNewBlock([]byte{}, []byte{}, 0, common.Address{}, nil, nil)
 
 	_, err = node.Blockchain().InsertChain([]*types.Block{block}, true)
@@ -71,7 +71,7 @@ func TestVerifyNewBlock(t *testing.T) {
 
 	txs := make(map[common.Address]types.Transactions)
 	stks := types2.StakingTransactions{}
-	node.Worker.CommitTransactions(txs, stks, common.Address{})
+	node.Worker.CommitTransactions(txs, stks, common.Address{}, func(core.StakingTransactionError) {})
 	block, _ := node.Worker.FinalizeNewBlock([]byte{}, []byte{}, 0, common.Address{}, nil, nil)
 
 	if err := node.VerifyNewBlock(block); err != nil {

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -6,12 +6,11 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/core/rawdb"
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/shard"
-	types2 "github.com/harmony-one/harmony/staking/types"
+	staking "github.com/harmony-one/harmony/staking/types"
 )
 
 // Constants of proposing a new block
@@ -99,21 +98,28 @@ func (node *Node) proposeNewBlock() (*types.Block, error) {
 	}
 
 	// TODO: integrate staking transaction into tx pool
-	pendingStakingTransactions := types2.StakingTransactions{}
+	pendingStakingTransactions := staking.StakingTransactions{}
 	// Only process staking transactions after pre-staking epoch happened.
 	if node.Blockchain().Config().IsPreStaking(node.Worker.GetCurrentHeader().Epoch()) {
 		node.pendingStakingTxMutex.Lock()
 		for _, tx := range node.pendingStakingTransactions {
 			pendingStakingTransactions = append(pendingStakingTransactions, tx)
 		}
-		node.pendingStakingTransactions = make(map[common.Hash]*types2.StakingTransaction)
+		node.pendingStakingTransactions = make(map[common.Hash]*staking.StakingTransaction)
 		node.pendingStakingTxMutex.Unlock()
 	}
 
 	if err := node.Worker.CommitTransactions(
 		pending, pendingStakingTransactions, coinbase,
-		func(payload core.StakingTransactionError) {
-			core.StakingTransactionErrorSink.Store(payload.TxHashID, payload)
+		func(payload staking.RPCTransactionError) {
+			const maxSize = 1024
+			node.errorSink.Lock()
+			if l := len(node.errorSink.failedTxns); l >= maxSize {
+				node.errorSink.failedTxns = append(node.errorSink.failedTxns[1:], payload)
+			} else {
+				node.errorSink.failedTxns = append(node.errorSink.failedTxns, payload)
+			}
+			node.errorSink.Unlock()
 		},
 	); err != nil {
 		utils.Logger().Error().Err(err).Msg("cannot commit transactions")

--- a/node/rpc.go
+++ b/node/rpc.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/rpc"
-
 	"github.com/harmony-one/harmony/hmy"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/hmyapi"
 	"github.com/harmony-one/harmony/internal/hmyapi/filters"
 	"github.com/harmony-one/harmony/internal/utils"
+	staking "github.com/harmony-one/harmony/staking/types"
 )
 
 const (
@@ -49,10 +49,17 @@ func (node *Node) IsCurrentlyLeader() bool {
 	return node.Consensus.IsLeader()
 }
 
+// ErroredStakingTransactionSink is the inmemory failed staking transactions this node has
+func (node *Node) ErroredStakingTransactionSink() []staking.RPCTransactionError {
+	return node.errorSink.failedTxns
+}
+
 // StartRPC start RPC service
 func (node *Node) StartRPC(nodePort string) error {
 	// Gather all the possible APIs to surface
-	harmony, _ = hmy.New(node, node.TxPool, node.CxPool, new(event.TypeMux), node.Consensus.ShardID)
+	harmony, _ = hmy.New(
+		node, node.TxPool, node.CxPool, new(event.TypeMux), node.Consensus.ShardID,
+	)
 
 	apis := node.APIs()
 

--- a/node/rpc.go
+++ b/node/rpc.go
@@ -51,6 +51,8 @@ func (node *Node) IsCurrentlyLeader() bool {
 
 // ErroredStakingTransactionSink is the inmemory failed staking transactions this node has
 func (node *Node) ErroredStakingTransactionSink() []staking.RPCTransactionError {
+	node.errorSink.Lock()
+	defer node.errorSink.Unlock()
 	return node.errorSink.failedTxns
 }
 

--- a/node/worker/worker.go
+++ b/node/worker/worker.go
@@ -52,7 +52,7 @@ type Worker struct {
 func (w *Worker) CommitTransactions(
 	pendingNormal map[common.Address]types.Transactions,
 	pendingStaking staking.StakingTransactions, coinbase common.Address,
-	stkingTxErrorSink func(core.StakingTransactionError),
+	stkingTxErrorSink func(staking.RPCTransactionError),
 ) error {
 
 	if w.current.gasPool == nil {
@@ -132,9 +132,9 @@ func (w *Worker) CommitTransactions(
 		for _, tx := range pendingStaking {
 			logs, err := w.commitStakingTransaction(tx, coinbase)
 			if txID := tx.Hash().Hex(); err != nil {
-				stkingTxErrorSink(core.StakingTransactionError{
+				stkingTxErrorSink(staking.RPCTransactionError{
 					TxHashID:             txID,
-					StakingDirective:     tx.StakingType().String(),
+					StakingDirective:     tx.StakingType(),
 					TimestampOfRejection: time.Now().Unix(),
 					ErrMessage:           err.Error(),
 				})

--- a/node/worker/worker.go
+++ b/node/worker/worker.go
@@ -25,11 +25,9 @@ import (
 
 // environment is the worker's current environment and holds all of the current state information.
 type environment struct {
-	signer types.Signer
-
-	state   *state.DB     // apply state changes here
-	gasPool *core.GasPool // available gas used to pack transactions
-
+	signer     types.Signer
+	state      *state.DB     // apply state changes here
+	gasPool    *core.GasPool // available gas used to pack transactions
 	header     *block.Header
 	txs        []*types.Transaction
 	stakingTxs staking.StakingTransactions
@@ -41,19 +39,21 @@ type environment struct {
 // Worker is the main object which takes care of submitting new work to consensus engine
 // and gathering the sealing result.
 type Worker struct {
-	config  *params.ChainConfig
-	factory blockfactory.Factory
-	chain   *core.BlockChain
-	current *environment // An environment for current running cycle.
-
-	engine consensus_engine.Engine
-
+	config   *params.ChainConfig
+	factory  blockfactory.Factory
+	chain    *core.BlockChain
+	current  *environment // An environment for current running cycle.
+	engine   consensus_engine.Engine
 	gasFloor uint64
 	gasCeil  uint64
 }
 
 // CommitTransactions commits transactions for new block.
-func (w *Worker) CommitTransactions(pendingNormal map[common.Address]types.Transactions, pendingStaking staking.StakingTransactions, coinbase common.Address) error {
+func (w *Worker) CommitTransactions(
+	pendingNormal map[common.Address]types.Transactions,
+	pendingStaking staking.StakingTransactions, coinbase common.Address,
+	stkingTxErrorSink func(core.StakingTransactionError),
+) error {
 
 	if w.current.gasPool == nil {
 		w.current.gasPool = new(core.GasPool).AddGas(w.current.header.GasLimit())
@@ -131,11 +131,21 @@ func (w *Worker) CommitTransactions(pendingNormal map[common.Address]types.Trans
 	if w.chain.ShardID() == shard.BeaconChainShardID {
 		for _, tx := range pendingStaking {
 			logs, err := w.commitStakingTransaction(tx, coinbase)
-			if err != nil {
-				utils.Logger().Error().Err(err).Str("stakingTxId", tx.Hash().Hex()).Msg("Commit staking transaction error")
+			if txID := tx.Hash().Hex(); err != nil {
+				stkingTxErrorSink(core.StakingTransactionError{
+					TxHashID:             txID,
+					StakingDirective:     tx.StakingType().String(),
+					TimestampOfRejection: time.Now().Unix(),
+					ErrMessage:           err.Error(),
+				})
+				utils.Logger().Error().Err(err).
+					Str("stakingTxId", txID).
+					Msg("Commit staking transaction error")
 			} else {
 				coalescedLogs = append(coalescedLogs, logs...)
-				utils.Logger().Info().Str("stakingTxId", tx.Hash().Hex()).Uint64("txGasLimit", tx.Gas()).Msg("StakingTransaction gas limit info")
+				utils.Logger().Info().Str("stakingTxId", tx.Hash().Hex()).
+					Uint64("txGasLimit", tx.Gas()).
+					Msg("StakingTransaction gas limit info")
 			}
 		}
 	}
@@ -145,11 +155,15 @@ func (w *Worker) CommitTransactions(pendingNormal map[common.Address]types.Trans
 	return nil
 }
 
-func (w *Worker) commitStakingTransaction(tx *staking.StakingTransaction, coinbase common.Address) ([]*types.Log, error) {
+func (w *Worker) commitStakingTransaction(
+	tx *staking.StakingTransaction, coinbase common.Address,
+) ([]*types.Log, error) {
 	snap := w.current.state.Snapshot()
 	gasUsed := w.current.header.GasUsed()
-	receipt, _, err :=
-		core.ApplyStakingTransaction(w.config, w.chain, &coinbase, w.current.gasPool, w.current.state, w.current.header, tx, &gasUsed, vm.Config{})
+	receipt, _, err := core.ApplyStakingTransaction(
+		w.config, w.chain, &coinbase, w.current.gasPool,
+		w.current.state, w.current.header, tx, &gasUsed, vm.Config{},
+	)
 	w.current.header.SetGasUsed(gasUsed)
 	if err != nil {
 		w.current.state.RevertToSnapshot(snap)

--- a/node/worker/worker.go
+++ b/node/worker/worker.go
@@ -134,7 +134,7 @@ func (w *Worker) CommitTransactions(
 			if txID := tx.Hash().Hex(); err != nil {
 				stkingTxErrorSink(staking.RPCTransactionError{
 					TxHashID:             txID,
-					StakingDirective:     tx.StakingType(),
+					StakingDirective:     tx.StakingType().String(),
 					TimestampOfRejection: time.Now().Unix(),
 					ErrMessage:           err.Error(),
 				})

--- a/node/worker/worker_test.go
+++ b/node/worker/worker_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	blockfactory "github.com/harmony-one/harmony/block/factory"
@@ -16,6 +15,7 @@ import (
 	"github.com/harmony-one/harmony/core/vm"
 	chain2 "github.com/harmony-one/harmony/internal/chain"
 	"github.com/harmony-one/harmony/internal/params"
+	staking "github.com/harmony-one/harmony/staking/types"
 )
 
 var (
@@ -78,7 +78,7 @@ func TestCommitTransactions(t *testing.T) {
 	// Commit the tx to the worker
 	txs := make(map[common.Address]types.Transactions)
 	txs[testBankAddress] = types.Transactions{tx}
-	err := worker.CommitTransactions(txs, nil, testBankAddress, func(core.StakingTransactionError) {})
+	err := worker.CommitTransactions(txs, nil, testBankAddress, func(staking.RPCTransactionError) {})
 	if err != nil {
 		t.Error(err)
 	}

--- a/node/worker/worker_test.go
+++ b/node/worker/worker_test.go
@@ -78,7 +78,7 @@ func TestCommitTransactions(t *testing.T) {
 	// Commit the tx to the worker
 	txs := make(map[common.Address]types.Transactions)
 	txs[testBankAddress] = types.Transactions{tx}
-	err := worker.CommitTransactions(txs, nil, testBankAddress)
+	err := worker.CommitTransactions(txs, nil, testBankAddress, func(core.StakingTransactionError) {})
 	if err != nil {
 		t.Error(err)
 	}

--- a/staking/types/rpc-result.go
+++ b/staking/types/rpc-result.go
@@ -1,0 +1,9 @@
+package types
+
+// RPCTransactionError ..
+type RPCTransactionError struct {
+	TxHashID             string    `json:"tx-hash-id"`
+	StakingDirective     Directive `json:"directive-kind"`
+	TimestampOfRejection int64     `json:"time-at-rejection"`
+	ErrMessage           string    `json:"error-message"`
+}

--- a/staking/types/rpc-result.go
+++ b/staking/types/rpc-result.go
@@ -2,8 +2,8 @@ package types
 
 // RPCTransactionError ..
 type RPCTransactionError struct {
-	TxHashID             string    `json:"tx-hash-id"`
-	StakingDirective     Directive `json:"directive-kind"`
-	TimestampOfRejection int64     `json:"time-at-rejection"`
-	ErrMessage           string    `json:"error-message"`
+	TxHashID             string `json:"tx-hash-id"`
+	StakingDirective     string `json:"directive-kind"`
+	TimestampOfRejection int64  `json:"time-at-rejection"`
+	ErrMessage           string `json:"error-message"`
 }

--- a/test/chain/main.go
+++ b/test/chain/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/harmony-one/harmony/crypto/hash"
 	"github.com/harmony-one/harmony/internal/params"
 	pkgworker "github.com/harmony-one/harmony/node/worker"
+	staking "github.com/harmony-one/harmony/staking/types"
 )
 
 const (
@@ -129,7 +130,7 @@ func fundFaucetContract(chain *core.BlockChain) {
 	txmap := make(map[common.Address]types.Transactions)
 	txmap[FaucetAddress] = txs
 
-	err := contractworker.CommitTransactions(txmap, nil, testUserAddress, func(core.StakingTransactionError) {})
+	err := contractworker.CommitTransactions(txmap, nil, testUserAddress, func(staking.RPCTransactionError) {})
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -170,7 +171,7 @@ func callFaucetContractToFundAnAddress(chain *core.BlockChain) {
 	txmap := make(map[common.Address]types.Transactions)
 	txmap[FaucetAddress] = types.Transactions{callfaucettx}
 
-	err = contractworker.CommitTransactions(txmap, nil, testUserAddress, func(core.StakingTransactionError) {})
+	err = contractworker.CommitTransactions(txmap, nil, testUserAddress, func(staking.RPCTransactionError) {})
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/test/chain/main.go
+++ b/test/chain/main.go
@@ -129,7 +129,7 @@ func fundFaucetContract(chain *core.BlockChain) {
 	txmap := make(map[common.Address]types.Transactions)
 	txmap[FaucetAddress] = txs
 
-	err := contractworker.CommitTransactions(txmap, nil, testUserAddress)
+	err := contractworker.CommitTransactions(txmap, nil, testUserAddress, func(core.StakingTransactionError) {})
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -170,7 +170,7 @@ func callFaucetContractToFundAnAddress(chain *core.BlockChain) {
 	txmap := make(map[common.Address]types.Transactions)
 	txmap[FaucetAddress] = types.Transactions{callfaucettx}
 
-	err = contractworker.CommitTransactions(txmap, nil, testUserAddress)
+	err = contractworker.CommitTransactions(txmap, nil, testUserAddress, func(core.StakingTransactionError) {})
 	if err != nil {
 		fmt.Println(err)
 	}


### PR DESCRIPTION
Quick way to add a way for downstream consumers to see what is going wrong with latest staking transactions. 


```
loc2='http://localhost:9500'

 curl -d '{
    "jsonrpc": "2.0",
     "method": "hmy_getCurrentTransactionErrorSink",
     "params": [],
     "id": 1
}' -H "Content-Type: application/json" -X POST ${loc2}
```