### PR TITLE
Add timestamp to transactions json

### DIFF
--- a/internal/hmyapi/transactionpool.go
+++ b/internal/hmyapi/transactionpool.go
@@ -111,7 +111,7 @@ func (s *PublicTransactionPoolAPI) GetTransactionByHash(ctx context.Context, has
 	// Try to return an already finalized transaction
 	tx, blockHash, blockNumber, index := rawdb.ReadTransaction(s.b.ChainDb(), hash)
 	block, _ := s.b.GetBlock(ctx, blockHash)
-	if block != nil {
+	if block == nil {
 		return nil
 	}
 	if tx != nil {
@@ -130,7 +130,7 @@ func (s *PublicTransactionPoolAPI) GetStakingTransactionByHash(ctx context.Conte
 	// Try to return an already finalized transaction
 	stx, blockHash, blockNumber, index := rawdb.ReadStakingTransaction(s.b.ChainDb(), hash)
 	block, _ := s.b.GetBlock(ctx, blockHash)
-	if block != nil {
+	if block == nil {
 		return nil
 	}
 	if stx != nil {

--- a/internal/hmyapi/transactionpool.go
+++ b/internal/hmyapi/transactionpool.go
@@ -110,8 +110,12 @@ func (s *PublicTransactionPoolAPI) GetTransactionByBlockHashAndIndex(ctx context
 func (s *PublicTransactionPoolAPI) GetTransactionByHash(ctx context.Context, hash common.Hash) *RPCTransaction {
 	// Try to return an already finalized transaction
 	tx, blockHash, blockNumber, index := rawdb.ReadTransaction(s.b.ChainDb(), hash)
+	block, _ := s.b.GetBlock(ctx, blockHash)
+	if block != nil {
+		return nil
+	}
 	if tx != nil {
-		return newRPCTransaction(tx, blockHash, blockNumber, index)
+		return newRPCTransaction(tx, blockHash, blockNumber, block.Time().Uint64(), index)
 	}
 	// No finalized transaction, try to retrieve it from the pool
 	if tx = s.b.GetPoolTransaction(hash); tx != nil {
@@ -125,8 +129,12 @@ func (s *PublicTransactionPoolAPI) GetTransactionByHash(ctx context.Context, has
 func (s *PublicTransactionPoolAPI) GetStakingTransactionByHash(ctx context.Context, hash common.Hash) *RPCStakingTransaction {
 	// Try to return an already finalized transaction
 	stx, blockHash, blockNumber, index := rawdb.ReadStakingTransaction(s.b.ChainDb(), hash)
+	block, _ := s.b.GetBlock(ctx, blockHash)
+	if block != nil {
+		return nil
+	}
 	if stx != nil {
-		return newRPCStakingTransaction(stx, blockHash, blockNumber, index)
+		return newRPCStakingTransaction(stx, blockHash, blockNumber, block.Time().Uint64(), index)
 	}
 	return nil
 }

--- a/internal/hmyapi/types.go
+++ b/internal/hmyapi/types.go
@@ -194,7 +194,7 @@ func newRPCValidator(validator *types2.Validator) *RPCValidator {
 
 // newRPCTransaction returns a transaction that will serialize to the RPC
 // representation, with the given location metadata set (if available).
-func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, timestamp uint64, uinindex uint64) *RPCTransaction {
+func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, timestamp uint64, index uint64) *RPCTransaction {
 	var signer types.Signer = types.FrontierSigner{}
 	if tx.Protected() {
 		signer = types.NewEIP155Signer(tx.ChainID())
@@ -333,7 +333,7 @@ func newRPCStakingTransaction(tx *types2.StakingTransaction, blockHash common.Ha
 
 // newRPCPendingTransaction returns a pending transaction that will serialize to the RPC representation
 func newRPCPendingTransaction(tx *types.Transaction) *RPCTransaction {
-	return newRPCTransaction(tx, common.Hash{}, 0, 0)
+	return newRPCTransaction(tx, common.Hash{}, 0, 0, 0)
 }
 
 // RPCBlock represents a block that will serialize to the RPC representation of a block


### PR DESCRIPTION
## Issue

TrustWallet requested tx timestamp to be returned in transactions api. They need it tomorrow. They either can query block right now and take timestamp there or we can update explorer nodes separately from mainnet now. 

## Test

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    NO

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    NO

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**
    NO

## TODO
