### PR TITLE
[rpc] Update ChainConfig JSON tags to match RPC reply format

### DIFF
--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -93,18 +93,22 @@ type TrustedCheckpoint struct {
 // that any network, identified by its genesis block, can have its own
 // set of configuration options.
 type ChainConfig struct {
-	ChainID *big.Int `json:"chainId"` // chainId identifies the current chain and is used for replay protection
+	// ChainId identifies the current chain and is used for replay protection
+	ChainID *big.Int `json:"chain-id"`
 
 	// CrossTxEpoch is the epoch where cross-shard transaction starts being
 	// processed.
-	CrossTxEpoch *big.Int `json:"crossTxEpoch,omitempty"`
+	CrossTxEpoch *big.Int `json:"cross-tx-epoch,omitempty"`
 
 	// CrossLinkEpoch is the epoch where beaconchain starts containing
 	// cross-shard links.
-	CrossLinkEpoch *big.Int `json:"crossLinkEpoch,omitempty"`
+	CrossLinkEpoch *big.Int `json:"cross-link-epoch,omitempty"`
 
-	EIP155Epoch *big.Int `json:"eip155Epoch,omitempty"` // EIP155 hard fork epoch (include EIP158 too)
-	S3Epoch     *big.Int `json:"s3Epoch,omitempty"`     // S3 epoch is the first epoch containing S3 mainnet and all ethereum update up to Constantinople
+	// EIP155 hard fork epoch (include EIP158 too)
+	EIP155Epoch *big.Int `json:"eip155-epoch,omitempty"`
+
+	// S3 epoch is the first epoch containing S3 mainnet and all ethereum update up to Constantinople
+	S3Epoch *big.Int `json:"s3-epoch,omitempty"`
 }
 
 // String implements the fmt.Stringer interface.


### PR DESCRIPTION
## Issue

`hmy_getNodeMetadata` reply formatting is inconsistant

```
$ ./hmy utility metadata
{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "blocks-per-epoch": 5,
    "blskey": "65f55eb3052f9e9f632b2923be594ba77c55543f5c58ee1454b9cfd658d25e06373b0f7d42a19c84768139ea294f6204",
    "chain-config": {
      "chainId": 2,
      "crossLinkEpoch": 3,
      "crossTxEpoch": 0,
      "eip155Epoch": 0,
      "s3Epoch": 0,
    },
    "current-epoch": 0,
    "is-leader": true,
    "network": "localnet",
    "role": "Validator",
    "shard-id": 0,
    "version": "Harmony (C) 2019. harmony, version v5472-master-20191208.0-95-ge2003b48-dirty (edgar@ 2020-01-20T17:11:16-0800)"
  }
}
```

```
$ ./hmy utility metadata
{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "blocks-per-epoch": 5,
    "blskey": "65f55eb3052f9e9f632b2923be594ba77c55543f5c58ee1454b9cfd658d25e06373b0f7d42a19c84768139ea294f6204",
    "chain-config": {
      "chain-id": 2,
      "cross-link-epoch": 3,
      "cross-tx-epoch": 0,
      "eip155-epoch": 0,
      "s3-epoch": 0,
    },
    "current-epoch": 0,
    "is-leader": true,
    "network": "localnet",
    "role": "Validator",
    "shard-id": 0,
    "version": "Harmony (C) 2019. harmony, version v5476-master-20191208.0-99-g10c4b91a-dirty (janetliang@ 2020-01-22T16:17:02-0800)"
  }
}
```

## Test

### Unit Test Coverage

Before:

```
$ go test -cover
PASS
coverage: 36.4% of statements
ok  	github.com/harmony-one/harmony/internal/params	0.004s
```

After:

```
$ go test -cover
PASS
coverage: 36.4% of statements
ok  	github.com/harmony-one/harmony/internal/params	0.005s
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**
   
     **NO**

## TODO
