### PR TITLE
when validator not found, don't try to extract it from the wrapper

### DIFF
--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -324,7 +324,10 @@ func (b *APIBackend) GetAllValidatorAddresses() []common.Address {
 // GetValidatorInformation returns the information of validator
 func (b *APIBackend) GetValidatorInformation(addr common.Address) *staking.Validator {
 	val, _ := b.hmy.BlockChain().ReadValidatorInformation(addr)
-	return &val.Validator
+	if val != nil {
+		return &val.Validator
+	}
+	return nil
 }
 
 var (


### PR DESCRIPTION
## Issue

When querying the validator information, if the validator is not found cli was showing `{}`.

With this fix, cli will report validator not found.

```
./hmy blockchain validator information one1...
commit: v275-874cc27, error: Catch all RPC error: validator not found: one1...
```