### PR TITLE
S3 blacklist

### DIFF
--- a/BLACKLIST.md
+++ b/BLACKLIST.md
@@ -1,0 +1,20 @@
+# Blacklist info
+
+The black list is a newline delimited file of wallet addresses. It can also support comments with the `#` character.
+
+## Default Location
+
+By default, the harmony binary looks for the file `./.hmy/blaklist.txt`.
+
+## Example File
+```
+one1spshr72utf6rwxseaz339j09ed8p6f8ke370zj
+one1uyshu2jgv8w465yc8kkny36thlt2wvel89tcmg  # This is a comment
+one1r4zyyjqrulf935a479sgqlpa78kz7zlcg2jfen
+
+```
+
+## Details
+
+Each transaction added to the tx-pool has its `to` and `from` address checked against this blacklist. 
+If there is a hit, the transaction is considered invalid and is dropped from the tx-pool.

--- a/cmd/client/txgen/main.go
+++ b/cmd/client/txgen/main.go
@@ -102,7 +102,7 @@ func setUpTXGen() *node.Node {
 	decider := quorum.NewDecider(quorum.SuperMajorityVote)
 	consensusObj, err := consensus.New(myhost, uint32(shardID), p2p.Peer{}, nil, decider)
 	chainDBFactory := &shardchain.MemDBFactory{}
-	txGen := node.New(myhost, consensusObj, chainDBFactory, false) //Changed it : no longer archival node.
+	txGen := node.New(myhost, consensusObj, chainDBFactory, nil, false) //Changed it : no longer archival node.
 	txGen.Client = client.NewClient(txGen.GetHost(), uint32(shardID))
 	consensusObj.ChainReader = txGen.Blockchain()
 	genesisShardingConfig := core.ShardingSchedule.InstanceForEpoch(big.NewInt(core.GenesisEpoch))

--- a/cmd/client/wallet/main.go
+++ b/cmd/client/wallet/main.go
@@ -304,7 +304,7 @@ func createWalletNode() *node.Node {
 		panic(err)
 	}
 	chainDBFactory := &shardchain.MemDBFactory{}
-	w := node.New(host, nil, chainDBFactory, false)
+	w := node.New(host, nil, chainDBFactory, nil, false)
 	w.Client = client.NewClient(w.GetHost(), uint32(shardID))
 
 	w.NodeConfig.SetRole(nodeconfig.ClientNode)

--- a/cmd/client/wallet_stress_test/main.go
+++ b/cmd/client/wallet_stress_test/main.go
@@ -187,7 +187,7 @@ func createWalletNode() *node.Node {
 		panic(err)
 	}
 	chainDBFactory := &shardchain.MemDBFactory{}
-	w := node.New(host, nil, chainDBFactory, false)
+	w := node.New(host, nil, chainDBFactory, nil, false)
 	w.Client = client.NewClient(w.GetHost(), uint32(shardID))
 
 	w.NodeConfig.SetRole(nodeconfig.ClientNode)

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -331,8 +331,7 @@ func setupConsensusAndNode(nodeConfig *nodeconfig.ConfigType) *node.Node {
 
 	blacklist, err := setupBlacklist()
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Blacklist error: %s\n", err.Error())
-		os.Exit(1)
+		utils.Logger().Warn().Msgf("Blacklist error: %s", err.Error())
 	}
 
 	// Current node.

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -152,7 +152,7 @@ var (
 	doRevertBefore = flag.Int("do_revert_before", -1, "If the current block is less than do_revert_before, revert all blocks until (including) revert_to block")
 	revertTo       = flag.Int("revert_to", -1, "The revert will rollback all blocks until and including block number revert_to")
 	// Blacklist of addresses
-	blacklistPath = flag.String("blacklist", "", "Path to newline delimited file of blacklisted wallet addresses")
+	blacklistPath = flag.String("blacklist", "./.hmy/blacklist.txt", "Path to newline delimited file of blacklisted wallet addresses")
 )
 
 func initSetup() {
@@ -331,7 +331,7 @@ func setupConsensusAndNode(nodeConfig *nodeconfig.ConfigType) *node.Node {
 
 	blacklist, err := setupBlacklist()
 	if err != nil {
-		utils.Logger().Warn().Msgf("Blacklist error: %s", err.Error())
+		utils.Logger().Warn().Msgf("Blacklist setup error: %s", err.Error())
 	}
 
 	// Current node.
@@ -439,7 +439,8 @@ func setupBlacklist() (*map[ethCommon.Address]struct{}, error) {
 	addrMap := make(map[ethCommon.Address]struct{})
 	for _, line := range strings.Split(string(dat), "\n") {
 		if len(line) != 0 { // blacklist file may have trailing empty string line
-			addr, err := common.Bech32ToAddress(line)
+			b32 := strings.TrimSpace(strings.Split(string(line), "#")[0])
+			addr, err := common.Bech32ToAddress(b32)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -152,7 +152,7 @@ var (
 	doRevertBefore = flag.Int("do_revert_before", -1, "If the current block is less than do_revert_before, revert all blocks until (including) revert_to block")
 	revertTo       = flag.Int("revert_to", -1, "The revert will rollback all blocks until and including block number revert_to")
 	// Blacklist of addresses
-	blacklistPath = flag.String("blacklist", "./blacklist.txt", "Path to blacklist file.")
+	blacklistPath = flag.String("blacklist", "", "Path to newline delimited file of blacklisted wallet addresses")
 )
 
 func initSetup() {
@@ -430,22 +430,20 @@ func setupConsensusAndNode(nodeConfig *nodeconfig.ConfigType) *node.Node {
 	return currentNode
 }
 
-func setupBlacklist() (*map[ethCommon.Address]bool, error) {
-	if _, err := os.Stat(*blacklistPath); os.IsNotExist(err) {
-		return nil, errors.New(fmt.Sprintf("blacklist file not found at `%s`", *blacklistPath))
-	}
+func setupBlacklist() (*map[ethCommon.Address]struct{}, error) {
+	utils.Logger().Debug().Msgf("Using blacklist file at `%s`", *blacklistPath)
 	dat, err := ioutil.ReadFile(*blacklistPath)
 	if err != nil {
 		return nil, err
 	}
-	addrMap := make(map[ethCommon.Address]bool)
+	addrMap := make(map[ethCommon.Address]struct{})
 	for _, line := range strings.Split(string(dat), "\n") {
 		if len(line) != 0 { // blacklist file may have trailing empty string line
 			addr, err := common.Bech32ToAddress(line)
 			if err != nil {
 				return nil, err
 			}
-			addrMap[addr] = true
+			addrMap[addr] = struct{}{}
 		}
 	}
 	return &addrMap, nil

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -4,12 +4,14 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
 	"path"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	ethCommon "github.com/ethereum/go-ethereum/common"
@@ -149,6 +151,8 @@ var (
 	// Bad block revert
 	doRevertBefore = flag.Int("do_revert_before", -1, "If the current block is less than do_revert_before, revert all blocks until (including) revert_to block")
 	revertTo       = flag.Int("revert_to", -1, "The revert will rollback all blocks until and including block number revert_to")
+	// Blacklist of addresses
+	blacklistPath = flag.String("blacklist", "./blacklist.txt", "Path to blacklist file.")
 )
 
 func initSetup() {
@@ -325,9 +329,15 @@ func setupConsensusAndNode(nodeConfig *nodeconfig.ConfigType) *node.Node {
 		currentConsensus.DisableViewChangeForTestingOnly()
 	}
 
+	blacklist, err := setupBlacklist()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Blacklist error: %s\n", err.Error())
+		os.Exit(1)
+	}
+
 	// Current node.
 	chainDBFactory := &shardchain.LDBFactory{RootDir: nodeConfig.DBDir}
-	currentNode := node.New(myHost, currentConsensus, chainDBFactory, *isArchival)
+	currentNode := node.New(myHost, currentConsensus, chainDBFactory, blacklist, *isArchival)
 
 	switch {
 	case *networkType == nodeconfig.Localnet:
@@ -419,6 +429,27 @@ func setupConsensusAndNode(nodeConfig *nodeconfig.ConfigType) *node.Node {
 	memprofiling.GetMemProfiling().Add("currentNode", currentNode)
 	memprofiling.GetMemProfiling().Add("currentConsensus", currentConsensus)
 	return currentNode
+}
+
+func setupBlacklist() (*map[ethCommon.Address]bool, error) {
+	if _, err := os.Stat(*blacklistPath); os.IsNotExist(err) {
+		return nil, errors.New(fmt.Sprintf("blacklist file not found at `%s`", *blacklistPath))
+	}
+	dat, err := ioutil.ReadFile(*blacklistPath)
+	if err != nil {
+		return nil, err
+	}
+	addrMap := make(map[ethCommon.Address]bool)
+	for _, line := range strings.Split(string(dat), "\n") {
+		if len(line) != 0 { // blacklist file may have trailing empty string line
+			addr, err := common.Bech32ToAddress(line)
+			if err != nil {
+				return nil, err
+			}
+			addrMap[addr] = true
+		}
+	}
+	return &addrMap, nil
 }
 
 func main() {

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -87,10 +87,10 @@ var (
 	ErrKnownTransaction = errors.New("known transaction")
 
 	// ErrBlacklistFrom is returned if a transaction's from/source address is blacklisted
-	ErrBlacklistFrom = errors.New("`from` address of transaction is blacklisted")
+	ErrBlacklistFrom = errors.New("`from` address of transaction in blacklist")
 
 	// ErrBlacklistTo is returned if a transaction's to/destination address is blacklisted
-	ErrBlacklistTo = errors.New("`to` address of transaction is blacklisted")
+	ErrBlacklistTo = errors.New("`to` address of transaction in blacklist")
 )
 
 var (
@@ -154,7 +154,7 @@ type TxPoolConfig struct {
 
 	Lifetime time.Duration // Maximum amount of time non-executable transaction are queued
 
-	Blacklist *map[common.Address]bool // Set of accounts that cannot be a part of any transaction
+	Blacklist *map[common.Address]struct{} // Set of accounts that cannot be a part of any transaction
 }
 
 // DefaultTxPoolConfig contains the default configurations for the transaction
@@ -173,7 +173,7 @@ var DefaultTxPoolConfig = TxPoolConfig{
 
 	Lifetime: 3 * time.Hour,
 
-	Blacklist: &map[common.Address]bool{},
+	Blacklist: &map[common.Address]struct{}{},
 }
 
 // sanitize checks the provided user configurations and changes anything that's
@@ -645,17 +645,20 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return ErrInvalidSender
 	}
 	// Make sure transaction does not have blacklisted addresses
-	if (*pool.config.Blacklist)[from] {
+	if _, exists := (*pool.config.Blacklist)[from]; exists {
 		if b32, err := hmyCommon.AddressToBech32(from); err == nil {
 			return errors.WithMessagef(ErrBlacklistFrom, "transaction sender is %s", b32)
 		}
 		return ErrBlacklistFrom
 	}
-	if tx.To() != nil && (*pool.config.Blacklist)[*tx.To()] {
-		if b32, err := hmyCommon.AddressToBech32(*tx.To()); err == nil {
-			return errors.WithMessagef(ErrBlacklistTo, "transaction receiver is %s", b32)
+	// Make sure transaction does not burn funds by sending funds to blacklisted address
+	if tx.To() != nil {
+		if _, exists := (*pool.config.Blacklist)[*tx.To()]; exists {
+			if b32, err := hmyCommon.AddressToBech32(*tx.To()); err == nil {
+				return errors.WithMessagef(ErrBlacklistTo, "transaction receiver is %s", b32)
+			}
+			return ErrBlacklistTo
 		}
-		return ErrBlacklistTo
 	}
 	// Drop non-local transactions under our own minimal accepted gas price
 	local = local || pool.locals.contains(from) // account may be local even if the transaction arrived from the network
@@ -872,14 +875,14 @@ func (pool *TxPool) promoteTx(addr common.Address, hash common.Hash, tx *types.T
 // the sender as a local one in the mean time, ensuring it goes around the local
 // pricing constraints.
 func (pool *TxPool) AddLocal(tx *types.Transaction) error {
-	return errors.Cause(pool.addTx(tx, !pool.config.NoLocals))
+	return pool.addTx(tx, !pool.config.NoLocals)
 }
 
 // AddRemote enqueues a single transaction into the pool if it is valid. If the
 // sender is not among the locally tracked ones, full pricing constraints will
 // apply.
 func (pool *TxPool) AddRemote(tx *types.Transaction) error {
-	return errors.Cause(pool.addTx(tx, false))
+	return pool.addTx(tx, false)
 }
 
 // AddLocals enqueues a batch of transactions into the pool if they are valid,
@@ -904,10 +907,11 @@ func (pool *TxPool) addTx(tx *types.Transaction, local bool) error {
 	// Try to inject the transaction and update any state
 	replace, err := pool.add(tx, local)
 	if err != nil {
-		if errors.Cause(err) != ErrKnownTransaction {
+		errCause := errors.Cause(err)
+		if errCause != ErrKnownTransaction {
 			pool.txnErrorSink([]types.RPCTransactionError{*types.NewRPCTransactionError(tx.Hash(), err)})
 		}
-		return err
+		return errCause
 	}
 	// If we added a new transaction, run promotion checks and return
 	if !replace {

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -36,6 +36,7 @@ import (
 	"github.com/harmony-one/harmony/block"
 	"github.com/harmony-one/harmony/core/state"
 	"github.com/harmony-one/harmony/core/types"
+	hmyCommon "github.com/harmony-one/harmony/internal/common"
 	"github.com/harmony-one/harmony/internal/utils"
 )
 
@@ -84,6 +85,12 @@ var (
 	// ErrKnownTransaction is returned if a transaction that is already in the pool
 	// attempting to be added to the pool.
 	ErrKnownTransaction = errors.New("known transaction")
+
+	// ErrBlacklistFrom is returned if a transaction's from/source address is blacklisted
+	ErrBlacklistFrom = errors.New("`from` address of transaction is blacklisted")
+
+	// ErrBlacklistto is returned if a transaction's to/destination address is blacklisted
+	ErrBlacklistTo = errors.New("`to` address of transaction is blacklisted")
 )
 
 var (
@@ -146,6 +153,8 @@ type TxPoolConfig struct {
 	GlobalQueue  uint64 // Maximum number of non-executable transaction slots for all accounts
 
 	Lifetime time.Duration // Maximum amount of time non-executable transaction are queued
+
+	Blacklist *map[common.Address]bool // Set of accounts that cannot be a part of any transaction
 }
 
 // DefaultTxPoolConfig contains the default configurations for the transaction
@@ -163,6 +172,8 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	GlobalQueue:  1024,
 
 	Lifetime: 3 * time.Hour,
+
+	Blacklist: &map[common.Address]bool{},
 }
 
 // sanitize checks the provided user configurations and changes anything that's
@@ -190,6 +201,11 @@ func (config *TxPoolConfig) sanitize() TxPoolConfig {
 			Msg("Sanitizing invalid txpool price bump")
 		conf.PriceBump = DefaultTxPoolConfig.PriceBump
 	}
+	if conf.Blacklist == nil {
+		utils.Logger().Warn().Msg("Sanitizing nil blacklist set")
+		conf.Blacklist = DefaultTxPoolConfig.Blacklist
+	}
+
 	return conf
 }
 
@@ -623,7 +639,23 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	// Make sure the transaction is signed properly
 	from, err := types.Sender(pool.signer, tx)
 	if err != nil {
-		return errors.WithMessagef(ErrInvalidSender, "transaction sender is %v", from)
+		if b32, err := hmyCommon.AddressToBech32(from); err == nil {
+			return errors.WithMessagef(ErrInvalidSender, "transaction sender is %s", b32)
+		}
+		return ErrInvalidSender
+	}
+	// Make sure transaction does not have blacklisted addresses
+	if (*pool.config.Blacklist)[from] {
+		if b32, err := hmyCommon.AddressToBech32(from); err == nil {
+			return errors.WithMessagef(ErrBlacklistFrom, "transaction sender is %s", b32)
+		}
+		return ErrBlacklistFrom
+	}
+	if tx.To() != nil && (*pool.config.Blacklist)[*tx.To()] {
+		if b32, err := hmyCommon.AddressToBech32(*tx.To()); err == nil {
+			return errors.WithMessagef(ErrBlacklistTo, "transaction receiver is %s", b32)
+		}
+		return ErrBlacklistTo
 	}
 	// Drop non-local transactions under our own minimal accepted gas price
 	local = local || pool.locals.contains(from) // account may be local even if the transaction arrived from the network

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -89,7 +89,7 @@ var (
 	// ErrBlacklistFrom is returned if a transaction's from/source address is blacklisted
 	ErrBlacklistFrom = errors.New("`from` address of transaction is blacklisted")
 
-	// ErrBlacklistto is returned if a transaction's to/destination address is blacklisted
+	// ErrBlacklistTo is returned if a transaction's to/destination address is blacklisted
 	ErrBlacklistTo = errors.New("`to` address of transaction is blacklisted")
 )
 

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -893,11 +893,7 @@ func (pool *TxPool) AddLocals(txs []*types.Transaction) []error {
 // If the senders are not among the locally tracked ones, full pricing constraints
 // will apply.
 func (pool *TxPool) AddRemotes(txs []*types.Transaction) []error {
-	errs := []error{}
-	for _, err := range pool.addTxs(txs, false) {
-		errs = append(errs, errors.Cause(err))
-	}
-	return errs
+	return pool.addTxs(txs, false)
 }
 
 // addTx enqueues a single transaction into the pool if it is valid.
@@ -938,14 +934,15 @@ func (pool *TxPool) addTxsLocked(txs []*types.Transaction, local bool) []error {
 	var erroredTxns []types.RPCTransactionError
 
 	for i, tx := range txs {
-		var replace bool
-		if replace, errs[i] = pool.add(tx, local); errs[i] == nil && !replace {
+		replace, err := pool.add(tx, local)
+		if err == nil && !replace {
 			from, _ := types.Sender(pool.signer, tx) // already validated
 			dirty[from] = struct{}{}
 		}
-		if errs[i] != nil && errors.Cause(errs[i]) != ErrKnownTransaction {
-			erroredTxns = append(erroredTxns, *types.NewRPCTransactionError(tx.Hash(), errs[i]))
+		if err != nil && err != ErrKnownTransaction {
+			erroredTxns = append(erroredTxns, *types.NewRPCTransactionError(tx.Hash(), err))
 		}
+		errs[i] = errors.Cause(err)
 	}
 	// Only reprocess the internal state if something was actually added
 	if len(dirty) > 0 {

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -893,7 +893,11 @@ func (pool *TxPool) AddLocals(txs []*types.Transaction) []error {
 // If the senders are not among the locally tracked ones, full pricing constraints
 // will apply.
 func (pool *TxPool) AddRemotes(txs []*types.Transaction) []error {
-	return pool.addTxs(txs, false)
+	errs := []error{}
+	for _, err := range pool.addTxs(txs, false) {
+		errs = append(errs, errors.Cause(err))
+	}
+	return errs
 }
 
 // addTx enqueues a single transaction into the pool if it is valid.

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -19,7 +19,6 @@ package core
 import (
 	"crypto/ecdsa"
 	"fmt"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"math/big"
 	"math/rand"
@@ -287,24 +286,21 @@ func TestBlacklistedTransactions(t *testing.T) {
 	(*DefaultTxPoolConfig.Blacklist)[bannedFromAcc] = false
 	(*DefaultTxPoolConfig.Blacklist)[bannedToAcc] = true
 	err := pool.AddRemotes([]*types.Transaction{badTx})
-	errCause := errors.Cause(err[0])
-	if errCause != ErrBlacklistTo {
-		t.Error("expected", ErrBlacklistTo, "got", errCause)
+	if err[0] != ErrBlacklistTo {
+		t.Error("expected", ErrBlacklistTo, "got", err[0])
 	}
 
 	(*DefaultTxPoolConfig.Blacklist)[bannedFromAcc] = true
 	(*DefaultTxPoolConfig.Blacklist)[bannedToAcc] = false
 	err = pool.AddRemotes([]*types.Transaction{badTx})
-	errCause = errors.Cause(err[0])
-	if errCause != ErrBlacklistFrom {
-		t.Error("expected", ErrBlacklistFrom, "got", errCause)
+	if err[0] != ErrBlacklistFrom {
+		t.Error("expected", ErrBlacklistFrom, "got", err[0])
 	}
 
 	// to acc is same for bad and good tx, so keep off blacklist for valid tx check
 	err = pool.AddRemotes([]*types.Transaction{goodTx})
-	errCause = errors.Cause(err[0])
-	if errCause != nil {
-		t.Error("expected", nil, "got", errCause)
+	if err[0] != nil {
+		t.Error("expected", nil, "got", err[0])
 	}
 
 	// cleanup blacklist config for other tests

--- a/node/node.go
+++ b/node/node.go
@@ -444,7 +444,7 @@ func (node *Node) GetSyncID() [SyncIDLength]byte {
 
 // New creates a new node.
 func New(host p2p.Host, consensusObj *consensus.Consensus,
-	chainDBFactory shardchain.DBFactory, blacklist *map[common.Address]bool, isArchival bool) *Node {
+	chainDBFactory shardchain.DBFactory, blacklist *map[common.Address]struct{}, isArchival bool) *Node {
 	node := Node{}
 	const sinkSize = 4096
 	node.syncFreq = SyncFrequency

--- a/node/node.go
+++ b/node/node.go
@@ -443,7 +443,8 @@ func (node *Node) GetSyncID() [SyncIDLength]byte {
 }
 
 // New creates a new node.
-func New(host p2p.Host, consensusObj *consensus.Consensus, chainDBFactory shardchain.DBFactory, isArchival bool) *Node {
+func New(host p2p.Host, consensusObj *consensus.Consensus,
+	chainDBFactory shardchain.DBFactory, blacklist *map[common.Address]bool, isArchival bool) *Node {
 	node := Node{}
 	const sinkSize = 4096
 	node.syncFreq = SyncFrequency
@@ -494,7 +495,9 @@ func New(host p2p.Host, consensusObj *consensus.Consensus, chainDBFactory shardc
 		node.ConfirmedBlockChannel = make(chan *types.Block)
 		node.BeaconBlockChannel = make(chan *types.Block)
 		node.recentTxsStats = make(types.RecentTxsStats)
-		node.TxPool = core.NewTxPool(core.DefaultTxPoolConfig, node.Blockchain().Config(), blockchain,
+		txPoolConfig := core.DefaultTxPoolConfig
+		txPoolConfig.Blacklist = blacklist
+		node.TxPool = core.NewTxPool(txPoolConfig, node.Blockchain().Config(), blockchain,
 			func(payload []types.RPCTransactionError) {
 				if len(payload) > 0 {
 					node.errorSink.Lock()

--- a/node/node_handler_test.go
+++ b/node/node_handler_test.go
@@ -32,7 +32,7 @@ func TestAddNewBlock(t *testing.T) {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
 	nodeconfig.SetNetworkType(nodeconfig.Devnet)
-	node := New(host, consensus, testDBFactory, false)
+	node := New(host, consensus, testDBFactory, nil, false)
 
 	txs := make(map[common.Address]types.Transactions)
 	node.Worker.CommitTransactions(txs, common.Address{})
@@ -64,7 +64,7 @@ func TestVerifyNewBlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
-	node := New(host, consensus, testDBFactory, false)
+	node := New(host, consensus, testDBFactory, nil, false)
 
 	txs := make(map[common.Address]types.Transactions)
 	node.Worker.CommitTransactions(txs, common.Address{})

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -40,7 +40,7 @@ func TestNewNode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
-	node := New(host, consensus, testDBFactory, false)
+	node := New(host, consensus, testDBFactory, nil, false)
 	if node.Consensus == nil {
 		t.Error("Consensus is not initialized for the node")
 	}
@@ -209,7 +209,7 @@ func TestAddPeers(t *testing.T) {
 	}
 	dRand := drand.New(host, 0, []p2p.Peer{leader, validator}, leader, nil, nil)
 
-	node := New(host, consensus, testDBFactory, false)
+	node := New(host, consensus, testDBFactory, nil, false)
 	node.DRand = dRand
 	r1 := node.AddPeers(peers1)
 	e1 := 2
@@ -259,7 +259,7 @@ func TestAddBeaconPeer(t *testing.T) {
 	}
 	dRand := drand.New(host, 0, []p2p.Peer{leader, validator}, leader, nil, nil)
 
-	node := New(host, consensus, testDBFactory, false)
+	node := New(host, consensus, testDBFactory, nil, false)
 	node.DRand = dRand
 	for _, p := range peers1 {
 		ret := node.AddBeaconPeer(p)

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -116,13 +116,7 @@ usage: ${progname} [-1ch] [-k KEYFILE]
    -P             enable public rpc end point (default:off)
    -v             print out the version of the node.sh
    -V             print out the version of the Harmony binary
-<<<<<<< HEAD
-=======
-   -z             run in staking mode
-   -y             run in legacy, foundational-node mode (default)
-   -M             support multi-key mode (default: off)
-   -B blacklist   specify file containing blacklisted accounts as a newline delimited file (default: ./blacklist.txt)
->>>>>>> a339f266... [node.sh] Add blacklist file specification option
+   -B blacklist   specify file containing blacklisted accounts as a newline delimited file (default: ./.hmy/blacklist.txt)
 
 examples:
 
@@ -168,8 +162,7 @@ node_type=validator
 shard_id=1
 download_harmony_db=false
 public_rpc=false
-multi_key=false
-blacklist=./blacklist.txt
+blacklist=./.hmy/blacklist.txt
 ${BLSKEYFILE=}
 
 unset OPTIND OPTARG opt

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -116,6 +116,13 @@ usage: ${progname} [-1ch] [-k KEYFILE]
    -P             enable public rpc end point (default:off)
    -v             print out the version of the node.sh
    -V             print out the version of the Harmony binary
+<<<<<<< HEAD
+=======
+   -z             run in staking mode
+   -y             run in legacy, foundational-node mode (default)
+   -M             support multi-key mode (default: off)
+   -B blacklist   specify file containing blacklisted accounts as a newline delimited file (default: ./blacklist.txt)
+>>>>>>> a339f266... [node.sh] Add blacklist file specification option
 
 examples:
 
@@ -149,7 +156,7 @@ BUCKET=pub.harmony.one
 OS=$(uname -s)
 
 unset start_clean loop run_as_root blspass do_not_download download_only metrics network node_type shard_id download_harmony_db db_file_to_dl
-unset upgrade_rel public_rpc
+unset upgrade_rel public_rpc staking_mode pub_port multi_key blacklist
 start_clean=false
 loop=true
 run_as_root=true
@@ -161,11 +168,13 @@ node_type=validator
 shard_id=1
 download_harmony_db=false
 public_rpc=false
+multi_key=false
+blacklist=./blacklist.txt
 ${BLSKEYFILE=}
 
 unset OPTIND OPTARG opt
 OPTIND=1
-while getopts :1chk:sSp:dDmN:tT:i:ba:U:PvV opt
+while getopts :1chk:sSp:dDmN:tT:i:ba:U:PvVB: opt
 do
    case "${opt}" in
    '?') usage "unrecognized option -${OPTARG}";;
@@ -188,6 +197,7 @@ do
    a) db_file_to_dl="${OPTARG}";;
    U) upgrade_rel="${OPTARG}";;
    P) public_rpc=true;;
+   B) blacklist="${OPTARG}";;
    v) msg "version: $version"
       exit 0 ;;
    V) LD_LIBRARY_PATH=. ./harmony -version
@@ -630,6 +640,7 @@ do
       -blskey_file "${BLSKEYFILE}"
       -network_type="${network_type}"
       -dns_zone="${dns_zone}"
+      -blacklist="${blacklist}"
    )
    if ${public_rpc}; then
       args+=(

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -150,7 +150,7 @@ BUCKET=pub.harmony.one
 OS=$(uname -s)
 
 unset start_clean loop run_as_root blspass do_not_download download_only metrics network node_type shard_id download_harmony_db db_file_to_dl
-unset upgrade_rel public_rpc staking_mode pub_port multi_key blacklist
+unset upgrade_rel public_rpc blacklist
 start_clean=false
 loop=true
 run_as_root=true


### PR DESCRIPTION
## Issue

Cherry-picked from #2172.

In the (unlikely) event of a successful attack/hack, implementing and rolling out a solution will take some time. A blacklist offers an easy and fast way to contain the situation while we work out a solution. 

The blacklist that we will be using will be maintained in the main repo's root for everyone to see (it will start off empty). Moreover, any transaction that was dropped because of a blacklisted account will be reported as such in our newly added `hmy_getCurrentTransactionErrorSink` RPC; which means it will be displayed in our explorer. 

#### Implementation highlights:
* The blacklist is read from a newline delimited file (by default it's `./blacklist.txt`).
* Each transaction added to the tx-pool has its `to` and `from` address checked against this blacklist. If there is a hit, the transaction is considered invalid and is dropped from the tx-pool. 
* Easy to rip out / revert in the future.

**Sample blacklist file:**
```
one1spshr72utf6rwxseaz339j09ed8p6f8ke370zj
one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur
one129r9pj3sk0re76f7zs3qz92rggmdgjhtwge62k
one12fuf7x9rgtdgqg7vgq0962c556m3p7afsxgvll
one1658znfwf40epvy7e46cqrmzyy54h4n0qa73nep
one17ys3gsd5gpuhx3juqe73sgtpzpvdusktuq7kfc

```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

9. **Does the existing `node.sh` continue to work with this change?**

    **YES**

10. **What should node operators know about this change?**

    **They can specify which blacklist they want to enforce, by default it will be `./blacklist.txt`. Moreover, they should know that the file is a newline delimited file (reference example above).**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**
