### PR TITLE
[rpc][staking] Simplify validator information RPC, expose ValidatorMe…

### DIFF
--- a/internal/hmyapi/types.go
+++ b/internal/hmyapi/types.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/harmony-one/harmony/shard"
-
 	types2 "github.com/harmony-one/harmony/staking/types"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -83,23 +81,6 @@ type HeaderInformation struct {
 	LastCommitBitmap string      `json:"lastCommitBitmap"`
 }
 
-// RPCValidator represents a validator
-type RPCValidator struct {
-	Address             string               `json:"address"`
-	SlotPubKeys         []shard.BlsPublicKey `json:"slot_pub_keys"`
-	SlotShardIDs        []int                `json:"slot_shard_ids"`
-	UnbondingHeight     *big.Int             `json:"unbonding_height"`
-	MinSelfDelegation   *big.Int             `json:"min_self_delegation"`
-	MaxTotalDelegation  *big.Int             `json:"max_total_delegation"`
-	Active              bool                 `json:"active"`
-	Commission          types2.Commission    `json:"commission"`
-	Description         types2.Description   `json:"description"`
-	CreationHeight      *big.Int             `json:"creation_height"`
-	Uptime              string               `json:"uptime"`
-	AvgVotingPower      string               `json:"avg_voting_power"`
-	TotalEffectiveStake string               `json:"total_effective_stake"`
-}
-
 // RPCDelegation represents a particular delegation to a validator
 type RPCDelegation struct {
 	ValidatorAddress string            `json:"validator_address" yaml:"validator_address"`
@@ -171,25 +152,6 @@ func newRPCCXReceipt(cx *types.CXReceipt, blockHash common.Hash, blockNumber uin
 	result.To = toAddr
 
 	return result
-}
-
-func newRPCValidator(validator *types2.Validator) *RPCValidator {
-	addr, _ := internal_common.AddressToBech32(validator.Address)
-	return &RPCValidator{
-		addr,
-		validator.SlotPubKeys,
-		nil,
-		validator.UnbondingHeight,
-		validator.MinSelfDelegation,
-		validator.MaxTotalDelegation,
-		validator.Active,
-		validator.Commission,
-		validator.Description,
-		validator.CreationHeight,
-		"",
-		"",
-		"",
-	}
 }
 
 // newRPCTransaction returns a transaction that will serialize to the RPC

--- a/staking/types/commission.go
+++ b/staking/types/commission.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 
@@ -10,19 +11,44 @@ import (
 type (
 	// Commission defines a commission parameters for a given validator.
 	Commission struct {
-		CommissionRates `json:"commission_rates" yaml:"commission_rates"`
-		UpdateHeight    *big.Int `json:"update_height" yaml:"update_height"` // the block height the commission rate was last changed
-
+		CommissionRates
+		UpdateHeight *big.Int
 	}
 
 	// CommissionRates defines the initial commission rates to be used for creating a
 	// validator.
 	CommissionRates struct {
-		Rate          numeric.Dec `json:"rate" yaml:"rate"`                       // the commission rate charged to delegators, as a fraction
-		MaxRate       numeric.Dec `json:"max_rate" yaml:"max_rate"`               // maximum commission rate which validator can ever charge, as a fraction
-		MaxChangeRate numeric.Dec `json:"max_change_rate" yaml:"max_change_rate"` // maximum increase of the validator commission every epoch, as a fraction
+		Rate          numeric.Dec // the commission rate charged to delegators, as a fraction
+		MaxRate       numeric.Dec // maximum commission rate which validator can ever charge, as a fraction
+		MaxChangeRate numeric.Dec // maximum increase of the validator commission every epoch, as a fraction
 	}
 )
+
+// MarshalJSON ..
+func (c Commission) MarshalJSON() ([]byte, error) {
+	type t struct {
+		CommissionRates `json:"commision-rates"`
+		UpdateHeight    string `json:"update-height"`
+	}
+	return json.Marshal(t{
+		CommissionRates: c.CommissionRates,
+		UpdateHeight:    c.UpdateHeight.String(),
+	})
+}
+
+// MarshalJSON ..
+func (cr CommissionRates) MarshalJSON() ([]byte, error) {
+	type t struct {
+		Rate          string `json:"rate"`
+		MaxRate       string `json:"max-rate"`
+		MaxChangeRate string `json:"max-change-rate"`
+	}
+	return json.Marshal(t{
+		Rate:          cr.Rate.String(),
+		MaxRate:       cr.MaxRate.String(),
+		MaxChangeRate: cr.MaxChangeRate.String(),
+	})
+}
 
 // String returns a human readable string representation of a validator.
 func (c Commission) String() string {

--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 
@@ -47,26 +48,26 @@ type ValidatorWrapper struct {
 
 // VotePerShard ..
 type VotePerShard struct {
-	ShardID     uint32
-	VotingPower numeric.Dec
+	ShardID     uint32      `json:"shard-id"`
+	VotingPower numeric.Dec `json:"voting-power"`
 }
 
 // KeysPerShard ..
 type KeysPerShard struct {
-	ShardID uint32
-	Keys    []shard.BlsPublicKey
+	ShardID uint32               `json:"shard-id"`
+	Keys    []shard.BlsPublicKey `json:"bls-public-keys"`
 }
 
 // ValidatorStats to record validator's performance and history records
 type ValidatorStats struct {
 	// The number of blocks the validator should've signed when in active mode (selected in committee)
-	NumBlocksToSign *big.Int `json:"num_blocks_to_sign" rlp:"nil"`
+	NumBlocksToSign *big.Int `rlp:"nil"`
 	// The number of blocks the validator actually signed
-	NumBlocksSigned *big.Int `json:"num_blocks_signed" rlp:"nil"`
+	NumBlocksSigned *big.Int `rlp:"nil"`
 	// The number of times they validator is jailed due to extensive downtime
-	NumJailed *big.Int `json:"num_jailed" rlp:"nil"`
+	NumJailed *big.Int `rlp:"nil"`
 	// TotalEffectiveStake is the total effective stake this validator has
-	TotalEffectiveStake numeric.Dec `json:"total_effective_stake" rlp:"nil"`
+	TotalEffectiveStake numeric.Dec `rlp:"nil"`
 	// VotingPowerPerShard ..
 	VotingPowerPerShard []VotePerShard
 	// BLSKeyPerShard ..
@@ -76,23 +77,72 @@ type ValidatorStats struct {
 // Validator - data fields for a validator
 type Validator struct {
 	// ECDSA address of the validator
-	Address common.Address `json:"address" yaml:"address"`
+	Address common.Address
 	// The BLS public key of the validator for consensus
-	SlotPubKeys []shard.BlsPublicKey `json:"slot_pub_keys" yaml:"slot_pub_keys"`
-	// if unbonding, height at which this validator has begun unbonding
-	UnbondingHeight *big.Int `json:"unbonding_height" yaml:"unbonding_height"`
+	SlotPubKeys []shard.BlsPublicKey
+	// TODO Remove this field
+	UnbondingHeight *big.Int
 	// validator's self declared minimum self delegation
-	MinSelfDelegation *big.Int `json:"min_self_delegation" yaml:"min_self_delegation"`
+	MinSelfDelegation *big.Int
 	// maximum total delegation allowed
-	MaxTotalDelegation *big.Int `json:"max_total_delegation" yaml:"max_total_delegation"`
+	MaxTotalDelegation *big.Int
 	// Is the validator active in the validating process or not
-	Active bool `json:"active" yaml:"active"`
+	Active bool
 	// commission parameters
-	Commission `json:"commission" yaml:"commission"`
+	Commission
 	// description for the validator
-	Description `json:"description" yaml:"description"`
+	Description
 	// CreationHeight is the height of creation
-	CreationHeight *big.Int `json:"creation_height" yaml:"creation_height"`
+	CreationHeight *big.Int
+}
+
+// MarshalJSON ..
+func (v *ValidatorStats) MarshalJSON() ([]byte, error) {
+	type t struct {
+		NumBlocksToSign     uint64         `json:"blocks-to-sign"`
+		NumBlocksSigned     uint64         `json:"blocks-signed"`
+		NumJailed           uint64         `json:"blocks-jailed"`
+		TotalEffectiveStake numeric.Dec    `json:"total-effective-stake"`
+		VotingPowerPerShard []VotePerShard `json:"voting-power-per-shard"`
+		BLSKeyPerShard      []KeysPerShard `json:"bls-keys-per-shard"`
+	}
+	return json.Marshal(t{
+		NumBlocksToSign:     v.NumBlocksToSign.Uint64(),
+		NumBlocksSigned:     v.NumBlocksSigned.Uint64(),
+		NumJailed:           v.NumJailed.Uint64(),
+		TotalEffectiveStake: v.TotalEffectiveStake,
+		VotingPowerPerShard: v.VotingPowerPerShard,
+		BLSKeyPerShard:      v.BLSKeyPerShard,
+	})
+
+}
+
+// MarshalJSON ..
+func (v *Validator) MarshalJSON() ([]byte, error) {
+	type t struct {
+		Address            string      `json:"one-address"`
+		SlotPubKeys        []string    `json:"bls-public-keys"`
+		MinSelfDelegation  uint64      `json:"min-self-delegation"`
+		MaxTotalDelegation uint64      `json:"max-total-delegation"`
+		Active             bool        `json:"active"`
+		Commission         Commission  `json:"commission"`
+		Description        Description `json:"description"`
+		CreationHeight     uint64      `json:"creation-height"`
+	}
+	slots := make([]string, len(v.SlotPubKeys))
+	for i := range v.SlotPubKeys {
+		slots[i] = v.SlotPubKeys[i].Hex()
+	}
+	return json.Marshal(t{
+		Address:            common2.MustAddressToBech32(v.Address),
+		SlotPubKeys:        slots,
+		MinSelfDelegation:  v.MinSelfDelegation.Uint64(),
+		MaxTotalDelegation: v.MaxTotalDelegation.Uint64(),
+		Active:             v.Active,
+		Commission:         v.Commission,
+		Description:        v.Description,
+		CreationHeight:     v.CreationHeight.Uint64(),
+	})
 }
 
 func printSlotPubKeys(pubKeys []shard.BlsPublicKey) string {


### PR DESCRIPTION
tested: 

for validator information, get: 

```json
{
  "one-address": "one1f33w8c3dupm30p4fhemy89646xw7xpxcnmy6e4",
  "bls-public-keys": [
    "5a95dc46ad64618b12d56cb76ae0eba1482ce50758620195cbb6596b2d2f399c505998b931cc01325c063f98c7845119"
  ],
  "min-self-delegation": 2000000000000000000,
  "max-total-delegation": 12283092772231053312,
  "active": true,
  "commission": {
    "rate": "0.100000000000000000",
    "max-rate": "1.000000000000000000",
    "max-change-rate": "0.050000000000000000"
  },
  "description": {
    "name": "RJ's Validator",
    "identity": "RJ",
    "website": "rongjian@harmony.one",
    "security_contact": "RJ",
    "details": "RJ the real validator"
  },
  "creation-height": 413883
}
```

for validator metrics, get: 

```json
{
  "blocks-to-sign": 0,
  "blocks-signed": 0,
  "blocks-jailed": 0,
  "total-effective-stake": "66125000000000000000.000000000000000000",
  "voting-power-per-shard": [
    { "shard-id": 2, "voting-power": "0.021775147928994083" }
  ],
  "bls-keys-per-shard": [
    {
      "shard-id": 2,
      "bls-public-keys": [
        "5a95dc46ad64618b12d56cb76ae0eba1482ce50758620195cbb6596b2d2f399c505998b931cc01325c063f98c7845119"
      ]
    }
  ]
}
```