### PR TITLE
[reward][slash] Skip over banned validators even if they signed blocks

### DIFF
--- a/consensus/votepower/roster.go
+++ b/consensus/votepower/roster.go
@@ -59,7 +59,6 @@ func NewRound() *Round {
 }
 
 type stakedVoter struct {
-	IsActive         bool               `json:"is-active"`
 	IsHarmonyNode    bool               `json:"is-harmony"`
 	EarningAccount   common.Address     `json:"earning-account"`
 	Identity         shard.BlsPublicKey `json:"bls-public-key"`
@@ -173,7 +172,6 @@ func Compute(staked shard.SlotList) (*Roster, error) {
 
 	for i := range staked {
 		member := stakedVoter{
-			IsActive:         true,
 			IsHarmonyNode:    true,
 			EarningAccount:   staked[i].EcdsaAddress,
 			Identity:         staked[i].BlsPublicKey,

--- a/consensus/votepower/roster_test.go
+++ b/consensus/votepower/roster_test.go
@@ -60,7 +60,6 @@ func TestCompute(t *testing.T) {
 	expectedRoster.RawStakedTotal = totalStake
 	for _, slot := range slotList {
 		newMember := stakedVoter{
-			IsActive:         true,
 			IsHarmonyNode:    false,
 			EarningAccount:   slot.EcdsaAddress,
 			EffectivePercent: numeric.ZeroDec(),
@@ -116,8 +115,7 @@ func compareRosters(a, b *Roster, t *testing.T) bool {
 }
 
 func compareStakedVoter(a, b stakedVoter) bool {
-	return a.IsActive == b.IsActive &&
-		a.IsHarmonyNode == b.IsHarmonyNode &&
+	return a.IsHarmonyNode == b.IsHarmonyNode &&
 		a.EarningAccount == b.EarningAccount &&
 		a.EffectivePercent.Equal(b.EffectivePercent) &&
 		a.EffectiveStake.Equal(b.EffectiveStake)
@@ -125,14 +123,12 @@ func compareStakedVoter(a, b stakedVoter) bool {
 
 func (s *stakedVoter) formatString() string {
 	type t struct {
-		IsActive         string `json:"active"`
 		IsHarmony        string `json:"harmony-node"`
 		EarningAccount   string `json:"one-address"`
 		EffectivePercent string `json:"effective-percent"`
 		EffectiveStake   string `json:"eposed-stake"`
 	}
 	data := t{
-		strconv.FormatBool(s.IsActive),
 		strconv.FormatBool(s.IsHarmonyNode),
 		s.EarningAccount.String(),
 		s.EffectivePercent.String(),


### PR DESCRIPTION
As things now, say a validator does a double sign in block 2 of a new epoch, then they have a whole rest of blocks during the epoch under which they can get block reward.

This PR changes rewarding logic to skip over banned validators for rewards. 