### PR TITLE
Balance by block s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ export GO111MODULE=on
 ```
 Note : Some of our scripts require bash 4.x support, please [install bash 4.x](http://tldrdevnotes.com/bash-upgrade-3-4-macos) on MacOS X.
 
+## Harmony docs and guides
+
+https://docs.harmony.one
+
+## API guides
+
+https://docs.harmony.one/home/developers/api
+
 ### Build all executables
 
 You can run the script `./scripts/go_executable_build.sh` to build all the executables.

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -212,8 +212,12 @@ func (b *APIBackend) GetPoolTransactions() (types.Transactions, error) {
 }
 
 // GetBalance returns balance of an given address.
-func (b *APIBackend) GetBalance(address common.Address) (*big.Int, error) {
-	return b.hmy.nodeAPI.GetBalanceOfAddress(address)
+func (b *APIBackend) GetBalance(ctx context.Context, address common.Address, blockNr rpc.BlockNumber) (*big.Int, error) {
+	state, _, err := b.StateAndHeaderByNumber(ctx, blockNr)
+	if state == nil || err != nil {
+		return nil, err
+	}
+	return state.GetBalance(address), state.Error()
 }
 
 // GetTransactionsHistory returns list of transactions hashes of address.

--- a/internal/hmyapi/apiv1/backend.go
+++ b/internal/hmyapi/apiv1/backend.go
@@ -62,7 +62,7 @@ type Backend interface {
 	ChainConfig() *params.ChainConfig
 	CurrentBlock() *types.Block
 	// Get balance
-	GetBalance(address common.Address) (*big.Int, error)
+	GetBalance(ctx context.Context, address common.Address, blockNr rpc.BlockNumber) (*big.Int, error)
 	// Get committee for a particular epoch
 	GetCommittee(epoch *big.Int) (*shard.Committee, error)
 	GetShardID() uint32

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -72,11 +72,11 @@ func (s *PublicBlockChainAPI) GetCommittee(ctx context.Context, epoch int64) (ma
 	}
 	validators := make([]map[string]interface{}, 0)
 	for _, validator := range committee.NodeList {
-		validatorBalance, err := s.b.GetBalance(validator.EcdsaAddress)
+		oneAddress, err := internal_common.AddressToBech32(validator.EcdsaAddress)
 		if err != nil {
 			return nil, err
 		}
-		oneAddress, err := internal_common.AddressToBech32(validator.EcdsaAddress)
+		validatorBalance, err := s.GetBalance(ctx, oneAddress, rpc.LatestBlockNumber)
 		if err != nil {
 			return nil, err
 		}
@@ -132,17 +132,21 @@ func (s *PublicBlockChainAPI) GetStorageAt(ctx context.Context, addr string, key
 	return res[:], state.Error()
 }
 
-// GetBalance returns the amount of Nano for the given address in the state of the
-// given block number. The rpc.LatestBlockNumber and rpc.PendingBlockNumber meta
-// block numbers are also allowed.
-func (s *PublicBlockChainAPI) GetBalance(ctx context.Context, address string, blockNr rpc.BlockNumber) (*hexutil.Big, error) {
-	// TODO: currently only get latest balance. Will add complete logic later.
+// GetBalanceByBlockNumber returns balance by block number.
+func (s *PublicBlockChainAPI) GetBalanceByBlockNumber(ctx context.Context, address string, blockNr rpc.BlockNumber) (*hexutil.Big, error) {
 	addr := internal_common.ParseAddr(address)
-	balance, err := s.b.GetBalance(addr)
+	balance, err := s.b.GetBalance(ctx, addr, blockNr)
 	if balance == nil {
 		return nil, err
 	}
 	return (*hexutil.Big)(balance), err
+}
+
+// GetBalance returns the amount of Nano for the given address in the state of the
+// given block number. The rpc.LatestBlockNumber and rpc.PendingBlockNumber meta
+// block numbers are also allowed.
+func (s *PublicBlockChainAPI) GetBalance(ctx context.Context, address string, blockNr rpc.BlockNumber) (*hexutil.Big, error) {
+	return s.GetBalanceByBlockNumber(ctx, address, rpc.LatestBlockNumber)
 }
 
 // BlockNumber returns the block number of the chain head.

--- a/internal/hmyapi/apiv2/backend.go
+++ b/internal/hmyapi/apiv2/backend.go
@@ -62,7 +62,7 @@ type Backend interface {
 	ChainConfig() *params.ChainConfig
 	CurrentBlock() *types.Block
 	// Get balance
-	GetBalance(address common.Address) (*big.Int, error)
+	GetBalance(ctx context.Context, address common.Address, blockNr rpc.BlockNumber) (*big.Int, error)
 	// Get committee for a particular epoch
 	GetCommittee(epoch *big.Int) (*shard.Committee, error)
 	GetShardID() uint32

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -84,11 +84,11 @@ func (s *PublicBlockChainAPI) GetCommittee(ctx context.Context, epoch int64) (ma
 	}
 	validators := make([]map[string]interface{}, 0)
 	for _, validator := range committee.NodeList {
-		validatorBalance, err := s.b.GetBalance(validator.EcdsaAddress)
+		oneAddress, err := internal_common.AddressToBech32(validator.EcdsaAddress)
 		if err != nil {
 			return nil, err
 		}
-		oneAddress, err := internal_common.AddressToBech32(validator.EcdsaAddress)
+		validatorBalance, err := s.GetBalance(ctx, oneAddress)
 		if err != nil {
 			return nil, err
 		}
@@ -144,10 +144,17 @@ func (s *PublicBlockChainAPI) GetStorageAt(ctx context.Context, addr string, key
 	return res[:], state.Error()
 }
 
-// GetBalance returns the amount of Nano for the given address in the state.
-func (s *PublicBlockChainAPI) GetBalance(ctx context.Context, address string) (*big.Int, error) {
+// GetBalanceByBlockNumber returns balance by block number.
+func (s *PublicBlockChainAPI) GetBalanceByBlockNumber(ctx context.Context, address string, blockNr int64) (*big.Int, error) {
 	addr := internal_common.ParseAddr(address)
-	return s.b.GetBalance(addr)
+	return s.b.GetBalance(ctx, addr, rpc.BlockNumber(blockNr))
+}
+
+// GetBalance returns the amount of Nano for the given address in the state of the
+// given block number. The rpc.LatestBlockNumber and rpc.PendingBlockNumber meta
+// block numbers are also allowed.
+func (s *PublicBlockChainAPI) GetBalance(ctx context.Context, address string) (*big.Int, error) {
+	return s.GetBalanceByBlockNumber(ctx, address, -1)
 }
 
 // BlockNumber returns the block number of the chain head.

--- a/internal/hmyapi/backend.go
+++ b/internal/hmyapi/backend.go
@@ -61,7 +61,7 @@ type Backend interface {
 	ChainConfig() *params.ChainConfig
 	CurrentBlock() *types.Block
 	// Get balance
-	GetBalance(address common.Address) (*big.Int, error)
+	GetBalance(ctx context.Context, address common.Address, blockNr rpc.BlockNumber) (*big.Int, error)
 	// Get validators for a particular epoch
 	GetCommittee(epoch *big.Int) (*shard.Committee, error)
 	GetShardID() uint32


### PR DESCRIPTION
## Issue

hmy_getBalanceByBlockNumber returns balance for a particular block number. hmy_getBalance returns for current block.

## Test

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
