### PR TITLE
Fix get failed/errored transactions sink

### DIFF
--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -84,7 +84,7 @@ func setupTxPool() (*TxPool, *ecdsa.PrivateKey) {
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	key, _ := crypto.GenerateKey()
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 
 	return pool, key
 }
@@ -194,7 +194,7 @@ func TestStateChangeDuringTransactionPoolReset(t *testing.T) {
 	tx0 := transaction(0, 100000, key)
 	tx1 := transaction(1, 100000, key)
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 	defer pool.Stop()
 
 	nonce := pool.State().GetNonce(address)
@@ -559,7 +559,7 @@ func TestTransactionPostponing(t *testing.T) {
 	statedb, _ := state.New(common.Hash{}, state.NewDatabase(ethdb.NewMemDatabase()))
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 	defer pool.Stop()
 
 	// Create two test accounts to produce different gap profiles with
@@ -721,7 +721,7 @@ func testTransactionQueueGlobalLimiting(t *testing.T, nolocals bool) {
 	config.NoLocals = nolocals
 	config.GlobalQueue = config.AccountQueue*3 - 1 // reduce the queue limits to shorten test time (-1 to make it non divisible)
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them (last one will be the local)
@@ -809,7 +809,7 @@ func testTransactionQueueTimeLimiting(t *testing.T, nolocals bool) {
 	config.Lifetime = time.Second
 	config.NoLocals = nolocals
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 	defer pool.Stop()
 
 	// Create two test accounts to ensure remotes expire but locals do not
@@ -921,7 +921,7 @@ func TestTransactionPendingGlobalLimiting(t *testing.T) {
 	config := testTxPoolConfig
 	config.GlobalSlots = config.AccountSlots * 10
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them
@@ -969,7 +969,7 @@ func TestTransactionCapClearsFromAll(t *testing.T) {
 	config.AccountQueue = 2
 	config.GlobalSlots = 8
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them
@@ -1001,7 +1001,7 @@ func TestTransactionPendingMinimumAllowance(t *testing.T) {
 	config := testTxPoolConfig
 	config.GlobalSlots = 0
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them
@@ -1043,7 +1043,7 @@ func TestTransactionPoolRepricingKeepsLocals(t *testing.T) {
 	statedb, _ := state.New(common.Hash{}, state.NewDatabase(ethdb.NewMemDatabase()))
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them
@@ -1122,7 +1122,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 	config.Journal = journal
 	config.Rejournal = time.Second
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 
 	// Create two test accounts to ensure remotes expire but locals do not
 	local, _ := crypto.GenerateKey()
@@ -1159,7 +1159,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 	statedb.SetNonce(crypto.PubkeyToAddress(local.PublicKey), 1)
 	blockchain = &testBlockChain{statedb, 1000000, new(event.Feed)}
 
-	pool = NewTxPool(config, params.TestChainConfig, blockchain)
+	pool = NewTxPool(config, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 
 	pending, queued = pool.Stats()
 	if queued != 0 {
@@ -1185,7 +1185,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 
 	statedb.SetNonce(crypto.PubkeyToAddress(local.PublicKey), 1)
 	blockchain = &testBlockChain{statedb, 1000000, new(event.Feed)}
-	pool = NewTxPool(config, params.TestChainConfig, blockchain)
+	pool = NewTxPool(config, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 
 	pending, queued = pool.Stats()
 	if pending != 0 {
@@ -1215,7 +1215,7 @@ func TestTransactionStatusCheck(t *testing.T) {
 	statedb, _ := state.New(common.Hash{}, state.NewDatabase(ethdb.NewMemDatabase()))
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 	defer pool.Stop()
 
 	// Create the test accounts to check various transaction statuses with

--- a/node/node.go
+++ b/node/node.go
@@ -490,7 +490,15 @@ func New(host p2p.Host, consensusObj *consensus.Consensus, chainDBFactory shardc
 		node.ConfirmedBlockChannel = make(chan *types.Block)
 		node.BeaconBlockChannel = make(chan *types.Block)
 		node.recentTxsStats = make(types.RecentTxsStats)
-		node.TxPool = core.NewTxPool(core.DefaultTxPoolConfig, node.Blockchain().Config(), blockchain)
+		node.TxPool = core.NewTxPool(core.DefaultTxPoolConfig, node.Blockchain().Config(), blockchain,
+			func(payload []types.RPCTransactionError) {
+				node.errorSink.Lock()
+				for i := range payload {
+					node.errorSink.failedTxns.Value = payload[i]
+					node.errorSink.failedTxns = node.errorSink.failedTxns.Next()
+				}
+				node.errorSink.Unlock()
+			})
 		node.CxPool = core.NewCxPool(core.CxPoolSize)
 		node.Worker = worker.New(node.Blockchain().Config(), blockchain, chain.Engine)
 

--- a/node/node.go
+++ b/node/node.go
@@ -492,12 +492,14 @@ func New(host p2p.Host, consensusObj *consensus.Consensus, chainDBFactory shardc
 		node.recentTxsStats = make(types.RecentTxsStats)
 		node.TxPool = core.NewTxPool(core.DefaultTxPoolConfig, node.Blockchain().Config(), blockchain,
 			func(payload []types.RPCTransactionError) {
-				node.errorSink.Lock()
-				for i := range payload {
-					node.errorSink.failedTxns.Value = payload[i]
-					node.errorSink.failedTxns = node.errorSink.failedTxns.Next()
+				if len(payload) > 0 {
+					node.errorSink.Lock()
+					for i := range payload {
+						node.errorSink.failedTxns.Value = payload[i]
+						node.errorSink.failedTxns = node.errorSink.failedTxns.Next()
+					}
+					node.errorSink.Unlock()
 				}
-				node.errorSink.Unlock()
 			})
 		node.CxPool = core.NewCxPool(core.CxPoolSize)
 		node.Worker = worker.New(node.Blockchain().Config(), blockchain, chain.Engine)

--- a/node/node_handler_test.go
+++ b/node/node_handler_test.go
@@ -35,8 +35,7 @@ func TestAddNewBlock(t *testing.T) {
 	node := New(host, consensus, testDBFactory, false)
 
 	txs := make(map[common.Address]types.Transactions)
-	node.Worker.CommitTransactions(txs, common.Address{},
-		func([]types.RPCTransactionError) {})
+	node.Worker.CommitTransactions(txs, common.Address{})
 	block, _ := node.Worker.FinalizeNewBlock([]byte{}, []byte{}, 0, common.Address{}, nil, nil)
 
 	err = node.AddNewBlock(block)
@@ -68,8 +67,7 @@ func TestVerifyNewBlock(t *testing.T) {
 	node := New(host, consensus, testDBFactory, false)
 
 	txs := make(map[common.Address]types.Transactions)
-	node.Worker.CommitTransactions(txs, common.Address{},
-		func([]types.RPCTransactionError) {})
+	node.Worker.CommitTransactions(txs, common.Address{})
 	block, _ := node.Worker.FinalizeNewBlock([]byte{}, []byte{}, 0, common.Address{}, nil, nil)
 
 	if err := node.VerifyNewBlock(block); err != nil {

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -88,15 +88,7 @@ func (node *Node) proposeNewBlock() (*types.Block, error) {
 	}
 
 	node.Worker.UpdateCurrent(coinbase)
-	if err := node.Worker.CommitTransactions(pending, coinbase,
-		func(payload []types.RPCTransactionError) {
-			node.errorSink.Lock()
-			for i := range payload {
-				node.errorSink.failedTxns.Value = payload[i]
-				node.errorSink.failedTxns = node.errorSink.failedTxns.Next()
-			}
-			node.errorSink.Unlock()
-		}); err != nil {
+	if err := node.Worker.CommitTransactions(pending, coinbase); err != nil {
 		ctxerror.Log15(utils.GetLogger().Error,
 			ctxerror.New("cannot commit transactions").
 				WithCause(err))

--- a/node/worker/worker_test.go
+++ b/node/worker/worker_test.go
@@ -81,7 +81,6 @@ func TestCommitTransactions(t *testing.T) {
 	err := worker.CommitTransactions(
 		txs,
 		testBankAddress,
-		func([]types.RPCTransactionError) {},
 	)
 
 	if err != nil {

--- a/test/chain/main.go
+++ b/test/chain/main.go
@@ -205,7 +205,7 @@ func main() {
 	genesis := gspec.MustCommit(database)
 	chain, _ := core.NewBlockChain(database, nil, gspec.Config, chain.Engine(), vm.Config{}, nil)
 
-	txpool := core.NewTxPool(core.DefaultTxPoolConfig, chainConfig, chain)
+	txpool := core.NewTxPool(core.DefaultTxPoolConfig, chainConfig, chain, func([]types.RPCTransactionError) {})
 
 	backend := &testWorkerBackend{
 		db:     database,

--- a/test/chain/main.go
+++ b/test/chain/main.go
@@ -129,8 +129,7 @@ func fundFaucetContract(chain *core.BlockChain) {
 	txmap := make(map[common.Address]types.Transactions)
 	txmap[FaucetAddress] = txs
 
-	err := contractworker.CommitTransactions(txmap, testUserAddress,
-		func([]types.RPCTransactionError) {})
+	err := contractworker.CommitTransactions(txmap, testUserAddress)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -171,8 +170,7 @@ func callFaucetContractToFundAnAddress(chain *core.BlockChain) {
 	txmap := make(map[common.Address]types.Transactions)
 	txmap[FaucetAddress] = types.Transactions{callfaucettx}
 
-	err = contractworker.CommitTransactions(txmap, testUserAddress,
-		func([]types.RPCTransactionError) {})
+	err = contractworker.CommitTransactions(txmap, testUserAddress)
 	if err != nil {
 		fmt.Println(err)
 	}


### PR DESCRIPTION
## Issue

Currently, one can only get failed/errored transactions if one knows the leader's IP address. This PR checks for failed transactions in the transaction pool, this any node can report failed or errored transactions.

## Test

### Unit Test Coverage

Before:

```
newNodeList:  [ECDSA: one1qqqrvvpcxu6rwvfnxc6ngvecx5mrgvf3254yj4, BLS: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 ECDSA: one1qq6n2de3xuuryven8qcnqvfcxuurwd3s837n5r, BLS: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 ECDSA: one1qqcnjv3kxqcnydfcxc6nyd3kxg6rqvpe5srx9h, BLS: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 ECDSA: one1qqqrgvp5xy6nxwf5x5mngve4xsmnvdfhekh0gx, BLS: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 ECDSA: one1qqen2ve5xvengvekxuerzdpjxvmnyd33m0urmm, BLS: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000]
PASS
coverage: 24.5% of statements
ok  	github.com/harmony-one/harmony/core	6.960s
```

```
PASS
coverage: 12.9% of statements
ok  	github.com/harmony-one/harmony/node	2.239s
```

After:

```
newNodeList:  [ECDSA: one1qqqrvvpcxu6rwvfnxc6ngvecx5mrgvf3254yj4, BLS: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 ECDSA: one1qq6n2de3xuuryven8qcnqvfcxuurwd3s837n5r, BLS: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 ECDSA: one1qqcnjv3kxqcnydfcxc6nyd3kxg6rqvpe5srx9h, BLS: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 ECDSA: one1qqqrgvp5xy6nxwf5x5mngve4xsmnvdfhekh0gx, BLS: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 ECDSA: one1qqen2ve5xvengvekxuerzdpjxvmnyd33m0urmm, BLS: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000]
PASS
coverage: 24.9% of statements
ok  	github.com/harmony-one/harmony/core	6.774s
```

```
PASS
coverage: 13.3% of statements
ok  	github.com/harmony-one/harmony/node	1.933s
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**