### PR TITLE
[rpc] Move lifetime outside of validator so always show APR

### DIFF
--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -84,9 +84,9 @@ type ValidatorWrapper struct {
 	Validator
 	Delegations Delegations
 	//
-	Counters counters
+	Counters counters `json:"-"`
 	// All the rewarded accumulated so far
-	BlockReward *big.Int
+	BlockReward *big.Int `json:"-"`
 }
 
 // Computed represents current epoch
@@ -136,11 +136,14 @@ type ValidatorRPCEnchanced struct {
 	TotalDelegated       *big.Int                 `json:"total-delegation"`
 	CurrentlyInCommittee bool                     `json:"currently-in-committee"`
 	EPoSStatus           string                   `json:"epos-status"`
+	Lifetime             *AccumulatedOverLifetime `json:"lifetime"`
 }
 
-type accumulatedOverLifetime struct {
-	BlockReward *big.Int `json:"reward-accumulated"`
-	Signing     counters `json:"blocks"`
+// AccumulatedOverLifetime ..
+type AccumulatedOverLifetime struct {
+	BlockReward *big.Int    `json:"reward-accumulated"`
+	Signing     counters    `json:"blocks"`
+	APR         numeric.Dec `json:"apr"`
 }
 
 func (w ValidatorWrapper) String() string {
@@ -152,21 +155,19 @@ func (w ValidatorWrapper) String() string {
 func (w ValidatorWrapper) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Validator
-		Address     string                  `json:"address"`
-		Delegations Delegations             `json:"delegations"`
-		Lifetime    accumulatedOverLifetime `json:"lifetime"`
+		Address     string      `json:"address"`
+		Delegations Delegations `json:"delegations"`
 	}{
 		w.Validator,
 		common2.MustAddressToBech32(w.Address),
 		w.Delegations,
-		accumulatedOverLifetime{w.BlockReward, w.Counters},
 	})
 }
 
 // ValidatorStats to record validator's performance and history records
 type ValidatorStats struct {
 	// APR ..
-	APR numeric.Dec `json:"current-apr"`
+	APR numeric.Dec `json:"-"`
 	// TotalEffectiveStake is the total effective stake this validator has
 	TotalEffectiveStake numeric.Dec `json:"total-effective-stake"`
 	// MetricsPerShard ..


### PR DESCRIPTION
@mikedoan @stephen-tse Here are adjustments to RPC to always show APR 

key point is that this `lifetime` field always exists 

```json
  "lifetime": {
      "apr": "0.000000000000000000",
      "blocks": {
        "signed": 0,
        "to-sign": 12
      },
      "reward-accumulated": 0
    },
```

example json of when in and not in committee 

in committee
```json
{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "current-epoch-performance": {
      "current-epoch-signing-percent": {
        "current-epoch-blocks-left": 7,
        "current-epoch-signed": 0,
        "current-epoch-signing-percentage": "0.000000000000000000",
        "current-epoch-to-sign": 5
      }
    },
    "currently-in-committee": true,
    "epos-status": "currently elected and not signing enough blocks to be eligible for election next epoch",
    "lifetime": {
      "apr": "0.000000000000000000",
      "blocks": {
        "signed": 0,
        "to-sign": 5
      },
      "reward-accumulated": 0
    },
    "metrics": {
      "by-shard": [
        {
          "bls-public-key": "790f87868d56594bff73320b50a2b9b9818ed30780a2aeacea6ec5e6c098e6ad073d61c73946d3855a9498cee8eca200",
          "earning-account": "one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7",
          "effective-stake": "8100000000000000000.000000000000000000",
          "group-percent": "1.000000000000000000",
          "overall-percent": "0.320000000000000002",
          "shard-id": 0
        }
      ],
      "total-effective-stake": "8100000000000000000.000000000000000000"
    },
    "total-delegation": 8100000000000000000,
    "validator": {
      "address": "one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7",
      "bls-public-keys": [
        "790f87868d56594bff73320b50a2b9b9818ed30780a2aeacea6ec5e6c098e6ad073d61c73946d3855a9498cee8eca200"
      ],
      "creation-height": 28,
      "delegations": [
        {
          "amount": 6600000000000000000,
          "delegator-address": "one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7",
          "reward": 0,
          "undelegations": []
        },
        {
          "amount": 1500000000000000000,
          "delegator-address": "one1nqevvacj3y5ltuef05my4scwy5wuqteur72jk5",
          "reward": 0,
          "undelegations": []
        }
      ],
      "details": "none",
      "identity": "test_account1",
      "last-epoch-in-committee": 3,
      "max-change-rate": "0.152212761523253600",
      "max-rate": "0.179184469782137200",
      "max-total-delegation": 13000000000000000000,
      "min-self-delegation": 1000000000000000000,
      "name": "_Test_key_validator1",
      "rate": "0.167983520183826780",
      "security-contact": "Edgar-VDM",
      "update-height": 28,
      "website": "harmony.one"
    }
  }
}
```

not in committee

```json
{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "current-epoch-performance": null,
    "currently-in-committee": false,
    "epos-status": "not eligible to be elected next epoch",
    "lifetime": {
      "apr": "0.000000000000000000",
      "blocks": {
        "signed": 0,
        "to-sign": 12
      },
      "reward-accumulated": 0
    },
    "metrics": null,
    "total-delegation": 8100000000000000000,
    "validator": {
      "address": "one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7",
      "bls-public-keys": [
        "790f87868d56594bff73320b50a2b9b9818ed30780a2aeacea6ec5e6c098e6ad073d61c73946d3855a9498cee8eca200"
      ],
      "creation-height": 36,
      "delegations": [
        {
          "amount": 6600000000000000000,
          "delegator-address": "one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7",
          "reward": 0,
          "undelegations": []
        },
        {
          "amount": 1500000000000000000,
          "delegator-address": "one1nqevvacj3y5ltuef05my4scwy5wuqteur72jk5",
          "reward": 0,
          "undelegations": []
        }
      ],
      "details": "none",
      "identity": "test_account1",
      "last-epoch-in-committee": 4,
      "max-change-rate": "0.152212761523253600",
      "max-rate": "0.179184469782137200",
      "max-total-delegation": 13000000000000000000,
      "min-self-delegation": 1000000000000000000,
      "name": "_Test_key_validator1",
      "rate": "0.167983520183826780",
      "security-contact": "Edgar-VDM",
      "update-height": 36,
      "website": "harmony.one"
    }
  }
}
```

