### PR TITLE
[profiling] Add support for pprof in the harmony binary + node.sh

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 	"math/big"
 	"math/rand"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path"
@@ -70,6 +72,7 @@ var (
 	freshDB          = flag.Bool("fresh_db", false, "true means the existing disk based db will be removed")
 	profile          = flag.Bool("profile", false, "Turn on profiling (CPU, Memory).")
 	metricsReportURL = flag.String("metrics_report_url", "", "If set, reports metrics to this URL.")
+	pprof            = flag.String("pprof", "", "what address and port the pprof profiling server should listen on")
 	versionFlag      = flag.Bool("version", false, "Output version info")
 	onlyLogTps       = flag.Bool("only_log_tps", false, "Only log TPS if true")
 	dnsZone          = flag.String("dns_zone", "", "if given and not empty, use peers from the zone (default: use libp2p peer discovery instead)")
@@ -140,6 +143,11 @@ var (
 )
 
 func initSetup() {
+
+	// Setup pprof
+	if addr := *pprof; addr != "" {
+		go func() { http.ListenAndServe(addr, nil) }()
+	}
 
 	// maybe request passphrase for bls key.
 	passphraseForBls()

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -125,6 +125,7 @@ options:
    -M             support multi-key mode (default: off)
    -A             enable archival node mode (default: off)
    -B blacklist   specify file containing blacklisted accounts as a newline delimited file (default: ./.hmy/blacklist.txt)
+   -R address     start a pprof profiling server listening on the specified address
    -I             use statically linked Harmony binary
 
 examples:
@@ -178,13 +179,14 @@ staking_mode=false
 multi_key=false
 archival=false
 blacklist=./.hmy/blacklist.txt
+pprof=""
 static=false
 verify=false
 ${BLSKEYFILE=}
 
 unset OPTIND OPTARG opt
 OPTIND=1
-while getopts :1chk:sSp:dDmN:tT:i:ba:U:PvVyzn:MAIB:Y opt
+while getopts :1chk:sSp:dDmN:tT:i:ba:U:PvVyzn:MAIB:R:Y opt
 do
    case "${opt}" in
    '?') usage "unrecognized option -${OPTARG}";;
@@ -211,6 +213,7 @@ do
    U) upgrade_rel="${OPTARG}";;
    P) public_rpc=true;;
    B) blacklist="${OPTARG}";;
+   R) pprof="${OPTARG}";;
    v) msg "version: $version"
       exit 0 ;;
    V) LD_LIBRARY_PATH=. ./harmony -version
@@ -725,6 +728,11 @@ do
    if ${public_rpc}; then
       args+=(
       -public_rpc
+      )
+   fi
+   if [ ! -z "${pprof}" ]; then
+      args+=(
+      -pprof "${pprof}"
       )
    fi
 # backward compatible with older harmony node software


### PR DESCRIPTION
This PR adds support for starting a pprof server using the specified args `-pprof ADDRESS` (for the harmony binary) or `-R ADDRESS` (for node.sh) 

Using the updated node.sh file, a node can be started with a pprof enabled server using e.g:
```
./node.sh -k bls.key -N staking -z -D -S -R localhost:6060
```

The above command will start the pprof server at http://localhost:6060 and you can interact with various endpoints (e.g. using a web browser) via http://localhost:6060/debug/pprof

Here are the endpoints that can be used:

**Memory / goroutines / misc**

- http://localhost:6060/debug/pprof/allocs - A sampling of all past memory allocations
- http://localhost:6060/debug/pprof/block - Stack traces that led to blocking on synchronization primitives
- http://localhost:6060/debug/pprof/cmdline - The command line invocation of the current program
- http://localhost:6060/debug/pprof/goroutine - Stack traces of all current goroutines
- http://localhost:6060/debug/pprof/heap - A sampling of memory allocations of live objects. You can specify the gc GET parameter to run GC before taking the heap sample.
- http://localhost:6060/debug/pprof/mutex - Stack traces of holders of contended mutexes
- http://localhost:6060/debug/pprof/threadcreate - Stack traces that led to the creation of new OS threads

**CPU:**

- http://localhost:6060/debug/pprof/profile?seconds=60 - CPU profile. You can specify the duration in the seconds GET parameter. After you get the profile file, use the go tool pprof command to investigate the profile.
- http://localhost:6060/debug/pprof/trace?seconds=60 - A trace of execution of the current program. You can specify the duration in the seconds GET parameter. After you get the trace file, use the go tool trace command to investigate the trace.

To export the data from these endpoints as PDF docs, you can use:
`go tool pprof --pdf http://localhost:6060/debug/pprof/profile?seconds=60 > cpu.pdf`

The PDF export functionality requires having graphviz installed.

Here's an example for how a heap profile can look: [Heap profile 5 - 252.22 mb allocated](https://docs.google.com/viewer?url=http://tools.harmony.one.s3.amazonaws.com/pprof/with-payload/profile005-spammers_active.pdf)

## Test

### Unit Test Coverage

Before:

```
$ go test -cover
?   	github.com/harmony-one/harmony/cmd/harmony	[no test files]
```

After:

```
$ go test -cover
?   	github.com/harmony-one/harmony/cmd/harmony	[no test files]
```

### Test/Run Logs

```
$ ./node.sh -k BLS_KEY.key -N staking -z -D -S -R http://localhost:6060
node.sh: using manually specified BLS key file: BLS_KEY.key
node.sh: binaries did not change
node.sh: public IP address autodetected: xxx.xxx.xxx.xxx
Enter passphrase for the BLS key file BLS_KEY.key:
node.sh: ############### Running Harmony Process ###############
Staking mode; node key BLS_KEY -> shard 3
```

```
$ curl http://localhost:6060/debug/pprof/allocs > allocs
$ ls -lh allocs
-rw-rw-r-- 1 deploy deploy 392K Mar  7 14:18 allocs
```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

9. **Does the existing `node.sh` continue to work with this change?**

    **YES**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## NOTE
I know that there's already some profiling support in the Harmony binary - but the existing profiling doesn't start a pprof server, and pprof + PDF exports of memory and CPU data is super handy for figuring out where the code allocates a lot of memory, uses a lot of CPU etc etc.