### PR TITLE
change active flag to pointer to string instead of bool

### DIFF
--- a/staking/types/messages.go
+++ b/staking/types/messages.go
@@ -74,7 +74,7 @@ type EditValidator struct {
 	SlotKeyToRemove    *shard.BlsPublicKey `json:"slot_key_to_remove" rlp:"nil"`
 	SlotKeyToAdd       *shard.BlsPublicKey `json:"slot_key_to_add" rlp:"nil"`
 	SlotKeyToAddSig    *shard.BLSSignature `json:"slot_key_to_add_sig" rlp:"nil"`
-	Active             *bool               `json:"active" rlp:"nil"`
+	Active             *string             `json:"active" rlp:"nil"`
 }
 
 // Delegate - type for delegating to a validator

--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"strconv"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -480,8 +481,12 @@ func UpdateValidatorFromEditMsg(validator *Validator, edit *EditValidator) error
 		}
 	}
 
-	if edit.Active != nil {
-		validator.Active = *edit.Active
+	if edit.Active != nil && *edit.Active != "" {
+		val, err := strconv.ParseBool(*edit.Active)
+		if err != nil {
+			return err
+		}
+		validator.Active = val
 	}
 
 	return nil


### PR DESCRIPTION
active flag was pointer to bool which could not be edited. changing it to pointer to string. since this is a data structure change, a new binary needs to be released so that go-sdk can be updated.