### PR TITLE
Fix format in staking transaction

### DIFF
--- a/internal/hmyapi/apiv1/types.go
+++ b/internal/hmyapi/apiv1/types.go
@@ -215,8 +215,12 @@ func newRPCStakingTransaction(tx *types2.StakingTransaction, blockHash common.Ha
 	switch stakingTxType {
 	case "CreateValidator":
 		msg := message.(types2.CreateValidator)
+		validatorAddress, err := internal_common.AddressToBech32(msg.ValidatorAddress)
+		if err != nil {
+			return nil
+		}
 		fields = map[string]interface{}{
-			"validatorAddress":   msg.ValidatorAddress,
+			"validatorAddress":   validatorAddress,
 			"name":               msg.Description.Name,
 			"commissionRate":     (*hexutil.Big)(msg.CommissionRates.Rate.Int),
 			"maxCommissionRate":  (*hexutil.Big)(msg.CommissionRates.MaxRate.Int),
@@ -232,8 +236,12 @@ func newRPCStakingTransaction(tx *types2.StakingTransaction, blockHash common.Ha
 		}
 	case "EditValidator":
 		msg := message.(types2.EditValidator)
+		validatorAddress, err := internal_common.AddressToBech32(msg.ValidatorAddress)
+		if err != nil {
+			return nil
+		}
 		fields = map[string]interface{}{
-			"validatorAddress":   msg.ValidatorAddress,
+			"validatorAddress":   validatorAddress,
 			"commisionRate":      (*hexutil.Big)(msg.CommissionRate.Int),
 			"name":               msg.Description.Name,
 			"minSelfDelegation":  (*hexutil.Big)(msg.MinSelfDelegation),
@@ -247,21 +255,41 @@ func newRPCStakingTransaction(tx *types2.StakingTransaction, blockHash common.Ha
 		}
 	case "CollectRewards":
 		msg := message.(types2.CollectRewards)
+		delegatorAddress, err := internal_common.AddressToBech32(msg.DelegatorAddress)
+		if err != nil {
+			return nil
+		}
 		fields = map[string]interface{}{
-			"delegatorAddress": msg.DelegatorAddress,
+			"delegatorAddress": delegatorAddress,
 		}
 	case "Delegate":
 		msg := message.(types2.Delegate)
+		delegatorAddress, err := internal_common.AddressToBech32(msg.DelegatorAddress)
+		if err != nil {
+			return nil
+		}
+		validatorAddress, err := internal_common.AddressToBech32(msg.ValidatorAddress)
+		if err != nil {
+			return nil
+		}
 		fields = map[string]interface{}{
-			"delegatorAddress": msg.DelegatorAddress,
-			"validatorAddress": msg.ValidatorAddress,
+			"delegatorAddress": delegatorAddress,
+			"validatorAddress": validatorAddress,
 			"amount":           (*hexutil.Big)(msg.Amount),
 		}
 	case "Undelegate":
 		msg := message.(types2.Undelegate)
+		delegatorAddress, err := internal_common.AddressToBech32(msg.DelegatorAddress)
+		if err != nil {
+			return nil
+		}
+		validatorAddress, err := internal_common.AddressToBech32(msg.ValidatorAddress)
+		if err != nil {
+			return nil
+		}
 		fields = map[string]interface{}{
-			"delegatorAddress": msg.DelegatorAddress,
-			"validatorAddress": msg.ValidatorAddress,
+			"delegatorAddress": delegatorAddress,
+			"validatorAddress": validatorAddress,
 			"amount":           (*hexutil.Big)(msg.Amount),
 		}
 	}

--- a/internal/hmyapi/apiv2/types.go
+++ b/internal/hmyapi/apiv2/types.go
@@ -216,8 +216,12 @@ func newRPCStakingTransaction(tx *types2.StakingTransaction, blockHash common.Ha
 	switch stakingTxType {
 	case "CreateValidator":
 		msg := message.(types2.CreateValidator)
+		validatorAddress, err := internal_common.AddressToBech32(msg.ValidatorAddress)
+		if err != nil {
+			return nil
+		}
 		fields = map[string]interface{}{
-			"validatorAddress":   msg.ValidatorAddress,
+			"validatorAddress":   validatorAddress,
 			"name":               msg.Description.Name,
 			"commissionRate":     (*big.Int)(msg.CommissionRates.Rate.Int),
 			"maxCommissionRate":  (*big.Int)(msg.CommissionRates.MaxRate.Int),
@@ -233,8 +237,12 @@ func newRPCStakingTransaction(tx *types2.StakingTransaction, blockHash common.Ha
 		}
 	case "EditValidator":
 		msg := message.(types2.EditValidator)
+		validatorAddress, err := internal_common.AddressToBech32(msg.ValidatorAddress)
+		if err != nil {
+			return nil
+		}
 		fields = map[string]interface{}{
-			"validatorAddress":   msg.ValidatorAddress,
+			"validatorAddress":   validatorAddress,
 			"commisionRate":      (*big.Int)(msg.CommissionRate.Int),
 			"name":               msg.Description.Name,
 			"minSelfDelegation":  (*big.Int)(msg.MinSelfDelegation),
@@ -248,21 +256,41 @@ func newRPCStakingTransaction(tx *types2.StakingTransaction, blockHash common.Ha
 		}
 	case "CollectRewards":
 		msg := message.(types2.CollectRewards)
+		delegatorAddress, err := internal_common.AddressToBech32(msg.DelegatorAddress)
+		if err != nil {
+			return nil
+		}
 		fields = map[string]interface{}{
-			"delegatorAddress": msg.DelegatorAddress,
+			"delegatorAddress": delegatorAddress,
 		}
 	case "Delegate":
 		msg := message.(types2.Delegate)
+		delegatorAddress, err := internal_common.AddressToBech32(msg.DelegatorAddress)
+		if err != nil {
+			return nil
+		}
+		validatorAddress, err := internal_common.AddressToBech32(msg.ValidatorAddress)
+		if err != nil {
+			return nil
+		}
 		fields = map[string]interface{}{
-			"delegatorAddress": msg.DelegatorAddress,
-			"validatorAddress": msg.ValidatorAddress,
+			"delegatorAddress": delegatorAddress,
+			"validatorAddress": validatorAddress,
 			"amount":           (*big.Int)(msg.Amount),
 		}
 	case "Undelegate":
 		msg := message.(types2.Undelegate)
+		delegatorAddress, err := internal_common.AddressToBech32(msg.DelegatorAddress)
+		if err != nil {
+			return nil
+		}
+		validatorAddress, err := internal_common.AddressToBech32(msg.ValidatorAddress)
+		if err != nil {
+			return nil
+		}
 		fields = map[string]interface{}{
-			"delegatorAddress": msg.DelegatorAddress,
-			"validatorAddress": msg.ValidatorAddress,
+			"delegatorAddress": delegatorAddress,
+			"validatorAddress": validatorAddress,
 			"amount":           (*big.Int)(msg.Amount),
 		}
 	}


### PR DESCRIPTION
## Issue

Yuriy have seen that RPCStakingTransaction fetch method return 0x addresses. I'm changing to bech32, also need to check if it doesn't break anything for apps. @mikedoan @fxfactorial @rlan35 

## Test

Localnet, postman. Test please if it doesn't break anything.

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    NO

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    NO

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    NO

## TODO
