### PR TITLE
Add libp2pctl

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -587,8 +587,8 @@ func main() {
 		}
 		tlsConfig := tls.Config{
 			Certificates: []tls.Certificate{cert},
-			ClientAuth: tls.RequireAndVerifyClientCert,
-			ClientCAs:  clientCAs,
+			ClientAuth:   tls.RequireAndVerifyClientCert,
+			ClientCAs:    clientCAs,
 		}
 		listenAddr := &net.TCPAddr{Port: port}
 		listener, err := net.ListenTCP("tcp", listenAddr)

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -567,7 +567,7 @@ func main() {
 	}
 
 	if *libp2pctlFlag {
-		port, err := getPort(*libp2pctlPortFlag)
+		port, err := net.LookupPort("tcp", *libp2pctlPortFlag)
 		if err != nil {
 			utils.FatalErrMsg(err, "cannot parse -libp2pctl_port %#v",
 				*libp2pctlPortFlag)
@@ -610,30 +610,4 @@ func main() {
 	}
 
 	currentNode.StartServer()
-}
-
-func getPort(s string) (int, error) {
-	if s == "" {
-		return 0, errors.New("empty port")
-	}
-	if s[0] != '+' && s[0] != '-' {
-		return net.LookupPort("tcp", s)
-	}
-	n, err := strconv.ParseUint(s[1:], 0, 16)
-	if err != nil {
-		return 0, err
-	}
-	num, err := net.LookupPort("tcp", *port)
-	if err != nil {
-		return 0, errors.Wrapf(err, "cannot parse -port value %#v", *port)
-	}
-	if s[0] == '+' {
-		num += int(n)
-	} else {
-		num -= int(n)
-	}
-	if num < 1 || num > 65535 {
-		return 0, errors.Wrapf(err, "offset result %v out of range", num)
-	}
-	return num, nil
 }

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -128,7 +128,7 @@ var (
 	revertBeacon   = flag.Bool("revert_beacon", false, "Whether to revert beacon chain or the chain this node is assigned to")
 	// libp2p control interface
 	libp2pctlFlag         = flag.Bool("libp2pctl", false, "Enable libp2p control interface")
-	libp2pctlPortFlag     = flag.String("libp2pctl_port", "-4000", "libp2pctl port number; if prefixed with +/-, treat as offset from the -port value (default: -5000)")
+	libp2pctlPortFlag     = flag.String("libp2pctl_port", "4000", "libp2pctl port number (default: 4000)")
 	libp2pctlCertFlag     = flag.String("libp2pctl_cert", "harmony-libp2pctl-cert.pem", "libp2pctl HTTPS certificate filename (default: harmony-libp2pctl.crt)")
 	libp2pctlKeyFlag      = flag.String("libp2pctl_key", "harmony-libp2pctl-key.pem", "libp2pctl HTTPS private key filename (default: harmony-libp2pctl.key)")
 	libp2pctlClientCAFlag = flag.String("libp2pct_client_ca", "harmony-libp2pctl-client-ca.pem", "libp2pctl HTTPS client CA (default: harmony-libp2pctl-ca.pem)")

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/hex"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"math/big"
 	"math/rand"
+	"net"
+	"net/http"
 	"os"
 	"path"
 	"runtime"
@@ -30,6 +35,7 @@ import (
 	"github.com/harmony-one/harmony/internal/memprofiling"
 	"github.com/harmony-one/harmony/internal/shardchain"
 	"github.com/harmony-one/harmony/internal/utils"
+	"github.com/harmony-one/harmony/libp2pctl"
 	"github.com/harmony-one/harmony/node"
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/p2p/p2pimpl"
@@ -120,6 +126,12 @@ var (
 	doRevertBefore = flag.Int("do_revert_before", 0, "If the current block is less than do_revert_before, revert all blocks until (including) revert_to block")
 	revertTo       = flag.Int("revert_to", 0, "The revert will rollback all blocks until and including block number revert_to")
 	revertBeacon   = flag.Bool("revert_beacon", false, "Whether to revert beacon chain or the chain this node is assigned to")
+	// libp2p control interface
+	libp2pctlFlag         = flag.Bool("libp2pctl", false, "Enable libp2p control interface")
+	libp2pctlPortFlag     = flag.String("libp2pctl_port", "-4000", "libp2pctl port number; if prefixed with +/-, treat as offset from the -port value (default: -5000)")
+	libp2pctlCertFlag     = flag.String("libp2pctl_cert", "harmony-libp2pctl-cert.pem", "libp2pctl HTTPS certificate filename (default: harmony-libp2pctl.crt)")
+	libp2pctlKeyFlag      = flag.String("libp2pctl_key", "harmony-libp2pctl-key.pem", "libp2pctl HTTPS private key filename (default: harmony-libp2pctl.key)")
+	libp2pctlClientCAFlag = flag.String("libp2pct_client_ca", "harmony-libp2pctl-client-ca.pem", "libp2pctl HTTPS client CA (default: harmony-libp2pctl-ca.pem)")
 )
 
 func initSetup() {
@@ -554,6 +566,43 @@ func main() {
 			Msg("StartRPC failed")
 	}
 
+	if *libp2pctlFlag {
+		port, err := getPort(*libp2pctlPortFlag)
+		if err != nil {
+			utils.FatalErrMsg(err, "cannot parse -libp2pctl_port %#v",
+				*libp2pctlPortFlag)
+		}
+		cert, err := tls.LoadX509KeyPair(*libp2pctlCertFlag, *libp2pctlKeyFlag)
+		if err != nil {
+			utils.FatalErrMsg(err, "cannot load libp2pctl TLS cert/key")
+		}
+		clientCAPEM, err := ioutil.ReadFile(*libp2pctlClientCAFlag)
+		if err != nil {
+			utils.FatalErrMsg(err, "cannot load libp2pctl client CA %s",
+				*libp2pctlClientCAFlag)
+		}
+		clientCAs := x509.NewCertPool()
+		if !clientCAs.AppendCertsFromPEM(clientCAPEM) {
+			utils.Fatal("no libp2pctl client CA in %s", *libp2pctlClientCAFlag)
+		}
+		tlsConfig := tls.Config{
+			Certificates: []tls.Certificate{cert},
+			ClientAuth: tls.RequireAndVerifyClientCert,
+			ClientCAs:  clientCAs,
+		}
+		listenAddr := &net.TCPAddr{Port: port}
+		listener, err := net.ListenTCP("tcp", listenAddr)
+		if err != nil {
+			utils.FatalErrMsg(err, "cannot listen on libp2pctl port %d",
+				port)
+		}
+		tlsListener := tls.NewListener(listener, &tlsConfig)
+		ctl := libp2pctl.New(myHost.GetP2PHost())
+		go func() { _ = http.Serve(tlsListener, ctl.Handler()) }()
+		utils.Logger().Info().Interface("listenAddr", listenAddr).
+			Msg("started libp2pctl")
+	}
+
 	// Run additional node collectors
 	// Collect node metrics if metrics flag is set
 	if currentNode.NodeConfig.GetMetricsFlag() {
@@ -561,4 +610,30 @@ func main() {
 	}
 
 	currentNode.StartServer()
+}
+
+func getPort(s string) (int, error) {
+	if s == "" {
+		return 0, errors.New("empty port")
+	}
+	if s[0] != '+' && s[0] != '-' {
+		return net.LookupPort("tcp", s)
+	}
+	n, err := strconv.ParseUint(s[1:], 0, 16)
+	if err != nil {
+		return 0, err
+	}
+	num, err := net.LookupPort("tcp", *port)
+	if err != nil {
+		return 0, errors.Wrapf(err, "cannot parse -port value %#v", *port)
+	}
+	if s[0] == '+' {
+		num += int(n)
+	} else {
+		num -= int(n)
+	}
+	if num < 1 || num > 65535 {
+		return 0, errors.Wrapf(err, "offset result %v out of range", num)
+	}
+	return num, nil
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -273,6 +273,12 @@ func AppendIfMissing(slice []common.Address, addr common.Address) []common.Addre
 	return append(slice, addr)
 }
 
+// Fatal prints the given message onto stderr, then exits with status 1.
+func Fatal(format string, args ...interface{}) {
+	_, _ = fmt.Fprintf(os.Stderr, format, args...)
+	os.Exit(1)
+}
+
 // PrintError prints the given error in the extended format (%+v) onto stderr.
 func PrintError(err error) {
 	_, _ = fmt.Fprintf(os.Stderr, "%+v\n", err)

--- a/libp2pctl/server.go
+++ b/libp2pctl/server.go
@@ -29,6 +29,8 @@ type EndpointID struct {
 	Addr ma.Multiaddr
 }
 
+// EndpointIDFromURLVar parses the given URL-variable-format endpoint ID in the
+// peer-id@url64-encoded-binary-multiaddr format into connection endpoint ID.
 func EndpointIDFromURLVar(v string) (EndpointID, error) {
 	idma := strings.SplitN(v, "@", 2)
 	if len(idma) != 2 {
@@ -50,13 +52,13 @@ func EndpointIDFromURLVar(v string) (EndpointID, error) {
 }
 
 // URLVar returns the encoded form of the receiver, suitable for use in a URL.
-func (id EndpointID) URLVar() string {
-	return id.ID.String() + "@" + url64Encode(id.Addr.Bytes())
+func (epid EndpointID) URLVar() string {
+	return epid.ID.String() + "@" + url64Encode(epid.Addr.Bytes())
 }
 
 // Key returns a struct usable as a map key.
-func (ep EndpointID) Key() EndpointKey {
-	return EndpointKey{ep.ID, string(ep.Addr.Bytes())}
+func (epid EndpointID) Key() EndpointKey {
+	return EndpointKey{epid.ID, string(epid.Addr.Bytes())}
 }
 
 // EndpointKey is a libp2p connection endpoint, usable as a map key.

--- a/libp2pctl/server.go
+++ b/libp2pctl/server.go
@@ -191,8 +191,8 @@ func newConnJSON(conn network.Conn) connJSON {
 }
 
 type connEntryJSON struct {
-	ID         ConnID
-	URL        string
+	ID  ConnID
+	URL string
 	connJSON
 }
 

--- a/libp2pctl/server.go
+++ b/libp2pctl/server.go
@@ -161,21 +161,8 @@ func (inst *Instance) Handler() http.Handler {
 	return inst.rtr
 }
 
-func httpWriteJSON(w http.ResponseWriter, data interface{}) error {
-	bytes, err := json.Marshal(data)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		return errors.Wrapf(err, "cannot marshal data")
-	}
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := w.Write(bytes); err != nil {
-		return errors.Wrapf(err, "cannot write JSON")
-	}
-	return nil
-}
-
 func (inst *Instance) getAddrs(w http.ResponseWriter, r *http.Request) {
-	if err := httpWriteJSON(w, inst.host.Addrs()); err != nil {
+	if err := json.NewEncoder(w).Encode(inst.host.Addrs()); err != nil {
 		utils.Logger().Err(err).Msg("cannot serve libp2p addresses")
 	}
 }
@@ -241,7 +228,7 @@ func (inst *Instance) getConns(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	if err := httpWriteJSON(w, conns); err != nil {
+	if err := json.NewEncoder(w).Encode(conns); err != nil {
 		utils.Logger().Err(err).Msg("cannot serve libp2p connections")
 	}
 	return
@@ -274,7 +261,7 @@ func (inst *Instance) getConn(w http.ResponseWriter, r *http.Request) {
 	case conn == nil:
 		w.WriteHeader(http.StatusNotFound)
 	default:
-		if err := httpWriteJSON(w, conn); err != nil {
+		if err := json.NewEncoder(w).Encode(conn); err != nil {
 			utils.Logger().Err(err).Interface("conn", conn).
 				Msg("cannot write connection details")
 		}
@@ -334,7 +321,7 @@ func (inst *Instance) getConnStat(w http.ResponseWriter, r *http.Request) {
 	case conn == nil:
 		w.WriteHeader(http.StatusNotFound)
 	default:
-		if err := httpWriteJSON(w, conn.Stat()); err != nil {
+		if err := json.NewEncoder(w).Encode(conn.Stat()); err != nil {
 			utils.Logger().Err(err).Msg("cannot serve connection stat")
 		}
 	}

--- a/libp2pctl/server.go
+++ b/libp2pctl/server.go
@@ -1,0 +1,352 @@
+package libp2pctl
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/gorilla/mux"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/peer"
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/pkg/errors"
+
+	"github.com/harmony-one/harmony/internal/utils"
+)
+
+// Shorthand aliases
+var (
+	url64Encode = base64.RawURLEncoding.EncodeToString
+	url64Decode = base64.RawURLEncoding.DecodeString
+)
+
+// EndpointID is a libp2p connection endpoint.
+type EndpointID struct {
+	ID   peer.ID
+	Addr ma.Multiaddr
+}
+
+func EndpointIDFromURLVar(v string) (EndpointID, error) {
+	idma := strings.SplitN(v, "@", 2)
+	if len(idma) != 2 {
+		return EndpointID{}, errors.New("no ID-multiaddr separator")
+	}
+	id, err := peer.IDB58Decode(idma[0])
+	if err != nil {
+		return EndpointID{}, errors.Wrap(err, "cannot parse peer ID")
+	}
+	mab, err := url64Decode(idma[1])
+	if err != nil {
+		return EndpointID{}, errors.Wrap(err, "cannot decode multiaddr")
+	}
+	ma, err := ma.NewMultiaddrBytes(mab)
+	if err != nil {
+		return EndpointID{}, errors.Wrap(err, "cannot parse multiaddr")
+	}
+	return EndpointID{id, ma}, nil
+}
+
+// URLVar returns the encoded form of the receiver, suitable for use in a URL.
+func (id EndpointID) URLVar() string {
+	return id.ID.String() + "@" + url64Encode(id.Addr.Bytes())
+}
+
+// Key returns a struct usable as a map key.
+func (ep EndpointID) Key() EndpointKey {
+	return EndpointKey{ep.ID, string(ep.Addr.Bytes())}
+}
+
+// EndpointKey is a libp2p connection endpoint, usable as a map key.
+type EndpointKey struct {
+	id   peer.ID
+	addr string
+}
+
+// ID returns the endpoint ID.
+func (k EndpointKey) ID() (EndpointID, error) {
+	addr, err := ma.NewMultiaddrBytes([]byte(k.addr))
+	if err != nil {
+		return EndpointID{}, errors.Wrap(err, "cannot convert multiaddr")
+	}
+	return EndpointID{k.id, addr}, nil
+}
+
+// ConnID is the identifier of a connection.
+type ConnID struct {
+	Local, Remote EndpointID
+}
+
+// Key returns a struct usable as a map key.
+func (n ConnID) Key() ConnKey {
+	return ConnKey{n.Local.Key(), n.Remote.Key()}
+}
+
+// ConnKey is a connection identifier, usable as a map key.
+type ConnKey struct {
+	local, remote EndpointKey
+}
+
+// ID returns the connection ID.
+func (k ConnKey) ID() (ConnID, error) {
+	local, err := k.local.ID()
+	if err != nil {
+		return ConnID{}, errors.Wrap(err, "cannot convert local key into ID")
+	}
+	remote, err := k.remote.ID()
+	if err != nil {
+		return ConnID{}, errors.Wrap(err, "cannot convert remote key into ID")
+	}
+	return ConnID{local, remote}, nil
+}
+
+// ConnIDFromConn returns the name of the given connection.
+func ConnIDFromConn(conn network.Conn) ConnID {
+	return ConnID{
+		Local:  EndpointID{conn.LocalPeer(), conn.LocalMultiaddr()},
+		Remote: EndpointID{conn.RemotePeer(), conn.RemoteMultiaddr()},
+	}
+}
+
+// Instance is a libp2pctl instance.
+type Instance struct {
+	host     host.Host
+	rtr      *mux.Router
+	conns    map[ConnKey]network.Conn
+	connsMtx sync.RWMutex
+	notifiee *notifiee
+}
+
+// New returns a libp2pctl instance associated with the given libp2p host.
+func New(host host.Host) *Instance {
+	rtr := mux.NewRouter()
+	rtrConn := rtr.Path("/conn/{local}/{remote}").Subrouter()
+	inst := &Instance{
+		host:  host,
+		rtr:   rtr,
+		conns: map[ConnKey]network.Conn{},
+	}
+	for _, conn := range host.Network().Conns() {
+		inst.addConn(conn)
+	}
+	inst.notifiee = &notifiee{inst}
+	host.Network().Notify(inst.notifiee)
+
+	rtr.Methods("GET").Path("/addrs").HandlerFunc(inst.getAddrs)
+	rtr.Methods("GET").Path("/conns").HandlerFunc(inst.getConns)
+	rtr.Methods("POST").Path("/conns").HandlerFunc(inst.postConns)
+	rtrConn.Methods("GET").Path("").HandlerFunc(inst.getConn).Name("conn")
+	rtrConn.Methods("DELETE").Path("").HandlerFunc(inst.deleteConn)
+	rtrConn.Methods("GET").Path("/stat").HandlerFunc(inst.getConnStat)
+
+	return inst
+}
+
+func (inst *Instance) addConn(conn network.Conn) {
+	inst.connsMtx.Lock()
+	defer inst.connsMtx.Unlock()
+	inst.conns[ConnIDFromConn(conn).Key()] = conn
+}
+
+func (inst *Instance) delConn(conn network.Conn) {
+	inst.connsMtx.Lock()
+	defer inst.connsMtx.Unlock()
+	delete(inst.conns, ConnIDFromConn(conn).Key())
+}
+
+// Handler returns an HTTP request handler of the libp2pctl instance.
+func (inst *Instance) Handler() http.Handler {
+	return inst.rtr
+}
+
+func httpWriteJSON(w http.ResponseWriter, data interface{}) error {
+	bytes, err := json.Marshal(data)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return errors.Wrapf(err, "cannot marshal data")
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(bytes); err != nil {
+		return errors.Wrapf(err, "cannot write JSON")
+	}
+	return nil
+}
+
+func (inst *Instance) getAddrs(w http.ResponseWriter, r *http.Request) {
+	if err := httpWriteJSON(w, inst.host.Addrs()); err != nil {
+		utils.Logger().Err(err).Msg("cannot serve libp2p addresses")
+	}
+}
+
+func (inst *Instance) connNames() (connNames []ConnID) {
+	for _, conn := range inst.host.Network().Conns() {
+		connNames = append(connNames, ConnIDFromConn(conn))
+	}
+	return connNames
+}
+
+type connJSON struct {
+	LocalPeer  peer.ID
+	LocalAddr  ma.Multiaddr
+	RemotePeer peer.ID
+	RemoteAddr ma.Multiaddr
+}
+
+func newConnJSON(conn network.Conn) connJSON {
+	return connJSON{
+		LocalPeer:  conn.LocalPeer(),
+		LocalAddr:  conn.LocalMultiaddr(),
+		RemotePeer: conn.RemotePeer(),
+		RemoteAddr: conn.RemoteMultiaddr(),
+	}
+}
+
+type connEntryJSON struct {
+	ID         ConnID
+	URL        string
+	connJSON
+}
+
+type connTableJSON []connEntryJSON
+
+func (inst *Instance) connTableJSON() (connTableJSON, error) {
+	resp := connTableJSON{}
+	for key, conn := range inst.conns {
+		id, err := key.ID()
+		if err != nil {
+			return nil, err
+		}
+		url, err := inst.rtr.Get("conn").URL(
+			"local", id.Local.URLVar(),
+			"remote", id.Remote.URLVar(),
+		)
+		if err != nil {
+			return nil, err
+		}
+		resp = append(resp, connEntryJSON{
+			ID:       id,
+			URL:      url.String(),
+			connJSON: newConnJSON(conn),
+		})
+	}
+	return resp, nil
+}
+
+func (inst *Instance) getConns(w http.ResponseWriter, r *http.Request) {
+	conns, err := inst.connTableJSON()
+	if err != nil {
+		utils.Logger().Err(err).Msg("cannot build connection table")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if err := httpWriteJSON(w, conns); err != nil {
+		utils.Logger().Err(err).Msg("cannot serve libp2p connections")
+	}
+	return
+}
+
+func (inst *Instance) lookupConn(r *http.Request) (network.Conn, error) {
+	vars := mux.Vars(r)
+	if vars == nil {
+		return nil, errors.New("cannot get route vars")
+	}
+	local, err := EndpointIDFromURLVar(vars["local"])
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid local endpoint %#v", vars["local"])
+	}
+	remote, err := EndpointIDFromURLVar(vars["local"])
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid remote endpoint %#v", vars["remote"])
+	}
+	inst.connsMtx.RLock()
+	defer inst.connsMtx.RUnlock()
+	return inst.conns[ConnID{local, remote}.Key()], nil
+}
+
+func (inst *Instance) getConn(w http.ResponseWriter, r *http.Request) {
+	conn, err := inst.lookupConn(r)
+	switch {
+	case err != nil:
+		utils.Logger().Err(err).Msg("cannot retrieve connection")
+		w.WriteHeader(http.StatusInternalServerError)
+	case conn == nil:
+		w.WriteHeader(http.StatusNotFound)
+	default:
+		if err := httpWriteJSON(w, conn); err != nil {
+			utils.Logger().Err(err).Interface("conn", conn).
+				Msg("cannot write connection details")
+		}
+	}
+}
+
+func (inst *Instance) deleteConn(w http.ResponseWriter, r *http.Request) {
+	conn, err := inst.lookupConn(r)
+	switch {
+	case err != nil:
+		utils.Logger().Err(err).Msg("cannot retrieve connection")
+		w.WriteHeader(http.StatusInternalServerError)
+	case conn == nil:
+		w.WriteHeader(http.StatusNotFound)
+	default:
+		if err := conn.Close(); err != nil {
+			utils.Logger().Err(err).
+				Interface("conn", ConnIDFromConn(conn)).
+				Msg("cannot close connection")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func (inst *Instance) postConns(w http.ResponseWriter, r *http.Request) {
+	switch r.Header.Get("Content-Type") {
+	case "", "application/json":
+	default:
+		w.WriteHeader(http.StatusUnsupportedMediaType)
+		return
+	}
+	ctx := r.Context()
+	var pi peer.AddrInfo
+	if err := json.NewDecoder(r.Body).Decode(&pi); err != nil {
+		utils.Logger().Err(err).Msg("cannot parse request body")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	utils.Logger().Info().Interface("remote", pi).
+		Msg("connecting to libp2p peer per libp2pctl request")
+	if err := inst.host.Connect(ctx, pi); err != nil {
+		utils.Logger().Err(err).Msg("cannot connect to libp2p peer")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (inst *Instance) getConnStat(w http.ResponseWriter, r *http.Request) {
+	conn, err := inst.lookupConn(r)
+	switch {
+	case err != nil:
+		utils.Logger().Err(err).Msg("cannot retrieve connection")
+		w.WriteHeader(http.StatusInternalServerError)
+	case conn == nil:
+		w.WriteHeader(http.StatusNotFound)
+	default:
+		if err := httpWriteJSON(w, conn.Stat()); err != nil {
+			utils.Logger().Err(err).Msg("cannot serve connection stat")
+		}
+	}
+}
+
+type notifiee struct {
+	inst *Instance
+}
+
+func (n *notifiee) Connected(_ network.Network, conn network.Conn)    { n.inst.addConn(conn) }
+func (n *notifiee) Disconnected(_ network.Network, conn network.Conn) { n.inst.delConn(conn) }
+func (n *notifiee) Listen(network.Network, ma.Multiaddr)              {}
+func (n *notifiee) ListenClose(network.Network, ma.Multiaddr)         {}
+func (n *notifiee) OpenedStream(network.Network, network.Stream)      {}
+func (n *notifiee) ClosedStream(network.Network, network.Stream)      {}


### PR DESCRIPTION
## Issue

Make it possible to control P2P connections from outside the harmony binary without having to restart or reconfigure it.  Also expose connection stats.

Since this is a disruptive operation, it requires client authentication (TLS cert auth).  Usability is to be determined/improved.

## Test

### Unit Test Coverage

TODO

### Test/Run Logs

TODO

## Operational Checklist

1. Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol? – **No**
s know about this planned change?**

8. Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol? – **No**

11. Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage? – **No**

## TODO

* [ ] Add UT
* [ ] Add sample request/responses