### PR TITLE
Add shard config for harmony/external voting power

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -18,6 +18,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/harmony-one/harmony/numeric"
+
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/harmony-one/bls/ffi/go/bls"
@@ -620,7 +622,7 @@ func main() {
 		}
 		// TODO (leo): use a passing list of accounts here
 		devnetConfig, err := shardingconfig.NewInstance(
-			uint32(*devnetNumShards), *devnetShardSize, *devnetHarmonySize, genesis.HarmonyAccounts, genesis.FoundationalNodeAccounts, nil, shardingconfig.VLBPE)
+			uint32(*devnetNumShards), *devnetShardSize, *devnetHarmonySize, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccounts, nil, shardingconfig.VLBPE)
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "ERROR invalid devnet sharding config: %s",
 				err)

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -484,6 +484,7 @@ func (consensus *Consensus) UpdateConsensusInformation() Mode {
 	}
 
 	committeeToSet := &shard.Committee{}
+	epochToSet := curEpoch
 	hasError := false
 
 	curShardState, err := committee.WithStakingEnabled.ReadFromDB(
@@ -526,7 +527,7 @@ func (consensus *Consensus) UpdateConsensusInformation() Mode {
 		}
 
 		committeeToSet = subComm
-
+		epochToSet = nextEpoch
 	} else {
 		consensus.SetEpochNum(curEpoch.Uint64())
 		subComm, err := curShardState.FindCommitteeByID(curHeader.ShardID())
@@ -558,7 +559,7 @@ func (consensus *Consensus) UpdateConsensusInformation() Mode {
 
 	// Update voters in the committee
 	if _, err := consensus.Decider.SetVoters(
-		committeeToSet,
+		committeeToSet, epochToSet,
 	); err != nil {
 		utils.Logger().Error().
 			Err(err).

--- a/consensus/quorum/one-node-one-vote.go
+++ b/consensus/quorum/one-node-one-vote.go
@@ -2,6 +2,7 @@ package quorum
 
 import (
 	"encoding/json"
+	"math/big"
 
 	bls_cosi "github.com/harmony-one/harmony/crypto/bls"
 	"github.com/harmony-one/harmony/internal/utils"
@@ -57,7 +58,7 @@ func (v *uniformVoteWeight) IsRewardThresholdAchieved() bool {
 }
 
 func (v *uniformVoteWeight) SetVoters(
-	subCommittee *shard.Committee,
+	subCommittee *shard.Committee, epoch *big.Int,
 ) (*TallyResult, error) {
 	// NO-OP do not add anything here
 	return nil, nil

--- a/consensus/quorum/one-node-staked-vote.go
+++ b/consensus/quorum/one-node-staked-vote.go
@@ -2,6 +2,7 @@ package quorum
 
 import (
 	"encoding/json"
+	"math/big"
 
 	"github.com/harmony-one/harmony/consensus/votepower"
 	bls_cosi "github.com/harmony-one/harmony/crypto/bls"
@@ -156,12 +157,12 @@ var (
 )
 
 func (v *stakedVoteWeight) SetVoters(
-	subCommittee *shard.Committee,
+	subCommittee *shard.Committee, epoch *big.Int,
 ) (*TallyResult, error) {
 	v.ResetPrepareAndCommitVotes()
 	v.ResetViewChangeVotes()
 
-	roster, err := votepower.Compute(subCommittee)
+	roster, err := votepower.Compute(subCommittee, epoch)
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/quorum/one-node-staked-vote_test.go
+++ b/consensus/quorum/one-node-staked-vote_test.go
@@ -1,6 +1,7 @@
 package quorum
 
 import (
+	"github.com/harmony-one/harmony/internal/configs/sharding"
 	"math/big"
 	"math/rand"
 	"strconv"
@@ -30,6 +31,7 @@ type secretKeyMap map[shard.BlsPublicKey]bls.SecretKey
 
 func init() {
 	basicDecider = NewDecider(SuperMajorityStake, shard.BeaconChainShardID)
+	shard.Schedule = shardingconfig.LocalnetSchedule
 }
 
 func generateRandomSlot() (shard.Slot, bls.SecretKey) {
@@ -67,7 +69,7 @@ func setupBaseCase() (Decider, *TallyResult, shard.SlotList, map[string]secretKe
 	decider.UpdateParticipants(pubKeys)
 	tally, err := decider.SetVoters(&shard.Committee{
 		shard.BeaconChainShardID, slotList,
-	})
+	}, big.NewInt(3))
 	if err != nil {
 		panic("Unable to SetVoters for Base Case")
 	}
@@ -94,7 +96,7 @@ func setupEdgeCase() (Decider, *TallyResult, shard.SlotList, secretKeyMap) {
 	decider.UpdateParticipants(pubKeys)
 	tally, err := decider.SetVoters(&shard.Committee{
 		shard.BeaconChainShardID, slotList,
-	})
+	}, big.NewInt(3))
 	if err != nil {
 		panic("Unable to SetVoters for Edge Case")
 	}

--- a/consensus/quorum/one-node-staked-vote_test.go
+++ b/consensus/quorum/one-node-staked-vote_test.go
@@ -1,11 +1,12 @@
 package quorum
 
 import (
-	"github.com/harmony-one/harmony/internal/configs/sharding"
 	"math/big"
 	"math/rand"
 	"strconv"
 	"testing"
+
+	shardingconfig "github.com/harmony-one/harmony/internal/configs/sharding"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/bls/ffi/go/bls"

--- a/consensus/quorum/quorum.go
+++ b/consensus/quorum/quorum.go
@@ -2,6 +2,7 @@ package quorum
 
 import (
 	"fmt"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/bls/ffi/go/bls"
@@ -111,7 +112,7 @@ type Decider interface {
 	fmt.Stringer
 	SignatureReader
 	DependencyInjectionWriter
-	SetVoters(subCommittee *shard.Committee) (*TallyResult, error)
+	SetVoters(subCommittee *shard.Committee, epoch *big.Int) (*TallyResult, error)
 	Policy() Policy
 	IsQuorumAchieved(Phase) bool
 	IsQuorumAchievedByMask(mask *bls_cosi.Mask) bool

--- a/consensus/votepower/roster.go
+++ b/consensus/votepower/roster.go
@@ -15,10 +15,6 @@ import (
 )
 
 var (
-	// HarmonysShare ..
-	HarmonysShare = numeric.MustNewDecFromStr("0.68")
-	// StakersShare ..
-	StakersShare = numeric.MustNewDecFromStr("0.32")
 	// ErrVotingPowerNotEqualOne ..
 	ErrVotingPowerNotEqualOne = errors.New("voting power not equal to one")
 )

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2278,7 +2278,10 @@ func (bc *BlockChain) UpdateValidatorVotingPower(
 
 	for i := range newEpochSuperCommittee.Shards {
 		subCommittee := &newEpochSuperCommittee.Shards[i]
-		roster, err := votepower.Compute(subCommittee)
+		if newEpochSuperCommittee.Epoch == nil {
+			return errors.New("nil epoch for voting power computation")
+		}
+		roster, err := votepower.Compute(subCommittee, newEpochSuperCommittee.Epoch)
 		if err != nil {
 			return err
 		}

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -521,7 +521,7 @@ func (b *APIBackend) GetSuperCommittees() (*quorum.Transition, error) {
 
 	for _, comm := range prevCommittee.Shards {
 		decider := quorum.NewDecider(quorum.SuperMajorityStake, comm.ShardID)
-		if _, err := decider.SetVoters(&comm); err != nil {
+		if _, err := decider.SetVoters(&comm, prevCommittee.Epoch); err != nil {
 			return nil, err
 		}
 		then.Deciders[fmt.Sprintf("shard-%d", comm.ShardID)] = decider
@@ -529,7 +529,7 @@ func (b *APIBackend) GetSuperCommittees() (*quorum.Transition, error) {
 
 	for _, comm := range nowCommittee.Shards {
 		decider := quorum.NewDecider(quorum.SuperMajorityStake, comm.ShardID)
-		if _, err := decider.SetVoters(&comm); err != nil {
+		if _, err := decider.SetVoters(&comm, nowCommittee.Epoch); err != nil {
 			return nil, err
 		}
 		now.Deciders[fmt.Sprintf("shard-%d", comm.ShardID)] = decider

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -208,7 +208,7 @@ func (e *engineImpl) VerifySeal(chain engine.ChainReader, header *block.Header) 
 			return nil, nil
 		})
 
-		if _, err := d.SetVoters(subComm); err != nil {
+		if _, err := d.SetVoters(subComm, slotList.Epoch); err != nil {
 			return err
 		}
 		if !d.IsQuorumAchievedByMask(mask) {
@@ -457,7 +457,7 @@ func (e *engineImpl) VerifyHeaderWithSignature(chain engine.ChainReader, header 
 			return nil, nil
 		})
 
-		if _, err := d.SetVoters(subComm); err != nil {
+		if _, err := d.SetVoters(subComm, e); err != nil {
 			return err
 		}
 		if !d.IsQuorumAchievedByMask(mask) {

--- a/internal/configs/sharding/localnet.go
+++ b/internal/configs/sharding/localnet.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/harmony-one/harmony/internal/params"
+	"github.com/harmony-one/harmony/numeric"
+
 	"github.com/harmony-one/harmony/internal/genesis"
 )
 
@@ -15,7 +18,6 @@ type localnetSchedule struct{}
 
 const (
 	localnetV1Epoch = 1
-	localnetV2Epoch = 2
 
 	localnetEpochBlock1 = 10
 	twoOne              = 5
@@ -28,7 +30,7 @@ const (
 
 func (localnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	switch {
-	case epoch.Cmp(big.NewInt(localnetV2Epoch)) >= 0:
+	case epoch.Cmp(params.LocalnetChainConfig.StakingEpoch) >= 0:
 		return localnetV2
 	case epoch.Cmp(big.NewInt(localnetV1Epoch)) >= 0:
 		return localnetV1
@@ -108,10 +110,10 @@ func (ls localnetSchedule) GetShardingStructure(numShard, shardID int) []map[str
 
 var (
 	localnetReshardingEpoch = []*big.Int{
-		big.NewInt(0), big.NewInt(localnetV1Epoch), big.NewInt(localnetV2Epoch),
+		big.NewInt(0), big.NewInt(localnetV1Epoch), params.LocalnetChainConfig.StakingEpoch,
 	}
 	// Number of shards, how many slots on each , how many slots owned by Harmony
-	localnetV0 = MustNewInstance(2, 7, 5, genesis.LocalHarmonyAccounts, genesis.LocalFnAccounts, localnetReshardingEpoch, LocalnetSchedule.BlocksPerEpoch())
-	localnetV1 = MustNewInstance(2, 8, 5, genesis.LocalHarmonyAccountsV1, genesis.LocalFnAccountsV1, localnetReshardingEpoch, LocalnetSchedule.BlocksPerEpoch())
-	localnetV2 = MustNewInstance(2, 9, 6, genesis.LocalHarmonyAccountsV2, genesis.LocalFnAccountsV2, localnetReshardingEpoch, LocalnetSchedule.BlocksPerEpoch())
+	localnetV0 = MustNewInstance(2, 7, 5, numeric.OneDec(), genesis.LocalHarmonyAccounts, genesis.LocalFnAccounts, localnetReshardingEpoch, LocalnetSchedule.BlocksPerEpoch())
+	localnetV1 = MustNewInstance(2, 8, 5, numeric.OneDec(), genesis.LocalHarmonyAccountsV1, genesis.LocalFnAccountsV1, localnetReshardingEpoch, LocalnetSchedule.BlocksPerEpoch())
+	localnetV2 = MustNewInstance(2, 9, 6, numeric.MustNewDecFromStr("0.68"), genesis.LocalHarmonyAccountsV2, genesis.LocalFnAccountsV2, localnetReshardingEpoch, LocalnetSchedule.BlocksPerEpoch())
 )

--- a/internal/configs/sharding/mainnet.go
+++ b/internal/configs/sharding/mainnet.go
@@ -3,6 +3,8 @@ package shardingconfig
 import (
 	"math/big"
 
+	"github.com/harmony-one/harmony/numeric"
+
 	"github.com/harmony-one/harmony/internal/genesis"
 )
 
@@ -138,15 +140,15 @@ func (ms mainnetSchedule) GetShardingStructure(numShard, shardID int) []map[stri
 var mainnetReshardingEpoch = []*big.Int{big.NewInt(0), big.NewInt(mainnetV0_1Epoch), big.NewInt(mainnetV0_2Epoch), big.NewInt(mainnetV0_3Epoch), big.NewInt(mainnetV0_4Epoch), big.NewInt(mainnetV1Epoch), big.NewInt(mainnetV1_1Epoch), big.NewInt(mainnetV1_2Epoch), big.NewInt(mainnetV1_3Epoch), big.NewInt(mainnetV1_4Epoch), big.NewInt(mainnetV1_5Epoch)}
 
 var (
-	mainnetV0   = MustNewInstance(4, 150, 112, genesis.HarmonyAccounts, genesis.FoundationalNodeAccounts, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
-	mainnetV0_1 = MustNewInstance(4, 152, 112, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_1, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
-	mainnetV0_2 = MustNewInstance(4, 200, 148, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_2, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
-	mainnetV0_3 = MustNewInstance(4, 210, 148, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_3, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
-	mainnetV0_4 = MustNewInstance(4, 216, 148, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_4, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
-	mainnetV1   = MustNewInstance(4, 250, 170, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
-	mainnetV1_1 = MustNewInstance(4, 250, 170, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_1, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
-	mainnetV1_2 = MustNewInstance(4, 250, 170, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_2, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
-	mainnetV1_3 = MustNewInstance(4, 250, 170, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_3, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
-	mainnetV1_4 = MustNewInstance(4, 250, 170, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_4, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
-	mainnetV1_5 = MustNewInstance(4, 250, 170, genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV0   = MustNewInstance(4, 150, 112, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccounts, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV0_1 = MustNewInstance(4, 152, 112, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_1, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV0_2 = MustNewInstance(4, 200, 148, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_2, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV0_3 = MustNewInstance(4, 210, 148, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_3, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV0_4 = MustNewInstance(4, 216, 148, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_4, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV1   = MustNewInstance(4, 250, 170, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV1_1 = MustNewInstance(4, 250, 170, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_1, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV1_2 = MustNewInstance(4, 250, 170, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_2, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV1_3 = MustNewInstance(4, 250, 170, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_3, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV1_4 = MustNewInstance(4, 250, 170, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_4, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV1_5 = MustNewInstance(4, 250, 170, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
 )

--- a/internal/configs/sharding/mock/shardingconfig.go
+++ b/internal/configs/sharding/mock/shardingconfig.go
@@ -8,6 +8,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	sharding "github.com/harmony-one/harmony/internal/configs/sharding"
 	genesis "github.com/harmony-one/harmony/internal/genesis"
+	numeric "github.com/harmony-one/harmony/numeric"
 	big "math/big"
 	reflect "reflect"
 )
@@ -238,6 +239,34 @@ func (m *MockInstance) NumHarmonyOperatedNodesPerShard() int {
 func (mr *MockInstanceMockRecorder) NumHarmonyOperatedNodesPerShard() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NumHarmonyOperatedNodesPerShard", reflect.TypeOf((*MockInstance)(nil).NumHarmonyOperatedNodesPerShard))
+}
+
+// HarmonyVotePercent mocks base method
+func (m *MockInstance) HarmonyVotePercent() numeric.Dec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HarmonyVotePercent")
+	ret0, _ := ret[0].(numeric.Dec)
+	return ret0
+}
+
+// HarmonyVotePercent indicates an expected call of HarmonyVotePercent
+func (mr *MockInstanceMockRecorder) HarmonyVotePercent() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HarmonyVotePercent", reflect.TypeOf((*MockInstance)(nil).HarmonyVotePercent))
+}
+
+// ExternalVotePercent mocks base method
+func (m *MockInstance) ExternalVotePercent() numeric.Dec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExternalVotePercent")
+	ret0, _ := ret[0].(numeric.Dec)
+	return ret0
+}
+
+// ExternalVotePercent indicates an expected call of ExternalVotePercent
+func (mr *MockInstanceMockRecorder) ExternalVotePercent() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalVotePercent", reflect.TypeOf((*MockInstance)(nil).ExternalVotePercent))
 }
 
 // HmyAccounts mocks base method

--- a/internal/configs/sharding/pangaea.go
+++ b/internal/configs/sharding/pangaea.go
@@ -3,6 +3,8 @@ package shardingconfig
 import (
 	"math/big"
 
+	"github.com/harmony-one/harmony/numeric"
+
 	"github.com/harmony-one/harmony/internal/genesis"
 	"github.com/harmony-one/harmony/internal/params"
 )
@@ -78,5 +80,5 @@ var pangaeaReshardingEpoch = []*big.Int{
 	params.PangaeaChainConfig.StakingEpoch,
 }
 
-var pangaeaV0 = MustNewInstance(4, 27, 27, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, pangaeaReshardingEpoch, PangaeaSchedule.BlocksPerEpoch())
-var pangaeaV1 = MustNewInstance(4, 50, 27, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, pangaeaReshardingEpoch, PangaeaSchedule.BlocksPerEpoch())
+var pangaeaV0 = MustNewInstance(4, 27, 27, numeric.OneDec(), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, pangaeaReshardingEpoch, PangaeaSchedule.BlocksPerEpoch())
+var pangaeaV1 = MustNewInstance(4, 50, 27, numeric.MustNewDecFromStr("0.68"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, pangaeaReshardingEpoch, PangaeaSchedule.BlocksPerEpoch())

--- a/internal/configs/sharding/partner.go
+++ b/internal/configs/sharding/partner.go
@@ -3,6 +3,8 @@ package shardingconfig
 import (
 	"math/big"
 
+	"github.com/harmony-one/harmony/numeric"
+
 	"github.com/harmony-one/harmony/internal/genesis"
 	"github.com/harmony-one/harmony/internal/params"
 )
@@ -80,5 +82,5 @@ var partnerReshardingEpoch = []*big.Int{
 	params.TestnetChainConfig.StakingEpoch,
 }
 
-var partnerV0 = MustNewInstance(2, 15, 15, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, partnerReshardingEpoch, PartnerSchedule.BlocksPerEpoch())
-var partnerV1 = MustNewInstance(2, 30, 15, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, partnerReshardingEpoch, PartnerSchedule.BlocksPerEpoch())
+var partnerV0 = MustNewInstance(2, 15, 15, numeric.OneDec(), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, partnerReshardingEpoch, PartnerSchedule.BlocksPerEpoch())
+var partnerV1 = MustNewInstance(2, 30, 15, numeric.MustNewDecFromStr("0.68"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, partnerReshardingEpoch, PartnerSchedule.BlocksPerEpoch())

--- a/internal/configs/sharding/shardingconfig.go
+++ b/internal/configs/sharding/shardingconfig.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/harmony-one/harmony/numeric"
+
 	"github.com/harmony-one/harmony/internal/genesis"
 )
 
@@ -56,6 +58,12 @@ type Instance interface {
 	// NumHarmonyOperatedNodesPerShard returns number of nodes in each shard
 	// that are operated by Harmony.
 	NumHarmonyOperatedNodesPerShard() int
+
+	// HarmonyVotePercent returns total percentage of voting power harmony nodes possess.
+	HarmonyVotePercent() numeric.Dec
+
+	// ExternalVotePercent returns total percentage of voting power external validators possess.
+	ExternalVotePercent() numeric.Dec
 
 	// HmyAccounts returns a list of Harmony accounts
 	HmyAccounts() []genesis.DeployAccount

--- a/internal/configs/sharding/stress.go
+++ b/internal/configs/sharding/stress.go
@@ -3,6 +3,8 @@ package shardingconfig
 import (
 	"math/big"
 
+	"github.com/harmony-one/harmony/numeric"
+
 	"github.com/harmony-one/harmony/internal/genesis"
 	"github.com/harmony-one/harmony/internal/params"
 )
@@ -80,5 +82,5 @@ var stressnetReshardingEpoch = []*big.Int{
 	params.StressnetChainConfig.StakingEpoch,
 }
 
-var stressnetV0 = MustNewInstance(2, 30, 30, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, stressnetReshardingEpoch, StressNetSchedule.BlocksPerEpoch())
-var stressnetV1 = MustNewInstance(2, 50, 30, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, stressnetReshardingEpoch, StressNetSchedule.BlocksPerEpoch())
+var stressnetV0 = MustNewInstance(2, 30, 30, numeric.OneDec(), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, stressnetReshardingEpoch, StressNetSchedule.BlocksPerEpoch())
+var stressnetV1 = MustNewInstance(2, 50, 30, numeric.MustNewDecFromStr("0.9"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, stressnetReshardingEpoch, StressNetSchedule.BlocksPerEpoch())

--- a/internal/configs/sharding/testnet.go
+++ b/internal/configs/sharding/testnet.go
@@ -3,6 +3,8 @@ package shardingconfig
 import (
 	"math/big"
 
+	"github.com/harmony-one/harmony/numeric"
+
 	"github.com/harmony-one/harmony/internal/genesis"
 	"github.com/harmony-one/harmony/internal/params"
 )
@@ -80,5 +82,5 @@ var testnetReshardingEpoch = []*big.Int{
 	params.TestnetChainConfig.StakingEpoch,
 }
 
-var testnetV0 = MustNewInstance(4, 25, 25, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())
-var testnetV1 = MustNewInstance(4, 50, 25, genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())
+var testnetV0 = MustNewInstance(4, 25, 25, numeric.OneDec(), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())
+var testnetV1 = MustNewInstance(4, 50, 25, numeric.MustNewDecFromStr("0.68"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())

--- a/node/node_cross_link.go
+++ b/node/node_cross_link.go
@@ -149,6 +149,6 @@ func (node *Node) VerifyCrossLink(cl types.CrossLink) error {
 	}
 
 	return verify.AggregateSigForCommittee(
-		committee, aggSig, cl.Hash(), cl.BlockNum(), cl.Bitmap(),
+		committee, aggSig, cl.Hash(), cl.BlockNum(), cl.Epoch(), cl.Bitmap(),
 	)
 }

--- a/staking/verify/verify.go
+++ b/staking/verify/verify.go
@@ -2,6 +2,7 @@ package verify
 
 import (
 	"encoding/binary"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/bls/ffi/go/bls"
@@ -23,6 +24,7 @@ func AggregateSigForCommittee(
 	aggSignature *bls.Sign,
 	hash common.Hash,
 	blockNum uint64,
+	epoch *big.Int,
 	bitmap []byte,
 ) error {
 	committerKeys, err := committee.BLSPublicKeys()
@@ -43,7 +45,7 @@ func AggregateSigForCommittee(
 	decider.SetMyPublicKeyProvider(func() (*multibls.PublicKey, error) {
 		return nil, nil
 	})
-	if _, err := decider.SetVoters(committee); err != nil {
+	if _, err := decider.SetVoters(committee, epoch); err != nil {
 		return err
 	}
 	if !decider.IsQuorumAchievedByMask(mask) {


### PR DESCRIPTION
Add the ability to adjust voting power based on epochs.

Give stressnet's harmony node 90% voting power.

Tested locally.