### PR TITLE
Add shard checking to Tx-Pool & correct blacklist

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -447,7 +447,7 @@ func setupConsensusAndNode(nodeConfig *nodeconfig.ConfigType) *node.Node {
 	return currentNode
 }
 
-func setupBlacklist() (*map[ethCommon.Address]struct{}, error) {
+func setupBlacklist() (map[ethCommon.Address]struct{}, error) {
 	utils.Logger().Debug().Msgf("Using blacklist file at `%s`", *blacklistPath)
 	dat, err := ioutil.ReadFile(*blacklistPath)
 	if err != nil {
@@ -464,7 +464,7 @@ func setupBlacklist() (*map[ethCommon.Address]struct{}, error) {
 			addrMap[addr] = struct{}{}
 		}
 	}
-	return &addrMap, nil
+	return addrMap, nil
 }
 
 func main() {

--- a/core/tx_list_test.go
+++ b/core/tx_list_test.go
@@ -32,7 +32,7 @@ func TestStrictTxListAdd(t *testing.T) {
 
 	txs := make(types.PoolTransactions, 1024)
 	for i := 0; i < len(txs); i++ {
-		txs[i] = transaction(uint64(i), 0, key)
+		txs[i] = transaction(0, uint64(i), 0, key)
 	}
 	// Insert the transactions in a random order
 	list := newTxList(true)

--- a/core/types/tx_pool.go
+++ b/core/types/tx_pool.go
@@ -21,6 +21,7 @@ type PoolTransaction interface {
 	Hash() common.Hash
 	Nonce() uint64
 	ChainID() *big.Int
+	ShardID() uint32
 	To() *common.Address
 	Size() common.StorageSize
 	Data() []byte

--- a/node/node.go
+++ b/node/node.go
@@ -439,7 +439,7 @@ func (node *Node) GetSyncID() [SyncIDLength]byte {
 
 // New creates a new node.
 func New(host p2p.Host, consensusObj *consensus.Consensus,
-	chainDBFactory shardchain.DBFactory, blacklist *map[common.Address]struct{}, isArchival bool) *Node {
+	chainDBFactory shardchain.DBFactory, blacklist map[common.Address]struct{}, isArchival bool) *Node {
 	node := Node{}
 	const sinkSize = 4096
 	node.errorSink = struct {

--- a/staking/types/transaction.go
+++ b/staking/types/transaction.go
@@ -180,6 +180,11 @@ func (tx *StakingTransaction) ChainID() *big.Int {
 	return deriveChainID(tx.data.V)
 }
 
+// ShardID returns which shard id this transaction was signed for, implicitly shard 0.
+func (tx *StakingTransaction) ShardID() uint32 {
+	return 0
+}
+
 // EncodeRLP implements rlp.Encoder
 func (tx *StakingTransaction) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, &tx.data)


### PR DESCRIPTION
## Issue

The tx-pool currently does not check for the ShardID and there is a slight programming error for the blacklist (pointer to a map). Both are fixed with this PR.

### Unit Test Coverage

Before:

```
PASS
coverage: 14.7% of statements
ok  	github.com/harmony-one/harmony/node	1.997s
```

```
PASS
coverage: 21.6% of statements
ok  	github.com/harmony-one/harmony/core	6.843s
```

After:

```
PASS
coverage: 14.7% of statements
ok  	github.com/harmony-one/harmony/node	2.352s
```

```
PASS
coverage: 21.7% of statements
ok  	github.com/harmony-one/harmony/core	6.709s
```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**
