### PR TITLE
Report failed (non-staking) transactions

### DIFF
--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -84,7 +84,7 @@ func setupTxPool() (*TxPool, *ecdsa.PrivateKey) {
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	key, _ := crypto.GenerateKey()
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 
 	return pool, key
 }
@@ -194,7 +194,7 @@ func TestStateChangeDuringTransactionPoolReset(t *testing.T) {
 	tx0 := transaction(0, 100000, key)
 	tx1 := transaction(1, 100000, key)
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 	defer pool.Stop()
 
 	nonce := pool.State().GetNonce(address)
@@ -559,7 +559,7 @@ func TestTransactionPostponing(t *testing.T) {
 	statedb, _ := state.New(common.Hash{}, state.NewDatabase(ethdb.NewMemDatabase()))
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 	defer pool.Stop()
 
 	// Create two test accounts to produce different gap profiles with
@@ -721,7 +721,7 @@ func testTransactionQueueGlobalLimiting(t *testing.T, nolocals bool) {
 	config.NoLocals = nolocals
 	config.GlobalQueue = config.AccountQueue*3 - 1 // reduce the queue limits to shorten test time (-1 to make it non divisible)
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them (last one will be the local)
@@ -809,7 +809,7 @@ func testTransactionQueueTimeLimiting(t *testing.T, nolocals bool) {
 	config.Lifetime = time.Second
 	config.NoLocals = nolocals
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 	defer pool.Stop()
 
 	// Create two test accounts to ensure remotes expire but locals do not
@@ -921,7 +921,7 @@ func TestTransactionPendingGlobalLimiting(t *testing.T) {
 	config := testTxPoolConfig
 	config.GlobalSlots = config.AccountSlots * 10
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them
@@ -969,7 +969,7 @@ func TestTransactionCapClearsFromAll(t *testing.T) {
 	config.AccountQueue = 2
 	config.GlobalSlots = 8
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them
@@ -1001,7 +1001,7 @@ func TestTransactionPendingMinimumAllowance(t *testing.T) {
 	config := testTxPoolConfig
 	config.GlobalSlots = 0
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them
@@ -1043,7 +1043,7 @@ func TestTransactionPoolRepricingKeepsLocals(t *testing.T) {
 	statedb, _ := state.New(common.Hash{}, state.NewDatabase(ethdb.NewMemDatabase()))
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them
@@ -1122,7 +1122,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 	config.Journal = journal
 	config.Rejournal = time.Second
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 
 	// Create two test accounts to ensure remotes expire but locals do not
 	local, _ := crypto.GenerateKey()
@@ -1159,7 +1159,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 	statedb.SetNonce(crypto.PubkeyToAddress(local.PublicKey), 1)
 	blockchain = &testBlockChain{statedb, 1000000, new(event.Feed)}
 
-	pool = NewTxPool(config, params.TestChainConfig, blockchain)
+	pool = NewTxPool(config, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 
 	pending, queued = pool.Stats()
 	if queued != 0 {
@@ -1185,7 +1185,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 
 	statedb.SetNonce(crypto.PubkeyToAddress(local.PublicKey), 1)
 	blockchain = &testBlockChain{statedb, 1000000, new(event.Feed)}
-	pool = NewTxPool(config, params.TestChainConfig, blockchain)
+	pool = NewTxPool(config, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 
 	pending, queued = pool.Stats()
 	if pending != 0 {
@@ -1215,7 +1215,7 @@ func TestTransactionStatusCheck(t *testing.T) {
 	statedb, _ := state.New(common.Hash{}, state.NewDatabase(ethdb.NewMemDatabase()))
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, func([]types.RPCTransactionError) {})
 	defer pool.Stop()
 
 	// Create the test accounts to check various transaction statuses with

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"math/big"
 	"sync/atomic"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -75,6 +76,15 @@ type RPCTransactionError struct {
 	TxHashID             string `json:"tx-hash-id"`
 	TimestampOfRejection int64  `json:"time-at-rejection"`
 	ErrMessage           string `json:"error-message"`
+}
+
+// NewRPCTransactionError ...
+func NewRPCTransactionError(hash common.Hash, err error) *RPCTransactionError {
+	return &RPCTransactionError{
+		TxHashID:             hash.Hex(),
+		TimestampOfRejection: time.Now().Unix(),
+		ErrMessage:           err.Error(),
+	}
 }
 
 //String print mode string

--- a/node/node.go
+++ b/node/node.go
@@ -330,13 +330,14 @@ func (node *Node) AddPendingStakingTransaction(
 // AddPendingTransaction adds one new transaction to the pending transaction list.
 // This is only called from SDK.
 func (node *Node) AddPendingTransaction(newTx *types.Transaction) {
-	// TODO: everyone should record txns, not just leader
-	if node.Consensus.IsLeader() && newTx.ShardID() == node.NodeConfig.ShardID {
+	if newTx.ShardID() == node.NodeConfig.ShardID {
 		node.addPendingTransactions(types.Transactions{newTx})
-	} else {
-		utils.Logger().Info().Str("Hash", newTx.Hash().Hex()).Msg("Broadcasting Tx")
-		node.tryBroadcast(newTx)
+		if node.NodeConfig.Role() != nodeconfig.ExplorerNode {
+			return
+		}
 	}
+	utils.Logger().Info().Str("Hash", newTx.Hash().Hex()).Msg("Broadcasting Tx")
+	node.tryBroadcast(newTx)
 }
 
 // AddPendingReceipts adds one receipt message to pending list.
@@ -501,7 +502,17 @@ func New(host p2p.Host, consensusObj *consensus.Consensus,
 		node.BlockChannel = make(chan *types.Block)
 		node.ConfirmedBlockChannel = make(chan *types.Block)
 		node.BeaconBlockChannel = make(chan *types.Block)
-		node.TxPool = core.NewTxPool(core.DefaultTxPoolConfig, node.Blockchain().Config(), blockchain)
+		node.TxPool = core.NewTxPool(core.DefaultTxPoolConfig, node.Blockchain().Config(), blockchain,
+			func(payload []types.RPCTransactionError) {
+				if len(payload) > 0 {
+					node.errorSink.Lock()
+					for i := range payload {
+						node.errorSink.failedTxns.Value = payload[i]
+						node.errorSink.failedTxns = node.errorSink.failedTxns.Next()
+					}
+					node.errorSink.Unlock()
+				}
+			})
 		node.CxPool = core.NewCxPool(core.CxPoolSize)
 		node.Worker = worker.New(node.Blockchain().Config(), blockchain, chain.Engine)
 

--- a/node/node_handler_test.go
+++ b/node/node_handler_test.go
@@ -40,7 +40,6 @@ func TestAddNewBlock(t *testing.T) {
 	node.Worker.CommitTransactions(
 		txs, stks, common.Address{},
 		func([]staking.RPCTransactionError) {},
-		func([]types.RPCTransactionError) {},
 	)
 	block, _ := node.Worker.FinalizeNewBlock([]byte{}, []byte{}, 0, common.Address{}, nil, nil)
 
@@ -77,7 +76,6 @@ func TestVerifyNewBlock(t *testing.T) {
 	node.Worker.CommitTransactions(
 		txs, stks, common.Address{},
 		func([]staking.RPCTransactionError) {},
-		func([]types.RPCTransactionError) {},
 	)
 	block, _ := node.Worker.FinalizeNewBlock([]byte{}, []byte{}, 0, common.Address{}, nil, nil)
 

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -131,14 +131,6 @@ func (node *Node) proposeNewBlock() (*types.Block, error) {
 			}
 			node.errorSink.Unlock()
 		},
-		func(payload []types.RPCTransactionError) {
-			node.errorSink.Lock()
-			for i := range payload {
-				node.errorSink.failedTxns.Value = payload[i]
-				node.errorSink.failedTxns = node.errorSink.failedTxns.Next()
-			}
-			node.errorSink.Unlock()
-		},
 	); err != nil {
 		utils.Logger().Error().Err(err).Msg("cannot commit transactions")
 		return nil, err

--- a/node/worker/worker_test.go
+++ b/node/worker/worker_test.go
@@ -81,7 +81,6 @@ func TestCommitTransactions(t *testing.T) {
 	err := worker.CommitTransactions(
 		txs, nil, testBankAddress,
 		func([]staking.RPCTransactionError) {},
-		func([]types.RPCTransactionError) {},
 	)
 	if err != nil {
 		t.Error(err)

--- a/test/chain/main.go
+++ b/test/chain/main.go
@@ -203,7 +203,7 @@ func main() {
 	genesis := gspec.MustCommit(database)
 	chain, _ := core.NewBlockChain(database, nil, gspec.Config, chain.Engine(), vm.Config{}, nil)
 
-	txpool := core.NewTxPool(core.DefaultTxPoolConfig, chainConfig, chain)
+	txpool := core.NewTxPool(core.DefaultTxPoolConfig, chainConfig, chain, func([]types.RPCTransactionError) {})
 
 	backend := &testWorkerBackend{
 		db:     database,

--- a/test/chain/main.go
+++ b/test/chain/main.go
@@ -130,7 +130,6 @@ func fundFaucetContract(chain *core.BlockChain) {
 	err := contractworker.CommitTransactions(
 		txmap, nil, testUserAddress,
 		func([]staking.RPCTransactionError) {},
-		func([]types.RPCTransactionError) {},
 	)
 	if err != nil {
 		fmt.Println(err)
@@ -173,7 +172,6 @@ func callFaucetContractToFundAnAddress(chain *core.BlockChain) {
 	err = contractworker.CommitTransactions(
 		txmap, nil, testUserAddress,
 		func([]staking.RPCTransactionError) {},
-		func([]types.RPCTransactionError) {},
 	)
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
## Issue

Similar to #2157 #2151, this PR will report failed (non-staking) transactions on all nodes instead of just on the leader. 

### Unit Test Coverage

Before:

```
PASS
coverage: 13.6% of statements
ok  	github.com/harmony-one/harmony/node	2.391s
```

```
PASS
coverage: 19.5% of statements
ok  	github.com/harmony-one/harmony/core	6.853s
```

After:

```
PASS
coverage: 14.0% of statements
ok  	github.com/harmony-one/harmony/node	2.067s
```

```
PASS
coverage: 20.4% of statements
ok  	github.com/harmony-one/harmony/core	6.656s
```

### Test/Run Logs

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**
