### PR TITLE
Add block epoch

### DIFF
--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -181,13 +181,19 @@ func (s *PublicBlockChainAPI) GetValidators(ctx context.Context, epoch int64) (m
 }
 
 // IsLastBlock checks if block is last epoch block.
-func (s *PublicBlockChainAPI) IsLastBlock(blockNum uint64) bool {
-	return shard.Schedule.IsLastBlock(blockNum)
+func (s *PublicBlockChainAPI) IsLastBlock(blockNum uint64) (bool, error) {
+	if s.b.GetShardID() == shard.BeaconChainShardID {
+		return shard.Schedule.IsLastBlock(blockNum), nil
+	}
+	return false, errNotBeaconChainShard
 }
 
 // EpochLastBlock returns epoch last block.
-func (s *PublicBlockChainAPI) EpochLastBlock(epoch uint64) uint64 {
-	return shard.Schedule.EpochLastBlock(epoch)
+func (s *PublicBlockChainAPI) EpochLastBlock(epoch uint64) (uint64, error) {
+	if s.b.GetShardID() == shard.BeaconChainShardID {
+		return shard.Schedule.EpochLastBlock(epoch), nil
+	}
+	return 0, errNotBeaconChainShard
 }
 
 // GetBlockSigners returns signers for a particular block.

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -180,6 +180,16 @@ func (s *PublicBlockChainAPI) GetValidators(ctx context.Context, epoch int64) (m
 	return result, nil
 }
 
+// IsLastBlock checks if block is last epoch block.
+func (s *PublicBlockChainAPI) IsLastBlock(blockNum uint64) bool {
+	return shard.Schedule.IsLastBlock(blockNum)
+}
+
+// EpochLastBlock returns epoch last block.
+func (s *PublicBlockChainAPI) EpochLastBlock(epoch uint64) uint64 {
+	return shard.Schedule.EpochLastBlock(epoch)
+}
+
 // GetBlockSigners returns signers for a particular block.
 func (s *PublicBlockChainAPI) GetBlockSigners(ctx context.Context, blockNr rpc.BlockNumber) ([]string, error) {
 	if uint64(blockNr) == 0 || uint64(blockNr) >= uint64(s.BlockNumber()) {

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -151,13 +151,19 @@ func (s *PublicBlockChainAPI) GetValidators(ctx context.Context, epoch int64) (m
 }
 
 // IsLastBlock checks if block is last epoch block.
-func (s *PublicBlockChainAPI) IsLastBlock(blockNum uint64) bool {
-	return shard.Schedule.IsLastBlock(blockNum)
+func (s *PublicBlockChainAPI) IsLastBlock(blockNum uint64) (bool, error) {
+	if s.b.GetShardID() == shard.BeaconChainShardID {
+		return shard.Schedule.IsLastBlock(blockNum), nil
+	}
+	return false, errNotBeaconChainShard
 }
 
 // EpochLastBlock returns epoch last block.
-func (s *PublicBlockChainAPI) EpochLastBlock(epoch uint64) uint64 {
-	return shard.Schedule.EpochLastBlock(epoch)
+func (s *PublicBlockChainAPI) EpochLastBlock(epoch uint64) (uint64, error) {
+	if s.b.GetShardID() == shard.BeaconChainShardID {
+		return shard.Schedule.EpochLastBlock(epoch), nil
+	}
+	return 0, errNotBeaconChainShard
 }
 
 // GetBlockSigners returns signers for a particular block.

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -150,6 +150,16 @@ func (s *PublicBlockChainAPI) GetValidators(ctx context.Context, epoch int64) (m
 	return result, nil
 }
 
+// IsLastBlock checks if block is last epoch block.
+func (s *PublicBlockChainAPI) IsLastBlock(blockNum uint64) bool {
+	return shard.Schedule.IsLastBlock(blockNum)
+}
+
+// EpochLastBlock returns epoch last block.
+func (s *PublicBlockChainAPI) EpochLastBlock(epoch uint64) uint64 {
+	return shard.Schedule.EpochLastBlock(epoch)
+}
+
 // GetBlockSigners returns signers for a particular block.
 func (s *PublicBlockChainAPI) GetBlockSigners(ctx context.Context, blockNr uint64) ([]string, error) {
 	if blockNr == 0 || blockNr >= uint64(s.BlockNumber()) {


### PR DESCRIPTION
## Issue

@mikedoan requested block epoch.

## Test

<img width="647" alt="Screenshot 2020-02-19 at 00 05 16" src="https://user-images.githubusercontent.com/52401354/74778409-8e17d300-52ac-11ea-8e03-ee5f8c8e7416.png">

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
