### PR TITLE
[rpc] Expose node's role into Metadata RPC

### DIFF
--- a/internal/hmyapi/harmony.go
+++ b/internal/hmyapi/harmony.go
@@ -53,6 +53,7 @@ type NodeMetadata struct {
 	ChainID      string `json:"chainid"`
 	IsLeader     bool   `json:"is-leader"`
 	ShardID      uint32 `json:"shard-id"`
+	Role         string `json:"role"`
 }
 
 // GetNodeMetadata produces a NodeMetadata record, data is from the answering RPC node
@@ -65,6 +66,7 @@ func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
 		s.b.ChainConfig().ChainID.String(),
 		s.b.IsLeader(),
 		s.b.GetShardID(),
+		cfg.Role().String(),
 	}
 }
 


### PR DESCRIPTION
for downstream consumer like watchdog, so we can easily know which node is explorer + its IP 