### PR TITLE
[config] Add localnet config for staking

### DIFF
--- a/internal/configs/node/config.go
+++ b/internal/configs/node/config.go
@@ -296,6 +296,8 @@ func (t NetworkType) ChainConfig() params.ChainConfig {
 		return *params.MainnetChainConfig
 	case Pangaea:
 		return *params.PangaeaChainConfig
+	case Localnet:
+		return *params.LocalnetChainConfig
 	default:
 		return *params.TestnetChainConfig
 	}

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -55,6 +55,17 @@ var (
 		S3Epoch:         big.NewInt(0),
 	}
 
+	// LocalnetChainConfig contains the chain parameters to run for local development.
+	LocalnetChainConfig = &ChainConfig{
+		ChainID:         TestnetChainID,
+		CrossTxEpoch:    big.NewInt(0),
+		CrossLinkEpoch:  big.NewInt(3),
+		StakingEpoch:    big.NewInt(4),
+		PreStakingEpoch: big.NewInt(2),
+		EIP155Epoch:     big.NewInt(0),
+		S3Epoch:         big.NewInt(0),
+	}
+
 	// AllProtocolChanges ...
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.


### PR DESCRIPTION
## Issue

Cannot do staking tests with current localnet config.

## Test

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**

Note: `test/deploy.sh` & `test/debug.sh` does not need to be changed as it already uses the Localnet network type.