### PR TITLE
[docker] updated docker support for mainnet

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,20 +1,31 @@
 FROM alpine
 
-RUN apk add --no-cache bash libstdc++ gmp-dev libc6-compat && ln -s libcrypto.so.1.1 /lib/libcrypto.so.10
+RUN apk add --no-cache bash libstdc++ gmp-dev libc6-compat bind-tools jq && ln -s libcrypto.so.1.1 /lib/libcrypto.so.10
 
 # default base port, rpc port and rest port
-EXPOSE 9000/tcp 14555/tcp 6000/tcp
+EXPOSE 9000/tcp 9500/tcp 9800/tcp 6000/tcp
 
-VOLUME ["/harmony/db", "/harmony/log"]
+VOLUME ["/harmony/harmony_db_0","/harmony/harmony_db_1","/harmony/harmony_db_2","/harmony/harmony_db_3","/harmony/log","/harmony/.hmy"]
 
-# Default BN for S3
-ENV BN_MA "/ip4/100.26.90.187/tcp/9874/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv,/ip4/54.213.43.194/tcp/9874/p2p/QmZJJx6AdaoEkGLrYG4JeLCKeCKDjnFz2wfHNHxAqFSGA9"
+# Default BN for S3/mainnet
+ENV NODE_BN_MNET "/ip4/100.26.90.187/tcp/9874/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv,/ip4/54.213.43.194/tcp/9874/p2p/QmZJJx6AdaoEkGLrYG4JeLCKeCKDjnFz2wfHNHxAqFSGA9,/ip4/13.113.101.219/tcp/12019/p2p/QmQayinFSgMMw5cSpDUiD9pQ2WeP6WNmGxpZ6ou3mdVFJX,/ip4/99.81.170.167/tcp/12019/p2p/QmRVbTpEYup8dSaURZfF6ByrMTSKa4UyUzJhSjahFzRqNj"
+
+# Long Running Test Net
+ENV NODE_BN_LRTN "/ip4/54.213.43.194/tcp/9868/p2p/QmZJJx6AdaoEkGLrYG4JeLCKeCKDjnFz2wfHNHxAqFSGA9,/ip4/100.26.90.187/tcp/9868/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv,/ip4/13.113.101.219/tcp/12018/p2p/QmQayinFSgMMw5cSpDUiD9pQ2WeP6WNmGxpZ6ou3mdVFJX"
+
+# Open Staking Test Net
+ENV NODE_BN_OSTN "/ip4/54.86.126.90/tcp/9880/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv,/ip4/52.40.84.2/tcp/9880/p2p/QmbPVwrqWsTYXq1RxGWcxx9SWaTUCfoo1wA6wmdbduWe29"
+
 ENV NODE_PORT "9000"
-ENV NODE_ACCOUNT_ID ""
+ENV NODE_BLSKEY ""
+ENV NODE_BLSPASS ""
+ENV NODE_DNS_ZONE "t.hmny.io"
+ENV NODE_RPC "true"
+ENV NODE_BLACKLIST ""
+ENV NODE_NETWORK_TYPE "mainnet"
 
 ENTRYPOINT ["/bin/run"]
 WORKDIR /harmony
 
 COPY run /bin/run
-COPY libbls384_256.so libmcl.so /lib/
 COPY harmony /bin/

--- a/scripts/docker/run
+++ b/scripts/docker/run
@@ -1,5 +1,26 @@
 #!/usr/bin/env bash
 
+unset -v progname
+progname="${0##*/}"
+
+unset -f msg err
+
+msg() {
+   case $# in
+   [1-9]*)
+      echo "${progname}: $*" >&2
+      ;;
+   esac
+}
+
+err() {
+   local code
+   code="${1}"
+   shift 1
+   msg "$@"
+   exit "${code}"
+}
+
 # https://www.linuxjournal.com/content/validating-ip-address-bash-script
 function valid_ip()
 {
@@ -18,19 +39,78 @@ function valid_ip()
   return $stat
 }
 
-PUB_IP=$(wget -qO- https://api.ipify.org)
-if valid_ip $PUB_IP; then
-  echo "MYIP = $PUB_IP"
-else
-  echo "NO valid public IP found: $PUB_IP"
-  exit 1
+function myip() {
+# get ipv4 address only, right now only support ipv4 addresses
+   PUB_IP=$(dig -4 @resolver1.opendns.com ANY myip.opendns.com +short)
+   if valid_ip $PUB_IP; then
+      msg "public IP address autodetected: $PUB_IP"
+   else
+      err 1 "NO valid public IP found: $PUB_IP"
+   fi
+}
+
+function add_env
+{
+   filename=$1
+   shift
+   grep -qxF "$@" $filename || echo "$@" >> $filename
+}
+
+function setup_env
+{
+   sysctl -w net.core.somaxconn=1024
+   sysctl -w net.core.netdev_max_backlog=65536
+   sysctl -w net.ipv4.tcp_tw_reuse=1
+   sysctl -w net.ipv4.tcp_rmem='4096 65536 16777216'
+   sysctl -w net.ipv4.tcp_wmem='4096 65536 16777216'
+   sysctl -w net.ipv4.tcp_mem='65536 131072 262144'
+
+   add_env /etc/security/limits.conf "* soft     nproc          65535"
+   add_env /etc/security/limits.conf "* hard     nproc          65535"
+   add_env /etc/security/limits.conf "* soft     nofile         65535"
+   add_env /etc/security/limits.conf "* hard     nofile         65535"
+   add_env /etc/security/limits.conf "root soft     nproc          65535"
+   add_env /etc/security/limits.conf "root hard     nproc          65535"
+   add_env /etc/security/limits.conf "root soft     nofile         65535"
+   add_env /etc/security/limits.conf "root hard     nofile         65535"
+   add_env /etc/pam.d/common-session "session required pam_limits.so"
+}
+
+# find my public ip address
+myip
+
+# setup runtime environment
+setup_env
+
+keydir=/harmony/.hmy
+
+args=(
+      -log_folder "/harmony/log"
+      -node_type "validator"
+      -network_type "mainnet"
+      -bootnodes "$NODE_BN_MNET"
+      -ip "$PUB_IP"
+      -port "$NODE_PORT"
+      -dns_zone "$NODE_DNS_ZONE"
+      -blspass "file:${keydir}/$NODE_BLSPASS"
+      -blskey_file "${keydir}/$NODE_BLSKEY"
+     )
+
+if [ "$NODE_BLACKLIST" != "" ]; then
+  args+=(
+    -blacklist "$NODE_BLACKLIST"
+    )
 fi
 
-if [ -z "$NODE_ACCOUNT_ID" ]; then
-  echo "No account id."
-  exit 2
+if [ "$NODE_RPC" == "true" ]; then
+  args+=(
+    -public_rpc
+  )
 fi
 
-harmony -log_folder log -bootnodes $BN_MA -ip $PUB_IP -port $NODE_PORT -is_genesis -account_index $NODE_ACCOUNT_ID
+msg "harmony ${args[@]}"
+ls -al ${keydir}
+
+harmony "${args[@]}"
 
 # vim: ai ts=2 sw=2 et sts=2 ft=sh


### PR DESCRIPTION
Test:

* put the keyfile and blspass.txt into keys/ directory
* start the docker image
sudo ./docker-node.sh -t test keyfile blspass.txt

* all logs will be stored in logs/ directory
* all db will be stored in db/harmony_db_0,1,2,3 directories

* to check the running log of the docker image
sudo docker logs -f harmony-test-9000

Signed-off-by: Leo Chen <leo@harmony.one>