### PR TITLE
Update the BLS pub key and signature aggregation to prevent rogue key attack

### DIFF
--- a/crypto/bls/bls.go
+++ b/crypto/bls/bls.go
@@ -1,10 +1,10 @@
 package bls
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"unsafe"
-	"encoding/hex"
 
 	"github.com/harmony-one/bls/ffi/go/bls"
 	"github.com/harmony-one/harmony/internal/ctxerror"
@@ -77,8 +77,8 @@ func TransformPublicKey(pub *bls.PublicKey) *bls.PublicKey {
 func AggregateSigWithPublicKey(m map[string]*bls.Sign) *bls.Sign {
 	var aggregatedSig bls.Sign
 	for pubkeyStr, sig := range m {
-		decodedPubKey, err :=  hex.DecodeString(pubkeyStr)
-		if (err != nil) {
+		decodedPubKey, err := hex.DecodeString(pubkeyStr)
+		if err != nil {
 			return nil
 		}
 
@@ -99,7 +99,7 @@ type Mask struct {
 // cosigners are disabled by default. If a public key is given it verifies that
 // it is present in the list of keys and sets the corresponding index in the
 // bitmask to 1 (enabled).
-func NewMask(publics []*bls.PublicKey, myKey *bls.PublicKey, optionalUsePubKeyHash...bool) (*Mask, error) {
+func NewMask(publics []*bls.PublicKey, myKey *bls.PublicKey, optionalUsePubKeyHash ...bool) (*Mask, error) {
 	m := &Mask{
 		Publics: publics,
 	}
@@ -122,7 +122,7 @@ func NewMask(publics []*bls.PublicKey, myKey *bls.PublicKey, optionalUsePubKeyHa
 	// additional flag to use
 	// old version (UsePubKeyHash == false)
 	// or new version (UsePubKeyHash == true)
-	if (len(optionalUsePubKeyHash)>0 &&  (optionalUsePubKeyHash[0])){
+	if len(optionalUsePubKeyHash) > 0 && (optionalUsePubKeyHash[0]) {
 		m.UsePubKeyHash = true
 	} else {
 		m.UsePubKeyHash = false
@@ -157,7 +157,7 @@ func (m *Mask) SetMask(mask []byte) error {
 		msk := byte(1) << uint(i&7)
 		if ((m.Bitmap[byt] & msk) == 0) && ((mask[byt] & msk) != 0) {
 			m.Bitmap[byt] ^= msk // flip bit in Bitmap from 0 to 1
-			if (m.UsePubKeyHash) {
+			if m.UsePubKeyHash {
 				m.AggregatePublic.Add(TransformPublicKey(m.Publics[i]))
 			} else {
 				m.AggregatePublic.Add(m.Publics[i])
@@ -165,7 +165,7 @@ func (m *Mask) SetMask(mask []byte) error {
 		}
 		if ((m.Bitmap[byt] & msk) != 0) && ((mask[byt] & msk) == 0) {
 			m.Bitmap[byt] ^= msk // flip bit in Bitmap from 1 to 0
-			if (m.UsePubKeyHash) {
+			if m.UsePubKeyHash {
 				m.AggregatePublic.Sub(TransformPublicKey(m.Publics[i]))
 			} else {
 				m.AggregatePublic.Sub(m.Publics[i])
@@ -185,7 +185,7 @@ func (m *Mask) SetBit(i int, enable bool) error {
 	msk := byte(1) << uint(i&7)
 	if ((m.Bitmap[byt] & msk) == 0) && enable {
 		m.Bitmap[byt] ^= msk // flip bit in Bitmap from 0 to 1
-		if (m.UsePubKeyHash) {
+		if m.UsePubKeyHash {
 			m.AggregatePublic.Add(TransformPublicKey(m.Publics[i]))
 		} else {
 			m.AggregatePublic.Add(m.Publics[i])
@@ -193,7 +193,7 @@ func (m *Mask) SetBit(i int, enable bool) error {
 	}
 	if ((m.Bitmap[byt] & msk) != 0) && !enable {
 		m.Bitmap[byt] ^= msk // flip bit in Bitmap from 1 to 0
-		if (m.UsePubKeyHash) {
+		if m.UsePubKeyHash {
 			m.AggregatePublic.Sub(TransformPublicKey(m.Publics[i]))
 		} else {
 			m.AggregatePublic.Sub(m.Publics[i])

--- a/crypto/bls/bls_test.go
+++ b/crypto/bls/bls_test.go
@@ -245,14 +245,13 @@ func TestSetMask(test *testing.T) {
 	}
 }
 
-
 func TestNewImplementationWithPublicKeyHash1(test *testing.T) {
 	secs := make([]*bls.SecretKey, 10)
 	pubs := make([]*bls.PublicKey, 10)
 	sigs := make([]*bls.Sign, 10)
 
 	m := "test test"
-	for i:= 0; i < 10; i++ {
+	for i := 0; i < 10; i++ {
 		secs[i] = RandPrivateKey()
 		pubs[i] = secs[i].GetPublicKey()
 		sigs[i] = secs[i].Sign(m)
@@ -261,12 +260,12 @@ func TestNewImplementationWithPublicKeyHash1(test *testing.T) {
 	aggPub := pubs[0]
 	aggSig := sigs[0]
 
-	for i:= 1; i < 10; i++ {
+	for i := 1; i < 10; i++ {
 		aggPub.Add(TransformPublicKey(pubs[i]))
 		aggSig.Add(TransformSignature(sigs[i], pubs[i].Serialize()))
 	}
 
-	if ! aggSig.Verify(aggPub, m) {
+	if !aggSig.Verify(aggPub, m) {
 		test.Error("Aggregated signature doesn't verify in new implementation ")
 	}
 }
@@ -277,7 +276,7 @@ func TestNewImplementationWithPublicKeyHash2(test *testing.T) {
 	sigs := make([]*bls.Sign, 10)
 
 	m := "test test"
-	for i:= 0; i < 10; i++ {
+	for i := 0; i < 10; i++ {
 		secs[i] = RandPrivateKey()
 		pubs[i] = secs[i].GetPublicKey()
 		sigs[i] = secs[i].Sign(m)
@@ -286,16 +285,16 @@ func TestNewImplementationWithPublicKeyHash2(test *testing.T) {
 	aggPub := pubs[0]
 	aggSig := sigs[0]
 
-	for i:= 1; i < 10; i++ {
+	for i := 1; i < 10; i++ {
 		aggPub.Add(TransformPublicKey(pubs[i]))
-		if (i != 5) {
+		if i != 5 {
 			aggSig.Add(TransformSignature(sigs[i], pubs[i].Serialize()))
 		}
 	}
 
 	aggPub.Sub(TransformPublicKey(pubs[5]))
 
-	if ! aggSig.Verify(aggPub, m) {
+	if !aggSig.Verify(aggPub, m) {
 		test.Error("Aggregated signature (add, sub) doesn't verify in new implementation ")
 	}
 }
@@ -304,26 +303,25 @@ func TestNewMaskWithPublicKeyHash1(test *testing.T) {
 	secs := make([]*bls.SecretKey, 10)
 	pubs := make([]*bls.PublicKey, 10)
 	sigs := make([]*bls.Sign, 10)
-	m    := make(map[string]*bls.Sign)
+	m := make(map[string]*bls.Sign)
 
 	mesg := "test test"
 	mask, _ := NewMask(pubs, nil, true)
 
-	for i:= 0; i < 10; i++ {
+	for i := 0; i < 10; i++ {
 		secs[i] = RandPrivateKey()
 		pubs[i] = secs[i].GetPublicKey()
 		sigs[i] = secs[i].Sign(mesg)
 
 		// add the odd public keys
-		if (i % 2 == 1) {
+		if i%2 == 1 {
 			m[pubs[i].SerializeToHexStr()] = sigs[i]
 			mask.SetBit(i, true)
 		}
 	}
 
 	aggSig := AggregateSigWithPublicKey(m)
-	if ! aggSig.Verify(mask.AggregatePublic, mesg) {
+	if !aggSig.Verify(mask.AggregatePublic, mesg) {
 		test.Error("NewMaskWithPublicKeyiHash1doesn't verify aggregated keys in new implementation ")
 	}
 }
-


### PR DESCRIPTION
## Update the BLS pub key and signature aggregation to prevent rogue key attack

This PR implements  the proposal from  https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html

NOTE:
It is not a GENERIC BLS aggregation algorithm.  It is ONLY USEFUL if the message been signed is the same.  It works for Harmony's use case.

To make the transition process as easy as possible, I updated the constructor for creating a new Mask.

func NewMask(publics []*bls.PublicKey, myKey *bls.PublicKey, optionalUsePubKeyHash...bool) (*Mask, error) 

The be aggregation algorithm can ONLY be turned on when the Mask constructor has an new optional parameter optionalUsePubKeyHash == true. 


To use it, just replace the old one

1) mask creation:
from:
prepareBitmap, _ := bls_cosi.NewMask(members, nil)
to:
prepareBitmap, _ := bls_cosi.NewMask(members, nil, true)

2) signature aggregation

m2Sig := bls_cosi.AggregateSig(...)

with the new one:

m2Sig := bls_cosi.AggregateSigWithPublicKey(...)

