### PR TITLE
[#2215] Fix sanity checks for total-max-delegation = 0

### DIFF
--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -212,7 +212,8 @@ func (w *ValidatorWrapper) SanityCheck() error {
 	}
 
 	// MaxTotalDelegation must not be less than MinSelfDelegation
-	if w.Validator.MaxTotalDelegation.Cmp(w.Validator.MinSelfDelegation) < 0 {
+	if w.Validator.MaxTotalDelegation.Cmp(w.Validator.MinSelfDelegation) < 0 &&
+		w.Validator.MaxTotalDelegation.Cmp(big.NewInt(0)) != 0 {
 		return errors.Wrapf(
 			errInvalidMaxTotalDelegation,
 			"max-total-delegation %s min-self-delegation %s",
@@ -223,7 +224,8 @@ func (w *ValidatorWrapper) SanityCheck() error {
 
 	totalDelegation := w.TotalDelegation()
 	// Total delegation must be <= MaxTotalDelegation
-	if totalDelegation.Cmp(w.Validator.MaxTotalDelegation) > 0 {
+	if totalDelegation.Cmp(w.Validator.MaxTotalDelegation) > 0 &&
+		w.Validator.MaxTotalDelegation.Cmp(big.NewInt(0)) != 0 {
 		return errors.Wrapf(
 			errInvalidTotalDelegation,
 			"total %s max-total %s",


### PR DESCRIPTION
## Issue

#2215 
Sanity checks didn't account for total max delegation being 0

## Test

### Unit Test Coverage

Before:

```
$ go test -cover
?   	github.com/harmony-one/harmony/staking	[no test files]
```

After:

```
$ go test -cover
?   	github.com/harmony-one/harmony/staking	[no test files]
```
## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**
    **NO**
