### PR TITLE
Check for EditValidator.active null or not

### DIFF
--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -495,7 +495,11 @@ func UpdateValidatorFromEditMsg(validator *Validator, edit *EditValidator) error
 	}
 
 	if edit.Active != nil {
-		validator.Active = *edit.Active
+		if *edit.Active {
+			validator.Active = true
+		}
+	} else {
+		validator.Active = false
 	}
 
 	return nil


### PR DESCRIPTION
## Issue
In RLP encoding, If input is non-value (uint(0), []byte{}, string(“”), empty pointer …), RLP encoding is 0x80. 

Scalar 0 :  big-endian interpretation of 0 consists of zeros - so after trimming, we get empty byte array. Empty byte array has length < 56, so it's length is encoded as 0+128 which is 0x80 in hex.

For EditValidator Active Field, if the value is pointer to false, then this field will be encoded to 0x80.
You can try the code below:

 var isActive bool = false
    msgEditValidator := EditValidator{...}; 
    msgEditValidator.isActive = &isActive;
  //encode to RLP
   rlpBytes, err := rlp.EncodeToBytes(msgEditValidator)
// RLP encoded value == 128    for *bool

 fmt.Println(rlpBytes[len(rlpBytes)-1])

 During decoding, the 0x80 will be decoded to nil.

So  the following code will fail  if edit.Active is actually mean to "false".
the RLP decoded validator.Active will be nil, instead of a pointer to "false"

if edit.Active != nil {
        validator.Active = *edit.Active
    }