### PR TITLE
Fixes for tx logs master

### DIFF
--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -142,15 +142,26 @@ func (b *APIBackend) GetLogs(ctx context.Context, blockHash common.Hash) ([][]*t
 	return nil, nil
 }
 
-// HeaderByHash ...
-func (b *APIBackend) HeaderByHash(ctx context.Context, blockHash common.Hash) (*block.Header, error) {
-	// TODO(ricl): implement
-	return nil, nil
+// GetLogs ...
+func (b *APIBackend) GetLogs(ctx context.Context, blockHash common.Hash) ([][]*types.Log, error) {
+	receipts := b.hmy.blockchain.GetReceiptsByHash(blockHash)
+	if receipts == nil {
+		return nil, errors.New("Missing receipts")
+	}
+	logs := make([][]*types.Log, len(receipts))
+	for i, receipt := range receipts {
+		logs[i] = receipt.Logs
+	}
+	return logs, nil
 }
 
-// ServiceFilter ...
-func (b *APIBackend) ServiceFilter(ctx context.Context, session *bloombits.MatcherSession) {
-	// TODO(ricl): implement
+// HeaderByHash ...
+func (b *APIBackend) HeaderByHash(ctx context.Context, blockHash common.Hash) (*block.Header, error) {
+	header := b.hmy.blockchain.GetHeaderByHash(blockHash)
+	if header == nil {
+		return nil, errors.New("Header is not found")
+	}
+	return header, nil
 }
 
 // SubscribeNewTxsEvent subcribes new tx event.

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -158,6 +158,11 @@ func (b *APIBackend) HeaderByHash(ctx context.Context, blockHash common.Hash) (*
 	return header, nil
 }
 
+// ServiceFilter ...
+func (b *APIBackend) ServiceFilter(ctx context.Context, session *bloombits.MatcherSession) {
+	// TODO(ricl): implement
+}
+
 // SubscribeNewTxsEvent subcribes new tx event.
 // TODO: this is not implemented or verified yet for harmony.
 func (b *APIBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Subscription {

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -138,12 +138,6 @@ func (b *APIBackend) ProtocolVersion() int {
 
 // GetLogs ...
 func (b *APIBackend) GetLogs(ctx context.Context, blockHash common.Hash) ([][]*types.Log, error) {
-	// TODO(ricl): implement
-	return nil, nil
-}
-
-// GetLogs ...
-func (b *APIBackend) GetLogs(ctx context.Context, blockHash common.Hash) ([][]*types.Log, error) {
 	receipts := b.hmy.blockchain.GetReceiptsByHash(blockHash)
 	if receipts == nil {
 		return nil, errors.New("Missing receipts")


### PR DESCRIPTION
## Issue

@mattlockyer found issue with past logs, turns out on api_backend they were not implemented.

## Test

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
