### PR TITLE
multi bls key support

### DIFF
--- a/consensus/consensus_leader_msg_test.go
+++ b/consensus/consensus_leader_msg_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/harmony-one/harmony/consensus/quorum"
 	"github.com/harmony-one/harmony/core/values"
 	"github.com/harmony-one/harmony/crypto/bls"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/ctxerror"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
@@ -23,8 +24,9 @@ func TestConstructAnnounceMessage(test *testing.T) {
 		test.Fatalf("newhost failure: %v", err)
 	}
 	decider := quorum.NewDecider(quorum.SuperMajorityVote)
+	blsPriKey := bls.RandPrivateKey()
 	consensus, err := New(
-		host, values.BeaconChainShardID, leader, bls.RandPrivateKey(), decider,
+		host, values.BeaconChainShardID, leader, nodeconfig.GetMultiBlsPrivateKey(blsPriKey), decider,
 	)
 	if err != nil {
 		test.Fatalf("Cannot create consensus: %v", err)
@@ -32,7 +34,7 @@ func TestConstructAnnounceMessage(test *testing.T) {
 	consensus.blockHash = [32]byte{}
 
 	message := &msg_pb.Message{}
-	msgBytes := consensus.constructAnnounceMessage()
+	msgBytes := consensus.constructAnnounceMessage(blsPriKey)
 	msgPayload, _ := proto.GetConsensusMessagePayload(msgBytes)
 
 	if err := protobuf.Unmarshal(msgPayload, message); err != nil {
@@ -56,8 +58,9 @@ func TestConstructPreparedMessage(test *testing.T) {
 		test.Fatalf("newhost failure: %v", err)
 	}
 	decider := quorum.NewDecider(quorum.SuperMajorityVote)
+	blsPriKey := bls.RandPrivateKey()
 	consensus, err := New(
-		host, values.BeaconChainShardID, leader, bls.RandPrivateKey(), decider,
+		host, values.BeaconChainShardID, leader, nodeconfig.GetMultiBlsPrivateKey(blsPriKey), decider,
 	)
 	if err != nil {
 		test.Fatalf("Cannot craeate consensus: %v", err)
@@ -76,7 +79,7 @@ func TestConstructPreparedMessage(test *testing.T) {
 		test.Log(ctxerror.New("prepareBitmap.SetKey").WithCause(err))
 	}
 
-	msgBytes, _ := consensus.constructPreparedMessage()
+	msgBytes, _ := consensus.constructPreparedMessage(blsPriKey)
 	msgPayload, _ := proto.GetConsensusMessagePayload(msgBytes)
 
 	msg := &msg_pb.Message{}

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -56,7 +56,7 @@ func (consensus *Consensus) GetNextRnd() ([vdFAndProofSize]byte, [32]byte, error
 }
 
 // Populates the common basic fields for all consensus message.
-func (consensus *Consensus) populateMessageFields(request *msg_pb.ConsensusRequest) {
+func (consensus *Consensus) populateMessageFields(request *msg_pb.ConsensusRequest, pubKey *bls.PublicKey) {
 	request.ViewId = consensus.viewID
 	request.BlockNum = consensus.blockNum
 	request.ShardId = consensus.ShardID
@@ -65,15 +65,15 @@ func (consensus *Consensus) populateMessageFields(request *msg_pb.ConsensusReque
 	request.BlockHash = consensus.blockHash[:]
 
 	// sender address
-	request.SenderPubkey = consensus.PubKey.Serialize()
+	request.SenderPubkey = pubKey.Serialize()
 	consensus.getLogger().Debug().
-		Str("senderKey", consensus.PubKey.SerializeToHexStr()).
+		Str("senderKey", pubKey.SerializeToHexStr()).
 		Msg("[populateMessageFields]")
 }
 
 // Signs the consensus message and returns the marshaled message.
-func (consensus *Consensus) signAndMarshalConsensusMessage(message *msg_pb.Message) ([]byte, error) {
-	err := consensus.signConsensusMessage(message)
+func (consensus *Consensus) signAndMarshalConsensusMessage(message *msg_pb.Message, priKey *bls.SecretKey) ([]byte, error) {
+	err := consensus.signConsensusMessage(message, priKey)
 	if err != nil {
 		return []byte{}, err
 	}
@@ -137,14 +137,14 @@ func NewFaker() *Consensus {
 }
 
 // Sign on the hash of the message
-func (consensus *Consensus) signMessage(message []byte) []byte {
+func (consensus *Consensus) signMessage(message []byte, priKey *bls.SecretKey) []byte {
 	hash := hash.Keccak256(message)
-	signature := consensus.priKey.SignHash(hash[:])
+	signature := priKey.SignHash(hash[:])
 	return signature.Serialize()
 }
 
 // Sign on the consensus message signature field.
-func (consensus *Consensus) signConsensusMessage(message *msg_pb.Message) error {
+func (consensus *Consensus) signConsensusMessage(message *msg_pb.Message, priKey *bls.SecretKey) error {
 	message.Signature = nil
 	// TODO: use custom serialization method rather than protobuf
 	marshaledMessage, err := protobuf.Marshal(message)
@@ -152,7 +152,7 @@ func (consensus *Consensus) signConsensusMessage(message *msg_pb.Message) error 
 		return err
 	}
 	// 64 byte of signature on previous data
-	signature := consensus.signMessage(marshaledMessage)
+	signature := consensus.signMessage(marshaledMessage, priKey)
 	message.Signature = signature
 	return nil
 }
@@ -389,7 +389,7 @@ func (consensus *Consensus) reportMetrics(block types.Block) {
 		txHashes = append(txHashes, hex.EncodeToString(txHash[:]))
 	}
 	metrics := map[string]interface{}{
-		"key":             hex.EncodeToString(consensus.PubKey.Serialize()),
+		"key":             hex.EncodeToString(consensus.LeaderPubKey.Serialize()),
 		"tps":             tps,
 		"txCount":         numOfTxs,
 		"nodeCount":       consensus.Decider.ParticipantsCount() + 1,
@@ -510,13 +510,13 @@ func (consensus *Consensus) UpdateConsensusInformation() Mode {
 
 	for _, key := range pubKeys {
 		// in committee
-		if key.IsEqual(consensus.PubKey) {
+		if consensus.PubKey.Contains(key) {
 			if hasError {
 				return Syncing
 			}
 
 			// If the leader changed and I myself become the leader
-			if !consensus.LeaderPubKey.IsEqual(oldLeader) && consensus.LeaderPubKey.IsEqual(consensus.PubKey) {
+			if !consensus.LeaderPubKey.IsEqual(oldLeader) && consensus.IsLeader() {
 				go func() {
 					utils.Logger().Debug().
 						Str("myKey", consensus.PubKey.SerializeToHexStr()).
@@ -536,8 +536,10 @@ func (consensus *Consensus) UpdateConsensusInformation() Mode {
 // IsLeader check if the node is a leader or not by comparing the public key of
 // the node with the leader public key
 func (consensus *Consensus) IsLeader() bool {
-	if consensus.PubKey != nil && consensus.LeaderPubKey != nil {
-		return consensus.PubKey.IsEqual(consensus.LeaderPubKey)
+	for _, key := range consensus.PubKey.PublicKey {
+		if key.IsEqual(consensus.LeaderPubKey) {
+			return true
+		}
 	}
 	return false
 }

--- a/consensus/consensus_service_test.go
+++ b/consensus/consensus_service_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/harmony-one/harmony/consensus/quorum"
 	"github.com/harmony-one/harmony/core/values"
 	"github.com/harmony-one/harmony/crypto/bls"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/p2p/p2pimpl"
@@ -23,7 +24,7 @@ func TestPopulateMessageFields(t *testing.T) {
 	blsPriKey := bls.RandPrivateKey()
 	decider := quorum.NewDecider(quorum.SuperMajorityVote)
 	consensus, err := New(
-		host, values.BeaconChainShardID, leader, blsPriKey, decider,
+		host, values.BeaconChainShardID, leader, nodeconfig.GetMultiBlsPrivateKey(blsPriKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
@@ -38,7 +39,7 @@ func TestPopulateMessageFields(t *testing.T) {
 		},
 	}
 	consensusMsg := msg.GetConsensus()
-	consensus.populateMessageFields(consensusMsg)
+	consensus.populateMessageFields(consensusMsg, blsPriKey.GetPublicKey())
 
 	if consensusMsg.ViewId != 2 {
 		t.Errorf("Consensus ID is not populated correctly")
@@ -59,8 +60,9 @@ func TestSignAndMarshalConsensusMessage(t *testing.T) {
 		t.Fatalf("newhost failure: %v", err)
 	}
 	decider := quorum.NewDecider(quorum.SuperMajorityVote)
+	blsPriKey := bls.RandPrivateKey()
 	consensus, err := New(
-		host, values.BeaconChainShardID, leader, bls.RandPrivateKey(), decider,
+		host, values.BeaconChainShardID, leader, nodeconfig.GetMultiBlsPrivateKey(blsPriKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
@@ -69,7 +71,7 @@ func TestSignAndMarshalConsensusMessage(t *testing.T) {
 	consensus.blockHash = [32]byte{}
 
 	msg := &msg_pb.Message{}
-	marshaledMessage, err := consensus.signAndMarshalConsensusMessage(msg)
+	marshaledMessage, err := consensus.signAndMarshalConsensusMessage(msg, blsPriKey)
 
 	if err != nil || len(marshaledMessage) == 0 {
 		t.Errorf("Failed to sign and marshal the message: %s", err)
@@ -88,7 +90,7 @@ func TestSetViewID(t *testing.T) {
 	}
 	decider := quorum.NewDecider(quorum.SuperMajorityVote)
 	consensus, err := New(
-		host, values.BeaconChainShardID, leader, bls.RandPrivateKey(), decider,
+		host, values.BeaconChainShardID, leader, nodeconfig.GetMultiBlsPrivateKey(bls.RandPrivateKey()), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/harmony-one/harmony/consensus/quorum"
 	"github.com/harmony-one/harmony/core/values"
 	"github.com/harmony-one/harmony/crypto/bls"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/p2p/p2pimpl"
@@ -20,7 +21,7 @@ func TestNew(test *testing.T) {
 	}
 	decider := quorum.NewDecider(quorum.SuperMajorityVote)
 	consensus, err := New(
-		host, values.BeaconChainShardID, leader, bls.RandPrivateKey(), decider,
+		host, values.BeaconChainShardID, leader, nodeconfig.GetMultiBlsPrivateKey(bls.RandPrivateKey()), decider,
 	)
 	if err != nil {
 		test.Fatalf("Cannot craeate consensus: %v", err)

--- a/consensus/consensus_validator_msg_test.go
+++ b/consensus/consensus_validator_msg_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/harmony-one/harmony/consensus/quorum"
 	"github.com/harmony-one/harmony/core/values"
 	"github.com/harmony-one/harmony/crypto/bls"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/p2p/p2pimpl"
@@ -22,14 +23,15 @@ func TestConstructPrepareMessage(test *testing.T) {
 		test.Fatalf("newhost failure: %v", err)
 	}
 	decider := quorum.NewDecider(quorum.SuperMajorityVote)
+	blsPriKey := bls.RandPrivateKey()
 	consensus, err := New(
-		host, values.BeaconChainShardID, leader, bls.RandPrivateKey(), decider,
+		host, values.BeaconChainShardID, leader, nodeconfig.GetMultiBlsPrivateKey(blsPriKey), decider,
 	)
 	if err != nil {
 		test.Fatalf("Cannot craeate consensus: %v", err)
 	}
 	consensus.blockHash = [32]byte{}
-	msgBytes := consensus.constructPrepareMessage()
+	msgBytes := consensus.constructPrepareMessage(blsPriKey.GetPublicKey(), blsPriKey)
 	msgBytes, err = proto.GetConsensusMessagePayload(msgBytes)
 	if err != nil {
 		test.Error("Error when getting consensus message", "error", err)
@@ -53,14 +55,15 @@ func TestConstructCommitMessage(test *testing.T) {
 		test.Fatalf("newhost failure: %v", err)
 	}
 	decider := quorum.NewDecider(quorum.SuperMajorityVote)
+	blsPriKey := bls.RandPrivateKey()
 	consensus, err := New(
-		host, values.BeaconChainShardID, leader, bls.RandPrivateKey(), decider,
+		host, values.BeaconChainShardID, leader, nodeconfig.GetMultiBlsPrivateKey(blsPriKey), decider,
 	)
 	if err != nil {
 		test.Fatalf("Cannot craeate consensus: %v", err)
 	}
 	consensus.blockHash = [32]byte{}
-	msg := consensus.constructCommitMessage([]byte("random string"))
+	msg := consensus.constructCommitMessage([]byte("random string"), blsPriKey.GetPublicKey(), blsPriKey)
 	msg, err = proto.GetConsensusMessagePayload(msg)
 	if err != nil {
 		test.Errorf("Failed to get consensus message")

--- a/consensus/fbft_log_test.go
+++ b/consensus/fbft_log_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/harmony-one/harmony/consensus/quorum"
 	"github.com/harmony-one/harmony/core/values"
 	"github.com/harmony-one/harmony/crypto/bls"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/p2p/p2pimpl"
@@ -22,15 +23,16 @@ func constructAnnounceMessage(t *testing.T) []byte {
 		t.Fatalf("newhost failure: %v", err)
 	}
 	decider := quorum.NewDecider(quorum.SuperMajorityVote)
+	blsPriKey := bls.RandPrivateKey()
 	consensus, err := New(
-		host, values.BeaconChainShardID, leader, bls.RandPrivateKey(), decider,
+		host, values.BeaconChainShardID, leader, nodeconfig.GetMultiBlsPrivateKey(blsPriKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot create consensus: %v", err)
 	}
 	consensus.blockHash = [32]byte{}
 
-	msgBytes := consensus.constructAnnounceMessage()
+	msgBytes := consensus.constructAnnounceMessage(blsPriKey)
 	msgPayload, _ := proto.GetConsensusMessagePayload(msgBytes)
 	return msgPayload
 }

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -129,12 +129,14 @@ func (consensus *Consensus) startViewChange(viewID uint64) {
 		Str("NextLeader", consensus.LeaderPubKey.SerializeToHexStr()).
 		Msg("[startViewChange]")
 
-	msgToSend := consensus.constructViewChangeMessage()
-	consensus.host.SendMessageToGroups([]nodeconfig.GroupID{
-		nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(consensus.ShardID)),
-	},
-		host.ConstructP2pMessage(byte(17), msgToSend),
-	)
+	for i, key := range consensus.PubKey.PublicKey {
+		msgToSend := consensus.constructViewChangeMessage(key, consensus.priKey.PrivateKey[i])
+		consensus.host.SendMessageToGroups([]nodeconfig.GroupID{
+			nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(consensus.ShardID)),
+		},
+			host.ConstructP2pMessage(byte(17), msgToSend),
+		)
+	}
 
 	consensus.consensusTimeout[timeoutViewChange].SetDuration(duration)
 	consensus.consensusTimeout[timeoutViewChange].Start()
@@ -150,7 +152,8 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 		return
 	}
 	newLeaderKey := recvMsg.LeaderPubkey
-	if !consensus.PubKey.IsEqual(newLeaderKey) {
+	newLeaderPriKey, err := consensus.GetLeaderPrivateKey(newLeaderKey)
+	if err != nil {
 		return
 	}
 
@@ -216,13 +219,13 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 		preparedMsg := consensus.FBFTLog.FindMessageByMaxViewID(preparedMsgs)
 		if preparedMsg == nil {
 			utils.Logger().Debug().Msg("[onViewChange] add my M2(NIL) type messaage")
-			consensus.nilSigs[recvMsg.ViewID][consensus.PubKey.SerializeToHexStr()] = consensus.priKey.SignHash(NIL)
-			consensus.nilBitmap[recvMsg.ViewID].SetKey(consensus.PubKey, true)
+			consensus.nilSigs[recvMsg.ViewID][consensus.PubKey.SerializeToHexStr()] = newLeaderPriKey.SignHash(NIL)
+			consensus.nilBitmap[recvMsg.ViewID].SetKey(newLeaderKey, true)
 		} else {
 			utils.Logger().Debug().Msg("[onViewChange] add my M1 type messaage")
 			msgToSign := append(preparedMsg.BlockHash[:], preparedMsg.Payload...)
-			consensus.bhpSigs[recvMsg.ViewID][consensus.PubKey.SerializeToHexStr()] = consensus.priKey.SignHash(msgToSign)
-			consensus.bhpBitmap[recvMsg.ViewID].SetKey(consensus.PubKey, true)
+			consensus.bhpSigs[recvMsg.ViewID][consensus.PubKey.SerializeToHexStr()] = newLeaderPriKey.SignHash(msgToSign)
+			consensus.bhpBitmap[recvMsg.ViewID].SetKey(newLeaderKey, true)
 		}
 	}
 	// add self m3 type message signature and bitmap
@@ -230,8 +233,8 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 	if !ok3 {
 		viewIDBytes := make([]byte, 8)
 		binary.LittleEndian.PutUint64(viewIDBytes, recvMsg.ViewID)
-		consensus.viewIDSigs[recvMsg.ViewID][consensus.PubKey.SerializeToHexStr()] = consensus.priKey.SignHash(viewIDBytes)
-		consensus.viewIDBitmap[recvMsg.ViewID].SetKey(consensus.PubKey, true)
+		consensus.viewIDSigs[recvMsg.ViewID][consensus.PubKey.SerializeToHexStr()] = newLeaderPriKey.SignHash(viewIDBytes)
+		consensus.viewIDBitmap[recvMsg.ViewID].SetKey(newLeaderKey, true)
 	}
 
 	// m2 type message
@@ -310,7 +313,7 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 				copy(preparedMsg.BlockHash[:], recvMsg.Payload[:32])
 				preparedMsg.Payload = make([]byte, len(recvMsg.Payload)-32)
 				copy(preparedMsg.Payload[:], recvMsg.Payload[32:])
-				preparedMsg.SenderPubkey = consensus.PubKey
+				preparedMsg.SenderPubkey = newLeaderKey
 				utils.Logger().Info().Msg("[onViewChange] New Leader Prepared Message Added")
 				consensus.FBFTLog.AddMessage(&preparedMsg)
 			}
@@ -355,7 +358,7 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 	// received enough view change messages, change state to normal consensus
 	if len(consensus.viewIDSigs[recvMsg.ViewID]) >= int(consensus.Decider.QuorumThreshold()) {
 		consensus.current.SetMode(Normal)
-		consensus.LeaderPubKey = consensus.PubKey
+		consensus.LeaderPubKey = newLeaderKey
 		consensus.ResetState()
 		if len(consensus.m1Payload) == 0 {
 			// TODO(Chao): explain why ReadySignal is sent only in this case but not the other case.
@@ -384,10 +387,10 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 			binary.LittleEndian.PutUint64(blockNumBytes, consensus.blockNum)
 			commitPayload := append(blockNumBytes, consensus.blockHash[:]...)
 			consensus.Decider.AddSignature(
-				quorum.Commit, consensus.PubKey, consensus.priKey.SignHash(commitPayload),
+				quorum.Commit, newLeaderKey, newLeaderPriKey.SignHash(commitPayload),
 			)
 
-			if err = consensus.commitBitmap.SetKey(consensus.PubKey, true); err != nil {
+			if err = consensus.commitBitmap.SetKey(newLeaderKey, true); err != nil {
 				utils.Logger().Debug().
 					Msg("[OnViewChange] New Leader commit bitmap set failed")
 				return
@@ -395,7 +398,7 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 		}
 
 		consensus.current.SetViewID(recvMsg.ViewID)
-		msgToSend := consensus.constructNewViewMessage(recvMsg.ViewID)
+		msgToSend := consensus.constructNewViewMessage(recvMsg.ViewID, newLeaderKey, newLeaderPriKey)
 
 		utils.Logger().Warn().
 			Int("payloadSize", len(consensus.m1Payload)).
@@ -539,10 +542,12 @@ func (consensus *Consensus) onNewView(msg *msg_pb.Message) {
 		blockNumHash := make([]byte, 8)
 		binary.LittleEndian.PutUint64(blockNumHash, consensus.blockNum)
 		commitPayload := append(blockNumHash, consensus.blockHash[:]...)
-		msgToSend := consensus.constructCommitMessage(commitPayload)
-
-		utils.Logger().Info().Msg("onNewView === commit")
-		consensus.host.SendMessageToGroups([]nodeconfig.GroupID{nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(consensus.ShardID))}, host.ConstructP2pMessage(byte(17), msgToSend))
+		groupID := []nodeconfig.GroupID{nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(consensus.ShardID))}
+		for i, key := range consensus.PubKey.PublicKey {
+			msgToSend := consensus.constructCommitMessage(commitPayload, key, consensus.priKey.PrivateKey[i])
+			utils.Logger().Info().Msg("onNewView === commit")
+			consensus.host.SendMessageToGroups(groupID, host.ConstructP2pMessage(byte(17), msgToSend))
+		}
 		utils.Logger().Debug().
 			Str("From", consensus.phase.String()).
 			Str("To", FBFTCommit.String()).

--- a/internal/configs/sharding/testnet.go
+++ b/internal/configs/sharding/testnet.go
@@ -68,4 +68,4 @@ func (ts testnetSchedule) GetShardingStructure(numShard, shardID int) []map[stri
 
 var testnetReshardingEpoch = []*big.Int{big.NewInt(0)}
 
-var testnetV0 = MustNewInstance(3, 10, 10, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch)
+var testnetV0 = MustNewInstance(2, 30, 30, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch)

--- a/node/node.go
+++ b/node/node.go
@@ -584,7 +584,7 @@ func (node *Node) CalculateInitShardState() (err error) {
 	}
 
 	for _, key := range pubKeys {
-		if key.IsEqual(node.Consensus.PubKey) {
+		if node.Consensus.PubKey.Contains(key) {
 			utils.Logger().Info().
 				Uint64("blockNum", blockNum).
 				Int("numPubKeys", len(pubKeys)).

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -344,7 +344,7 @@ func (node *Node) PostConsensusProcessing(newBlock *types.Block, commitSigAndBit
 	// TODO: randomly selected a few validators to broadcast messages instead of only leader broadcast
 	// TODO: refactor the asynchronous calls to separate go routine.
 	node.lastConsensusTime = time.Now().Unix()
-	if node.Consensus.PubKey.IsEqual(node.Consensus.LeaderPubKey) {
+	if node.Consensus.IsLeader() {
 		if node.NodeConfig.ShardID == 0 {
 			node.BroadcastNewBlock(newBlock)
 		}

--- a/node/node_handler_test.go
+++ b/node/node_handler_test.go
@@ -26,7 +26,7 @@ func TestAddNewBlock(t *testing.T) {
 	}
 	decider := quorum.NewDecider(quorum.SuperMajorityVote)
 	consensus, err := consensus.New(
-		host, values.BeaconChainShardID, leader, blsKey, decider,
+		host, values.BeaconChainShardID, leader, nodeconfig.GetMultiBlsPrivateKey(blsKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
@@ -59,7 +59,7 @@ func TestVerifyNewBlock(t *testing.T) {
 	}
 	decider := quorum.NewDecider(quorum.SuperMajorityVote)
 	consensus, err := consensus.New(
-		host, values.BeaconChainShardID, leader, blsKey, decider,
+		host, values.BeaconChainShardID, leader, nodeconfig.GetMultiBlsPrivateKey(blsKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)

--- a/node/node_metrics.go
+++ b/node/node_metrics.go
@@ -43,12 +43,14 @@ func (node *Node) UpdateTxPoolSizeForMetrics(txPoolSize uint64) {
 
 // UpdateBalanceForMetrics uppdates node balance for metrics service.
 func (node *Node) UpdateBalanceForMetrics() {
-	curBalance, err := node.GetBalanceOfAddress(node.Consensus.SelfAddress)
-	if err != nil {
-		return
+	for _, addr := range node.Consensus.SelfAddress {
+		curBalance, err := node.GetBalanceOfAddress(addr)
+		if err != nil {
+			return
+		}
+		utils.Logger().Info().Msgf("Updating metrics node balance %d", curBalance.Uint64())
+		metrics.UpdateNodeBalance(curBalance)
 	}
-	utils.Logger().Info().Msgf("Updating metrics node balance %d", curBalance.Uint64())
-	metrics.UpdateNodeBalance(curBalance)
 }
 
 // UpdateLastConsensusTimeForMetrics uppdates last consensus reached time for metrics service.

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -78,7 +78,7 @@ func (node *Node) WaitForConsensusReadyV2(readySignal chan struct{}, stopChan ch
 
 func (node *Node) proposeNewBlock() (*types.Block, error) {
 	// Update worker's current header and state data in preparation to propose/process new transactions
-	coinbase := node.Consensus.SelfAddress
+	coinbase := node.Consensus.SelfAddress[node.Consensus.LeaderPubKey.SerializeToHexStr()]
 
 	// Prepare transactions including staking transactions
 	pending, err := node.TxPool.Pending()

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -15,6 +15,7 @@ import (
 	bls2 "github.com/harmony-one/harmony/crypto/bls"
 	"github.com/harmony-one/harmony/crypto/pki"
 	"github.com/harmony-one/harmony/drand"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/shardchain"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
@@ -35,7 +36,7 @@ func TestNewNode(t *testing.T) {
 	}
 	decider := quorum.NewDecider(quorum.SuperMajorityVote)
 	consensus, err := consensus.New(
-		host, values.BeaconChainShardID, leader, blsKey, decider,
+		host, values.BeaconChainShardID, leader, nodeconfig.GetMultiBlsPrivateKey(blsKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
@@ -202,7 +203,7 @@ func TestAddPeers(t *testing.T) {
 	}
 	decider := quorum.NewDecider(quorum.SuperMajorityVote)
 	consensus, err := consensus.New(
-		host, values.BeaconChainShardID, leader, blsKey, decider,
+		host, values.BeaconChainShardID, leader, nodeconfig.GetMultiBlsPrivateKey(blsKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
@@ -252,7 +253,7 @@ func TestAddBeaconPeer(t *testing.T) {
 	}
 	decider := quorum.NewDecider(quorum.SuperMajorityVote)
 	consensus, err := consensus.New(
-		host, values.BeaconChainShardID, leader, blsKey, decider,
+		host, values.BeaconChainShardID, leader, nodeconfig.GetMultiBlsPrivateKey(blsKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)


### PR DESCRIPTION
- [testnet] use a new testnet for multi-key test

Signed-off-by: Leo Chen <leo@harmony.one>

- adding support for multiple initial accounts for multi-key scenarios

- minor fixes

- changing viewchange duration to exponential

[multi-key] use 2 shards for testnet of multi-key (#2)

Signed-off-by: Leo Chen <leo@harmony.one>

## Issue

<!-- link to the issue number or description of the issue -->

## Test

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
