### PR TITLE
fix GetNodeMetaData bug caused by multi-bls feature for explorer node

### DIFF
--- a/internal/configs/node/config.go
+++ b/internal/configs/node/config.go
@@ -267,7 +267,10 @@ func GetPublicRPC() bool {
 }
 
 // SerializeToHexStr wrapper
-func (multiKey MultiBlsPublicKey) SerializeToHexStr() string {
+func (multiKey *MultiBlsPublicKey) SerializeToHexStr() string {
+	if multiKey == nil {
+		return ""
+	}
 	var builder strings.Builder
 	for _, pubKey := range multiKey.PublicKey {
 		builder.WriteString(pubKey.SerializeToHexStr())


### PR DESCRIPTION
GetNodeMetaData returns `{}` on explorer node. This fix should make it return metadata with `""` for the bls key field.
This fix is already in the master. I could not cherry pick it, as the multi-bls on master diverged quite a bit in terms of files and structure.
Hence this PR.