### PR TITLE
Fix node sync issue which caused failure to sign and node being kicked out

### DIFF
--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -805,7 +805,7 @@ Loop:
 			}
 			ss.purgeOldBlocksFromCache()
 			if consensus != nil {
-				consensus.UpdateConsensusInformation()
+				consensus.SetMode(consensus.UpdateConsensusInformation())
 			}
 		}
 	}

--- a/consensus/checks.go
+++ b/consensus/checks.go
@@ -11,7 +11,7 @@ import (
 const MaxBlockNumDiff = 100
 
 func (consensus *Consensus) validatorSanityChecks(msg *msg_pb.Message) bool {
-	consensus.getLogger().Info().
+	consensus.getLogger().Debug().
 		Uint64("blockNum", msg.GetConsensus().BlockNum).
 		Uint64("viewID", msg.GetConsensus().ViewId).
 		Str("msgType", msg.Type.String()).
@@ -47,7 +47,7 @@ func (consensus *Consensus) validatorSanityChecks(msg *msg_pb.Message) bool {
 }
 
 func (consensus *Consensus) leaderSanityChecks(msg *msg_pb.Message) bool {
-	consensus.getLogger().Info().
+	consensus.getLogger().Debug().
 		Uint64("blockNum", msg.GetConsensus().BlockNum).
 		Uint64("viewID", msg.GetConsensus().ViewId).
 		Str("msgType", msg.Type.String()).
@@ -196,7 +196,7 @@ func (consensus *Consensus) onPreparedSanityChecks(
 }
 
 func (consensus *Consensus) viewChangeSanityCheck(msg *msg_pb.Message) bool {
-	consensus.getLogger().Info().
+	consensus.getLogger().Debug().
 		Uint64("blockNum", msg.GetConsensus().BlockNum).
 		Uint64("viewID", msg.GetConsensus().ViewId).
 		Str("msgType", msg.Type.String()).

--- a/consensus/checks.go
+++ b/consensus/checks.go
@@ -174,7 +174,7 @@ func (consensus *Consensus) onPreparedSanityChecks(
 			Msg("[OnPrepared] BlockHash not match")
 		return false
 	}
-	if consensus.current.Mode() == Normal || consensus.current.Mode() == Syncing {
+	if consensus.current.Mode() == Normal {
 		err := chain.Engine.VerifyHeader(consensus.ChainReader, blockObj.Header(), true)
 		if err != nil {
 			consensus.getLogger().Error().

--- a/consensus/checks.go
+++ b/consensus/checks.go
@@ -164,7 +164,7 @@ func (consensus *Consensus) onPreparedSanityChecks(
 			Msg("[OnPrepared] BlockHash not match")
 		return false
 	}
-	if consensus.current.Mode() == Normal {
+	if consensus.current.Mode() == Normal || consensus.current.Mode() == Syncing {
 		err := chain.Engine.VerifyHeader(consensus.ChainReader, blockObj.Header(), true)
 		if err != nil {
 			consensus.getLogger().Error().

--- a/consensus/checks.go
+++ b/consensus/checks.go
@@ -11,6 +11,11 @@ import (
 const MaxBlockNumDiff = 100
 
 func (consensus *Consensus) validatorSanityChecks(msg *msg_pb.Message) bool {
+	consensus.getLogger().Info().
+		Uint64("blockNum", msg.GetConsensus().BlockNum).
+		Uint64("viewID", msg.GetConsensus().ViewId).
+		Str("msgType", msg.Type.String()).
+		Msg("[validatorSanityChecks] Checking new message")
 	senderKey, err := consensus.verifySenderKey(msg)
 	if err != nil {
 		if err == shard.ErrValidNotInCommittee {
@@ -42,6 +47,11 @@ func (consensus *Consensus) validatorSanityChecks(msg *msg_pb.Message) bool {
 }
 
 func (consensus *Consensus) leaderSanityChecks(msg *msg_pb.Message) bool {
+	consensus.getLogger().Info().
+		Uint64("blockNum", msg.GetConsensus().BlockNum).
+		Uint64("viewID", msg.GetConsensus().ViewId).
+		Str("msgType", msg.Type.String()).
+		Msg("[leaderSanityChecks] Checking new message")
 	senderKey, err := consensus.verifySenderKey(msg)
 	if err != nil {
 		if err == shard.ErrValidNotInCommittee {
@@ -186,6 +196,11 @@ func (consensus *Consensus) onPreparedSanityChecks(
 }
 
 func (consensus *Consensus) viewChangeSanityCheck(msg *msg_pb.Message) bool {
+	consensus.getLogger().Info().
+		Uint64("blockNum", msg.GetConsensus().BlockNum).
+		Uint64("viewID", msg.GetConsensus().ViewId).
+		Str("msgType", msg.Type.String()).
+		Msg("[viewChangeSanityCheck] Checking new message")
 	senderKey, err := consensus.verifyViewChangeSenderKey(msg)
 	if err != nil {
 		consensus.getLogger().Error().Err(err).Msgf(

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -112,7 +112,7 @@ type Consensus struct {
 	// verified block to state sync broadcast
 	VerifiedNewBlock chan *types.Block
 	// will trigger state syncing when blockNum is low
-	blockNumLowChan chan struct{}
+	BlockNumLowChan chan struct{}
 	// Channel for DRG protocol to send pRnd (preimage of randomness resulting from combined vrf
 	// randomnesses) to consensus. The first 32 bytes are randomness, the rest is for bitmap.
 	PRndChannel chan []byte
@@ -163,11 +163,6 @@ func (consensus *Consensus) BlocksNotSynchronized() {
 	consensus.syncNotReadyChan <- struct{}{}
 }
 
-// WaitForSyncing informs the node syncing service to start syncing
-func (consensus *Consensus) WaitForSyncing() {
-	<-consensus.blockNumLowChan
-}
-
 // VdfSeedSize returns the number of VRFs for VDF computation
 func (consensus *Consensus) VdfSeedSize() int {
 	return int(consensus.Decider.ParticipantsCount()) * 2 / 3
@@ -204,7 +199,7 @@ func New(
 	consensus.Decider = Decider
 	consensus.host = host
 	consensus.msgSender = NewMessageSender(host)
-	consensus.blockNumLowChan = make(chan struct{})
+	consensus.BlockNumLowChan = make(chan struct{})
 	// FBFT related
 	consensus.FBFTLog = NewFBFTLog()
 	consensus.phase = FBFTAnnounce

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -32,12 +32,9 @@ func (consensus *Consensus) handleMessageUpdate(payload []byte) {
 	// when node is in ViewChanging mode, it still accepts normal messages into FBFTLog
 	// in order to avoid possible trap forever but drop PREPARE and COMMIT
 	// which are message types specifically for a node acting as leader
-	switch {
-	case (consensus.current.Mode() == ViewChanging) &&
+	if (consensus.current.Mode() == ViewChanging) &&
 		(msg.Type == msg_pb.MessageType_PREPARE ||
-			msg.Type == msg_pb.MessageType_COMMIT):
-		return
-	case consensus.current.Mode() == Listening:
+			msg.Type == msg_pb.MessageType_COMMIT) {
 		return
 	}
 
@@ -62,16 +59,8 @@ func (consensus *Consensus) handleMessageUpdate(payload []byte) {
 		}
 	}
 
-	notMemberButStillCatchup := !consensus.Decider.AmIMemberOfCommitee() &&
-		msg.Type == msg_pb.MessageType_COMMITTED
-
-	if notMemberButStillCatchup {
-		consensus.onCommitted(msg)
-		return
-	}
-
 	intendedForValidator, intendedForLeader :=
-		!(consensus.IsLeader() && consensus.current.Mode() == Normal),
+		!consensus.IsLeader(),
 		consensus.IsLeader()
 
 	switch t := msg.Type; true {

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -28,6 +28,13 @@ func (consensus *Consensus) handleMessageUpdate(payload []byte) {
 		consensus.getLogger().Error().Err(err).Msg("Failed to unmarshal message payload.")
 		return
 	}
+	if msg.GetConsensus() != nil {
+		consensus.getLogger().Info().
+			Uint64("blockNum", msg.GetConsensus().BlockNum).
+			Uint64("viewID", msg.GetConsensus().ViewId).
+			Str("msgType", msg.Type.String()).
+			Msg("[handleMessageUpdate] MsgChan")
+	}
 
 	// when node is in ViewChanging mode, it still accepts normal messages into FBFTLog
 	// in order to avoid possible trap forever but drop PREPARE and COMMIT
@@ -474,7 +481,6 @@ func (consensus *Consensus) Start(
 				consensus.announce(newBlock)
 
 			case msg := <-consensus.MsgChan:
-				consensus.getLogger().Debug().Msg("[ConsensusMainLoop] MsgChan")
 				consensus.handleMessageUpdate(msg)
 
 			case viewID := <-consensus.commitFinishChan:

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -28,13 +28,6 @@ func (consensus *Consensus) handleMessageUpdate(payload []byte) {
 		consensus.getLogger().Error().Err(err).Msg("Failed to unmarshal message payload.")
 		return
 	}
-	if msg.GetConsensus() != nil {
-		consensus.getLogger().Info().
-			Uint64("blockNum", msg.GetConsensus().BlockNum).
-			Uint64("viewID", msg.GetConsensus().ViewId).
-			Str("msgType", msg.Type.String()).
-			Msg("[handleMessageUpdate] MsgChan")
-	}
 
 	// when node is in ViewChanging mode, it still accepts normal messages into FBFTLog
 	// in order to avoid possible trap forever but drop PREPARE and COMMIT

--- a/core/offchain.go
+++ b/core/offchain.go
@@ -147,7 +147,7 @@ func (bc *BlockChain) CommitOffChainData(
 	}
 
 	// Writing beacon chain cross links
-	if header.ShardID() == shard.BeaconChainShardID &&
+	if isBeaconChain &&
 		bc.chainConfig.IsCrossLink(block.Epoch()) &&
 		len(header.CrossLinks()) > 0 {
 		crossLinks := &types.CrossLinks{}
@@ -192,13 +192,16 @@ func (bc *BlockChain) CommitOffChainData(
 			Msgf(msg, len(*crossLinks), num)
 		utils.Logger().Debug().Msgf(msg, len(*crossLinks), num)
 	}
-	// Roll up latest crosslinks
-	for i, c := uint32(0), shard.Schedule.InstanceForEpoch(
-		epoch,
-	).NumShards(); i < c; i++ {
-		if err := bc.LastContinuousCrossLink(batch, i); err != nil {
-			utils.Logger().Info().
-				Err(err).Msg("could not batch process last continuous crosslink")
+
+	if isBeaconChain {
+		// Roll up latest crosslinks
+		for i, c := uint32(0), shard.Schedule.InstanceForEpoch(
+			epoch,
+		).NumShards(); i < c; i++ {
+			if err := bc.LastContinuousCrossLink(batch, i); err != nil {
+				utils.Logger().Info().
+					Err(err).Msg("could not batch process last continuous crosslink")
+			}
 		}
 	}
 

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -205,55 +205,60 @@ func (node *Node) DoBeaconSyncing() {
 func (node *Node) DoSyncing(bc *core.BlockChain, worker *worker.Worker, willJoinConsensus bool) {
 	ticker := time.NewTicker(time.Duration(node.syncFreq) * time.Second)
 	// TODO ek – infinite loop; add shutdown/cleanup logic
-SyncingLoop:
 	for {
 		select {
 		case <-ticker.C:
+			node.doSync(bc, worker, willJoinConsensus)
 		case <-node.Consensus.BlockNumLowChan:
-			if node.stateSync == nil {
-				node.stateSync = syncing.CreateStateSync(node.SelfPeer.IP, node.SelfPeer.Port, node.GetSyncID())
-				utils.Logger().Debug().Msg("[SYNC] initialized state sync")
-			}
-			if node.stateSync.GetActivePeerNumber() < MinConnectedPeers {
-				shardID := bc.ShardID()
-				peers, err := node.SyncingPeerProvider.SyncingPeers(shardID)
-				if err != nil {
-					utils.Logger().Warn().
-						Err(err).
-						Uint32("shard_id", shardID).
-						Msg("cannot retrieve syncing peers")
-					continue SyncingLoop
-				}
-				if err := node.stateSync.CreateSyncConfig(peers, false); err != nil {
-					utils.Logger().Warn().
-						Err(err).
-						Interface("peers", peers).
-						Msg("[SYNC] create peers error")
-					continue SyncingLoop
-				}
-				utils.Logger().Debug().Int("len", node.stateSync.GetActivePeerNumber()).Msg("[SYNC] Get Active Peers")
-			}
-			// TODO: treat fake maximum height
-			if node.stateSync.IsOutOfSync(bc) {
-				node.stateMutex.Lock()
-				node.State = NodeNotInSync
-				node.stateMutex.Unlock()
-				if willJoinConsensus {
-					node.Consensus.BlocksNotSynchronized()
-				}
-				node.stateSync.SyncLoop(bc, worker, false, node.Consensus)
-				if willJoinConsensus {
-					node.stateMutex.Lock()
-					node.State = NodeReadyForConsensus
-					node.stateMutex.Unlock()
-					node.Consensus.BlocksSynchronized()
-				}
-			}
+			node.doSync(bc, worker, willJoinConsensus)
+		}
+	}
+}
+
+// doSync keep the node in sync with other peers, willJoinConsensus means the node will try to join consensus after catch up
+func (node *Node) doSync(bc *core.BlockChain, worker *worker.Worker, willJoinConsensus bool) {
+	if node.stateSync == nil {
+		node.stateSync = syncing.CreateStateSync(node.SelfPeer.IP, node.SelfPeer.Port, node.GetSyncID())
+		utils.Logger().Debug().Msg("[SYNC] initialized state sync")
+	}
+	if node.stateSync.GetActivePeerNumber() < MinConnectedPeers {
+		shardID := bc.ShardID()
+		peers, err := node.SyncingPeerProvider.SyncingPeers(shardID)
+		if err != nil {
+			utils.Logger().Warn().
+				Err(err).
+				Uint32("shard_id", shardID).
+				Msg("cannot retrieve syncing peers")
+			return
+		}
+		if err := node.stateSync.CreateSyncConfig(peers, false); err != nil {
+			utils.Logger().Warn().
+				Err(err).
+				Interface("peers", peers).
+				Msg("[SYNC] create peers error")
+			return
+		}
+		utils.Logger().Debug().Int("len", node.stateSync.GetActivePeerNumber()).Msg("[SYNC] Get Active Peers")
+	}
+	// TODO: treat fake maximum height
+	if node.stateSync.IsOutOfSync(bc) {
+		node.stateMutex.Lock()
+		node.State = NodeNotInSync
+		node.stateMutex.Unlock()
+		if willJoinConsensus {
+			node.Consensus.BlocksNotSynchronized()
+		}
+		node.stateSync.SyncLoop(bc, worker, false, node.Consensus)
+		if willJoinConsensus {
 			node.stateMutex.Lock()
 			node.State = NodeReadyForConsensus
 			node.stateMutex.Unlock()
+			node.Consensus.BlocksSynchronized()
 		}
 	}
+	node.stateMutex.Lock()
+	node.State = NodeReadyForConsensus
+	node.stateMutex.Unlock()
 }
 
 // SupportBeaconSyncing sync with beacon chain for archival node in beacon chan or non-beacon node


### PR DESCRIPTION
Node in listening mode doesn't process any consensus message, which make them less likely to stay sync'ed and have to always rely on state sync to happen once per 1 min. Also there wasn't a channel for consensus to trigger state sync in time.

This PR includes the following changes:
1. Always set consensus mode after UpdateConsenusInformation()
2. Still process consensus messages even in Listening mode
3. Don't send back consensus replies in Listening mode
4. Trigger state sync immediate if receiving a committed message that have higher height.
5. Do not print BINGO if the validator is in Listening mode

Tested in OSTN for case of 1) new validator joining consensus; 2) existing validator drop out and join again immediately