### PR TITLE
[Audit] Refactor offchain commit and fix consistency issue due to batch write

### DIFF
--- a/consensus/votepower/roster.go
+++ b/consensus/votepower/roster.go
@@ -204,7 +204,7 @@ func Compute(staked shard.SlotList) (*Roster, error) {
 			lastStakedVoter = &member
 		} else { // Our node
 			member.EffectivePercent = HarmonysShare.Quo(ourCount)
-			member.RawPercent = member.EffectivePercent
+			member.RawPercent = member.EffectivePercent.Quo(HarmonysShare)
 			ourPercentage = ourPercentage.Add(member.EffectivePercent)
 		}
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2487,6 +2487,7 @@ func (bc *BlockChain) UpdateStakingMetaData(
 func (bc *BlockChain) prepareStakingMetaData(
 	txns staking.StakingTransactions, state *state.DB,
 ) (newValidators []common.Address, newDelegations map[common.Address]staking.DelegationIndexes, err error) {
+	newDelegations = map[common.Address]staking.DelegationIndexes{}
 	for _, txn := range txns {
 		payload, err := txn.RLPEncodeStakeMsg()
 		if err != nil {

--- a/core/evm.go
+++ b/core/evm.go
@@ -37,7 +37,7 @@ type ChainContext interface {
 	GetHeader(common.Hash, uint64) *block.Header
 
 	// ReadDelegationsByDelegator returns the validators list of a delegator
-	ReadDelegationsByDelegator(common.Address) ([]staking.DelegationIndex, error)
+	ReadDelegationsByDelegator(common.Address) (staking.DelegationIndexes, error)
 
 	// ReadValidatorSnapshot returns the snapshot of validator at the beginning of current epoch.
 	ReadValidatorSnapshot(common.Address) (*staking.ValidatorWrapper, error)

--- a/core/rawdb/accessors_offchain.go
+++ b/core/rawdb/accessors_offchain.go
@@ -278,12 +278,12 @@ func WriteValidatorList(
 }
 
 // ReadDelegationsByDelegator retrieves the list of validators delegated by a delegator
-func ReadDelegationsByDelegator(db DatabaseReader, delegator common.Address) ([]staking.DelegationIndex, error) {
+func ReadDelegationsByDelegator(db DatabaseReader, delegator common.Address) (staking.DelegationIndexes, error) {
 	data, err := db.Get(delegatorValidatorListKey(delegator))
 	if err != nil || len(data) == 0 {
-		return []staking.DelegationIndex{}, nil
+		return staking.DelegationIndexes{}, nil
 	}
-	addrs := []staking.DelegationIndex{}
+	addrs := staking.DelegationIndexes{}
 	if err := rlp.DecodeBytes(data, &addrs); err != nil {
 		utils.Logger().Error().Err(err).Msg("Unable to Decode delegations from database")
 		return nil, err
@@ -292,8 +292,8 @@ func ReadDelegationsByDelegator(db DatabaseReader, delegator common.Address) ([]
 }
 
 // WriteDelegationsByDelegator stores the list of validators delegated by a delegator
-func WriteDelegationsByDelegator(db DatabaseWriter, delegator common.Address, indices []staking.DelegationIndex) error {
-	bytes, err := rlp.EncodeToBytes(indices)
+func WriteDelegationsByDelegator(db DatabaseWriter, delegator common.Address, indexes staking.DelegationIndexes) error {
+	bytes, err := rlp.EncodeToBytes(indexes)
 	if err != nil {
 		utils.Logger().Error().Msg("[writeDelegationsByDelegator] Failed to encode")
 	}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -272,6 +272,7 @@ func ApplyStakingTransaction(
 	// TODO(audit): add more log to staking txns; expose them in block explorer.
 	if config.IsReceiptLog(header.Epoch()) {
 		receipt.Logs = statedb.GetLogs(tx.Hash())
+		utils.Logger().Info().Interface("CollectReward", receipt.Logs)
 	}
 
 	return receipt, gas, nil

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -263,14 +263,15 @@ func GetPendingCXKey(shardID uint32, blockNum uint64) string {
 	return key
 }
 
-// AppendIfMissing returns a list of unique addresses
-func AppendIfMissing(slice []common.Address, addr common.Address) []common.Address {
+// AppendIfMissing appends an item if it's missing in the slice, returns appended slice and true
+// Otherwise, return the original slice and false
+func AppendIfMissing(slice []common.Address, addr common.Address) ([]common.Address, bool) {
 	for _, ele := range slice {
 		if ele == addr {
-			return slice
+			return slice, false
 		}
 	}
-	return append(slice, addr)
+	return append(slice, addr), true
 }
 
 // PrintError prints the given error in the extended format (%+v) onto stderr.

--- a/staking/types/delegation.go
+++ b/staking/types/delegation.go
@@ -97,6 +97,9 @@ func (u Undelegations) String() string {
 	return string(s)
 }
 
+// DelegationIndexes is a slice of DelegationIndex
+type DelegationIndexes []DelegationIndex
+
 // DelegationIndex stored the index of a delegation in the validator's delegation list
 type DelegationIndex struct {
 	ValidatorAddress common.Address

--- a/staking/types/delegation_test.go
+++ b/staking/types/delegation_test.go
@@ -41,7 +41,7 @@ func TestUndelegate(t *testing.T) {
 }
 
 func TestTotalInUndelegation(t *testing.T) {
-	var totalAmount *big.Int = delegation.TotalInUndelegation()
+	var totalAmount = delegation.TotalInUndelegation()
 
 	// check the total amount of undelegation
 	if totalAmount.Cmp(big.NewInt(3000)) != 0 {


### PR DESCRIPTION
Previously the change to batch write to DB would cause issue if there are multiple createValidator or delegation happens in the same block for the same address. 

The reason is that the batch write of the metadata only take effect at the end of all the changes. But it won't reflect it if reading in the middle of the operations, which may cause race condition.

This change take care of the issue by adding a cache layer to accumulate all the changes and batch write them at the end.

Tested locally.