### PR TITLE
Expose rewards to RPC API

### DIFF
--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -21,8 +21,8 @@ import (
 	"github.com/harmony-one/harmony/core/vm"
 	"github.com/harmony-one/harmony/internal/params"
 	"github.com/harmony-one/harmony/shard"
-	staking "github.com/harmony-one/harmony/staking/types"
 	"github.com/harmony-one/harmony/staking/network"
+	staking "github.com/harmony-one/harmony/staking/types"
 )
 
 // APIBackend An implementation of internal/hmyapi/Backend. Full client.

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -22,6 +22,7 @@ import (
 	"github.com/harmony-one/harmony/internal/params"
 	"github.com/harmony-one/harmony/shard"
 	staking "github.com/harmony-one/harmony/staking/types"
+	"github.com/harmony-one/harmony/staking/network"
 )
 
 // APIBackend An implementation of internal/hmyapi/Backend. Full client.
@@ -430,4 +431,9 @@ func (b *APIBackend) GetCurrentTransactionErrorSink() []types.RPCTransactionErro
 // GetPendingCXReceipts ..
 func (b *APIBackend) GetPendingCXReceipts() []*types.CXReceiptsProof {
 	return b.hmy.nodeAPI.PendingCXReceipts()
+}
+
+// GetCurrentUtilityMetrics ..
+func (b *APIBackend) GetCurrentUtilityMetrics() (*network.UtilityMetric, error) {
+	return network.NewUtilityMetricSnapshot(b.hmy.BlockChain())
 }

--- a/internal/hmyapi/apiv1/backend.go
+++ b/internal/hmyapi/apiv1/backend.go
@@ -16,6 +16,7 @@ import (
 	"github.com/harmony-one/harmony/core/vm"
 	"github.com/harmony-one/harmony/internal/params"
 	"github.com/harmony-one/harmony/shard"
+	"github.com/harmony-one/harmony/staking/network"
 	staking "github.com/harmony-one/harmony/staking/types"
 )
 
@@ -81,4 +82,5 @@ type Backend interface {
 	GetCurrentTransactionErrorSink() []types.RPCTransactionError
 	GetMedianRawStakeSnapshot() *big.Int
 	GetPendingCXReceipts() []*types.CXReceiptsProof
+	GetCurrentUtilityMetrics() (*network.UtilityMetric, error)
 }

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -635,7 +635,7 @@ func (s *PublicBlockChainAPI) GetDelegationByDelegatorAndValidator(ctx context.C
 	return nil, nil
 }
 
-// GetCurrentUtilityMetrics, only available for shard 0.
+// GetCurrentUtilityMetrics ..
 func (s *PublicBlockChainAPI) GetCurrentUtilityMetrics() (*network.UtilityMetric, error) {
 	if s.b.GetShardID() == shard.BeaconChainShardID {
 		return s.b.GetCurrentUtilityMetrics()

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -20,6 +20,7 @@ import (
 	internal_common "github.com/harmony-one/harmony/internal/common"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/shard"
+	"github.com/harmony-one/harmony/staking/network"
 	staking "github.com/harmony-one/harmony/staking/types"
 )
 
@@ -632,4 +633,12 @@ func (s *PublicBlockChainAPI) GetDelegationByDelegatorAndValidator(ctx context.C
 		}, nil
 	}
 	return nil, nil
+}
+
+// GetCurrentUtilityMetrics, only available for shard 0.
+func (s *PublicBlockChainAPI) GetCurrentUtilityMetrics() (*network.UtilityMetric, error) {
+	if s.b.GetShardID() == shard.BeaconChainShardID {
+		return s.b.GetCurrentUtilityMetrics()
+	}
+	return nil, errNotBeaconChainShard
 }

--- a/internal/hmyapi/apiv2/backend.go
+++ b/internal/hmyapi/apiv2/backend.go
@@ -16,6 +16,7 @@ import (
 	"github.com/harmony-one/harmony/core/vm"
 	"github.com/harmony-one/harmony/internal/params"
 	"github.com/harmony-one/harmony/shard"
+	"github.com/harmony-one/harmony/staking/network"
 	staking "github.com/harmony-one/harmony/staking/types"
 )
 
