### PR TITLE
[availability] Fix regression to skip over harmony run nodes

### DIFF
--- a/staking/availability/measure.go
+++ b/staking/availability/measure.go
@@ -118,6 +118,14 @@ func bumpCount(
 ) error {
 	for i := range signers {
 		addr := signers[i].EcdsaAddress
+
+		// NOTE if the signer address is not part of the staked addrs,
+		// then it must be a harmony operated node running,
+		// hence keep on going
+		if _, isAddrForStaked := stakedAddrSet[addr]; !isAddrForStaked {
+			continue
+		}
+
 		wrapper, err := state.ValidatorWrapper(addr)
 		if err != nil {
 			return err


### PR DESCRIPTION
Accidental mistake done during last minute refactoring of availability 