### PR TITLE
making min/max delegations string instead of uint64

### DIFF
--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -128,8 +128,8 @@ func (v *Validator) MarshalJSON() ([]byte, error) {
 	type t struct {
 		Address            string      `json:"one-address"`
 		SlotPubKeys        []string    `json:"bls-public-keys"`
-		MinSelfDelegation  uint64      `json:"min-self-delegation"`
-		MaxTotalDelegation uint64      `json:"max-total-delegation"`
+		MinSelfDelegation  string      `json:"min-self-delegation"`
+		MaxTotalDelegation string      `json:"max-total-delegation"`
 		Active             bool        `json:"active"`
 		Commission         Commission  `json:"commission"`
 		Description        Description `json:"description"`
@@ -142,8 +142,8 @@ func (v *Validator) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t{
 		Address:            common2.MustAddressToBech32(v.Address),
 		SlotPubKeys:        slots,
-		MinSelfDelegation:  v.MinSelfDelegation.Uint64(),
-		MaxTotalDelegation: v.MaxTotalDelegation.Uint64(),
+		MinSelfDelegation:  v.MinSelfDelegation.String(),
+		MaxTotalDelegation: v.MaxTotalDelegation.String(),
 		Active:             v.Active,
 		Commission:         v.Commission,
 		Description:        v.Description,


### PR DESCRIPTION
## Issue

<!-- link to the issue number or description of the issue -->
https://github.com/harmony-one/harmony/issues/2196

## Test

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO