### PR TITLE
[compilation] Fix -race compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ libs:
 exe:
 	./scripts/go_executable_build.sh
 
+race:
+	./scripts/go_executable_build.sh -r
+
 test:
 	./test/debug.sh
 


### PR DESCRIPTION
## Issue

The current build script `scripts/go_executable_build.sh` can't compile binaries using `-race` because of `-gcflags` currently being set to perform concurrent compilation (`-gcflags="all=-c 2"`).

When running `./scripts/go_executable_build.sh -r` using the current build script it will fail:
```
$ ./scripts/go_executable_build.sh -r
building cmd/client/wallet/main.go cmd/client/wallet/generated_wallet.ini.go
# unicode/utf16
compile: cannot use concurrent backend compilation with provided flags; invoked as [/Users/sebastianjohnsson/.gvm/gos/go1.13.7/pkg/tool/darwin_amd64/compile -o $WORK/b042/_pkg_.a -trimpath $WORK/b042=> -race -c 2 -p unicode/utf16 -std -complete -installsuffix race -buildid qLUNkreJ40SQ4lF4MLEZ/qLUNkreJ40SQ4lF4MLEZ -goversion go1.13.7 -D  -importcfg $WORK/b042/importcfg -pack ../../../../../../.gvm/gos/go1.13.7/src/unicode/utf16/utf16.go]
```
---
Using this PR, `./scripts/go_executable_build.sh -r` will correctly compile binaries with `-race` enabled:
```
$ ./scripts/go_executable_build.sh -r
building cmd/client/wallet/main.go cmd/client/wallet/generated_wallet.ini.go
Harmony (C) 2019. wallet, version v5649-master-20191208.0-272-gaf3bbd77 (sebastianjohnsson@ 2020-03-09T21:17:04+0700)
building cmd/bootnode/main.go
Harmony (C) 2019. bootnode, version v5649-master-20191208.0-272-gaf3bbd77 (sebastianjohnsson@ 2020-03-09T21:17:04+0700)
building cmd/harmony/main.go
Harmony (C) 2020. harmony, version v5649-master-20191208.0-272-gaf3bbd77 (sebastianjohnsson@ 2020-03-09T21:17:04+0700)
```
---
This PR also adds a `make race` build action + fixes the debug mode which would never be set to true despite passing `-d` to the script (`d` was missing from `getopts`)

## Test

### Unit Test Coverage

Before:

```
$ go test -cover
?   	github.com/harmony-one/harmony/scripts	[no test files]
```

After:

```
$ go test -cover
?   	github.com/harmony-one/harmony/scripts	[no test files]
```

### Test/Run Logs

```
$ ./scripts/go_executable_build.sh -r
building cmd/client/wallet/main.go cmd/client/wallet/generated_wallet.ini.go
Harmony (C) 2019. wallet, version v5649-master-20191208.0-272-gaf3bbd77 (sebastianjohnsson@ 2020-03-09T21:17:04+0700)
building cmd/bootnode/main.go
Harmony (C) 2019. bootnode, version v5649-master-20191208.0-272-gaf3bbd77 (sebastianjohnsson@ 2020-03-09T21:17:04+0700)
building cmd/harmony/main.go
Harmony (C) 2020. harmony, version v5649-master-20191208.0-272-gaf3bbd77 (sebastianjohnsson@ 2020-03-09T21:17:04+0700)
```

```
$ ./scripts/go_executable_build.sh
building cmd/client/wallet/main.go cmd/client/wallet/generated_wallet.ini.go
Harmony (C) 2019. wallet, version v5649-master-20191208.0-272-gaf3bbd77 (sebastianjohnsson@ 2020-03-09T21:21:59+0700)
building cmd/bootnode/main.go
Harmony (C) 2019. bootnode, version v5649-master-20191208.0-272-gaf3bbd77 (sebastianjohnsson@ 2020-03-09T21:21:59+0700)
building cmd/harmony/main.go
Harmony (C) 2020. harmony, version v5649-master-20191208.0-272-gaf3bbd77 (sebastianjohnsson@ 2020-03-09T21:21:59+0700)
```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**
