### PR TITLE
fixing explorer node returning empty for GetNodeMetaData api

### DIFF
--- a/multibls/multibls.go
+++ b/multibls/multibls.go
@@ -17,7 +17,10 @@ type PublicKey struct {
 }
 
 // SerializeToHexStr wrapper
-func (multiKey PublicKey) SerializeToHexStr() string {
+func (multiKey *PublicKey) SerializeToHexStr() string {
+	if multiKey == nil {
+		return ""
+	}
 	var builder strings.Builder
 	for _, pubKey := range multiKey.PublicKey {
 		builder.WriteString(pubKey.SerializeToHexStr())


### PR DESCRIPTION
GetNodeMetaData api returns empty due to multibls key feature integration for explorer node. This fix should fix the problem.