@@ -81,4 +82,5 @@ type Backend interface {
 	GetCurrentTransactionErrorSink() []types.RPCTransactionError
 	GetMedianRawStakeSnapshot() *big.Int
 	GetPendingCXReceipts() []*types.CXReceiptsProof
+	GetCurrentUtilityMetrics() (*network.UtilityMetric, error)
 }

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -20,6 +20,7 @@ import (
 	internal_common "github.com/harmony-one/harmony/internal/common"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/shard"
+	"github.com/harmony-one/harmony/staking/network"
 	staking "github.com/harmony-one/harmony/staking/types"
 )
 
@@ -594,4 +595,12 @@ func (s *PublicBlockChainAPI) GetDelegationByDelegatorAndValidator(ctx context.C
 		}, nil
 	}
 	return nil, nil
+}
+
+// GetCurrentUtilityMetrics, only available for shard 0.
+func (s *PublicBlockChainAPI) GetCurrentUtilityMetrics() (*network.UtilityMetric, error) {
+	if s.b.GetShardID() == shard.BeaconChainShardID {
+		return s.b.GetCurrentUtilityMetrics()
+	}
+	return nil, errNotBeaconChainShard
 }

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -597,7 +597,7 @@ func (s *PublicBlockChainAPI) GetDelegationByDelegatorAndValidator(ctx context.C
 	return nil, nil
 }
 
