### PR TITLE
Add staking network settings to node.sh

### DIFF
--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -248,6 +248,15 @@ testnet)
   network_type=testnet
   dns_zone=p.hmny.io
   ;;
+staking)
+  bootnodes=(
+    /ip4/54.86.126.90/tcp/9867/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv
+    /ip4/52.40.84.2/tcp/9867/p2p/QmbPVwrqWsTYXq1RxGWcxx9SWaTUCfoo1wA6wmdbduWe29
+  )
+  REL=testnet
+  network_type=testnet
+  dns_zone=os.hmny.io
+  ;;
 devnet)
   bootnodes=(
     /ip4/52.40.84.2/tcp/9870/p2p/QmZJJx6AdaoEkGLrYG4JeLCKeCKDjnFz2wfHNHxAqFSGA9


### PR DESCRIPTION
## Issue

There are no network settings for the staking testnet in node.sh

## Usage / test
```
$ curl -LOs https://raw.githubusercontent.com/SebastianJ/harmony/nodesh-staking-network/scripts/node.sh && chmod u+x node.sh && curl -LO https://harmony.one/hmycli && mv hmycli hmy && chmod u+x hmy

$ ./hmy keys generate-bls-key

$ ln -s *.key bls.key

$ ./node.sh -k bls.key -N staking -z -S
node.sh: using manually specified BLS key file: bls.key
diff: md5sum.txt: No such file or directory
node.sh: downloaded harmony
node.sh: downloaded wallet
node.sh: downloaded bootnode
node.sh: public IP address autodetected: xxx.xxx.xxx.xxx
Enter passphrase for the BLS key file bls.key: 
node.sh: ############### Running Harmony Process ###############
Staking mode; node key 375b66371991246bcd27737d4ab85e74cd3c39c888278c4eefd0fcafa6a80fa3ae956a1107fa95f666a549322d93a695 -> shard 2
```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    NO

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    NO

9. **Does the existing `node.sh` continue to work with this change?**

    The only change is adding the staking network settings - no other settings have been modified

10. **What should node operators know about this change?**

    Use `-N staking` to run the node in the new staking network (os.hmny.io)

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    NO

## TODO
