### PR TITLE
Shutdown the node program for sys interrupt too

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -645,7 +645,7 @@ func main() {
 		for {
 			select {
 			case sig := <-osSignal:
-				if sig == os.Kill || sig == syscall.SIGTERM || sig == os.Interrupt{
+				if sig == os.Kill || sig == syscall.SIGTERM || sig == os.Interrupt {
 					fmt.Printf("Got %s signal. Gracefully shutting down...\n", sig)
 					currentNode.ShutDown()
 				}

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -645,14 +645,9 @@ func main() {
 		for {
 			select {
 			case sig := <-osSignal:
-				if sig == os.Kill || sig == syscall.SIGTERM {
+				if sig == os.Kill || sig == syscall.SIGTERM || sig == os.Interrupt{
 					fmt.Printf("Got %s signal. Gracefully shutting down...\n", sig)
 					currentNode.ShutDown()
-				}
-				if sig == os.Interrupt {
-					fmt.Printf("Got %s signal. Dumping state to DB...\n", sig)
-					currentNode.Blockchain().Stop()
-					currentNode.Beaconchain().Stop()
 				}
 			}
 		}


### PR DESCRIPTION
Our validators are used to use Ctrl+c to shut down the node. We should keep that behavior as is.