### PR TITLE
staking txn. look up by hash fix on api backend rawdb storage

### DIFF
--- a/block/factory/factory.go
+++ b/block/factory/factory.go
@@ -30,7 +30,7 @@ func NewFactory(chainConfig *params.ChainConfig) Factory {
 func (f *factory) NewHeader(epoch *big.Int) *block.Header {
 	var impl blockif.Header
 	switch {
-	case f.chainConfig.IsPreStaking(epoch):
+	case f.chainConfig.IsPreStaking(epoch) || f.chainConfig.IsStaking(epoch):
 		impl = v3.NewHeader()
 	case f.chainConfig.IsCrossLink(epoch):
 		impl = v2.NewHeader()

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -993,6 +993,7 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 		rawdb.WriteBody(batch, block.Hash(), block.NumberU64(), block.Body())
 		rawdb.WriteReceipts(batch, block.Hash(), block.NumberU64(), receipts)
 		rawdb.WriteTxLookupEntries(batch, block)
+		rawdb.WriteStakingTxLookupEntries(batch, block)
 
 		stats.processed++
 
@@ -1144,6 +1145,7 @@ func (bc *BlockChain) WriteBlockWithState(
 
 	// Write the positional metadata for transaction/receipt lookups and preimages
 	rawdb.WriteTxLookupEntries(batch, block)
+	rawdb.WriteStakingTxLookupEntries(batch, block)
 	rawdb.WriteCxLookupEntries(batch, block)
 	rawdb.WritePreimages(batch, block.NumberU64(), state.Preimages())
 
@@ -2174,6 +2176,13 @@ func (bc *BlockChain) IsSpent(cxp *types.CXReceiptsProof) bool {
 // returns 0, 0 if not found
 func (bc *BlockChain) ReadTxLookupEntry(txID common.Hash) (common.Hash, uint64, uint64) {
 	return rawdb.ReadTxLookupEntry(bc.db, txID)
+}
+
+// ReadStakingTxLookupEntry returns where the given staking transaction resides in the chain,
+// as a (block hash, block number, index in transaction list) triple.
+// returns 0, 0 if not found
+func (bc *BlockChain) ReadStakingTxLookupEntry(txID common.Hash) (common.Hash, uint64, uint64) {
+	return rawdb.ReadStakingTxLookupEntry(bc.db, txID)
 }
 
 // ReadValidatorInformationAt reads staking

--- a/core/rawdb/accessors_indexes_test.go
+++ b/core/rawdb/accessors_indexes_test.go
@@ -47,7 +47,10 @@ func TestLookupStorage(t *testing.T) {
 	tx3 := types.NewTransaction(3, common.BytesToAddress([]byte{0x33}), 0, big.NewInt(333), 3333, big.NewInt(33333), []byte{0x33, 0x33, 0x33})
 	txs := []*types.Transaction{tx1, tx2, tx3}
 
-	block := types.NewBlock(blockfactory.NewTestHeader().With().Number(big.NewInt(314)).Header(), txs, types.Receipts{&types.Receipt{}, &types.Receipt{}, &types.Receipt{}}, nil, nil, nil)
+	stx := sampleCreateValidatorStakingTxn()
+	stxs := []*staking.StakingTransaction{stx}
+
+	block := types.NewBlock(blockfactory.NewTestHeader().With().Number(big.NewInt(314)).Header(), txs, types.Receipts{&types.Receipt{}, &types.Receipt{}, &types.Receipt{}}, nil, nil, stxs)
 
 	// Check that no transactions entries are in a pristine database
 	for i, tx := range txs {
@@ -55,9 +58,15 @@ func TestLookupStorage(t *testing.T) {
 			t.Fatalf("tx #%d [%x]: non existent transaction returned: %v", i, tx.Hash(), txn)
 		}
 	}
+	for i, stx := range stxs {
+		if stxn, _, _, _ := ReadStakingTransaction(db, stx.Hash()); stxn != nil {
+			t.Fatalf("stx #%d [%x]: non existent staking transaction returned: %v", i, stxn.Hash(), stxn)
+		}
+	}
 	// Insert all the transactions into the database, and verify contents
 	WriteBlock(db, block)
 	WriteTxLookupEntries(db, block)
+	WriteStakingTxLookupEntries(db, block)
 
 	for i, tx := range txs {
 		if txn, hash, number, index := ReadTransaction(db, tx.Hash()); txn == nil {
@@ -71,11 +80,29 @@ func TestLookupStorage(t *testing.T) {
 			}
 		}
 	}
+	for i, stx := range stxs {
+		if txn, hash, number, index := ReadStakingTransaction(db, stx.Hash()); txn == nil {
+			t.Fatalf("tx #%d [%x]: staking transaction not found", i, stx.Hash())
+		} else {
+			if hash != block.Hash() || number != block.NumberU64() || index != uint64(i) {
+				t.Fatalf("stx #%d [%x]: positional metadata mismatch: have %x/%d/%d, want %x/%v/%v", i, stx.Hash(), hash, number, index, block.Hash(), block.NumberU64(), i)
+			}
+			if stx.Hash() != txn.Hash() {
+				t.Fatalf("stx #%d [%x]: staking transaction mismatch: have %v, want %v", i, stx.Hash(), txn, stx)
+			}
+		}
+	}
 	// Delete the transactions and check purge
 	for i, tx := range txs {
 		DeleteTxLookupEntry(db, tx.Hash())
 		if txn, _, _, _ := ReadTransaction(db, tx.Hash()); txn != nil {
 			t.Fatalf("tx #%d [%x]: deleted transaction returned: %v", i, tx.Hash(), txn)
+		}
+	}
+	for i, stx := range txs {
+		DeleteStakingTxLookupEntry(db, stx.Hash())
+		if stxn, _, _, _ := ReadStakingTransaction(db, stx.Hash()); stxn != nil {
+			t.Fatalf("stx #%d [%x]: deleted staking transaction returned: %v", i, stx.Hash(), stxn)
 		}
 	}
 }
@@ -84,6 +111,26 @@ func TestLookupStorage(t *testing.T) {
 func TestMixedLookupStorage(t *testing.T) {
 	db := ethdb.NewMemDatabase()
 	tx := types.NewTransaction(1, common.BytesToAddress([]byte{0x11}), 0, big.NewInt(111), 1111, big.NewInt(11111), []byte{0x11, 0x11, 0x11})
+	stx := sampleCreateValidatorStakingTxn()
+
+	txs := []*types.Transaction{tx}
+	stxs := []*staking.StakingTransaction{stx}
+	header := blockfactory.NewTestHeader().With().Number(big.NewInt(314)).Header()
+	block := types.NewBlock(header, txs, types.Receipts{&types.Receipt{}, &types.Receipt{}}, nil, nil, stxs)
+
+	WriteBlock(db, block)
+	WriteTxLookupEntries(db, block)
+	WriteStakingTxLookupEntries(db, block)
+
+	if recTx, _, _, _ := ReadStakingTransaction(db, tx.Hash()); recTx != nil {
+		t.Fatal("got staking transactions with plain tx hash")
+	}
+	if recTx, _, _, _ := ReadTransaction(db, stx.Hash()); recTx != nil {
+		t.Fatal("got plain transactions with staking tx hash")
+	}
+}
+
+func sampleCreateValidatorStakingTxn() *staking.StakingTransaction {
 	key, _ := crypto.GenerateKey()
 	stakePayloadMaker := func() (staking.Directive, interface{}) {
 		p := &bls.PublicKey{}
@@ -123,17 +170,5 @@ func TestMixedLookupStorage(t *testing.T) {
 		}
 	}
 	stx, _ := staking.NewStakingTransaction(0, 1e10, big.NewInt(10000), stakePayloadMaker)
-	txs := []*types.Transaction{tx}
-	stxs := []*staking.StakingTransaction{stx}
-	header := blockfactory.NewTestHeader().With().Number(big.NewInt(314)).Header()
-	block := types.NewBlock(header, txs, types.Receipts{&types.Receipt{}, &types.Receipt{}}, nil, nil, stxs)
-	WriteBlock(db, block)
-	WriteTxLookupEntries(db, block)
-
-	if recTx, _, _, _ := ReadStakingTransaction(db, tx.Hash()); recTx != nil {
-		t.Fatal("got staking transactions with plain tx hash")
-	}
-	if recTx, _, _, _ := ReadTransaction(db, stx.Hash()); recTx != nil {
-		t.Fatal("got plain transactions with staking tx hash")
-	}
+	return stx
 }

--- a/core/rawdb/accessors_indexes_test.go
+++ b/core/rawdb/accessors_indexes_test.go
@@ -50,7 +50,14 @@ func TestLookupStorage(t *testing.T) {
 	stx := sampleCreateValidatorStakingTxn()
 	stxs := []*staking.StakingTransaction{stx}
 
-	block := types.NewBlock(blockfactory.NewTestHeader().With().Number(big.NewInt(314)).Header(), txs, types.Receipts{&types.Receipt{}, &types.Receipt{}, &types.Receipt{}}, nil, nil, stxs)
+	receipts := types.Receipts{
+		&types.Receipt{},
+		&types.Receipt{},
+		&types.Receipt{},
+		&types.Receipt{},
+	}
+
+	block := types.NewBlock(blockfactory.NewTestHeader().With().Number(big.NewInt(314)).Header(), txs, receipts, nil, nil, stxs)
 
 	// Check that no transactions entries are in a pristine database
 	for i, tx := range txs {

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -48,9 +48,10 @@ var (
 	blockBodyPrefix     = []byte("b") // blockBodyPrefix + num (uint64 big endian) + hash -> block body
 	blockReceiptsPrefix = []byte("r") // blockReceiptsPrefix + num (uint64 big endian) + hash -> block receipts
 
-	txLookupPrefix  = []byte("l")  // txLookupPrefix + hash -> transaction/receipt lookup metadata
-	cxLookupPrefix  = []byte("cx") // cxLookupPrefix + hash -> cxReceipt lookup metadata
-	bloomBitsPrefix = []byte("B")  // bloomBitsPrefix + bit (uint16 big endian) + section (uint64 big endian) + hash -> bloom bits
+	txLookupPrefix        = []byte("l")  // txLookupPrefix + hash -> transaction/receipt lookup metadata
+	stakingTxLookupPrefix = []byte("st") // stakingTxLookupPrefix + hash -> staking transaction lookup metadataasd
+	cxLookupPrefix        = []byte("cx") // cxLookupPrefix + hash -> cxReceipt lookup metadata
+	bloomBitsPrefix       = []byte("B")  // bloomBitsPrefix + bit (uint16 big endian) + section (uint64 big endian) + hash -> bloom bits
 
 	shardStatePrefix = []byte("ss") // shardStatePrefix + num (uint64 big endian) + hash -> shardState
 	lastCommitsKey   = []byte("LastCommits")
@@ -103,6 +104,14 @@ type TxLookupEntry struct {
 	Index      uint64
 }
 
+// StakingTxLookupEntry is a positional metadata to help looking up the data content of
+// a staking transaction or receipt given only its hash.
+type StakingTxLookupEntry struct {
+	BlockHash  common.Hash
+	BlockIndex uint64
+	Index      uint64
+}
+
 // encodeBlockNumber encodes a block number as big endian uint64
 func encodeBlockNumber(number uint64) []byte {
 	enc := make([]byte, 8)
@@ -143,6 +152,11 @@ func blockReceiptsKey(number uint64, hash common.Hash) []byte {
 // txLookupKey = txLookupPrefix + hash
 func txLookupKey(hash common.Hash) []byte {
 	return append(txLookupPrefix, hash.Bytes()...)
+}
+
+// stakingTxLookupKey = stakingTxLookupPrefix + hash
+func stakingTxLookupKey(hash common.Hash) []byte {
+	return append(stakingTxLookupPrefix, hash.Bytes()...)
 }
 
 // cxLookupKey = cxLookupPrefix + hash


### PR DESCRIPTION
## Issue

https://github.com/harmony-one/harmony/issues/2552
## Test

### Unit Test Coverage

```
~/go/src/github.com/harmony-one/harmony (staking_txn_support) $ go test ./core/rawdb/

ok      github.com/harmony-one/harmony/core/rawdb       0.290s    
```
