### PR TITLE
[webhook][rpc][availability] Hooks, current signing, remove median-stake cached values

### DIFF
--- a/consensus/engine/consensus_engine.go
+++ b/consensus/engine/consensus_engine.go
@@ -122,7 +122,7 @@ type Engine interface {
 		receipts []*types.Receipt, outcxs []*types.CXReceipt,
 		incxs []*types.CXReceiptsProof, stks []*staking.StakingTransaction,
 		doubleSigners slash.Records,
-	) (*types.Block, *big.Int, error)
+	) (*types.Block, map[common.Address]struct{}, *big.Int, error)
 
 	// Seal generates a new sealing request for the given input block and pushes
 	// the result into the given channel.

--- a/consensus/engine/consensus_engine.go
+++ b/consensus/engine/consensus_engine.go
@@ -122,7 +122,7 @@ type Engine interface {
 		receipts []*types.Receipt, outcxs []*types.CXReceipt,
 		incxs []*types.CXReceiptsProof, stks []*staking.StakingTransaction,
 		doubleSigners slash.Records,
-	) (*types.Block, map[common.Address]struct{}, *big.Int, error)
+	) (*types.Block, *big.Int, error)
 
 	// Seal generates a new sealing request for the given input block and pushes
 	// the result into the given channel.

--- a/consensus/votepower/roster.go
+++ b/consensus/votepower/roster.go
@@ -110,6 +110,7 @@ func AggregateRosters(rosters []RosterPerShard) map[common.Address]Staker {
 							ShardID:             roster.ShardID,
 							VotingPowerRaw:      value.RawPercent,
 							VotingPowerAdjusted: value.EffectivePercent,
+							EffectiveStake:      value.EffectiveStake,
 						},
 					)
 					for i := range payload.BLSPublicKeysOwned {
@@ -123,7 +124,8 @@ func AggregateRosters(rosters []RosterPerShard) map[common.Address]Staker {
 					result[value.EarningAccount] = Staker{
 						TotalEffectiveStake: value.EffectiveStake,
 						VotingPower: []staking.VotePerShard{
-							{roster.ShardID, value.RawPercent, value.EffectivePercent},
+							{roster.ShardID, value.RawPercent,
+								value.EffectivePercent, value.EffectiveStake},
 						},
 						BLSPublicKeysOwned: []staking.KeysPerShard{
 							{roster.ShardID, []shard.BlsPublicKey{key}}},

--- a/consensus/votepower/roster.go
+++ b/consensus/votepower/roster.go
@@ -106,7 +106,11 @@ func AggregateRosters(rosters []RosterPerShard) map[common.Address]Staker {
 						value.EffectiveStake,
 					)
 					payload.VotingPower = append(payload.VotingPower,
-						staking.VotePerShard{roster.ShardID, value.EffectivePercent},
+						staking.VotePerShard{
+							ShardID:             roster.ShardID,
+							VotingPowerRaw:      value.RawPercent,
+							VotingPowerAdjusted: value.EffectivePercent,
+						},
 					)
 					for i := range payload.BLSPublicKeysOwned {
 						if payload.BLSPublicKeysOwned[i].ShardID == roster.ShardID {
@@ -119,7 +123,7 @@ func AggregateRosters(rosters []RosterPerShard) map[common.Address]Staker {
 					result[value.EarningAccount] = Staker{
 						TotalEffectiveStake: value.EffectiveStake,
 						VotingPower: []staking.VotePerShard{
-							{roster.ShardID, value.EffectivePercent},
+							{roster.ShardID, value.RawPercent, value.EffectivePercent},
 						},
 						BLSPublicKeysOwned: []staking.KeysPerShard{
 							{roster.ShardID, []shard.BlsPublicKey{key}}},

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2489,20 +2489,6 @@ func (bc *BlockChain) UpdateStakingMetaData(
 			batch, createValidator.ValidatorAddress, createValidator.ValidatorAddress, root,
 		)
 	case staking.DirectiveEditValidator:
-		editVal := decodePayload.(*staking.EditValidator)
-		if active := editVal.Active; active != nil && *active {
-			list, err := bc.ReadValidatorList()
-			if err != nil {
-				return err
-			}
-			if list == nil {
-				list = []common.Address{}
-			}
-			list = utils.AppendIfMissing(list, editVal.ValidatorAddress)
-			if err := bc.WriteValidatorList(batch, list); err != nil {
-				return err
-			}
-		}
 	case staking.DirectiveDelegate:
 		delegate := decodePayload.(*staking.Delegate)
 		return bc.addDelegationIndex(

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2489,6 +2489,20 @@ func (bc *BlockChain) UpdateStakingMetaData(
 			batch, createValidator.ValidatorAddress, createValidator.ValidatorAddress, root,
 		)
 	case staking.DirectiveEditValidator:
+		editVal := decodePayload.(*staking.EditValidator)
+		if active := editVal.Active; active != nil && *active {
+			list, err := bc.ReadValidatorList()
+			if err != nil {
+				return err
+			}
+			if list == nil {
+				list = []common.Address{}
+			}
+			list = utils.AppendIfMissing(list, editVal.ValidatorAddress)
+			if err := bc.WriteValidatorList(batch, list); err != nil {
+				return err
+			}
+		}
 	case staking.DirectiveDelegate:
 		delegate := decodePayload.(*staking.Delegate)
 		return bc.addDelegationIndex(

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -259,7 +259,7 @@ func (bc *BlockChain) ValidateNewBlock(block *types.Block) error {
 
 	// NOTE Order of mutating state here matters.
 	// Process block using the parent state as reference point.
-	receipts, cxReceipts, _, usedGas, _, _, err := bc.processor.Process(
+	receipts, cxReceipts, _, usedGas, _, err := bc.processor.Process(
 		block, state, bc.vmConfig,
 	)
 	if err != nil {
@@ -1056,7 +1056,7 @@ func (bc *BlockChain) WriteBlockWithoutState(block *types.Block, td *big.Int) (e
 func (bc *BlockChain) WriteBlockWithState(
 	block *types.Block, receipts []*types.Receipt,
 	cxReceipts []*types.CXReceipt, payout *big.Int,
-	missedThreshold map[common.Address]struct{}, state *state.DB,
+	state *state.DB,
 ) (status WriteStatus, err error) {
 	bc.wg.Add(1)
 	defer bc.wg.Done()
@@ -1135,7 +1135,7 @@ func (bc *BlockChain) WriteBlockWithState(
 	// Write offchain data
 	if status, err := bc.CommitOffChainData(
 		batch, block, receipts,
-		cxReceipts, payout, state, root, missedThreshold,
+		cxReceipts, payout, state, root,
 	); err != nil {
 		return status, err
 	}
@@ -1327,7 +1327,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifyHeaders bool) (int, 
 		}
 
 		// Process block using the parent state as reference point.
-		receipts, cxReceipts, logs, usedGas, payout, missedThreshold, err := bc.processor.Process(
+		receipts, cxReceipts, logs, usedGas, payout, err := bc.processor.Process(
 			block, state, bc.vmConfig,
 		)
 		if err != nil {
@@ -1346,7 +1346,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifyHeaders bool) (int, 
 
 		// Write the block to the chain and get the status.
 		status, err := bc.WriteBlockWithState(
-			block, receipts, cxReceipts, payout, missedThreshold, state,
+			block, receipts, cxReceipts, payout, state,
 		)
 		if err != nil {
 			return i, events, coalescedLogs, err

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -167,7 +167,12 @@ func (b *BlockGen) PrevBlock(index int) *types.Block {
 // Blocks created by GenerateChain do not contain valid proof of work
 // values. Inserting them into BlockChain requires use of FakePow or
 // a similar non-validating proof of work implementation.
-func GenerateChain(config *params.ChainConfig, parent *types.Block, engine consensus_engine.Engine, db ethdb.Database, n int, gen func(int, *BlockGen)) ([]*types.Block, []types.Receipts) {
+func GenerateChain(
+	config *params.ChainConfig, parent *types.Block,
+	engine consensus_engine.Engine, db ethdb.Database,
+	n int,
+	gen func(int, *BlockGen),
+) ([]*types.Block, []types.Receipts) {
 	if config == nil {
 		config = params.TestChainConfig
 	}
@@ -175,12 +180,17 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 	blocks, receipts := make(types.Blocks, n), make([]types.Receipts, n)
 	chainreader := &fakeChainReader{config: config}
 	genblock := func(i int, parent *types.Block, statedb *state.DB) (*types.Block, types.Receipts) {
-		b := &BlockGen{i: i, chain: blocks, parent: parent, statedb: statedb, config: config, factory: factory, engine: engine}
+		b := &BlockGen{
+			i:       i,
+			chain:   blocks,
+			parent:  parent,
+			statedb: statedb,
+			config:  config,
+			factory: factory,
+			engine:  engine,
+		}
 		b.header = makeHeader(chainreader, parent, statedb, b.engine, factory)
 
-		//if config.DAOForkSupport && config.DAOForkBlock != nil && config.DAOForkBlock.Cmp(b.header.Number) == 0 {
-		//	misc.ApplyDAOHardFork(statedb)
-		//}
 		// Execute any user modifications to the block
 		if gen != nil {
 			gen(i, b)
@@ -188,7 +198,9 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 
 		if b.engine != nil {
 			// Finalize and seal the block
-			block, _, err := b.engine.Finalize(chainreader, b.header, statedb, b.txs, b.receipts, nil, nil, nil, nil)
+			block, _, _, err := b.engine.Finalize(
+				chainreader, b.header, statedb, b.txs, b.receipts, nil, nil, nil, nil,
+			)
 			if err != nil {
 				panic(err)
 			}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -198,7 +198,7 @@ func GenerateChain(
 
 		if b.engine != nil {
 			// Finalize and seal the block
-			block, _, _, err := b.engine.Finalize(
+			block, _, err := b.engine.Finalize(
 				chainreader, b.header, statedb, b.txs, b.receipts, nil, nil, nil, nil,
 			)
 			if err != nil {

--- a/core/offchain.go
+++ b/core/offchain.go
@@ -15,12 +15,19 @@ import (
 
 // CommitOffChainData write off chain data of a block onto db writer.
 func (bc *BlockChain) CommitOffChainData(
-	batch rawdb.DatabaseWriter, block *types.Block, receipts []*types.Receipt,
-	cxReceipts []*types.CXReceipt, payout *big.Int, state *state.DB, root common.Hash) (status WriteStatus, err error) {
-	//// Write receipts of the block
+	batch rawdb.DatabaseWriter,
+	block *types.Block,
+	receipts []*types.Receipt,
+	cxReceipts []*types.CXReceipt,
+	payout *big.Int,
+	state *state.DB,
+	root common.Hash,
+	missedThreshold map[common.Address]struct{},
+) (status WriteStatus, err error) {
+	// Write receipts of the block
 	rawdb.WriteReceipts(batch, block.Hash(), block.NumberU64(), receipts)
 
-	//// Cross-shard txns
+	// Cross-shard txns
 	epoch := block.Header().Epoch()
 	if bc.chainConfig.HasCrossTxFields(block.Epoch()) {
 		shardingConfig := shard.Schedule.InstanceForEpoch(epoch)
@@ -31,9 +38,13 @@ func (bc *BlockChain) CommitOffChainData(
 			}
 
 			shardReceipts := types.CXReceipts(cxReceipts).GetToShardReceipts(uint32(i))
-			err := rawdb.WriteCXReceipts(batch, uint32(i), block.NumberU64(), block.Hash(), shardReceipts)
-			if err != nil {
-				utils.Logger().Error().Err(err).Interface("shardReceipts", shardReceipts).Int("toShardID", i).Msg("WriteCXReceipts cannot write into database")
+			if err := rawdb.WriteCXReceipts(
+				batch, uint32(i), block.NumberU64(), block.Hash(), shardReceipts,
+			); err != nil {
+				utils.Logger().Error().Err(err).
+					Interface("shardReceipts", shardReceipts).
+					Int("toShardID", i).
+					Msg("WriteCXReceipts cannot write into database")
 				return NonStatTy, err
 			}
 		}
@@ -41,9 +52,9 @@ func (bc *BlockChain) CommitOffChainData(
 		bc.WriteCXReceiptsProofSpent(batch, block.IncomingReceipts())
 	}
 
-	//// VRF + VDF
-	//check non zero VRF field in header and add to local db
-	//if len(block.Vrf()) > 0 {
+	// VRF + VDF
+	// check non zero VRF field in header and add to local db
+	// if len(block.Vrf()) > 0 {
 	//	vrfBlockNumbers, _ := bc.ReadEpochVrfBlockNums(block.Header().Epoch())
 	//	if (len(vrfBlockNumbers) > 0) && (vrfBlockNumbers[len(vrfBlockNumbers)-1] == block.NumberU64()) {
 	//		utils.Logger().Error().
@@ -75,7 +86,7 @@ func (bc *BlockChain) CommitOffChainData(
 	//	}
 	//}
 
-	//// Shard State and Validator Update
+	// Shard State and Validator Update
 	header := block.Header()
 	if len(header.ShardState()) > 0 {
 		// Write shard state for the new epoch
@@ -107,47 +118,56 @@ func (bc *BlockChain) CommitOffChainData(
 
 	// Do bookkeeping for new staking txns
 	for _, tx := range block.StakingTransactions() {
-		err = bc.UpdateStakingMetaData(batch, tx, root)
 		// keep offchain database consistency with onchain we need revert
 		// but it should not happend unless local database corrupted
-		if err != nil {
+		if err := bc.UpdateStakingMetaData(batch, tx, root); err != nil {
 			utils.Logger().Debug().Msgf("oops, UpdateStakingMetaData failed, err: %+v", err)
 			return NonStatTy, err
 		}
 	}
 
 	// Update voting power of validators for all shards
-	if block.ShardID() == shard.BeaconChainShardID &&
-		len(block.Header().ShardState()) > 0 {
-		shardState := new(shard.State)
-
-		if shardState, err = shard.DecodeWrapper(block.Header().ShardState()); err == nil {
+	if ss := block.Header().ShardState(); len(ss) > 0 &&
+		block.ShardID() == shard.BeaconChainShardID {
+		shardState := &shard.State{}
+		if shardState, err = shard.DecodeWrapper(ss); err == nil {
 			if err = bc.UpdateValidatorVotingPower(batch, shardState); err != nil {
-				utils.Logger().Err(err).Msg("[UpdateValidatorVotingPower] Failed to update voting power")
+				utils.Logger().
+					Err(err).
+					Msg("[UpdateValidatorVotingPower] Failed to update voting power")
 			}
 		} else {
-			utils.Logger().Err(err).Msg("[UpdateValidatorVotingPower] Failed to decode shard state")
+			utils.Logger().
+				Err(err).
+				Msg("[UpdateValidatorVotingPower] Failed to decode shard state")
 		}
 	}
 
-	//// Writing beacon chain cross links
+	// Writing beacon chain cross links
 	if header.ShardID() == shard.BeaconChainShardID &&
 		bc.chainConfig.IsCrossLink(block.Epoch()) &&
 		len(header.CrossLinks()) > 0 {
 		crossLinks := &types.CrossLinks{}
 		err = rlp.DecodeBytes(header.CrossLinks(), crossLinks)
 		if err != nil {
-			header.Logger(utils.Logger()).Warn().Err(err).Msg("[insertChain/crosslinks] cannot parse cross links")
+			header.Logger(
+				utils.Logger()).
+				Warn().Err(err).
+				Msg("[insertChain/crosslinks] cannot parse cross links")
 			return NonStatTy, err
 		}
 		if !crossLinks.IsSorted() {
-			header.Logger(utils.Logger()).Warn().Err(err).Msg("[insertChain/crosslinks] cross links are not sorted")
+			header.Logger(utils.Logger()).Warn().
+				Err(err).Msg("[insertChain/crosslinks] cross links are not sorted")
 			return NonStatTy, errors.New("proposed cross links are not sorted")
 		}
 		for _, crossLink := range *crossLinks {
 			// Process crosslink
 			if err := bc.WriteCrossLinks(batch, types.CrossLinks{crossLink}); err == nil {
-				utils.Logger().Info().Uint64("blockNum", crossLink.BlockNum()).Uint32("shardID", crossLink.ShardID()).Msg("[insertChain/crosslinks] Cross Link Added to Beaconchain")
+				utils.Logger().Info().
+					Uint64("blockNum", crossLink.BlockNum()).
+					Uint32("shardID", crossLink.ShardID()).
+					Msg("[insertChain/crosslinks] Cross Link Added to Beaconchain")
 			}
 
 			cl0, _ := bc.ReadShardLastCrossLink(crossLink.ShardID())
@@ -156,13 +176,16 @@ func (bc *BlockChain) CommitOffChainData(
 			}
 		}
 
-		//clean/update local database cache after crosslink inserted into blockchain
+		// clean/update local database cache after crosslink inserted into blockchain
 		num, err := bc.DeleteFromPendingCrossLinks(*crossLinks)
 		if err != nil {
 			const msg = "DeleteFromPendingCrossLinks, crosslinks in header %d,  pending crosslinks: %d, problem: %+v"
 			utils.Logger().Debug().Msgf(msg, len(*crossLinks), num, err)
 		}
-		utils.Logger().Debug().Msgf("DeleteFromPendingCrossLinks, crosslinks in header %d,  pending crosslinks: %d", len(*crossLinks), num)
+		const msg = "DeleteFromPendingCrossLinks, crosslinks in header %d,  pending crosslinks: %d"
+		utils.Logger().
+			Debug().
+			Msgf(msg, len(*crossLinks), num)
 	}
 	// Roll up latest crosslinks
 	for i := uint32(0); i < shard.Schedule.InstanceForEpoch(epoch).NumShards(); i++ {

--- a/core/rawdb/accessors_offchain.go
+++ b/core/rawdb/accessors_offchain.go
@@ -260,8 +260,11 @@ func ReadValidatorList(db DatabaseReader, electedOnly bool) ([]common.Address, e
 }
 
 // WriteValidatorList stores staking validator's information by its address
-// Writes only for elected validators if electedOnly==true, otherwise, writes for all validators
-func WriteValidatorList(db DatabaseWriter, addrs []common.Address, electedOnly bool) error {
+// Writes only for elected validators
+// if electedOnly==true, otherwise, writes for all validators
+func WriteValidatorList(
+	db DatabaseWriter, addrs []common.Address, electedOnly bool,
+) error {
 	key := validatorListKey
 	if electedOnly {
 		key = electedValidatorListKey
@@ -271,10 +274,7 @@ func WriteValidatorList(db DatabaseWriter, addrs []common.Address, electedOnly b
 	if err != nil {
 		utils.Logger().Error().Msg("[WriteValidatorList] Failed to encode")
 	}
-	if err := db.Put(key, bytes); err != nil {
-		utils.Logger().Error().Msg("[WriteValidatorList] Failed to store to database")
-	}
-	return err
+	return db.Put(key, bytes)
 }
 
 // ReadDelegationsByDelegator retrieves the list of validators delegated by a delegator

--- a/core/types.go
+++ b/core/types.go
@@ -19,6 +19,7 @@ package core
 import (
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/core/state"
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/core/vm"
@@ -57,6 +58,8 @@ type Validator interface {
 // failed.
 type Processor interface {
 	Process(block *types.Block, statedb *state.DB, cfg vm.Config) (
-		types.Receipts, types.CXReceipts, []*types.Log, uint64, *big.Int, error,
+		types.Receipts, types.CXReceipts,
+		[]*types.Log, uint64, *big.Int,
+		map[common.Address]struct{}, error,
 	)
 }

--- a/core/types.go
+++ b/core/types.go
@@ -19,7 +19,6 @@ package core
 import (
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/core/state"
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/core/vm"
@@ -59,7 +58,6 @@ type Validator interface {
 type Processor interface {
 	Process(block *types.Block, statedb *state.DB, cfg vm.Config) (
 		types.Receipts, types.CXReceipts,
-		[]*types.Log, uint64, *big.Int,
-		map[common.Address]struct{}, error,
+		[]*types.Log, uint64, *big.Int, error,
 	)
 }

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -102,9 +102,7 @@ func (b *APIBackend) GetPoolNonce(ctx context.Context, addr common.Address) (uin
 
 // SendTx ...
 func (b *APIBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
-	// return b.hmy.txPool.Add(ctx, signedTx)
-	b.hmy.nodeAPI.AddPendingTransaction(signedTx)
-	return nil // TODO(ricl): AddPendingTransaction should return error
+	return b.hmy.nodeAPI.AddPendingTransaction(signedTx)
 }
 
 // ChainConfig ...
@@ -309,8 +307,7 @@ func (b *APIBackend) IsLeader() bool {
 func (b *APIBackend) SendStakingTx(
 	ctx context.Context,
 	newStakingTx *staking.StakingTransaction) error {
-	b.hmy.nodeAPI.AddPendingStakingTransaction(newStakingTx)
-	return nil
+	return b.hmy.nodeAPI.AddPendingStakingTransaction(newStakingTx)
 }
 
 // GetElectedValidatorAddresses returns the address of elected validators for current epoch
@@ -338,12 +335,13 @@ func (b *APIBackend) GetValidatorInformation(
 		s, _ := internal_common.AddressToBech32(addr)
 		return nil, errors.Wrapf(err, "not found address in snapshot %s", s)
 	}
+
 	signed, toSign, quotient, err := availability.ComputeCurrentSigning(snapshot, wrapper)
 	if err != nil {
 		return nil, err
 	}
 	return &staking.ValidatorRPCEnchanced{
-		ValidatorWrapper:         *wrapper,
+		Wrapper:                  *wrapper,
 		CurrentSigningPercentage: staking.Computed{signed, toSign, quotient},
 	}, nil
 }

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -339,11 +339,13 @@ func (b *APIBackend) GetValidatorInformation(
 		return nil, errors.Wrapf(err, "not found address in snapshot %s", s)
 	}
 	signed, toSign, quotient, err := availability.ComputeCurrentSigning(snapshot, wrapper)
+	if err != nil {
+		return nil, err
+	}
 	return &staking.ValidatorRPCEnchanced{
-			ValidatorWrapper:         *wrapper,
-			CurrentSigningPercentage: staking.Computed{signed, toSign, quotient},
-		},
-		nil
+		ValidatorWrapper:         *wrapper,
+		CurrentSigningPercentage: staking.Computed{signed, toSign, quotient},
+	}, nil
 }
 
 // GetMedianRawStakeSnapshot ..

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -342,9 +342,15 @@ func (b *APIBackend) GetValidatorInformation(
 	if err != nil {
 		return nil, err
 	}
+	stats, err := b.hmy.BlockChain().ReadValidatorStats(addr)
+	if err != nil {
+		return nil, err
+	}
+
 	return &staking.ValidatorRPCEnchanced{
 		Wrapper:                  *wrapper,
 		CurrentSigningPercentage: staking.Computed{signed, toSign, quotient},
+		CurrentVotingPower:       stats.VotingPowerPerShard,
 	}, nil
 }
 

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -549,3 +549,8 @@ func (b *APIBackend) GetSuperCommittees() (*quorum.Transition, error) {
 
 	return &quorum.Transition{then, now}, nil
 }
+
+// GetCurrentBadBlocks ..
+func (b *APIBackend) GetCurrentBadBlocks() []core.BadBlock {
+	return b.hmy.BlockChain().BadBlocks()
+}

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -102,7 +102,8 @@ func (b *APIBackend) GetPoolNonce(ctx context.Context, addr common.Address) (uin
 
 // SendTx ...
 func (b *APIBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
-	return b.hmy.nodeAPI.AddPendingTransaction(signedTx)
+	b.hmy.nodeAPI.AddPendingTransaction(signedTx)
+	return nil
 }
 
 // ChainConfig ...
@@ -307,7 +308,8 @@ func (b *APIBackend) IsLeader() bool {
 func (b *APIBackend) SendStakingTx(
 	ctx context.Context,
 	newStakingTx *staking.StakingTransaction) error {
-	return b.hmy.nodeAPI.AddPendingStakingTransaction(newStakingTx)
+	b.hmy.nodeAPI.AddPendingStakingTransaction(newStakingTx)
+	return nil
 }
 
 // GetElectedValidatorAddresses returns the address of elected validators for current epoch

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -21,6 +21,7 @@ import (
 	"github.com/harmony-one/harmony/core/vm"
 	internal_common "github.com/harmony-one/harmony/internal/common"
 	"github.com/harmony-one/harmony/internal/params"
+	"github.com/harmony-one/harmony/numeric"
 	"github.com/harmony-one/harmony/shard"
 	"github.com/harmony-one/harmony/staking/availability"
 	"github.com/harmony-one/harmony/staking/effective"
@@ -334,8 +335,13 @@ func (b *APIBackend) GetValidatorInformation(
 	}
 	snapshot, err := b.hmy.BlockChain().ReadValidatorSnapshot(addr)
 	if err != nil {
-		s, _ := internal_common.AddressToBech32(addr)
-		return nil, errors.Wrapf(err, "not found address in snapshot %s", s)
+		return &staking.ValidatorRPCEnchanced{
+			Wrapper: *wrapper,
+			CurrentSigningPercentage: staking.Computed{
+				common.Big0, common.Big0, numeric.ZeroDec(),
+			},
+			CurrentVotingPower: []staking.VotePerShard{},
+		}, nil
 	}
 
 	signed, toSign, quotient, err := availability.ComputeCurrentSigning(snapshot, wrapper)

--- a/hmy/backend.go
+++ b/hmy/backend.go
@@ -41,8 +41,8 @@ type Harmony struct {
 
 // NodeAPI is the list of functions from node used to call rpc apis.
 type NodeAPI interface {
-	AddPendingStakingTransaction(*staking.StakingTransaction)
-	AddPendingTransaction(newTx *types.Transaction)
+	AddPendingStakingTransaction(*staking.StakingTransaction) error
+	AddPendingTransaction(newTx *types.Transaction) error
 	Blockchain() *core.BlockChain
 	AccountManager() *accounts.Manager
 	GetBalanceOfAddress(address common.Address) (*big.Int, error)

--- a/internal/chain/reward.go
+++ b/internal/chain/reward.go
@@ -32,18 +32,17 @@ func ballotResultBeaconchain(
 func AccumulateRewards(
 	bc engine.ChainReader, state *state.DB, header *block.Header,
 	rewarder reward.Distributor, beaconChain engine.ChainReader,
-) (map[common.Address]struct{}, *big.Int, error) {
-	blockNum, missedSigningThreshold :=
-		header.Number().Uint64(), map[common.Address]struct{}{}
+) (*big.Int, error) {
+	blockNum := header.Number().Uint64()
 
 	if blockNum == 0 {
 		// genesis block has no parent to reward.
-		return missedSigningThreshold, network.NoReward, nil
+		return network.NoReward, nil
 	}
 
 	if bc.Config().IsStaking(header.Epoch()) &&
 		bc.CurrentHeader().ShardID() != shard.BeaconChainShardID {
-		return missedSigningThreshold, network.NoReward, nil
+		return network.NoReward, nil
 	}
 
 	// After staking
@@ -55,7 +54,7 @@ func AccumulateRewards(
 			beaconChain, header.Time().Int64(),
 		)
 		if err != nil {
-			return missedSigningThreshold, network.NoReward, err
+			return network.NoReward, err
 		}
 		howMuchOff, adjustBy := network.Adjustment(*percentageStaked)
 		defaultReward = defaultReward.Add(adjustBy)
@@ -68,7 +67,7 @@ func AccumulateRewards(
 		// If too much is staked, then possible to have negative reward,
 		// not an error, just a possible economic situation, hence we return
 		if defaultReward.IsNegative() {
-			return missedSigningThreshold, network.NoReward, nil
+			return network.NoReward, nil
 		}
 
 		newRewards := big.NewInt(0)
@@ -76,25 +75,22 @@ func AccumulateRewards(
 		// Take care of my own beacon chain committee, _ is missing, for slashing
 		members, payable, missing, err := ballotResultBeaconchain(beaconChain, header)
 		if err != nil {
-			return missedSigningThreshold, network.NoReward, err
+			return network.NoReward, err
 		}
 
-		missedThresholdBeacon, err := availability.IncrementValidatorSigningCounts(
+		if err := availability.IncrementValidatorSigningCounts(
 			beaconChain,
 			shard.Committee{shard.BeaconChainShardID, members}.StakedValidators(),
 			state,
 			payable,
 			missing,
-		)
-		if err != nil {
-			return missedSigningThreshold, network.NoReward, err
+		); err != nil {
+			return network.NoReward, err
 		}
-		for k := range missedThresholdBeacon {
-			missedSigningThreshold[k] = struct{}{}
-		}
+
 		votingPower, err := votepower.Compute(members)
 		if err != nil {
-			return missedSigningThreshold, network.NoReward, err
+			return network.NoReward, err
 		}
 
 		for beaconMember := range payable {
@@ -104,14 +100,14 @@ func AccumulateRewards(
 			if !voter.IsHarmonyNode {
 				snapshot, err := bc.ReadValidatorSnapshot(voter.EarningAccount)
 				if err != nil {
-					return missedSigningThreshold, network.NoReward, err
+					return network.NoReward, err
 				}
 				due := defaultReward.Mul(
 					voter.EffectivePercent.Quo(votepower.StakersShare),
 				).RoundInt()
 				newRewards = new(big.Int).Add(newRewards, due)
 				if err := state.AddReward(snapshot, due); err != nil {
-					return missedSigningThreshold, network.NoReward, err
+					return network.NoReward, err
 				}
 			}
 		}
@@ -120,7 +116,7 @@ func AccumulateRewards(
 		if cxLinks := header.CrossLinks(); len(cxLinks) > 0 {
 			crossLinks := types.CrossLinks{}
 			if err := rlp.DecodeBytes(cxLinks, &crossLinks); err != nil {
-				return missedSigningThreshold, network.NoReward, err
+				return network.NoReward, err
 			}
 
 			type slotPayable struct {
@@ -141,7 +137,7 @@ func AccumulateRewards(
 				shardState, err := bc.ReadShardState(cxLink.Epoch())
 
 				if err != nil {
-					return missedSigningThreshold, network.NoReward, err
+					return network.NoReward, err
 				}
 
 				subComm := shardState.FindCommitteeByID(cxLink.ShardID())
@@ -150,23 +146,19 @@ func AccumulateRewards(
 				)
 
 				if err != nil {
-					return nil, network.NoReward, err
+					return network.NoReward, err
 				}
 
 				staked := subComm.StakedValidators()
-				missedThresholdShard, err := availability.IncrementValidatorSigningCounts(
+				if err := availability.IncrementValidatorSigningCounts(
 					beaconChain, staked, state, payableSigners, missing,
-				)
-				if err != nil {
-					return missedSigningThreshold, network.NoReward, err
-				}
-				for k := range missedThresholdShard {
-					missedSigningThreshold[k] = struct{}{}
+				); err != nil {
+					return network.NoReward, err
 				}
 
 				votingPower, err := votepower.Compute(payableSigners)
 				if err != nil {
-					return missedSigningThreshold, network.NoReward, err
+					return network.NoReward, err
 				}
 				for j := range payableSigners {
 					voter := votingPower.Voters[payableSigners[j].BlsPublicKey]
@@ -209,19 +201,19 @@ func AccumulateRewards(
 				for payThem := range resultsHandle[bucket] {
 					snapshot, err := bc.ReadValidatorSnapshot(resultsHandle[bucket][payThem].payee)
 					if err != nil {
-						return missedSigningThreshold, network.NoReward, err
+						return network.NoReward, err
 					}
 					due := resultsHandle[bucket][payThem].payout.TruncateInt()
 					newRewards = new(big.Int).Add(newRewards, due)
 					if err := state.AddReward(snapshot, due); err != nil {
-						return missedSigningThreshold, network.NoReward, err
+						return network.NoReward, err
 					}
 				}
 			}
 
-			return missedSigningThreshold, newRewards, nil
+			return newRewards, nil
 		}
-		return missedSigningThreshold, network.NoReward, nil
+		return network.NoReward, nil
 	}
 
 	// Before staking
@@ -235,13 +227,13 @@ func AccumulateRewards(
 	if parentHeader.Number().Cmp(common.Big0) == 0 {
 		// Parent is an epoch block,
 		// which is not signed in the usual manner therefore rewards nothing.
-		return missedSigningThreshold, network.NoReward, nil
+		return network.NoReward, nil
 	}
 
 	_, signers, _, err := availability.BallotResult(bc, header, header.ShardID())
 
 	if err != nil {
-		return missedSigningThreshold, network.NoReward, err
+		return network.NoReward, err
 	}
 
 	totalAmount := rewarder.Award(
@@ -260,7 +252,7 @@ func AccumulateRewards(
 			Int64("block-reward", network.BlockReward.Int64()).
 			Int64("total-amount-paid-out", totalAmount.Int64()).
 			Msg("Total paid out was not equal to block-reward")
-		return missedSigningThreshold, nil, errors.Wrapf(
+		return nil, errors.Wrapf(
 			network.ErrPayoutNotEqualBlockReward, "payout "+totalAmount.String(),
 		)
 	}
@@ -274,5 +266,5 @@ func AccumulateRewards(
 		Str("TotalAmount", totalAmount.String()).
 		Msg("[Block Reward] Successfully paid out block reward")
 
-	return missedSigningThreshold, totalAmount, nil
+	return totalAmount, nil
 }

--- a/internal/hmyapi/apiv1/backend.go
+++ b/internal/hmyapi/apiv1/backend.go
@@ -86,4 +86,5 @@ type Backend interface {
 	GetCurrentUtilityMetrics() (*network.UtilityMetric, error)
 	GetSuperCommittees() (*quorum.Transition, error)
 	GetTotalStakingSnapshot() *big.Int
+	GetCurrentBadBlocks() []core.BadBlock
 }

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -584,13 +584,13 @@ func (s *PublicBlockChainAPI) GetValidatorInformation(
 // If page is -1, return all instead of `validatorsPageSize` elements.
 func (s *PublicBlockChainAPI) GetAllValidatorInformation(
 	ctx context.Context, page int,
-) ([]*staking.ValidatorWrapper, error) {
+) ([]*staking.ValidatorRPCEnchanced, error) {
 	if page < -1 {
 		return nil, errors.Errorf("page given %d cannot be less than -1", page)
 	}
 	addresses := s.b.GetAllValidatorAddresses()
 	if page != -1 && len(addresses) <= page*validatorsPageSize {
-		return make([]*staking.ValidatorWrapper, 0), nil
+		return make([]*staking.ValidatorRPCEnchanced, 0), nil
 	}
 	validatorsNum := len(addresses)
 	start := 0
@@ -601,13 +601,13 @@ func (s *PublicBlockChainAPI) GetAllValidatorInformation(
 			validatorsNum = len(addresses) - start
 		}
 	}
-	validators := make([]*staking.ValidatorWrapper, validatorsNum)
+	validators := make([]*staking.ValidatorRPCEnchanced, validatorsNum)
 	for i := start; i < start+validatorsNum; i++ {
 		information, err := s.b.GetValidatorInformation(addresses[i])
 		if err != nil {
 			return nil, err
 		}
-		validators[i-start] = &information.ValidatorWrapper
+		validators[i-start] = information
 	}
 	return validators, nil
 }

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -811,6 +811,11 @@ func (s *PublicBlockChainAPI) GetSuperCommittees() (*quorum.Transition, error) {
 	return nil, errNotBeaconChainShard
 }
 
+// GetCurrentBadBlocks ..
+func (s *PublicBlockChainAPI) GetCurrentBadBlocks() []core.BadBlock {
+	return s.b.GetCurrentBadBlocks()
+}
+
 // GetTotalSupply ..
 func (s *PublicBlockChainAPI) GetTotalSupply() (numeric.Dec, error) {
 	return numeric.NewDec(initSupply), nil

--- a/internal/hmyapi/apiv2/backend.go
+++ b/internal/hmyapi/apiv2/backend.go
@@ -86,4 +86,5 @@ type Backend interface {
 	GetCurrentUtilityMetrics() (*network.UtilityMetric, error)
 	GetSuperCommittees() (*quorum.Transition, error)
 	GetTotalStakingSnapshot() *big.Int
+	GetCurrentBadBlocks() []core.BadBlock
 }

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -541,7 +541,8 @@ func (s *PublicBlockChainAPI) GetValidatorMetrics(ctx context.Context, address s
 func (s *PublicBlockChainAPI) GetValidatorInformation(
 	ctx context.Context, address string,
 ) (*staking.ValidatorRPCEnchanced, error) {
-	return s.GetValidatorInformation(ctx, address)
+	validatorAddress := internal_common.ParseAddr(address)
+	return s.b.GetValidatorInformation(validatorAddress)
 }
 
 // GetAllValidatorInformation returns information about all validators.

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -776,6 +776,11 @@ func (s *PublicBlockChainAPI) GetSuperCommittees() (*quorum.Transition, error) {
 	return nil, errNotBeaconChainShard
 }
 
+// GetCurrentBadBlocks ..
+func (s *PublicBlockChainAPI) GetCurrentBadBlocks() []core.BadBlock {
+	return s.b.GetCurrentBadBlocks()
+}
+
 // GetTotalSupply ..
 func (s *PublicBlockChainAPI) GetTotalSupply() (numeric.Dec, error) {
 	return numeric.NewDec(initSupply), nil

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -549,13 +549,13 @@ func (s *PublicBlockChainAPI) GetValidatorInformation(
 // If page is -1, return all else return the pagination.
 func (s *PublicBlockChainAPI) GetAllValidatorInformation(
 	ctx context.Context, page int,
-) ([]*staking.ValidatorWrapper, error) {
+) ([]*staking.ValidatorRPCEnchanced, error) {
 	if page < -1 {
 		return nil, errors.Errorf("page given %d cannot be less than -1", page)
 	}
 	addresses := s.b.GetAllValidatorAddresses()
 	if page != -1 && len(addresses) <= page*validatorsPageSize {
-		return make([]*staking.ValidatorWrapper, 0), nil
+		return make([]*staking.ValidatorRPCEnchanced, 0), nil
 	}
 	validatorsNum := len(addresses)
 	start := 0
@@ -566,13 +566,13 @@ func (s *PublicBlockChainAPI) GetAllValidatorInformation(
 			validatorsNum = len(addresses) - start
 		}
 	}
-	validators := make([]*staking.ValidatorWrapper, validatorsNum)
+	validators := make([]*staking.ValidatorRPCEnchanced, validatorsNum)
 	for i := start; i < start+validatorsNum; i++ {
 		information, err := s.b.GetValidatorInformation(addresses[i])
 		if err != nil {
 			return nil, err
 		}
-		validators[i-start] = &information.ValidatorWrapper
+		validators[i-start] = information
 	}
 	return validators, nil
 }

--- a/internal/hmyapi/backend.go
+++ b/internal/hmyapi/backend.go
@@ -88,6 +88,7 @@ type Backend interface {
 	GetCurrentUtilityMetrics() (*network.UtilityMetric, error)
 	GetSuperCommittees() (*quorum.Transition, error)
 	GetTotalStakingSnapshot() *big.Int
+	GetCurrentBadBlocks() []core.BadBlock
 }
 
 // GetAPIs returns all the APIs.

--- a/node/node.go
+++ b/node/node.go
@@ -317,32 +317,36 @@ func (node *Node) addPendingStakingTransactions(newStakingTxs staking.StakingTra
 }
 
 // AddPendingStakingTransaction staking transactions
-func (node *Node) AddPendingStakingTransaction(newStakingTx *staking.StakingTransaction) {
+func (node *Node) AddPendingStakingTransaction(
+	newStakingTx *staking.StakingTransaction,
+) error {
 	if node.NodeConfig.ShardID == shard.BeaconChainShardID {
 		errs := node.addPendingStakingTransactions(staking.StakingTransactions{newStakingTx})
 		for i := range errs {
 			if errs[i] != nil {
-				return
+				return errs[i]
 			}
 		}
 		utils.Logger().Info().Str("Hash", newStakingTx.Hash().Hex()).Msg("Broadcasting Staking Tx")
 		node.tryBroadcastStaking(newStakingTx)
 	}
+	return nil
 }
 
 // AddPendingTransaction adds one new transaction to the pending transaction list.
 // This is only called from SDK.
-func (node *Node) AddPendingTransaction(newTx *types.Transaction) {
+func (node *Node) AddPendingTransaction(newTx *types.Transaction) error {
 	if newTx.ShardID() == node.NodeConfig.ShardID {
 		errs := node.addPendingTransactions(types.Transactions{newTx})
 		for i := range errs {
 			if errs[i] != nil {
-				return
+				return errs[i]
 			}
 		}
 		utils.Logger().Info().Str("Hash", newTx.Hash().Hex()).Msg("Broadcasting Tx")
 		node.tryBroadcast(newTx)
 	}
+	return nil
 }
 
 // AddPendingReceipts adds one receipt message to pending list.

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -1,7 +1,6 @@
 package node
 
 import (
-	"errors"
 	"sort"
 	"strings"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/shard"
 	staking "github.com/harmony-one/harmony/staking/types"
+	"github.com/pkg/errors"
 )
 
 // Constants of proposing a new block

--- a/node/worker/worker.go
+++ b/node/worker/worker.go
@@ -422,7 +422,7 @@ func (w *Worker) FinalizeNewBlock(
 	state := w.current.state.Copy()
 	copyHeader := types.CopyHeader(w.current.header)
 	// TODO: feed coinbase into here so the proposer gets extra rewards.
-	block, _, err := w.engine.Finalize(
+	block, _, _, err := w.engine.Finalize(
 		w.chain, copyHeader, state, w.current.txs, w.current.receipts,
 		w.current.outcxs, w.current.incxs, w.current.stakingTxs,
 		w.current.slashes,
@@ -435,7 +435,9 @@ func (w *Worker) FinalizeNewBlock(
 }
 
 // New create a new worker object.
-func New(config *params.ChainConfig, chain *core.BlockChain, engine consensus_engine.Engine) *Worker {
+func New(
+	config *params.ChainConfig, chain *core.BlockChain, engine consensus_engine.Engine,
+) *Worker {
 	worker := &Worker{
 		config:  config,
 		factory: blockfactory.NewFactory(config),

--- a/node/worker/worker.go
+++ b/node/worker/worker.go
@@ -447,7 +447,7 @@ func (w *Worker) FinalizeNewBlock(
 	state := w.current.state.Copy()
 	copyHeader := types.CopyHeader(w.current.header)
 	// TODO: feed coinbase into here so the proposer gets extra rewards.
-	block, _, _, err := w.engine.Finalize(
+	block, _, err := w.engine.Finalize(
 		w.chain, copyHeader, state, w.current.txs, w.current.receipts,
 		w.current.outcxs, w.current.incxs, w.current.stakingTxs,
 		w.current.slashes,

--- a/staking/availability/measure.go
+++ b/staking/availability/measure.go
@@ -190,6 +190,14 @@ func ComputeCurrentSigning(
 		new(big.Int).Sub(statsNow.NumBlocksSigned, snapSigned),
 		new(big.Int).Sub(statsNow.NumBlocksToSign, snapToSign)
 
+	if toSign.Cmp(common.Big0) == 0 {
+		utils.Logger().Info().
+			RawJSON("snapshot", []byte(snapshot.String())).
+			RawJSON("current", []byte(wrapper.String())).
+			Msg("toSign is 0, perhaps did not receive crosslink proving signing")
+		return signed, toSign, numeric.ZeroDec(), nil
+	}
+
 	if signed.Sign() == -1 {
 		return nil, nil, numeric.ZeroDec(), errors.Wrapf(
 			errNegativeSign, "diff for signed period wrong: stat %s, snapshot %s",
@@ -206,6 +214,7 @@ func ComputeCurrentSigning(
 
 	s1, s2 :=
 		numeric.NewDecFromBigInt(signed), numeric.NewDecFromBigInt(toSign)
+
 	quotient := s1.Quo(s2)
 	return signed, toSign, quotient, nil
 }
@@ -233,14 +242,6 @@ func compute(
 	}
 
 	signed, toSign, quotient, err := ComputeCurrentSigning(snapshot, wrapper)
-
-	if toSign.Cmp(common.Big0) == 0 {
-		utils.Logger().Info().
-			RawJSON("snapshot", []byte(snapshot.String())).
-			RawJSON("current", []byte(wrapper.String())).
-			Msg("toSign is 0, perhaps did not receive crosslink proving signing")
-		return nil
-	}
 
 	if err != nil {
 		return err

--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -87,19 +87,8 @@ type Computed struct {
 
 // ValidatorRPCEnchanced contains extra information for RPC consumer
 type ValidatorRPCEnchanced struct {
-	ValidatorWrapper
-	CurrentSigningPercentage Computed
-}
-
-// MarshalJSON ..
-func (w ValidatorRPCEnchanced) MarshalJSON() ([]byte, error) {
-	return json.Marshal(struct {
-		ValidatorWrapper
-		CurrentSigningPercentage Computed `json:"current-epoch-signing-percent"`
-	}{
-		w.ValidatorWrapper,
-		w.CurrentSigningPercentage,
-	})
+	Wrapper                  ValidatorWrapper `json:"validator"`
+	CurrentSigningPercentage Computed         `json:"current-epoch-signing-percent"`
 }
 
 func (w ValidatorWrapper) String() string {

--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -114,8 +114,9 @@ func (w ValidatorWrapper) MarshalJSON() ([]byte, error) {
 
 // VotePerShard ..
 type VotePerShard struct {
-	ShardID     uint32      `json:"shard-id"`
-	VotingPower numeric.Dec `json:"voting-power"`
+	ShardID             uint32      `json:"shard-id"`
+	VotingPowerRaw      numeric.Dec `json:"voting-power-raw"`
+	VotingPowerAdjusted numeric.Dec `json:"voting-power-adjusted"`
 }
 
 // KeysPerShard ..

--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -117,6 +117,7 @@ type VotePerShard struct {
 	ShardID             uint32      `json:"shard-id"`
 	VotingPowerRaw      numeric.Dec `json:"voting-power-raw"`
 	VotingPowerAdjusted numeric.Dec `json:"voting-power-adjusted"`
+	EffectiveStake      numeric.Dec `json:"effective-stake"`
 }
 
 // KeysPerShard ..

--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -89,6 +89,7 @@ type Computed struct {
 type ValidatorRPCEnchanced struct {
 	Wrapper                  ValidatorWrapper `json:"validator"`
 	CurrentSigningPercentage Computed         `json:"current-epoch-signing-percent"`
+	CurrentVotingPower       []VotePerShard   `json:"current-epoch-voting-power"`
 }
 
 func (w ValidatorWrapper) String() string {


### PR DESCRIPTION
Further non-protocol changing improvements for OSTN

1. Do webhook call for when node drops in availabiltity signing
2. Remove accidential infinite recursion 
3. Never ignore errors in legacy RPCs
4. Expose bad block as an RPC, watchdog as downstream consumer
5. Remove signers that missed signing threshold from validatorlist, which is suspected of causing caching problems for median-stake. 