### PR TITLE
Report failed transactions

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"math/big"
 	"sync/atomic"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -38,6 +39,15 @@ type RPCTransactionError struct {
 	TxHashID             string `json:"tx-hash-id"`
 	TimestampOfRejection int64  `json:"time-at-rejection"`
 	ErrMessage           string `json:"error-message"`
+}
+
+// NewRPCTransactionError ...
+func NewRPCTransactionError(hash common.Hash, err error) *RPCTransactionError {
+	return &RPCTransactionError{
+		TxHashID:             hash.String(),
+		TimestampOfRejection: time.Now().Unix(),
+		ErrMessage:           err.Error(),
+	}
 }
 
 // no go:generate gencodec -type txdata -field-override txdataMarshaling -out gen_tx_json.go

--- a/node/node.go
+++ b/node/node.go
@@ -323,12 +323,16 @@ func (node *Node) AddPendingStakingTransaction(
 // AddPendingTransaction adds one new transaction to the pending transaction list.
 // This is only called from SDK.
 func (node *Node) AddPendingTransaction(newTx *types.Transaction) {
-	if node.Consensus.IsLeader() && newTx.ShardID() == node.NodeConfig.ShardID {
+	role := node.NodeConfig.Role()
+	if newTx.ShardID() == node.NodeConfig.ShardID && (node.Consensus.IsLeader() || role == nodeconfig.ExplorerNode) {
 		node.addPendingTransactions(types.Transactions{newTx})
-	} else {
-		utils.Logger().Info().Str("Hash", newTx.Hash().Hex()).Msg("Broadcasting Tx")
-		node.tryBroadcast(newTx)
+		if role != nodeconfig.ExplorerNode {
+			return
+		}
 	}
+	utils.Logger().Info().Str("Hash", newTx.Hash().Hex()).Msg("Broadcasting Tx")
+	node.tryBroadcast(newTx)
+
 }
 
 // AddPendingReceipts adds one receipt message to pending list.


### PR DESCRIPTION
## Issue

Currently, an explorer node only broadcasts transactions and does not processes it. This PR makes the explorer process and broadcast transactions. Moreover, there are some missing error reports when a promotion removes a transaction. This PR adds those errors to the error sink. 

### Unit Test Coverage

Before:

```
PASS
coverage: 13.3% of statements
ok  	github.com/harmony-one/harmony/node	2.301s
```

```
newNodeList:  [ECDSA: one1qqqrvvpcxu6rwvfnxc6ngvecx5mrgvf3254yj4, BLS: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 ECDSA: one1qq6n2de3xuuryven8qcnqvfcxuurwd3s837n5r, BLS: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 ECDSA: one1qqcnjv3kxqcnydfcxc6nyd3kxg6rqvpe5srx9h, BLS: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 ECDSA: one1qqqrgvp5xy6nxwf5x5mngve4xsmnvdfhekh0gx, BLS: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 ECDSA: one1qqen2ve5xvengvekxuerzdpjxvmnyd33m0urmm, BLS: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000]
PASS
coverage: 24.9% of statements
ok  	github.com/harmony-one/harmony/core	6.712s
```

After:

```
PASS
coverage: 13.3% of statements
ok  	github.com/harmony-one/harmony/node	2.183s
```

```
newNodeList:  [ECDSA: one1qqqrvvpcxu6rwvfnxc6ngvecx5mrgvf3254yj4, BLS: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 ECDSA: one1qq6n2de3xuuryven8qcnqvfcxuurwd3s837n5r, BLS: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 ECDSA: one1qqcnjv3kxqcnydfcxc6nyd3kxg6rqvpe5srx9h, BLS: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 ECDSA: one1qqqrgvp5xy6nxwf5x5mngve4xsmnvdfhekh0gx, BLS: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 ECDSA: one1qqen2ve5xvengvekxuerzdpjxvmnyd33m0urmm, BLS: 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000]
PASS
coverage: 25.2% of statements
ok  	github.com/harmony-one/harmony/core	6.705s
```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. 

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**