### PR TITLE
changing the testnet config back to normal

### DIFF
--- a/internal/configs/sharding/testnet.go
+++ b/internal/configs/sharding/testnet.go
@@ -68,4 +68,4 @@ func (ts testnetSchedule) GetShardingStructure(numShard, shardID int) []map[stri
 
 var testnetReshardingEpoch = []*big.Int{big.NewInt(0)}
 
-var testnetV0 = MustNewInstance(2, 30, 30, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch)
+var testnetV0 = MustNewInstance(3, 10, 10, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch)


### PR DESCRIPTION
For multi key network launch we changed the testnet config to 2, 30, 30. Reverting this back to 3, 10, 10.