### PR TITLE
[rpc][config] Extend node metadata RPC with chain config, block per e…

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -364,10 +364,12 @@ func setupConsensusAndNode(nodeConfig *nodeconfig.ConfigType) *node.Node {
 
 	switch *nodeType {
 	case "explorer":
+		nodeconfig.SetDefaultRole(nodeconfig.ExplorerNode)
 		currentNode.NodeConfig.SetRole(nodeconfig.ExplorerNode)
 		currentNode.NodeConfig.SetShardGroupID(nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(*shardID)))
 		currentNode.NodeConfig.SetClientGroupID(nodeconfig.NewClientGroupIDByShardID(nodeconfig.ShardID(*shardID)))
 	case "validator":
+		nodeconfig.SetDefaultRole(nodeconfig.Validator)
 		currentNode.NodeConfig.SetRole(nodeconfig.Validator)
 		if nodeConfig.ShardID == shard.BeaconChainShardID {
 			currentNode.NodeConfig.SetShardGroupID(nodeconfig.NewGroupIDByShardID(shard.BeaconChainShardID))
@@ -459,7 +461,7 @@ func main() {
 		}
 		// TODO (leo): use a passing list of accounts here
 		devnetConfig, err := shardingconfig.NewInstance(
-			uint32(*devnetNumShards), *devnetShardSize, *devnetHarmonySize, genesis.HarmonyAccounts, genesis.FoundationalNodeAccounts, nil)
+			uint32(*devnetNumShards), *devnetShardSize, *devnetHarmonySize, genesis.HarmonyAccounts, genesis.FoundationalNodeAccounts, nil, shardingconfig.VLBPE)
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "ERROR invalid devnet sharding config: %s",
 				err)

--- a/internal/configs/node/config.go
+++ b/internal/configs/node/config.go
@@ -120,6 +120,11 @@ func GetDefaultConfig() *ConfigType {
 	return &defaultConfig
 }
 
+// SetDefaultRole ..
+func SetDefaultRole(r Role) {
+	defaultConfig.role = r
+}
+
 func (conf *ConfigType) String() string {
 	return fmt.Sprintf("%s/%s/%s:%v,%v", conf.beacon, conf.group, conf.client, conf.isClient, conf.ShardID)
 }

--- a/internal/configs/sharding/instance.go
+++ b/internal/configs/sharding/instance.go
@@ -26,6 +26,7 @@ type instance struct {
 	hmyAccounts                     []genesis.DeployAccount
 	fnAccounts                      []genesis.DeployAccount
 	reshardingEpoch                 []*big.Int
+	blocksPerEpoch                  uint64
 }
 
 // NewInstance creates and validates a new sharding configuration based
@@ -34,7 +35,7 @@ func NewInstance(
 	numShards uint32, numNodesPerShard, numHarmonyOperatedNodesPerShard int,
 	hmyAccounts []genesis.DeployAccount,
 	fnAccounts []genesis.DeployAccount,
-	reshardingEpoch []*big.Int,
+	reshardingEpoch []*big.Int, blocksE uint64,
 ) (Instance, error) {
 	if numShards < 1 {
 		return nil, ctxerror.New("sharding config must have at least one shard",
@@ -62,6 +63,7 @@ func NewInstance(
 		hmyAccounts:                     hmyAccounts,
 		fnAccounts:                      fnAccounts,
 		reshardingEpoch:                 reshardingEpoch,
+		blocksPerEpoch:                  blocksE,
 	}, nil
 }
 
@@ -72,14 +74,21 @@ func MustNewInstance(
 	numShards uint32, numNodesPerShard, numHarmonyOperatedNodesPerShard int,
 	hmyAccounts []genesis.DeployAccount,
 	fnAccounts []genesis.DeployAccount,
-	reshardingEpoch []*big.Int,
+	reshardingEpoch []*big.Int, blocksPerEpoch uint64,
 ) Instance {
 	sc, err := NewInstance(
-		numShards, numNodesPerShard, numHarmonyOperatedNodesPerShard, hmyAccounts, fnAccounts, reshardingEpoch)
+		numShards, numNodesPerShard, numHarmonyOperatedNodesPerShard,
+		hmyAccounts, fnAccounts, reshardingEpoch, blocksPerEpoch,
+	)
 	if err != nil {
 		panic(err)
 	}
 	return sc
+}
+
+// BlocksPerEpoch ..
+func (sc instance) BlocksPerEpoch() uint64 {
+	return sc.blocksPerEpoch
 }
 
 // NumShards returns the number of shards in the network.

--- a/internal/configs/sharding/localnet.go
+++ b/internal/configs/sharding/localnet.go
@@ -111,7 +111,7 @@ var (
 		big.NewInt(0), big.NewInt(localnetV1Epoch), big.NewInt(localnetV2Epoch),
 	}
 	// Number of shards, how many slots on each , how many slots owned by Harmony
-	localnetV0 = MustNewInstance(2, 7, 5, genesis.LocalHarmonyAccounts, genesis.LocalFnAccounts, localnetReshardingEpoch)
-	localnetV1 = MustNewInstance(2, 8, 5, genesis.LocalHarmonyAccountsV1, genesis.LocalFnAccountsV1, localnetReshardingEpoch)
-	localnetV2 = MustNewInstance(2, 9, 6, genesis.LocalHarmonyAccountsV2, genesis.LocalFnAccountsV2, localnetReshardingEpoch)
+	localnetV0 = MustNewInstance(2, 7, 5, genesis.LocalHarmonyAccounts, genesis.LocalFnAccounts, localnetReshardingEpoch, LocalnetSchedule.BlocksPerEpoch())
+	localnetV1 = MustNewInstance(2, 8, 5, genesis.LocalHarmonyAccountsV1, genesis.LocalFnAccountsV1, localnetReshardingEpoch, LocalnetSchedule.BlocksPerEpoch())
+	localnetV2 = MustNewInstance(2, 9, 6, genesis.LocalHarmonyAccountsV2, genesis.LocalFnAccountsV2, localnetReshardingEpoch, LocalnetSchedule.BlocksPerEpoch())
 )

--- a/internal/configs/sharding/mainnet.go
+++ b/internal/configs/sharding/mainnet.go
@@ -137,14 +137,16 @@ func (ms mainnetSchedule) GetShardingStructure(numShard, shardID int) []map[stri
 
 var mainnetReshardingEpoch = []*big.Int{big.NewInt(0), big.NewInt(mainnetV0_1Epoch), big.NewInt(mainnetV0_2Epoch), big.NewInt(mainnetV0_3Epoch), big.NewInt(mainnetV0_4Epoch), big.NewInt(mainnetV1Epoch), big.NewInt(mainnetV1_1Epoch), big.NewInt(mainnetV1_2Epoch), big.NewInt(mainnetV1_3Epoch), big.NewInt(mainnetV1_4Epoch), big.NewInt(mainnetV1_5Epoch)}
 
-var mainnetV0 = MustNewInstance(4, 150, 112, genesis.HarmonyAccounts, genesis.FoundationalNodeAccounts, mainnetReshardingEpoch)
-var mainnetV0_1 = MustNewInstance(4, 152, 112, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_1, mainnetReshardingEpoch)
-var mainnetV0_2 = MustNewInstance(4, 200, 148, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_2, mainnetReshardingEpoch)
-var mainnetV0_3 = MustNewInstance(4, 210, 148, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_3, mainnetReshardingEpoch)
-var mainnetV0_4 = MustNewInstance(4, 216, 148, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_4, mainnetReshardingEpoch)
-var mainnetV1 = MustNewInstance(4, 250, 170, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1, mainnetReshardingEpoch)
-var mainnetV1_1 = MustNewInstance(4, 250, 170, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_1, mainnetReshardingEpoch)
-var mainnetV1_2 = MustNewInstance(4, 250, 170, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_2, mainnetReshardingEpoch)
-var mainnetV1_3 = MustNewInstance(4, 250, 170, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_3, mainnetReshardingEpoch)
-var mainnetV1_4 = MustNewInstance(4, 250, 170, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_4, mainnetReshardingEpoch)
-var mainnetV1_5 = MustNewInstance(4, 250, 170, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch)
+var (
+	mainnetV0   = MustNewInstance(4, 150, 112, genesis.HarmonyAccounts, genesis.FoundationalNodeAccounts, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV0_1 = MustNewInstance(4, 152, 112, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_1, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV0_2 = MustNewInstance(4, 200, 148, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_2, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV0_3 = MustNewInstance(4, 210, 148, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_3, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV0_4 = MustNewInstance(4, 216, 148, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_4, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV1   = MustNewInstance(4, 250, 170, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV1_1 = MustNewInstance(4, 250, 170, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_1, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV1_2 = MustNewInstance(4, 250, 170, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_2, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV1_3 = MustNewInstance(4, 250, 170, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_3, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV1_4 = MustNewInstance(4, 250, 170, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_4, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV1_5 = MustNewInstance(4, 250, 170, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+)

--- a/internal/configs/sharding/mock/shardingconfig.go
+++ b/internal/configs/sharding/mock/shardingconfig.go
@@ -296,3 +296,17 @@ func (mr *MockInstanceMockRecorder) ReshardingEpoch() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReshardingEpoch", reflect.TypeOf((*MockInstance)(nil).ReshardingEpoch))
 }
+
+// BlocksPerEpoch mocks base method
+func (m *MockInstance) BlocksPerEpoch() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BlocksPerEpoch")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// BlocksPerEpoch indicates an expected call of BlocksPerEpoch
+func (mr *MockInstanceMockRecorder) BlocksPerEpoch() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlocksPerEpoch", reflect.TypeOf((*MockInstance)(nil).BlocksPerEpoch))
+}

--- a/internal/configs/sharding/pangaea.go
+++ b/internal/configs/sharding/pangaea.go
@@ -51,7 +51,7 @@ func (ps pangaeaSchedule) ConsensusRatio() float64 {
 var pangaeaReshardingEpoch = []*big.Int{common.Big0}
 
 var pangaeaV0 = MustNewInstance(
-	2, 50, 40, genesis.PangaeaAccounts, genesis.FoundationalPangaeaAccounts, pangaeaReshardingEpoch)
+	2, 50, 40, genesis.PangaeaAccounts, genesis.FoundationalPangaeaAccounts, pangaeaReshardingEpoch, PangaeaSchedule.BlocksPerEpoch())
 
 // TODO: remove it after randomness feature turned on mainnet
 //RandonnessStartingEpoch returns starting epoch of randonness generation

--- a/internal/configs/sharding/shardingconfig.go
+++ b/internal/configs/sharding/shardingconfig.go
@@ -68,6 +68,9 @@ type Instance interface {
 
 	// ReshardingEpoch returns a list of Epoch while off-chain resharding happens
 	ReshardingEpoch() []*big.Int
+
+	// Count of blocks per epoch
+	BlocksPerEpoch() uint64
 }
 
 // genShardingStructure return sharding structure, given shard number and its patterns.

--- a/internal/configs/sharding/testnet.go
+++ b/internal/configs/sharding/testnet.go
@@ -80,5 +80,5 @@ var testnetReshardingEpoch = []*big.Int{
 	params.PangaeaChainConfig.StakingEpoch,
 }
 
-var testnetV0 = MustNewInstance(3, 100, 80, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch)
-var testnetV1 = MustNewInstance(3, 100, 68, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch)
+var testnetV0 = MustNewInstance(3, 100, 80, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())
+var testnetV1 = MustNewInstance(3, 100, 68, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())


### PR DESCRIPTION
Expose more information like the known, important epochs. Expose block number in RPC but only if beaconchain, fix a lingering mistake on node role not set in default config. 


Examples of hitting up both plain node and explorer, 

```
 ./hmy utility metadata --node=http://localhost:9500
{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "blocks-per-epoch": 5,
    "blskey": "65f55eb3052f9e9f632b2923be594ba77c55543f5c58ee1454b9cfd658d25e06373b0f7d42a19c84768139ea294f6204",
    "chain-config": {
      "chainId": 2,
      "crossLinkEpoch": 3,
      "crossTxEpoch": 0,
      "eip155Epoch": 0,
      "preStakingEpoch": 2,
      "s3Epoch": 0,
      "stakingEpoch": 4
    },
    "current-epoch": 0,
    "is-leader": true,
    "network": "localnet",
    "role": "Validator",
    "shard-id": 0,
    "version": "Harmony (C) 2019. harmony, version v5454-master-20191208.0-77-g0f56f4cc-dirty (edgar@ 2020-01-16T18:34:30-0800)"
  }
}(Thu Jan-1 6:35:03pm)-(CPU 4.6%:0:Net 1031)-(edgar:~/go/src/github.com/harmony-one/go-sdk)-(20M:14)
> ./hmy utility metadata --node=http://localhost:9599
{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "blocks-per-epoch": 5,
    "blskey": "",
    "chain-config": {
      "chainId": 2,
      "crossLinkEpoch": 3,
      "crossTxEpoch": 0,
      "eip155Epoch": 0,
      "preStakingEpoch": 2,
      "s3Epoch": 0,
      "stakingEpoch": 4
    },
    "is-leader": false,
    "current-epoch": 0,
    "network": "localnet",
    "role": "ExplorerNode",
    "shard-id": 0,
    "version": "Harmony (C) 2019. harmony, version v5454-master-20191208.0-77-g0f56f4cc-dirty (edgar@ 2020-01-16T18:34:30-0800)"
  }
```