### PR TITLE
unnecessary message that is misleading node runners

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -228,8 +228,6 @@ func findAccountsByPubKeys(config shardingconfig.Instance, pubKeys []*bls.Public
 		_, account := config.FindAccount(keyStr)
 		if account != nil {
 			initialAccounts = append(initialAccounts, account)
-		} else {
-			fmt.Printf("Bls key not found: %s\n", keyStr)
 		}
 	}
 }


### PR DESCRIPTION
This error message is not needed. When the node is run, it simply misleads to the thinking that bls key was not found. 