### PR TITLE
Remove committee in explorer service

### DIFF
--- a/api/service/explorer/storage.go
+++ b/api/service/explorer/storage.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/internal/utils"
-	"github.com/harmony-one/harmony/shard"
 )
 
 // Constants for storage.
@@ -21,7 +20,6 @@ const (
 	BlockPrefix     = "b"
 	TXPrefix        = "tx"
 	AddressPrefix   = "ad"
-	CommitteePrefix = "cp"
 )
 
 // GetBlockInfoKey ...
@@ -42,11 +40,6 @@ func GetBlockKey(id int) string {
 // GetTXKey ...
 func GetTXKey(hash string) string {
 	return fmt.Sprintf("%s_%s", TXPrefix, hash)
-}
-
-// GetCommitteeKey ...
-func GetCommitteeKey(shardID uint32, epoch uint64) string {
-	return fmt.Sprintf("%s_%d_%d", CommitteePrefix, shardID, epoch)
 }
 
 var storage *Storage
@@ -118,23 +111,6 @@ func (storage *Storage) Dump(block *types.Block, height uint64) {
 	if err := batch.Write(); err != nil {
 		utils.Logger().Warn().Err(err).Msg("cannot write batch")
 	}
-}
-
-// DumpCommittee commits validators for shardNum and epoch.
-func (storage *Storage) DumpCommittee(shardID uint32, epoch uint64, committee shard.Committee) error {
-	batch := storage.db.NewBatch()
-	// Store committees.
-	committeeData, err := rlp.EncodeToBytes(committee)
-	if err != nil {
-		return err
-	}
-	if err := batch.Put([]byte(GetCommitteeKey(shardID, epoch)), committeeData); err != nil {
-		return err
-	}
-	if err := batch.Write(); err != nil {
-		return err
-	}
-	return nil
 }
 
 // UpdateTXStorage ...

--- a/api/service/explorer/storage_test.go
+++ b/api/service/explorer/storage_test.go
@@ -8,12 +8,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/harmony-one/bls/ffi/go/bls"
 
 	blockfactory "github.com/harmony-one/harmony/block/factory"
 	"github.com/harmony-one/harmony/core/types"
-	"github.com/harmony-one/harmony/shard"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -35,11 +32,6 @@ func TestGetBlockKey(t *testing.T) {
 // Test for GetTXKey
 func TestGetTXKey(t *testing.T) {
 	assert.Equal(t, GetTXKey("abcd"), "tx_abcd", "error")
-}
-
-// Test for GetCommitteeKey
-func TestGetCommitteeKey(t *testing.T) {
-	assert.Equal(t, GetCommitteeKey(uint32(0), uint64(0)), "cp_0_0", "error")
 }
 
 func TestInit(t *testing.T) {
@@ -77,37 +69,6 @@ func TestDump(t *testing.T) {
 	blockData, err := rlp.EncodeToBytes(block)
 	assert.Nil(t, err, "should be nil")
 	assert.Equal(t, bytes.Compare(data, blockData), 0, "should be equal")
-}
-
-func TestDumpCommittee(t *testing.T) {
-	blsPubKey1 := new(bls.PublicKey)
-	blsPubKey2 := new(bls.PublicKey)
-	err := blsPubKey1.DeserializeHexStr("1c1fb28d2de96e82c3d9b4917eb54412517e2763112a3164862a6ed627ac62e87ce274bb4ea36e6a61fb66a15c263a06")
-	assert.Nil(t, err, "should be nil")
-	err = blsPubKey2.DeserializeHexStr("02c8ff0b88f313717bc3a627d2f8bb172ba3ad3bb9ba3ecb8eed4b7c878653d3d4faf769876c528b73f343967f74a917")
-	assert.Nil(t, err, "should be nil")
-	BlsPublicKey1 := new(shard.BlsPublicKey)
-	BlsPublicKey2 := new(shard.BlsPublicKey)
-	BlsPublicKey1.FromLibBLSPublicKey(blsPubKey1)
-	BlsPublicKey2.FromLibBLSPublicKey(blsPubKey2)
-	nodeID1 := shard.Slot{EcdsaAddress: common.HexToAddress("52789f18a342da8023cc401e5d2b14a6b710fba9"), BlsPublicKey: *BlsPublicKey1}
-	nodeID2 := shard.Slot{EcdsaAddress: common.HexToAddress("7c41e0668b551f4f902cfaec05b5bdca68b124ce"), BlsPublicKey: *BlsPublicKey2}
-	nodeIDList := []shard.Slot{nodeID1, nodeID2}
-	committee := shard.Committee{ShardID: uint32(0), Slots: nodeIDList}
-	shardID := uint32(0)
-	epoch := uint64(0)
-	ins := GetStorageInstance("1.1.1.1", "3333", true)
-	err = ins.DumpCommittee(shardID, epoch, committee)
-	if err != nil {
-		assert.Nilf(t, err, "should be nil, but %s", err.Error())
-	}
-	db := ins.GetDB()
-
-	data, err := db.Get([]byte(GetCommitteeKey(shardID, epoch)))
-	assert.Nil(t, err, "should be nil")
-	committeeData, err := rlp.EncodeToBytes(committee)
-	assert.Nil(t, err, "should be nil")
-	assert.Equal(t, bytes.Compare(data, committeeData), 0, "should be equal")
 }
 
 func TestUpdateAddressStorage(t *testing.T) {

--- a/api/service/explorer/structs.go
+++ b/api/service/explorer/structs.go
@@ -35,11 +35,6 @@ type Address struct {
 	TXs     []*Transaction `json:"txs"`
 }
 
-// Committee contains list of node validators of a particular shard and epoch.
-type Committee struct {
-	Validators []*Validator `json:"validators"`
-}
-
 // Validator contains harmony validator node address and its balance.
 type Validator struct {
 	Address string   `json:"address"`

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -553,10 +553,6 @@ func main() {
 	if currentNode.NodeConfig.GetMetricsFlag() {
 		go currentNode.CollectMetrics()
 	}
-	// Commit committtee if node role is explorer
-	if currentNode.NodeConfig.Role() == nodeconfig.ExplorerNode {
-		go currentNode.CommitCommittee()
-	}
 
 	currentNode.StartServer()
 }


### PR DESCRIPTION
## Issue

Code with committee is redundant now, because we're using hmy api for explorer and also it started causing strange error https://github.com/harmony-one/harmony/issues/1990. hmy api also doesn't use it. So best solution to simply remove it.

## Test

I run all APIs, localnet and tests locally. Also removed committee from all places and there were no crashes.

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    NO

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    NO

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    NO

## TODO
