### PR TITLE
adding support for validating multibls for same shard

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -250,6 +250,9 @@ func setupStakingNodeAccount() error {
 	if err != nil {
 		return errors.Wrap(err, "cannot determine shard to join")
 	}
+	if err := nodeconfig.GetDefaultConfig().ValidateConsensusKeysForSameShard(pubKey.PublicKey, shardID); err != nil {
+		return err
+	}
 	for _, blsKey := range pubKey.PublicKey {
 		initialAccount := &genesis.DeployAccount{}
 		initialAccount.ShardID = shardID


### PR DESCRIPTION
For multi-bls feature, need to validate if all keys belong to the same shard. Fixes https://github.com/harmony-one/harmony/issues/2376