### PR TITLE
[#2197] Return error address in BECH32, instead of hex

### DIFF
--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -536,7 +536,8 @@ func (s *PublicBlockChainAPI) GetValidatorMetrics(ctx context.Context, address s
 	validatorAddress := internal_common.ParseAddr(address)
 	stats := s.b.GetValidatorStats(validatorAddress)
 	if stats == nil {
-		return nil, fmt.Errorf("validator stats not found: %s", validatorAddress.Hex())
+		addr, _ := internal_common.AddressToBech32(validatorAddress)
+		return nil, fmt.Errorf("validator stats not found: %s", addr)
 	}
 	return stats, nil
 }
@@ -546,7 +547,8 @@ func (s *PublicBlockChainAPI) GetValidatorInformation(ctx context.Context, addre
 	validatorAddress := internal_common.ParseAddr(address)
 	validator := s.b.GetValidatorInformation(validatorAddress)
 	if validator == nil {
-		return nil, fmt.Errorf("validator not found: %s", validatorAddress.Hex())
+		addr, _ := internal_common.AddressToBech32(validatorAddress)
+		return nil, fmt.Errorf("validator not found: %s", addr)
 	}
 	return validator, nil
 }

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -501,7 +501,8 @@ func (s *PublicBlockChainAPI) GetValidatorMetrics(ctx context.Context, address s
 	validatorAddress := internal_common.ParseAddr(address)
 	stats := s.b.GetValidatorStats(validatorAddress)
 	if stats == nil {
-		return nil, fmt.Errorf("validator stats not found: %s", validatorAddress.Hex())
+		addr, _ := internal_common.AddressToBech32(validatorAddress)
+		return nil, fmt.Errorf("validator stats not found: %s", addr)
 	}
 	return stats, nil
 }
@@ -511,7 +512,8 @@ func (s *PublicBlockChainAPI) GetValidatorInformation(ctx context.Context, addre
 	validatorAddress := internal_common.ParseAddr(address)
 	validator := s.b.GetValidatorInformation(validatorAddress)
 	if validator == nil {
-		return nil, fmt.Errorf("validator not found: %s", validatorAddress.Hex())
+		addr, _ := internal_common.AddressToBech32(validatorAddress)
+		return nil, fmt.Errorf("validator not found: %s", addr)
 	}
 	return validator, nil
 }


### PR DESCRIPTION
## Issue

#2197 

$ hmy blockchain validator metrics one1txy0a2szxlk7z0dvvfgv24kjjv60w2mcnyfl8a
Metrics are only available for Validators that have participated in consensus committee.
commit: v267-ab1654e, error: Catch all RPC error: validator stats not found: one1txy0a2szxlk7z0dvvfgv24kjjv60w2mcnyfl8a
check hmy cookbook for valid examples or try adding a `--help` flag
