### PR TITLE
Emit fatal init error details to stderr w/o panics

### DIFF
--- a/cmd/client/txgen/main.go
+++ b/cmd/client/txgen/main.go
@@ -78,12 +78,12 @@ var (
 func setUpTXGen() *node.Node {
 	nodePriKey, _, err := utils.LoadKeyFromFile(*keyFile)
 	if err != nil {
-		panic(err)
+		utils.FatalErrMsg(err, "cannot load key from %s", *keyFile)
 	}
 
 	peerPubKey := bls.RandPrivateKey().GetPublicKey()
 	if peerPubKey == nil {
-		panic(fmt.Errorf("generate key error"))
+		utils.FatalErrMsg(err, "cannot generate BLS key")
 	}
 	shardID := *shardIDFlag
 	selfPeer := p2p.Peer{IP: *ip, Port: *port, ConsensusPubKey: peerPubKey}
@@ -91,9 +91,6 @@ func setUpTXGen() *node.Node {
 	// Nodes containing blockchain data to mirror the shards' data in the network
 
 	myhost, err := p2pimpl.NewHost(&selfPeer, nodePriKey)
-	if err != nil {
-		panic("unable to new host in txgen")
-	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error :%v \n", err)
 		os.Exit(1)
@@ -141,7 +138,7 @@ func main() {
 	if len(p2putils.BootNodes) == 0 {
 		bootNodeAddrs, err := p2putils.StringsToAddrs(p2putils.DefaultBootNodeAddrStrings)
 		if err != nil {
-			panic(err)
+			utils.FatalErrMsg(err, "cannot parse default bootnode list")
 		}
 		p2putils.BootNodes = bootNodeAddrs
 	}

--- a/cmd/client/wallet/main.go
+++ b/cmd/client/wallet/main.go
@@ -291,7 +291,7 @@ func readProfile(profile string) {
 func createWalletNode() *node.Node {
 	bootNodeAddrs, err := p2putils.StringsToAddrs(walletProfile.Bootnodes)
 	if err != nil {
-		panic(err)
+		utils.FatalErrMsg(err, "cannot parse bootnodes %#v", walletProfile.Bootnodes)
 	}
 	p2putils.BootNodes = bootNodeAddrs
 	shardID := 0
@@ -303,7 +303,7 @@ func createWalletNode() *node.Node {
 	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", port)
 	host, err := p2pimpl.NewHost(&self, priKey)
 	if err != nil {
-		panic(err)
+		utils.FatalErrMsg(err, "cannot initialize network")
 	}
 	chainDBFactory := &shardchain.MemDBFactory{}
 	w := node.New(host, nil, chainDBFactory, false)
@@ -361,11 +361,11 @@ func _exportAccount(account accounts.Account) {
 		filename := fmt.Sprintf(".hmy/%s.key", common2.MustAddressToBech32(account.Address))
 		f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
-			panic("Failed to open keystore")
+			utils.FatalErrMsg(err, "cannot open exported key file %s", filename)
 		}
 		_, err = f.Write(data)
 		if err != nil {
-			panic("Failed to write to keystore")
+			utils.FatalErrMsg(err, "cannot write to exported key file %s", filename)
 		}
 		if err := f.Close(); err != nil {
 			fmt.Println(ctxerror.New("cannot close key file",
@@ -489,12 +489,12 @@ func processImportCommnad() {
 
 	data, err := ioutil.ReadFile(priKey)
 	if err != nil {
-		panic("Failed to readfile")
+		utils.FatalErrMsg(err, "cannot load private key file %s", priKey)
 	}
 
 	account, err := ks.Import(data, pass, pass)
 	if err != nil {
-		panic("Failed to import the private key")
+		utils.FatalErrMsg(err, "cannot import private key in file %s", priKey)
 	}
 	fmt.Printf("Private key imported for account: %s\n", common2.MustAddressToBech32(account.Address))
 }
@@ -955,7 +955,7 @@ func GetFreeToken(address common.Address) {
 func clearKeystore() {
 	dir, err := ioutil.ReadDir(keystoreDir)
 	if err != nil {
-		panic("Failed to read keystore directory")
+		utils.FatalErrMsg(err, "cannot read keystore directory %s", keystoreDir)
 	}
 	for _, d := range dir {
 		subdir := path.Join([]string{keystoreDir, d.Name()}...)

--- a/cmd/client/wallet_stress_test/main.go
+++ b/cmd/client/wallet_stress_test/main.go
@@ -175,7 +175,7 @@ func readProfile(profile string) {
 func createWalletNode() *node.Node {
 	bootNodeAddrs, err := p2putils.StringsToAddrs(walletProfile.Bootnodes)
 	if err != nil {
-		panic(err)
+		utils.FatalErrMsg(err, "cannot parse bootnodes %#v", walletProfile.Bootnodes)
 	}
 	p2putils.BootNodes = bootNodeAddrs
 	shardID := 0
@@ -186,7 +186,7 @@ func createWalletNode() *node.Node {
 	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "6999")
 	host, err := p2pimpl.NewHost(&self, priKey)
 	if err != nil {
-		panic(err)
+		utils.FatalErrMsg(err, "cannot initialize network")
 	}
 	chainDBFactory := &shardchain.MemDBFactory{}
 	w := node.New(host, nil, chainDBFactory, false)
@@ -444,7 +444,7 @@ func GetFreeToken(address common.Address) {
 func clearKeystore() {
 	dir, err := ioutil.ReadDir(keystoreDir)
 	if err != nil {
-		panic("Failed to read keystore directory")
+		utils.FatalErrMsg(err, "cannot read keystore directory %s", keystoreDir)
 	}
 	for _, d := range dir {
 		subdir := path.Join([]string{keystoreDir, d.Name()}...)

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -159,7 +159,8 @@ func initSetup() {
 	if len(p2putils.BootNodes) == 0 {
 		bootNodeAddrs, err := p2putils.StringsToAddrs(p2putils.DefaultBootNodeAddrStrings)
 		if err != nil {
-			panic(err)
+			utils.FatalErrMsg(err, "cannot parse default bootnode list %#v",
+				p2putils.DefaultBootNodeAddrStrings)
 		}
 		p2putils.BootNodes = bootNodeAddrs
 	}

--- a/cmd/keygen/main.go
+++ b/cmd/keygen/main.go
@@ -11,6 +11,7 @@ import (
 	crypto2 "github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/harmony-one/harmony/internal/common"
+	"github.com/harmony-one/harmony/internal/utils"
 )
 
 var (
@@ -36,7 +37,7 @@ func main() {
 			}
 			priKey, err := crypto2.GenerateKey()
 			if err != nil {
-				panic("Failed to generate the private key")
+				utils.FatalErrMsg(err, "cannot generate wallet key")
 			}
 			crypto2.FromECDSA(priKey)
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/pkg/errors"
+
 	bls2 "github.com/harmony-one/harmony/crypto/bls"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -269,4 +271,28 @@ func AppendIfMissing(slice []common.Address, addr common.Address) []common.Addre
 		}
 	}
 	return append(slice, addr)
+}
+
+// PrintError prints the given error in the extended format (%+v) onto stderr.
+func PrintError(err error) {
+	_, _ = fmt.Fprintf(os.Stderr, "%+v\n", err)
+}
+
+// FatalError prints the given error in the extended format (%+v) onto stderr,
+// then exits with status 1.
+func FatalError(err error) {
+	PrintError(err)
+	os.Exit(1)
+}
+
+// PrintErrMsg prints the given error wrapped with the given message in the
+// extended format (%+v) onto stderr.
+func PrintErrMsg(err error, format string, args ...interface{}) {
+	PrintError(errors.WithMessagef(err, format, args...))
+}
+
+// FatalErrMsg prints the given error wrapped with the given message in the
+// extended format (%+v) onto stderr, then exits with status 1.
+func FatalErrMsg(err error, format string, args ...interface{}) {
+	FatalError(errors.WithMessagef(err, format, args...))
 }

--- a/p2p/host/hostv2/util.go
+++ b/p2p/host/hostv2/util.go
@@ -1,9 +1,0 @@
-package hostv2
-
-import "github.com/harmony-one/harmony/internal/utils"
-
-func catchError(err error) {
-	if err != nil {
-		utils.Logger().Panic().Err(err).Msg("catchError")
-	}
-}

--- a/p2p/p2pimpl/p2pimpl.go
+++ b/p2p/p2pimpl/p2pimpl.go
@@ -14,7 +14,10 @@ import (
 // for hostv2, it generates multiaddress, keypair and add PeerID to peer, add priKey to host
 // TODO (leo) The peerstore has to be persisted on disk.
 func NewHost(self *p2p.Peer, key libp2p_crypto.PrivKey) (p2p.Host, error) {
-	h := hostv2.New(self, key)
+	h, err := hostv2.New(self, key)
+	if err != nil {
+		return nil, err
+	}
 
 	utils.Logger().Info().
 		Str("self", net.JoinHostPort(self.IP, self.Port)).


### PR DESCRIPTION
## Issue

`harmony`, `bootnode`, `wallet`, and friends panic upon various initialization errors without printing details/root causes.  Convert panics into stderr prints + graceful exits with status 1.

## Test

### Unit Test Coverage

No change (top-level commands are not covered by UT).

### Test/Run Logs

When `bootnode` is run as a regular user with the cache directory with no read-write permission (stdout redirected to devnull to omit `BN_MA` message):

```
$ bin/bootnode > /dev/null
open .dht-127.0.0.1-9876: permission denied
cannot open directory ".dht-127.0.0.1-9876"
github.com/dgraph-io/badger.acquireDirectoryLock
        /Users/ek/go/pkg/mod/github.com/dgraph-io/badger@v1.6.0-rc1/dir_unix.go:56
github.com/dgraph-io/badger.Open
        /Users/ek/go/pkg/mod/github.com/dgraph-io/badger@v1.6.0-rc1/db.go:231
github.com/ipfs/go-ds-badger.NewDatastore
        /Users/ek/go/pkg/mod/github.com/ipfs/go-ds-badger@v0.0.5/datastore.go:85
main.main
        /Users/ek/h/harmony/cmd/bootnode/main.go:78
runtime.main
        /Users/ek/.gimme/versions/go1.12.7.darwin.amd64/src/runtime/proc.go:200
runtime.goexit
        /Users/ek/.gimme/versions/go1.12.7.darwin.amd64/src/runtime/asm_amd64.s:1337
cannot initialize DHT cache at .dht-127.0.0.1-9876
$ echo $?
1
```

The printed error above follows the extended error format furnished by the `"github.com/pkg/errors"` package.

* The innermost error (root cause) is displayed first.
* The outermost error (top-level disposition) is displayed last.  In the example above, it is the `cannot initialize DHT cache at .dht-127.0.0.1-9876` message.
* For each error printed, if there is a stack trace associated with it, the stack trace is displayed after the error message.

The example above, when read bottom-to-top, shows:

* `cannot initialize DHT cache at .dht-127.0.0.1-9876`, caused by:
    * `cannot open directory ".dht-127.0.0.1-9876"`, caused by:
        * `open .dht-127.0.0.1-9876: permission denied`, the root cause.

Note that the interim-level error has a stack trace.  It says the error occurred in the `"github.com/dgraph-io/badger".acquireDirectoryLock` function, in github.com/dgraph-io/badger@v1.6.0-rc1/dir_unix.go line 56.  This stemmed from our call to the `"github.com/ipfs/go-ds-badger".NewDatastore` function in bootnode main.go line 78.


## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES**

9. **Does the existing `node.sh` continue to work with this change?**

    Yes

10. **What should node operators know about this change?**

    Various panic messages have been converted to proper error messages.  Those who detect and take actions upon panic messages may have to update the strings/patterns they use for panic detection.

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**