### PR TITLE
[WIP] Consensus message metrics

### DIFF
--- a/consensus/checks.go
+++ b/consensus/checks.go
@@ -10,27 +10,29 @@ func (consensus *Consensus) validatorSanityChecks(msg *msg_pb.Message) bool {
 	senderKey, err := consensus.verifySenderKey(msg)
 	if err != nil {
 		if err == errValidNotInCommittee {
-			consensus.getLogger().Info().
-				Msg("sender key not in this slot's subcommittee")
+			errMsg := "[SanityChecks] Sender key not in this slot's subcommittee"
+			consensus.getLogger().Info().Msg(errMsg)
+			addToConsensusLog(msg, errMsg)
 		} else {
-			consensus.getLogger().Error().Err(err).Msg("VerifySenderKey failed")
+			errMsg := "[SanityChecks] VerifySenderKey failed"
+			consensus.getLogger().Error().Err(err).Msg(errMsg)
+			addToConsensusLog(msg, errMsg)
 		}
-		incrementReceivedErrors(msg.GetType().String(), errSender)
 		return false
 	}
 
 	if !senderKey.IsEqual(consensus.LeaderPubKey) &&
 		consensus.current.Mode() == Normal && !consensus.ignoreViewIDCheck {
-		consensus.getLogger().Warn().Msg("[OnPrepared] SenderKey not match leader PubKey")
-		incrementReceivedErrors(msg.GetType().String(), senderKey. SerializeToHexStr())
+		errMsg := "[SanityChecks] SenderKey not match leader PubKey"
+		consensus.getLogger().Warn().Msg(errMsg)
+		addToConsensusLog(msg, errMsg)
 		return false
 	}
 
 	if err := verifyMessageSig(senderKey, msg); err != nil {
-		consensus.getLogger().Error().Err(err).Msg(
-			"Failed to verify sender's signature",
-		)
-		incrementReceivedErrors(msg.GetType().String(), senderKey.SerializeToHexStr())
+		errMsg := "[SanityChecks] Failed to verify sender's signature"
+		consensus.getLogger().Error().Err(err).Msg(errMsg)
+		addToConsensusLog(msg, errMsg)
 		return false
 	}
 
@@ -41,98 +43,105 @@ func (consensus *Consensus) leaderSanityChecks(msg *msg_pb.Message) bool {
 	senderKey, err := consensus.verifySenderKey(msg)
 	if err != nil {
 		if err == errValidNotInCommittee {
-			consensus.getLogger().Info().Msg(
-				"[OnAnnounce] sender key not in this slot's subcommittee",
-			)
+			errMsg := "[LeaderSanityChecks] sender key not in this slot's subcommittee"
+			consensus.getLogger().Info().Msg(errMsg)
+			addToConsensusLog(msg, errMsg)
 		} else {
-			consensus.getLogger().Error().Err(err).Msg("[OnAnnounce] VerifySenderKey failed")
+			errMsg := "[LeaderSanityChecks] VerifySenderKey failed"
+			consensus.getLogger().Error().Err(err).Msg(errMsg)
+			addToConsensusLog(msg, errMsg)
 		}
-		incrementReceivedErrors(msg.GetType().String(), errSender)
 		return false
 	}
 	if err = verifyMessageSig(senderKey, msg); err != nil {
-		consensus.getLogger().Error().Err(err).Msg(
-			"[OnPrepare] Failed to verify sender's signature",
-		)
-		incrementReceivedErrors(msg.GetType().String(), senderKey.SerializeToHexStr())
+		errMsg := "[LeaderSanityChecks] failed to verify sender's signature"
+		consensus.getLogger().Error().Err(err).Msg(errMsg)
+		addToConsensusLog(msg, errMsg)
 		return false
 	}
 
 	return true
 }
 
-func (consensus *Consensus) onCommitSanityChecks(
-	recvMsg *FBFTMessage,
-) bool {
+func (consensus *Consensus) onCommitSanityChecks(msg *msg_pb.Message) bool {
+	recvMsg, _ := ParseFBFTMessage(msg)
 	if recvMsg.ViewID != consensus.viewID || recvMsg.BlockNum != consensus.blockNum {
+		errMsg := "[OnCommit] BlockNum/ViewID not match"
 		consensus.getLogger().Debug().
 			Uint64("MsgViewID", recvMsg.ViewID).
 			Uint64("MsgBlockNum", recvMsg.BlockNum).
 			Uint64("blockNum", consensus.blockNum).
 			Str("ValidatorPubKey", recvMsg.SenderPubkey.SerializeToHexStr()).
-			Msg("[OnCommit] BlockNum/viewID not match")
-		incrementReceivedErrors(recvMsg.MessageType.String(), recvMsg.SenderPubkey.SerializeToHexStr())
+			Msg(errMsg)
+		addToConsensusLog(msg, errMsg)
 		return false
 	}
 
 	if !consensus.FBFTLog.HasMatchingAnnounce(consensus.blockNum, recvMsg.BlockHash) {
+		errMsg := "[OnCommit] Cannot find matching Announce message"
 		consensus.getLogger().Debug().
 			Hex("MsgBlockHash", recvMsg.BlockHash[:]).
 			Uint64("MsgBlockNum", recvMsg.BlockNum).
 			Uint64("blockNum", consensus.blockNum).
-			Msg("[OnCommit] Cannot find matching blockhash")
-		incrementReceivedErrors(recvMsg.MessageType.String(), recvMsg.SenderPubkey.SerializeToHexStr())
+			Msg(errMsg)
+		addToConsensusLog(msg, errMsg)
 		return false
 	}
 
 	if !consensus.FBFTLog.HasMatchingPrepared(consensus.blockNum, recvMsg.BlockHash) {
+		errMsg := "[OnCommit] Cannot find matching Prepared message"
 		consensus.getLogger().Debug().
 			Hex("blockHash", recvMsg.BlockHash[:]).
 			Uint64("blockNum", consensus.blockNum).
-			Msg("[OnCommit] Cannot find matching prepared message")
-		incrementReceivedErrors(recvMsg.MessageType.String(), recvMsg.SenderPubkey.SerializeToHexStr())
+			Msg(errMsg)
+		addToConsensusLog(msg, errMsg)
 		return false
 	}
 	return true
 }
 
 func (consensus *Consensus) onPreparedSanityChecks(
-	blockObj *types.Block, recvMsg *FBFTMessage,
+	blockObj *types.Block, msg *msg_pb.Message,
 ) bool {
+	recvMsg, _ := ParseFBFTMessage(msg)
 	if blockObj.NumberU64() != recvMsg.BlockNum ||
 		recvMsg.BlockNum < consensus.blockNum {
+		errMsg := "[OnPrepared] BlockNum not match"
 		consensus.getLogger().Warn().
 			Uint64("MsgBlockNum", recvMsg.BlockNum).
 			Uint64("blockNum", blockObj.NumberU64()).
-			Msg("[OnPrepared] BlockNum not match")
-		incrementReceivedErrors(recvMsg.MessageType.String(), recvMsg.SenderPubkey.SerializeToHexStr())
+			Msg(errMsg)
+		addToConsensusLog(msg, errMsg)
 		return false
 	}
 	if blockObj.Header().Hash() != recvMsg.BlockHash {
+		errMsg := "[OnPrepared] BlockHash not match"
 		consensus.getLogger().Warn().
 			Uint64("MsgBlockNum", recvMsg.BlockNum).
 			Hex("MsgBlockHash", recvMsg.BlockHash[:]).
 			Str("blockObjHash", blockObj.Header().Hash().Hex()).
-			Msg("[OnPrepared] BlockHash not match")
-		incrementReceivedErrors(recvMsg.MessageType.String(), recvMsg.SenderPubkey.SerializeToHexStr())
+			Msg(errMsg)
+		addToConsensusLog(msg, errMsg)
 		return false
 	}
 	if consensus.current.Mode() == Normal {
 		err := chain.Engine.VerifyHeader(consensus.ChainReader, blockObj.Header(), true)
 		if err != nil {
+			errMsg := "[OnPrepared] Block header is not verified successfully"
 			consensus.getLogger().Error().
 				Err(err).
 				Str("inChain", consensus.ChainReader.CurrentHeader().Number().String()).
 				Str("MsgBlockNum", blockObj.Header().Number().String()).
-				Msg("[OnPrepared] Block header is not verified successfully")
-			incrementReceivedErrors(recvMsg.MessageType.String(), recvMsg.SenderPubkey.SerializeToHexStr())
+				Msg(errMsg)
+			addToConsensusLog(msg, errMsg)
 			return false
 		}
 		if consensus.BlockVerifier == nil {
 			// do nothing
 		} else if err := consensus.BlockVerifier(blockObj); err != nil {
-			consensus.getLogger().Error().Err(err).Msg("[OnPrepared] Block verification failed")
-			incrementReceivedErrors(recvMsg.MessageType.String(), recvMsg.SenderPubkey.SerializeToHexStr())
+			errMsg := "[OnPrepared] Block verification failed"
+			consensus.getLogger().Error().Err(err).Msg(errMsg)
+			addToConsensusLog(msg, errMsg)
 			return false
 		}
 	}

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -26,6 +26,7 @@ func (consensus *Consensus) handleMessageUpdate(payload []byte) {
 	msg := &msg_pb.Message{}
 	if err := protobuf.Unmarshal(payload, msg); err != nil {
 		consensus.getLogger().Error().Err(err).Msg("Failed to unmarshal message payload.")
+		incrementReceivedErrors(errMessage, errSender)
 		return
 	}
 

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -25,8 +25,9 @@ func (consensus *Consensus) handleMessageUpdate(payload []byte) {
 	}
 	msg := &msg_pb.Message{}
 	if err := protobuf.Unmarshal(payload, msg); err != nil {
-		consensus.getLogger().Error().Err(err).Msg("Failed to unmarshal message payload.")
-		incrementReceivedErrors(errMessage, errSender)
+		errMsg := "[handleMessageUpdate] Failed to unmarshal messsage"
+		consensus.getLogger().Error().Err(err).Msg(errMsg)
+		addToConsensusLog(nil, errMsg)
 		return
 	}
 

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -121,6 +121,8 @@ func (consensus *Consensus) onPrepare(msg *msg_pb.Message) {
 			Uint64("blockNum", consensus.blockNum).
 			Msg("[OnPrepare] No Matching Announce message")
 		incrementReceivedErrors(recvMsg.MessageType.String(), recvMsg.SenderPubkey.SerializeToHexStr())
+		// NOTE: Corner case during ViewChange, Leader potentially not have matching Announce
+		//       If Leader receives majority consensus on Prepare, Leader should not be able to block consensus in this case
 		//return
 	}
 

--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -1,0 +1,171 @@
+package consensus
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"contrib.go.opencensus.io/exporter/prometheus"
+	protobuf "github.com/golang/protobuf/proto"
+	"github.com/harmony-one/harmony/api/proto/message"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+var (
+	defaultBytesDistribution        = view.Distribution(1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296)
+	defaultMillisecondsDistribution = view.Distribution(0.01, 0.05, 0.1, 0.3, 0.6, 0.8, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000)
+)
+
+// Keys
+var (
+	KeyMessageType, _ = tag.NewKey("message_type")
+	KeyBlsKey, _      = tag.NewKey("bls_key")
+	KeyErrorMsg, _    = tag.NewKey("error_msg")
+)
+
+// Measures
+var (
+	ReceivedMessages       = stats.Int64("consensus/received_messages", "Total number of messages received per RPC", stats.UnitDimensionless)
+	ReceivedMessageErrors  = stats.Int64("consensus/received_message_errors", "Total number of errors for messages received per RPC", stats.UnitDimensionless)
+	ReceivedBytes          = stats.Int64("consensus/received_bytes", "Total received bytes per RPC", stats.UnitBytes)
+	InboundRequestLatency  = stats.Float64("consensus/inbound_request_latency", "Latency per RPC", stats.UnitMilliseconds)
+	OutboundRequestLatency = stats.Float64("consensus/outbound_request_latency", "Latency per RPC", stats.UnitMilliseconds)
+	SentMessages           = stats.Int64("consensus/sent_messages", "Total number of messages sent per RPC", stats.UnitDimensionless)
+	SentMessageErrors      = stats.Int64("consensus/sent_message_errors", "Total number of errors for messages sent per RPC", stats.UnitDimensionless)
+	SentBytes              = stats.Int64("consensus/sent_bytes", "Total sent bytes per RPC", stats.UnitBytes)
+)
+
+var ConsensusViews = []*view.View{
+	&view.View{
+		Measure:     ReceivedMessages,
+		TagKeys:     []tag.Key{KeyMessageType, KeyBlsKey},
+		Aggregation: view.Count(),
+	},
+	&view.View{
+		Measure:     ReceivedMessageErrors,
+		TagKeys:     []tag.Key{KeyMessageType, KeyBlsKey, KeyErrorMsg},
+		Aggregation: view.Count(),
+	},
+	&view.View{
+		Measure:     ReceivedBytes,
+		TagKeys:     []tag.Key{KeyMessageType, KeyBlsKey},
+		Aggregation: defaultBytesDistribution,
+	},
+	&view.View{
+		Measure:     InboundRequestLatency,
+		TagKeys:     []tag.Key{KeyMessageType, KeyBlsKey},
+		Aggregation: defaultMillisecondsDistribution,
+	},
+	&view.View{
+		Measure:     OutboundRequestLatency,
+		TagKeys:     []tag.Key{KeyMessageType, KeyBlsKey},
+		Aggregation: defaultMillisecondsDistribution,
+	},
+	&view.View{
+		Measure:     SentMessages,
+		TagKeys:     []tag.Key{KeyMessageType, KeyBlsKey},
+		Aggregation: view.Count(),
+	},
+	&view.View{
+		Measure:     SentMessageErrors,
+		TagKeys:     []tag.Key{KeyMessageType, KeyBlsKey, KeyErrorMsg},
+		Aggregation: view.Count(),
+	},
+	&view.View{
+		Measure:     SentBytes,
+		TagKeys:     []tag.Key{KeyMessageType, KeyBlsKey},
+		Aggregation: defaultBytesDistribution,
+	},
+}
+
+// Testing code && Remove before merge
+func init() {
+	if err := view.Register(ConsensusViews...); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to register the views: %v\n", err)
+		os.Exit(1)
+	}
+	pe, err := prometheus.NewExporter(prometheus.Options{
+		Namespace: "harmony",
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create the Prometheus stats exporter: %v", err)
+	}
+	go func() {
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", pe)
+		if err := http.ListenAndServe(":8888", mux); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to run Prometheus scrape endpoint: %v", err)
+		}
+	}()
+}
+
+func incrementReceivedMessages(msg *message.Message, pubKey string) {
+	msgType := msg.GetType().String()
+	ctx, _ := tag.New(
+		context.Background(),
+		tag.Upsert(KeyMessageType, msgType),
+	)
+
+	stats.RecordWithTags(
+		ctx,
+		[]tag.Mutator{
+			tag.Upsert(KeyMessageType, msgType),
+			tag.Upsert(KeyBlsKey, pubKey),
+		},
+		ReceivedMessages.M(1),
+		ReceivedBytes.M(int64(protobuf.Size(msg))),
+	)
+}
+
+func incrementSentMessages(msg []byte, phase, pubKey string) {
+	ctx, _ := tag.New(
+		context.Background(),
+		tag.Upsert(KeyMessageType, phase),
+	)
+
+	stats.RecordWithTags(
+		ctx,
+		[]tag.Mutator{
+			tag.Upsert(KeyMessageType, phase),
+			tag.Upsert(KeyBlsKey, pubKey),
+		},
+		SentMessages.M(1),
+		SentBytes.M(int64(len(msg))),
+	)
+}
+
+func incrementReceivedErrors(phase, pubKey string) {
+	ctx, _ := tag.New(
+		context.Background(),
+		tag.Upsert(KeyMessageType, phase),
+	)
+
+	stats.RecordWithTags(
+		ctx,
+		[]tag.Mutator{
+			tag.Upsert(KeyMessageType, phase),
+			tag.Upsert(KeyBlsKey, pubKey),
+		},
+		ReceivedMessageErrors.M(1),
+	)
+}
+
+func incrementSentErrors(phase, pubKey string) {
+	ctx, _ := tag.New(
+		context.Background(),
+		tag.Upsert(KeyMessageType, phase),
+	)
+
+	stats.RecordWithTags(
+		ctx,
+		[]tag.Mutator{
+			tag.Upsert(KeyMessageType, phase),
+			tag.Upsert(KeyBlsKey, pubKey),
+		},
+		SentMessageErrors.M(1),
+	)
+}

--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -16,7 +16,12 @@ import (
 )
 
 var (
-	defaultBytesDistribution        = view.Distribution(1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296)
+	errSender  = "Invalid/Unknown sender"
+	errMessage = "Invalid/Unknown message type"
+)
+
+var (
+	defaultBytesDistribution        = view.Distribution(256, 512, 768, 1024, 1280, 1536, 1792, 2048, 2304, 2560, 2816, 3072)
 	defaultMillisecondsDistribution = view.Distribution(0.01, 0.05, 0.1, 0.3, 0.6, 0.8, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000)
 )
 

--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -1,230 +1,122 @@
 package consensus
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"strings"
-	"time"
+  "container/ring"
+  "encoding/json"
+  "sync"
+  "time"
 
-	protobuf "github.com/golang/protobuf/proto"
+  protobuf "github.com/golang/protobuf/proto"
 	"github.com/harmony-one/harmony/api/proto/message"
-
-	"go.opencensus.io/stats"
-	"go.opencensus.io/stats/view"
-	"go.opencensus.io/tag"
+  "github.com/harmony-one/harmony/crypto/bls"
 )
+
+// Ring buffer size
+const bufferSize = 1024
+
+type MessageLog struct {
+  MessageType   string `json:"messageType"`
+  MessageSender string `json:"senderBlsKey"`
+  CurrentLeader string `json:"leaderBlsKey,omitempty"`
+  MessageSize   int    `json:"messageSize"`
+  ErrorMessage  string `json:"errorMessage,omitempty"`
+  ShardID       uint32 `json:"shardID"`
+  ViewID        uint64 `json:"viewID"`
+  BlockNum      uint64 `json:"blockHeight"`
+  BlockHash     string `json:"blockHash,omitempty"`
+  Timestamp     string `json:"timestamp"` //Timestamp at which finished being processed
+  Received      bool   `json:"receivedMessage,omitempty"`
+}
+
+// Consensus message log, including errors, saving in memory
+type ConsensusLog struct {
+  Log *ring.Ring
+  sync.Mutex
+}
 
 var (
-	errSender  = "Invalid/Unknown sender"
-	errMessage = "Invalid/Unknown message type"
+  cLog           ConsensusLog
+  // TODO: Come back to this error
+  errParsePubKey = "Unable to parse bls key"
+  timeFormat     = "Jan 2 15:04:05 2006 UTC"
 )
 
-var (
-	defaultBytesDistribution        = view.Distribution(256, 512, 768, 1024, 1280, 1536, 1792, 2048, 2304, 2560, 2816, 3072)
-	defaultMillisecondsDistribution = view.Distribution(0.01, 0.05, 0.1, 0.3, 0.6, 0.8, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000)
-)
-
-// Keys
-var (
-	KeyMessageType, _ = tag.NewKey("message_type")
-	KeyBlsKey, _      = tag.NewKey("bls_key")
-	KeyErrorMsg, _    = tag.NewKey("error_msg")
-)
-
-// Measures
-var (
-	ReceivedMessages       = stats.Int64("consensus/received_messages", "Total number of messages received per RPC", stats.UnitDimensionless)
-	ReceivedMessageErrors  = stats.Int64("consensus/received_message_errors", "Total number of errors for messages received per RPC", stats.UnitDimensionless)
-	ReceivedBytes          = stats.Int64("consensus/received_bytes", "Total received bytes per RPC", stats.UnitBytes)
-	InboundRequestLatency  = stats.Float64("consensus/inbound_request_latency", "Latency per RPC", stats.UnitMilliseconds)
-	OutboundRequestLatency = stats.Float64("consensus/outbound_request_latency", "Latency per RPC", stats.UnitMilliseconds)
-	SentMessages           = stats.Int64("consensus/sent_messages", "Total number of messages sent per RPC", stats.UnitDimensionless)
-	SentMessageErrors      = stats.Int64("consensus/sent_message_errors", "Total number of errors for messages sent per RPC", stats.UnitDimensionless)
-	SentBytes              = stats.Int64("consensus/sent_bytes", "Total sent bytes per RPC", stats.UnitBytes)
-)
-
-var ConsensusViews = []*view.View{
-	&view.View{
-		Name:        "ReceivedMessages",
-		Measure:     ReceivedMessages,
-		TagKeys:     []tag.Key{KeyMessageType, KeyBlsKey},
-		Aggregation: view.Count(),
-	},
-	&view.View{
-		Name:        "ReceivedMessageErrors",
-		Measure:     ReceivedMessageErrors,
-		TagKeys:     []tag.Key{KeyMessageType, KeyBlsKey, KeyErrorMsg},
-		Aggregation: view.Count(),
-	},
-	&view.View{
-		Name:        "ReceivedBytes",
-		Measure:     ReceivedBytes,
-		TagKeys:     []tag.Key{KeyMessageType, KeyBlsKey},
-		Aggregation: defaultBytesDistribution,
-	},
-	&view.View{
-		Name:        "InboundRequestLatency",
-		Measure:     InboundRequestLatency,
-		TagKeys:     []tag.Key{KeyMessageType, KeyBlsKey},
-		Aggregation: defaultMillisecondsDistribution,
-	},
-	&view.View{
-		Name:        "OutboundRequestLatency",
-		Measure:     OutboundRequestLatency,
-		TagKeys:     []tag.Key{KeyMessageType, KeyBlsKey},
-		Aggregation: defaultMillisecondsDistribution,
-	},
-	&view.View{
-		Name:        "SentMessages",
-		Measure:     SentMessages,
-		TagKeys:     []tag.Key{KeyMessageType, KeyBlsKey},
-		Aggregation: view.Count(),
-	},
-	&view.View{
-		Name:        "SentMessageErrors",
-		Measure:     SentMessageErrors,
-		TagKeys:     []tag.Key{KeyMessageType, KeyBlsKey, KeyErrorMsg},
-		Aggregation: view.Count(),
-	},
-	&view.View{
-		Name:        "SentBytes",
-		Measure:     SentBytes,
-		TagKeys:     []tag.Key{KeyMessageType, KeyBlsKey},
-		Aggregation: defaultBytesDistribution,
-	},
-}
-
-type ConcensusMetrics struct {
-	NumSent           []MessageDataPoint   `json:"sentMessages"`
-	BytesSentHist     []HistogramDataPoint `json:"sentBytes"`
-	NumSentErrors     []ErrorDataPoint     `json:"sentErrors"`
-	NumReceived	      []MessageDataPoint   `json:"receivedMessages"`
-	BytesReceivedHist []HistogramDataPoint `json:"receivedBytes"`
-	NumReceivedErrors []ErrorDataPoint     `json:"receivedErrors"`
-}
-
-type MessageDataPoint struct {
-	MessageType string `json:"messageType"`
-	BlsKey      string `json:"blsKey"`
-}
-
-type ErrorDataPoint struct {
-	MessageType  string `json:"messageType"`
-	BlsKey       string `json:"blsKey"`
-	ErrorMessage string `json:"errorMessage,omitempty"`
-}
-
-type HistogramDataPoint struct {
-	Bucket string `json:"bucket"`
-	Value  string `json:"count"`
-}
-
-type printExporter struct {}
-
-func (pe *printExporter) ExportView(vd *view.Data) {
-	fmt.Println("Consensus Metrics")
-	for i, row := range vd.Rows {
-		fmt.Printf("\tRow: %#d: %#v\n", i, row)
-	}
-  fmt.Printf("StartTime: %s EndTime: %s\n\n", vd.Start.Round(0), vd.End.Round(0))
-}
-
-// Testing code && Remove before merge
 func init() {
-	if err := view.Register(ConsensusViews...); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to register the views: %v\n", err)
-		os.Exit(1)
-	}
-	view.RegisterExporter(new(printExporter))
-	view.SetReportingPeriod(60 * time.Second)
+  cLog = ConsensusLog{}
+  cLog.Log = ring.New(bufferSize)
 }
 
-func incrementReceivedMessages(msg *message.Message, pubKey string) {
-	msgType := msg.GetType().String()
-	ctx, _ := tag.New(
-		context.Background(),
-		tag.Upsert(KeyMessageType, msgType),
-	)
-
-	stats.RecordWithTags(
-		ctx,
-		[]tag.Mutator{
-			tag.Upsert(KeyMessageType, msgType),
-			tag.Upsert(KeyBlsKey, pubKey),
-		},
-		ReceivedMessages.M(1),
-		ReceivedBytes.M(int64(protobuf.Size(msg))),
-	)
+// errMsg = "", means no errors
+func addToConsensusLog(msg *message.Message, errMsg string) {
+  msgToAdd := MessageLog{}
+  // If message is nil, then failed to unmarshal message
+  if (msg == nil) {
+    msgToAdd.ErrorMessage = errMsg
+    msgToAdd.Timestamp = getFormattedTime()
+  } else if (msg.Type == message.MessageType_VIEWCHANGE || msg.Type == message.MessageType_NEWVIEW) {
+    // View change messages
+    viewChangeMessage := msg.GetViewchange()
+    msgToAdd = MessageLog{
+      msg.Type.String(),
+      getKeyAsString(viewChangeMessage.GetSenderPubkey()),
+      getKeyAsString(viewChangeMessage.GetLeaderPubkey()),
+      int(protobuf.Size(msg)),
+      errMsg,
+      viewChangeMessage.GetShardId(),
+      viewChangeMessage.GetViewId(),
+      viewChangeMessage.GetBlockNum(),
+      "", // No block hash for ViewChange messages
+      getFormattedTime(),
+      false,
+    }
+  } else {
+    // Other consensus messages
+    consensusMessage := msg.GetConsensus()
+    msgToAdd = MessageLog{
+      msg.Type.String(),
+      getKeyAsString(consensusMessage.GetSenderPubkey()),
+      "", // TODO: Come back to this, Leader not propagated in Consensus messages
+      int(protobuf.Size(msg)),
+      errMsg,
+      consensusMessage.GetShardId(),
+      consensusMessage.GetViewId(),
+      consensusMessage.GetBlockNum(),
+      string(consensusMessage.GetBlockHash()),
+      getFormattedTime(),
+      false,
+    }
+  }
+  // Lock & add to ring buffer
+  cLog.Lock()
+  defer cLog.Unlock()
+  cLog.Log.Value = msgToAdd
+  cLog.Log = cLog.Log.Next()
+  return
 }
 
-func incrementSentMessages(msg []byte, phase, pubKey string) {
-	ctx, _ := tag.New(
-		context.Background(),
-		tag.Upsert(KeyMessageType, phase),
-	)
-
-	stats.RecordWithTags(
-		ctx,
-		[]tag.Mutator{
-			tag.Upsert(KeyMessageType, phase),
-			tag.Upsert(KeyBlsKey, pubKey),
-		},
-		SentMessages.M(1),
-		SentBytes.M(int64(len(msg))),
-	)
+func getKeyAsString(key []byte) string {
+  pubKey, err := bls.BytesToBlsPublicKey(key)
+  if err != nil {
+    return errParsePubKey //TODO: Come back to this
+  }
+  return pubKey.SerializeToHexStr()
 }
 
-func incrementReceivedErrors(phase, pubKey string) {
-	ctx, _ := tag.New(
-		context.Background(),
-		tag.Upsert(KeyMessageType, phase),
-	)
-
-	stats.RecordWithTags(
-		ctx,
-		[]tag.Mutator{
-			tag.Upsert(KeyMessageType, phase),
-			tag.Upsert(KeyBlsKey, pubKey),
-		},
-		ReceivedMessageErrors.M(1),
-	)
+func getFormattedTime() string {
+  return time.Now().Format(timeFormat)
 }
 
-func incrementSentErrors(phase, pubKey string) {
-	ctx, _ := tag.New(
-		context.Background(),
-		tag.Upsert(KeyMessageType, phase),
-	)
-
-	stats.RecordWithTags(
-		ctx,
-		[]tag.Mutator{
-			tag.Upsert(KeyMessageType, phase),
-			tag.Upsert(KeyBlsKey, pubKey),
-		},
-		SentMessageErrors.M(1),
-	)
-}
-
-func GetConsensusMetrics() {
-	data := ConsensusMetrics{}
-	for i, v := range ConsensusViews {
-		if strings.HasSuffix(v.Name, "Latency") {
-			continue
-		} else if strings.HasSuffix(v.Name, "Bytes") {
-			byteData := HistogramMetrics{}
-
-		} else if strings.HasSuffix(v.Name, "Errors") {
-			// Process Errors
-		} else {
-			messageData := []MessageDataPoint{}
-			// Process data
-			if strings.HasPrefix(v.Name, "Sent") {
-				data.NumSent = messageData
-			} else {
-				data.NumReceived = messageData
-			}
-		}
-	}
+// Return JSON for ring buffer
+func GetRawMetrics() []byte {
+  rawMetrics := []MessageLog{}
+  cLog.Lock()
+  defer cLog.Unlock()
+  cLog.Log.Do(func (v interface{}) {
+    rawMetrics = append(rawMetrics, v.(MessageLog))
+  })
+  out, err := json.Marshal(rawMetrics)
+  if err != nil {
+    return []byte{} //TODO: Come back to this
+  }
+  return out
 }


### PR DESCRIPTION
## Issue

Add way to dump past consensus messages (sent & received), including errors.

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**

## TODO

Add RPC that calls `consensus.GetRawMetrics()` to output metrics.