### PR TITLE
Add pending CX receipts API to master

### DIFF
--- a/core/types/gen_cx_receipt_json.go
+++ b/core/types/gen_cx_receipt_json.go
@@ -1,0 +1,182 @@
+package types
+
+import (
+	"encoding/json"
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/harmony-one/harmony/block"
+	internal_common "github.com/harmony-one/harmony/internal/common"
+)
+
+// MarshalJSON marshals as JSON.
+func (r CXReceipt) MarshalJSON() ([]byte, error) {
+	// CXReceipt represents a receipt for cross-shard transaction
+	type CXReceipt struct {
+		TxHash    common.Hash `json:"txHash"     gencodec:"required"`
+		From      string      `json:"from"`
+		To        string      `json:"to"`
+		ShardID   uint32      `json:"shardID"`
+		ToShardID uint32      `json:"toShardID"`
+		Amount    *big.Int    `json:"amount"`
+	}
+	var enc CXReceipt
+	enc.Amount = r.Amount
+	enc.ShardID = r.ShardID
+	enc.ToShardID = r.ToShardID
+	enc.TxHash = r.TxHash
+	address, err := internal_common.AddressToBech32(r.From)
+	if err != nil {
+		return nil, err
+	}
+	enc.From = address
+	if r.To == nil {
+		address = ""
+	} else {
+		address, err = internal_common.AddressToBech32(*r.To)
+	}
+	if err != nil {
+		return nil, err
+	}
+	enc.To = address
+	return json.Marshal(&enc)
+}
+
+// UnmarshalJSON unmarshals from JSON.
+func (r *CXReceipt) UnmarshalJSON(input []byte) error {
+	type CXReceipt struct {
+		TxHash    *common.Hash `json:"txHash"     gencodec:"required"`
+		From      string       `json:"from"`
+		To        string       `json:"to"`
+		ShardID   uint32       `json:"shardID"`
+		ToShardID uint32       `json:"toShardID"`
+		Amount    *big.Int     `json:"amount"`
+	}
+	var dec CXReceipt
+	var err error
+	if err = json.Unmarshal(input, &dec); err != nil {
+		return err
+	}
+	if dec.TxHash == nil {
+		return errors.New("missing required field 'txHash' for CXReceipt")
+	}
+	r.TxHash = *dec.TxHash
+	if dec.From == "" {
+		return errors.New("missing required field 'from' for CXReceipt")
+	}
+	r.From, err = internal_common.Bech32ToAddress(dec.From)
+	if err != nil {
+		return err
+	}
+	r.ShardID = dec.ShardID
+	to, err := internal_common.Bech32ToAddress(dec.To)
+	if err != nil {
+		return err
+	}
+	*r.To = to
+	r.ToShardID = dec.ToShardID
+	if dec.Amount != nil {
+		r.Amount = dec.Amount
+	}
+	return nil
+}
+
+// MarshalJSON marshals as JSON.
+func (r CXMerkleProof) MarshalJSON() ([]byte, error) {
+	type CXMerkleProof struct {
+		BlockNum      *big.Int      `json:"blockNum"`
+		BlockHash     common.Hash   `json:"blockHash"   gencodec:"required"`
+		ShardID       uint32        `json:"shardID"`
+		CXReceiptHash common.Hash   `json:"receiptHash" gencodec:"required"`
+		ShardIDs      []uint32      `json:"shardIDs"`
+		CXShardHashes []common.Hash `json:"shardHashes" gencodec:"required"`
+	}
+	var enc CXMerkleProof
+	enc.BlockNum = r.BlockNum
+	enc.BlockHash = r.BlockHash
+	enc.ShardID = r.ShardID
+	enc.CXReceiptHash = r.CXReceiptHash
+	enc.ShardIDs = r.ShardIDs
+	enc.CXShardHashes = r.CXShardHashes
+	return json.Marshal(&enc)
+}
+
+// UnmarshalJSON unmarshals from JSON.
+func (r *CXMerkleProof) UnmarshalJSON(input []byte) error {
+	type CXMerkleProof struct {
+		BlockNum      *big.Int       `json:"blockNum"`
+		BlockHash     *common.Hash   `json:"blockHash"   gencodec:"required"`
+		ShardID       uint32         `json:"shardID"`
+		CXReceiptHash *common.Hash   `json:"receiptHash" gencodec:"required"`
+		ShardIDs      []uint32       `json:"shardIDs"`
+		CXShardHashes []*common.Hash `json:"shardHashes" gencodec:"required"`
+	}
+	var dec CXMerkleProof
+	if err := json.Unmarshal(input, &dec); err != nil {
+		return err
+	}
+	if dec.BlockHash == nil {
+		return errors.New("missing required field 'blockHash' for CXMerkleProof")
+	}
+	if dec.BlockNum == nil {
+		return errors.New("missing required field 'blockNum' for CXMerkleProof")
+	}
+	if dec.CXReceiptHash == nil {
+		return errors.New("missing required field 'cxReceiptHash' for CXMerkleProof")
+	}
+	r.BlockHash = *dec.BlockHash
+	r.BlockNum = dec.BlockNum
+	r.CXReceiptHash = *dec.CXReceiptHash
+	r.ShardID = dec.ShardID
+	r.ShardIDs = dec.ShardIDs
+	for _, cxShardHash := range dec.CXShardHashes {
+		r.CXShardHashes = append(r.CXShardHashes, *cxShardHash)
+	}
+	return nil
+}
+
+// MarshalJSON marshals as JSON.
+func (r CXReceiptsProof) MarshalJSON() ([]byte, error) {
+	type CXReceiptsProof struct {
+		Receipts     []*CXReceipt   `json:"receipts"     gencodec:"required"`
+		MerkleProof  *CXMerkleProof `json:"merkleProof"  gencodec:"required"` 
+		Header       *block.Header  `json:"header"       gencoded:"required"`
+		CommitSig    []byte         `json:"commitSig"`
+		CommitBitmap []byte         `json:"commitBitmap"`
+	}
+	var enc CXReceiptsProof
+	enc.Receipts = r.Receipts
+	enc.MerkleProof = r.MerkleProof
+	enc.Header = r.Header
+	enc.CommitSig = r.CommitSig
+	enc.CommitBitmap = r.CommitBitmap
+	return json.Marshal(&enc)
+}
+
+// UnmarshalJSON unmarshals from JSON.
+func (r *CXReceiptsProof) UnmarshalJSON(input []byte) error {
+	type CXReceiptsProof struct {
+		Receipts     []*CXReceipt   `json:"receipts"     gencodec:"required"`
+		MerkleProof  *CXMerkleProof `json:"merkleProof"  gencodec:"required"` 
+		Header       *block.Header  `json:"header"       gencoded:"required"`
+		CommitSig    []byte         `json:"commitSig"`
+		CommitBitmap []byte         `json:"commitBitmap"`
+	}
+	var dec CXReceiptsProof
+	if err := json.Unmarshal(input, &dec); err != nil {
+		return err
+	}
+	if dec.MerkleProof == nil {
+		return errors.New("missing required field 'merkleProof' for CXReceiptsProof")
+	}
+	if dec.Header == nil {
+		return errors.New("missing required field 'header' for CXReceipt")
+	}
+	r.MerkleProof = dec.MerkleProof
+	r.Header = dec.Header
+	r.Receipts = dec.Receipts
+	r.CommitSig = dec.CommitSig
+	r.CommitBitmap = dec.CommitBitmap
+	return nil
+}

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -433,3 +433,8 @@ func (b *APIBackend) GetCurrentTransactionErrorSink() []types.RPCTransactionErro
 func (b *APIBackend) IsBeaconChainExplorerNode() bool {
 	return b.hmy.nodeAPI.IsBeaconChainExplorerNode()
 }