-// GetCurrentUtilityMetrics, only available for shard 0.
+// GetCurrentUtilityMetrics ..
 func (s *PublicBlockChainAPI) GetCurrentUtilityMetrics() (*network.UtilityMetric, error) {
 	if s.b.GetShardID() == shard.BeaconChainShardID {
 		return s.b.GetCurrentUtilityMetrics()

--- a/internal/hmyapi/backend.go
+++ b/internal/hmyapi/backend.go
@@ -18,6 +18,7 @@ import (
 	"github.com/harmony-one/harmony/internal/hmyapi/apiv2"
 	"github.com/harmony-one/harmony/internal/params"
 	"github.com/harmony-one/harmony/shard"
+	"github.com/harmony-one/harmony/staking/network"
 	staking "github.com/harmony-one/harmony/staking/types"
 )
 
@@ -83,6 +84,7 @@ type Backend interface {
 	GetCurrentTransactionErrorSink() []types.RPCTransactionError
 	GetMedianRawStakeSnapshot() *big.Int
 	GetPendingCXReceipts() []*types.CXReceiptsProof
+	GetCurrentUtilityMetrics() (*network.UtilityMetric, error)
 }
 
 // GetAPIs returns all the APIs.

--- a/staking/network/reward.go
+++ b/staking/network/reward.go
@@ -1,0 +1,89 @@
+package network
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/harmony-one/harmony/common/denominations"
+	"github.com/harmony-one/harmony/consensus/engine"
+	"github.com/harmony-one/harmony/consensus/reward"
+	"github.com/harmony-one/harmony/internal/utils"
+	"github.com/harmony-one/harmony/numeric"
+)
+
+var (
+	// BlockReward is the block reward, to be split evenly among block signers.
+	BlockReward = new(big.Int).Mul(big.NewInt(24), big.NewInt(denominations.One))
+	// BaseStakedReward is the base block reward for epos.
+	BaseStakedReward = numeric.NewDecFromBigInt(new(big.Int).Mul(
+		big.NewInt(18), big.NewInt(denominations.One),
+	))
+	// BlockRewardStakedCase is the baseline block reward in staked case -
+	totalTokens = numeric.NewDecFromBigInt(
+		new(big.Int).Mul(big.NewInt(12600000000), big.NewInt(denominations.One)),
+	)
+	targetStakedPercentage = numeric.MustNewDecFromStr("0.35")
+	dynamicAdjust          = numeric.MustNewDecFromStr("0.4")
+	// ErrPayoutNotEqualBlockReward ..
+	ErrPayoutNotEqualBlockReward = errors.New("total payout not equal to blockreward")
+	// NoReward ..
+	NoReward = common.Big0
+)
+
+func adjust(amount numeric.Dec) numeric.Dec {
+	return amount.MulTruncate(
+		numeric.NewDecFromBigInt(big.NewInt(denominations.One)),
+	)
+}
+
+// Adjustment ..
+func Adjustment(percentageStaked numeric.Dec) (numeric.Dec, numeric.Dec) {
+	howMuchOff := targetStakedPercentage.Sub(percentageStaked)
+	adjustBy := adjust(
+		howMuchOff.MulTruncate(numeric.NewDec(100)).Mul(dynamicAdjust),
+	)
+	return howMuchOff, adjustBy
+}
+
+// WhatPercentStakedNow ..
+func WhatPercentStakedNow(
+	beaconchain engine.ChainReader,
+	timestamp int64,
+) (*big.Int, *numeric.Dec, error) {
+	stakedNow := numeric.ZeroDec()
+	// Only active validators' stake is counted in stake ratio because only their stake is under slashing risk
+	active, err := beaconchain.ReadActiveValidatorList()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	soFarDoledOut, err := beaconchain.ReadBlockRewardAccumulator(
+		beaconchain.CurrentHeader().Number().Uint64(),
+	)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	dole := numeric.NewDecFromBigInt(soFarDoledOut)
+
+	for i := range active {
+		wrapper, err := beaconchain.ReadValidatorInformation(active[i])
+		if err != nil {
+			return nil, nil, err
+		}
+		stakedNow = stakedNow.Add(
+			numeric.NewDecFromBigInt(wrapper.TotalDelegation()),
+		)
+	}
+	percentage := stakedNow.Quo(totalTokens.Mul(
+		reward.PercentageForTimeStamp(timestamp),
+	).Add(dole))
+	utils.Logger().Info().
+		Str("so-far-doled-out", dole.String()).
+		Str("staked-percentage", percentage.String()).
+		Str("currently-staked", stakedNow.String()).
+		Msg("Computed how much staked right now")
+	return soFarDoledOut, &percentage, nil
+}

--- a/staking/network/values.go
+++ b/staking/network/values.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"encoding/json"
 	"math/big"
 	"time"
 
@@ -16,6 +17,22 @@ type UtilityMetric struct {
 	Adjustment              numeric.Dec
 }
 
+// MarshalJSON for UtilityMetric.
+func (u UtilityMetric) MarshalJSON() ([]byte, error) {
+	type UtilityMetric struct {
+		AccumulatorSnapshot     *big.Int    `json:"accumulator"`
+		CurrentStakedPercentage numeric.Dec `json:"stakedPercentage"`
+		Deviation               numeric.Dec `json:"deviation"`
+		Adjustment              numeric.Dec `json:"adjustment"`
+	}
+	var enc UtilityMetric
+	enc.AccumulatorSnapshot = u.AccumulatorSnapshot
+	enc.CurrentStakedPercentage = u.CurrentStakedPercentage
+	enc.Deviation = u.Deviation
+	enc.Adjustment = u.Adjustment
+	return json.Marshal(&enc)
+}
+	
 // NewUtilityMetricSnapshot ..
 func NewUtilityMetricSnapshot(beaconchain engine.ChainReader) (*UtilityMetric, error) {
 	soFarDoledOut, percentageStaked, err := WhatPercentStakedNow(

--- a/staking/network/values.go
+++ b/staking/network/values.go
@@ -32,7 +32,7 @@ func (u UtilityMetric) MarshalJSON() ([]byte, error) {
 	enc.Adjustment = u.Adjustment
 	return json.Marshal(&enc)
 }
-	
+
 // NewUtilityMetricSnapshot ..
 func NewUtilityMetricSnapshot(beaconchain engine.ChainReader) (*UtilityMetric, error) {
 	soFarDoledOut, percentageStaked, err := WhatPercentStakedNow(

--- a/staking/network/values.go
+++ b/staking/network/values.go
@@ -17,22 +17,6 @@ type UtilityMetric struct {
 	Adjustment              numeric.Dec
 }
 
-// MarshalJSON for UtilityMetric.
-func (u UtilityMetric) MarshalJSON() ([]byte, error) {
-	type UtilityMetric struct {
-		AccumulatorSnapshot     *big.Int    `json:"accumulator"`
-		CurrentStakedPercentage numeric.Dec `json:"staked-percentage"`
-		Deviation               numeric.Dec `json:"deviation"`
-		Adjustment              numeric.Dec `json:"adjustment"`
-	}
-	var enc UtilityMetric
-	enc.AccumulatorSnapshot = u.AccumulatorSnapshot
-	enc.CurrentStakedPercentage = u.CurrentStakedPercentage
-	enc.Deviation = u.Deviation
-	enc.Adjustment = u.Adjustment
-	return json.Marshal(&enc)
-}
-
 // NewUtilityMetricSnapshot ..
 func NewUtilityMetricSnapshot(beaconchain engine.ChainReader) (*UtilityMetric, error) {
 	soFarDoledOut, percentageStaked, err := WhatPercentStakedNow(

--- a/staking/network/values.go
+++ b/staking/network/values.go
@@ -1,0 +1,9 @@
+package network
+
+import "math/big"
+
+// Reward ..
+type Reward struct {
+	AccumulatorSnapshot     *big.Int `json:"block-reward-accumulator"`
+	CurrentStakedPercentage *big.Int `json:"block-reward-accumulator"`
+}

--- a/staking/network/values.go
+++ b/staking/network/values.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"encoding/json"
 	"math/big"
 	"time"
 

--- a/staking/network/values.go
+++ b/staking/network/values.go
@@ -1,9 +1,15 @@
 package network
 
-import "math/big"
+import (
+	"math/big"
 
-// Reward ..
-type Reward struct {
-	AccumulatorSnapshot     *big.Int `json:"block-reward-accumulator"`
-	CurrentStakedPercentage *big.Int `json:"block-reward-accumulator"`
+	"github.com/harmony-one/harmony/numeric"
+)
+
+// UtilityMetric ..
+type UtilityMetric struct {
+	AccumulatorSnapshot     *big.Int
+	CurrentStakedPercentage *big.Int
+	Deviation               numeric.Dec
+	Adjustment              numeric.Dec
 }

--- a/staking/network/values.go
+++ b/staking/network/values.go
@@ -21,7 +21,7 @@ type UtilityMetric struct {
 func (u UtilityMetric) MarshalJSON() ([]byte, error) {
 	type UtilityMetric struct {
 		AccumulatorSnapshot     *big.Int    `json:"accumulator"`
-		CurrentStakedPercentage numeric.Dec `json:"stakedPercentage"`
+		CurrentStakedPercentage numeric.Dec `json:"staked-percentage"`
 		Deviation               numeric.Dec `json:"deviation"`
 		Adjustment              numeric.Dec `json:"adjustment"`
 	}

--- a/staking/network/values.go
+++ b/staking/network/values.go
@@ -2,14 +2,30 @@ package network
 
 import (
 	"math/big"
+	"time"
 
+	"github.com/harmony-one/harmony/consensus/engine"
 	"github.com/harmony-one/harmony/numeric"
 )
 
 // UtilityMetric ..
 type UtilityMetric struct {
 	AccumulatorSnapshot     *big.Int
-	CurrentStakedPercentage *big.Int
+	CurrentStakedPercentage numeric.Dec
 	Deviation               numeric.Dec
 	Adjustment              numeric.Dec
+}
+
+// NewUtilityMetricSnapshot ..
+func NewUtilityMetricSnapshot(beaconchain engine.ChainReader) (*UtilityMetric, error) {
+	soFarDoledOut, percentageStaked, err := WhatPercentStakedNow(
+		beaconchain, time.Now().Unix(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	howMuchOff, adjustBy := Adjustment(*percentageStaked)
+	return &UtilityMetric{
+		soFarDoledOut, *percentageStaked, howMuchOff, adjustBy,
+	}, nil
 }


### PR DESCRIPTION
## Issue

Edgar asked to expose rewards for RPC API. It contains branch from @fxfactorial PR.

curl -d '{
    "jsonrpc":"2.0",
    "method":"hmy_getCurrentUtilityMetrics",
    "params":[],
    "id":1
}' -H 'Content-Type:application/json' -X POST 'http://api.s0.b.hmny.io/' curl

## Test

<img width="1175" alt="Screenshot 2020-02-05 at 20 28 42" src="https://user-images.githubusercontent.com/52401354/73866559-1e3e2d00-4856-11ea-8a6e-61c8144ca10a.png">


### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
