### PR TITLE
[debug] Fix explorer node lagging behind

### DIFF
--- a/node/node_explorer.go
+++ b/node/node_explorer.go
@@ -47,7 +47,7 @@ func (node *Node) ExplorerMessageHandler(payload []byte) {
 			return
 		}
 
-		if node.Consensus.Decider.IsQuorumAchievedByMask(mask, false) {
+		if !node.Consensus.Decider.IsQuorumAchievedByMask(mask, false) {
 			utils.Logger().Error().Msg("[Explorer] not have enough signature power")
 			return
 		}


### PR DESCRIPTION
## Issue
Explorer node is lagging on OSTN, because it's not processing `COMMITTED` messages from the leader & the node is only getting blocks from state syncing blocks.

Early return caused by inverted conditional.
