### PR TITLE
Add fork logic for added receipt logs

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -21,7 +21,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -33,9 +32,6 @@ import (
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/internal/params"
 )
-
-// Beacon chain block 1213181 is a one-off block with empty receipts which is expected to be non-empty.
-const beaconBadBlock = 1213181
 
 // BlockValidator is responsible for validating block headers, uncles and
 // processed state.
@@ -96,16 +92,12 @@ func (v *BlockValidator) ValidateState(block *types.Block, statedb *state.DB, re
 	// Validate the received block's bloom with the one derived from the generated receipts.
 	// For valid blocks this should always validate to true.
 	rbloom := types.CreateBloom(receipts)
-	// Beacon chain block 1213181 is a one-off block with empty receipts which is expected to be non-empty.
-	// Skip the validation for it to avoid failure.
-	if rbloom != header.Bloom() && (block.NumberU64() != beaconBadBlock || block.ShardID() != 0) {
+	if rbloom != header.Bloom() {
 		return fmt.Errorf("invalid bloom (remote: %x  local: %x)", header.Bloom(), rbloom)
 	}
 	// Tre receipt Trie's root (R = (Tr [[H1, R1], ... [Hn, R1]]))
 	receiptSha := types.DeriveSha(receipts)
-	// Beacon chain block 1213181 is a one-off block with empty receipts which is expected to be non-empty.
-	// Skip the validation for it to avoid failure.
-	if receiptSha != header.ReceiptHash() && (block.NumberU64() != beaconBadBlock || block.ShardID() != 0) {
+	if receiptSha != header.ReceiptHash() {
 		return fmt.Errorf("invalid receipt root hash (remote: %x local: %x)", header.ReceiptHash(), receiptSha)
 	}
 

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -188,8 +188,10 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	if msg.To() == nil {
 		receipt.ContractAddress = crypto.CreateAddress(vmenv.Context.Origin, tx.Nonce())
 	}
-	// Set the receipt logs and create a bloom for filtering
-	receipt.Logs = statedb.GetLogs(tx.Hash())
+	// Set the receipt logs (only added after 2M block) and create a bloom for filtering
+	if header.Number().Uint64() > 2000000 {
+		receipt.Logs = statedb.GetLogs(tx.Hash())
+	}
 	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
 
 	var cxReceipt *types.CXReceipt


### PR DESCRIPTION
The receipt log was added and released to mainnet, which changed the bloom filter and receipt root calculation and it's not compatible with existing mainnet blocks.

Tested on mainnet node.