### PR TITLE
Add raw tx size limitation at network layer to help with DOS attacks

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -179,7 +179,7 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	AccountQueue: 64,
 	GlobalQueue:  1024,
 
-	Lifetime: 3 * time.Hour,
+	Lifetime: 30 * time.Minute,
 
 	Blacklist: map[common.Address]struct{}{},
 }
@@ -657,8 +657,8 @@ func (pool *TxPool) validateTx(tx types.PoolTransaction, local bool) error {
 	if tx.ShardID() != pool.chain.CurrentBlock().ShardID() {
 		return errors.WithMessagef(ErrInvalidShard, "transaction shard is %d", tx.ShardID())
 	}
-	// Heuristic limit, reject transactions over 32KB to prevent DOS attacks
-	if tx.Size() > 32*1024 {
+	// For DOS prevention, reject excessively large transactions.
+	if tx.Size() >= types.MaxPoolTransactionDataSize {
 		return errors.WithMessagef(ErrOversizedData, "transaction size is %s", tx.Size().String())
 	}
 	// Transactions can't be negative. This may never happen using RLP decoded

--- a/core/types/tx_pool.go
+++ b/core/types/tx_pool.go
@@ -11,6 +11,13 @@ import (
 	staking "github.com/harmony-one/harmony/staking/types"
 )
 
+const (
+	//MaxPoolTransactionDataSize is a 32KB heuristic data limit for DOS prevention
+	MaxPoolTransactionDataSize = 32 * 1024
+	//MaxEncodedPoolTransactionSize is a heuristic raw/encoded data size limit. It has an additional 10KB for metadata
+	MaxEncodedPoolTransactionSize = MaxPoolTransactionDataSize + (10 * 1024)
+)
+
 var (
 	// ErrUnknownPoolTxType is returned when attempting to assert a PoolTransaction to its concrete type
 	ErrUnknownPoolTxType = errors.New("unknown transaction type in tx-pool")

--- a/internal/hmyapi/apiv1/transactionpool.go
+++ b/internal/hmyapi/apiv1/transactionpool.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/harmony-one/harmony/accounts"
+	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/core/rawdb"
 	"github.com/harmony-one/harmony/core/types"
 	internal_common "github.com/harmony-one/harmony/internal/common"
@@ -209,6 +210,10 @@ func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args Sen
 func (s *PublicTransactionPoolAPI) SendRawStakingTransaction(
 	ctx context.Context, encodedTx hexutil.Bytes,
 ) (common.Hash, error) {
+	if len(encodedTx) >= types.MaxEncodedPoolTransactionSize {
+		err := errors.Wrapf(core.ErrOversizedData, "encoded tx size: %d", len(encodedTx))
+		return common.Hash{}, err
+	}
 	tx := new(staking.StakingTransaction)
 	if err := rlp.DecodeBytes(encodedTx, tx); err != nil {
 		return common.Hash{}, err
@@ -224,6 +229,10 @@ func (s *PublicTransactionPoolAPI) SendRawStakingTransaction(
 // SendRawTransaction will add the signed transaction to the transaction pool.
 // The sender is responsible for signing the transaction and using the correct nonce.
 func (s *PublicTransactionPoolAPI) SendRawTransaction(ctx context.Context, encodedTx hexutil.Bytes) (common.Hash, error) {
+	if len(encodedTx) >= types.MaxEncodedPoolTransactionSize {
+		err := errors.Wrapf(core.ErrOversizedData, "encoded tx size: %d", len(encodedTx))
+		return common.Hash{}, err
+	}
 	tx := new(types.Transaction)
 	if err := rlp.DecodeBytes(encodedTx, tx); err != nil {
 		return common.Hash{}, err

--- a/internal/hmyapi/apiv2/transactionpool.go
+++ b/internal/hmyapi/apiv2/transactionpool.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/harmony-one/harmony/accounts"
+	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/core/rawdb"
 	"github.com/harmony-one/harmony/core/types"
 	internal_common "github.com/harmony-one/harmony/internal/common"
@@ -207,6 +208,10 @@ func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args Sen
 func (s *PublicTransactionPoolAPI) SendRawStakingTransaction(
 	ctx context.Context, encodedTx hexutil.Bytes,
 ) (common.Hash, error) {
+	if len(encodedTx) >= types.MaxEncodedPoolTransactionSize {
+		err := errors.Wrapf(core.ErrOversizedData, "encoded tx size: %d", len(encodedTx))
+		return common.Hash{}, err
+	}
 	tx := new(staking.StakingTransaction)
 	if err := rlp.DecodeBytes(encodedTx, tx); err != nil {
 		return common.Hash{}, err
@@ -222,6 +227,10 @@ func (s *PublicTransactionPoolAPI) SendRawStakingTransaction(
 // SendRawTransaction will add the signed transaction to the transaction pool.
 // The sender is responsible for signing the transaction and using the correct nonce.
 func (s *PublicTransactionPoolAPI) SendRawTransaction(ctx context.Context, encodedTx hexutil.Bytes) (common.Hash, error) {
+	if len(encodedTx) >= types.MaxEncodedPoolTransactionSize {
+		err := errors.Wrapf(core.ErrOversizedData, "encoded tx size: %d", len(encodedTx))
+		return common.Hash{}, err
+	}
 	tx := new(types.Transaction)
 	if err := rlp.DecodeBytes(encodedTx, tx); err != nil {
 		return common.Hash{}, err

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -13,6 +13,7 @@ import (
 	proto_discovery "github.com/harmony-one/harmony/api/proto/discovery"
 	proto_node "github.com/harmony-one/harmony/api/proto/node"
 	"github.com/harmony-one/harmony/block"
+	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/core/types"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/ctxerror"
@@ -187,6 +188,10 @@ func (node *Node) HandleMessage(content []byte, sender libp2p_peer.ID) {
 }
 
 func (node *Node) transactionMessageHandler(msgPayload []byte) {
+	if len(msgPayload) >= types.MaxEncodedPoolTransactionSize {
+		utils.Logger().Warn().Err(core.ErrOversizedData).Msgf("encoded tx size: %d", len(msgPayload))
+		return
+	}
 	if len(msgPayload) < 1 {
 		utils.Logger().Debug().Msgf("Invalid transaction message size")
 		return
@@ -208,6 +213,10 @@ func (node *Node) transactionMessageHandler(msgPayload []byte) {
 }
 
 func (node *Node) stakingMessageHandler(msgPayload []byte) {
+	if len(msgPayload) >= types.MaxEncodedPoolTransactionSize {
+		utils.Logger().Warn().Err(core.ErrOversizedData).Msgf("encoded tx size: %d", len(msgPayload))
+		return
+	}
 	if len(msgPayload) < 1 {
 		utils.Logger().Debug().Msgf("Invalid staking transaction message size")
 		return


### PR DESCRIPTION
## Issue

Currently, a node accepts transactions of any size and processes it. This could lead to OOM (described in #2187). We can help prevent this by dropping transactions that are obviously too big before ever decoding them and feeding it to the transaction pool. 

### Unit Test Coverage

Before:

```
PASS
coverage: 21.9% of statements
ok  	github.com/harmony-one/harmony/core	6.897s
```

```
PASS
coverage: 14.2% of statements
ok  	github.com/harmony-one/harmony/node	2.035s
```

After:

```
PASS
coverage: 21.9% of statements
ok  	github.com/harmony-one/harmony/core	7.121s
```

```
PASS
coverage: 14.1% of statements
ok  	github.com/harmony-one/harmony/node	2.134s
```

### Test/Run Logs
Basic test suite [here](https://gist.github.com/Daniel-VDM/28d0b646c938074004c0250d218c0778).

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**
