### PR TITLE
adding checks to prevent malicious leader behaviors

### DIFF
--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -97,9 +97,11 @@ func (consensus *Consensus) handleMessageUpdate(payload []byte) {
 		intendedForLeader &&
 		consensus.leaderSanityChecks(msg):
 		consensus.onCommit(msg)
-	case t == msg_pb.MessageType_VIEWCHANGE:
+	case t == msg_pb.MessageType_VIEWCHANGE &&
+		consensus.viewChangeSanityCheck(msg):
 		consensus.onViewChange(msg)
-	case t == msg_pb.MessageType_NEWVIEW:
+	case t == msg_pb.MessageType_NEWVIEW &&
+		consensus.viewChangeSanityCheck(msg):
 		consensus.onNewView(msg)
 	}
 }


### PR DESCRIPTION
1. validator in ViewChangeMode should not trigger another view change on conflicting announce message
2. Do not process blocks that are further than max block number from the current block
3. Do not process view change that have view id further than max view id number from the current view id
4. Add more checks to onNewView for handling receive message view id and sender key verification for new leader
5. force block header verification for syncing mode
6. refactor onViewChange and onNewView sanity checks into checks.go