### PR TITLE
add endpoint url to getNodeMetadata RPC response

### DIFF
--- a/internal/hmyapi/apiv1/harmony.go
+++ b/internal/hmyapi/apiv1/harmony.go
@@ -56,6 +56,7 @@ type NodeMetadata struct {
 	CurrentEpoch   uint64             `json:"current-epoch"`
 	BlocksPerEpoch *uint64            `json:"blocks-per-epoch,omitempty"`
 	Role           string             `json:"role"`
+	EndpointURL    string             `json:"endpoint-url"`
 }
 
 // GetNodeMetadata produces a NodeMetadata record, data is from the answering RPC node
@@ -70,6 +71,11 @@ func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
 		blockEpoch = &b
 	}
 
+	//Uses GetShardingStructure to expose endpoint URL
+	numShard := shard.Schedule.InstanceForEpoch(header.Epoch()).NumShards()
+	shardStructure := shard.Schedule.GetShardingStructure(int(numShard), int(s.b.GetShardID()))
+	endpointURL := shardStructure[int(s.b.GetShardID())]["http"].(string)
+
 	return NodeMetadata{
 		cfg.ConsensusPubKey.SerializeToHexStr(),
 		nodeconfig.GetVersion(),
@@ -80,5 +86,6 @@ func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
 		header.Epoch().Uint64(),
 		blockEpoch,
 		cfg.Role().String(),
+		endpointURL,
 	}
 }

--- a/internal/hmyapi/apiv2/harmony.go
+++ b/internal/hmyapi/apiv2/harmony.go
@@ -55,6 +55,7 @@ type NodeMetadata struct {
 	CurrentEpoch   uint64             `json:"current-epoch"`
 	BlocksPerEpoch *uint64            `json:"blocks-per-epoch,omitempty"`
 	Role           string             `json:"role"`
+	EndpointURL    string             `json:"endpoint-url"`
 }
 
 // GetNodeMetadata produces a NodeMetadata record, data is from the answering RPC node
@@ -69,6 +70,11 @@ func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
 		blockEpoch = &b
 	}
 
+	//Uses GetShardingStructure to expose endpoint URL
+	numShard := shard.Schedule.InstanceForEpoch(header.Epoch()).NumShards()
+	shardStructure := shard.Schedule.GetShardingStructure(int(numShard), int(s.b.GetShardID()))
+	endpointURL := shardStructure[int(s.b.GetShardID())]["http"].(string)
+
 	return NodeMetadata{
 		cfg.ConsensusPubKey.SerializeToHexStr(),
 		nodeconfig.GetVersion(),
@@ -79,5 +85,6 @@ func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
 		header.Epoch().Uint64(),
 		blockEpoch,
 		cfg.Role().String(),
+		endpointURL,
 	}
 }


### PR DESCRIPTION
## Issue

Endpoint tag should be exposed by watchdog.

## Test
N/A
## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**

## TODO
Expose the newly added endpoint-url field in the hmy_getNodeMetadata RPC response in watchdog.