+
+// GetPendingCXReceipts ..
+func (b *APIBackend) GetPendingCXReceipts() []*types.CXReceiptsProof {
+	return b.hmy.nodeAPI.PendingCXReceipts()
+}

--- a/hmy/backend.go
+++ b/hmy/backend.go
@@ -51,6 +51,7 @@ type NodeAPI interface {
 	ErroredStakingTransactionSink() []staking.RPCTransactionError
 	ErroredTransactionSink() []types.RPCTransactionError
 	IsBeaconChainExplorerNode() bool
+	PendingCXReceipts() []*types.CXReceiptsProof
 }
 
 // New creates a new Harmony object (including the

--- a/internal/hmyapi/backend.go
+++ b/internal/hmyapi/backend.go
@@ -82,6 +82,7 @@ type Backend interface {
 	GetCurrentTransactionErrorSink() []types.RPCTransactionError
 	IsBeaconChainExplorerNode() bool
 	GetMedianRawStakeSnapshot() *big.Int
+	GetPendingCXReceipts() []*types.CXReceiptsProof
 }
 
 // GetAPIs returns all the APIs.

--- a/internal/hmyapi/transactionpool.go
+++ b/internal/hmyapi/transactionpool.go
@@ -352,3 +352,8 @@ func (s *PublicTransactionPoolAPI) GetCXReceiptByHash(ctx context.Context, hash 
 	}
 	return nil
 }
+
+// GetPendingCXReceipts ..
+func (s *PublicTransactionPoolAPI) GetPendingCXReceipts(ctx context.Context) []*types.CXReceiptsProof {
+	return s.b.GetPendingCXReceipts()
+}

--- a/node/rpc.go
+++ b/node/rpc.go
@@ -46,6 +46,17 @@ func (node *Node) IsCurrentlyLeader() bool {
 	return node.Consensus.IsLeader()
 }
 
+// PendingCXReceipts returns node.pendingCXReceiptsProof
+func (node *Node) PendingCXReceipts() []*types.CXReceiptsProof {
+	cxReceipts := make([]*types.CXReceiptsProof, len(node.pendingCXReceipts))
+	i := 0
+	for _, cxReceipt := range node.pendingCXReceipts {
+		cxReceipts[i] = cxReceipt
+		i++
+	}
+	return cxReceipts
+}
+
 // ErroredStakingTransactionSink is the inmemory failed staking transactions this node has
 func (node *Node) ErroredStakingTransactionSink() []staking.RPCTransactionError {
 	node.errorSink.Lock()


### PR DESCRIPTION
## Issue

Edgar requested cross links and cx receipts to be moved to master, but node.pendingCrossLinks is missing, so moving only receipts for now.

## Test

Tested, method is available and works the same.

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
