### PR TITLE
suppress prompt to the action to clean up old db and logs

### DIFF
--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -605,7 +605,9 @@ done
 if [[ "${start_clean}" == "true" && "${network_type}" != "mainnet" ]]
 then
    msg "cleaning up old database/logs (-c)"
-   read -rp "Remove old database/logs? (Y/n) " yesno
+   # set a 2s timeout, and set its default return value to Y (true)
+   read -rp -t 2 "Remove old database/logs? (Y/n) " yesno
+   yesno=${yesno:-Y}
    echo
    if [[ "$yesno" == "y" || "$yesno" == "Y" ]]; then
       unset -v backup_dir now


### PR DESCRIPTION
read the src and understood the logic, the risk is low to remove this prompt. 

Two safety checks for this action (already there):

* `-c` enabled
* !mainnet network
