### PR TITLE
Get validator info by block

### DIFF
--- a/internal/hmyapi/apiv1/backend.go
+++ b/internal/hmyapi/apiv1/backend.go
@@ -74,7 +74,7 @@ type Backend interface {
 	SendStakingTx(ctx context.Context, newStakingTx *staking.StakingTransaction) error
 	GetElectedValidatorAddresses() []common.Address
 	GetAllValidatorAddresses() []common.Address
-	GetValidatorInformation(addr common.Address) (*staking.ValidatorRPCEnchanced, error)
+	GetValidatorInformation(addr common.Address, block *types.Block) (*staking.ValidatorRPCEnchanced, error)
 	GetDelegationsByValidator(validator common.Address) []*staking.Delegation
 	GetDelegationsByDelegator(delegator common.Address) ([]common.Address, []*staking.Delegation)
 	GetValidatorSelfDelegation(addr common.Address) *big.Int

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -568,15 +568,30 @@ func (s *PublicBlockChainAPI) GetElectedValidatorAddresses() ([]string, error) {
 func (s *PublicBlockChainAPI) GetValidatorInformation(
 	ctx context.Context, address string,
 ) (*staking.ValidatorRPCEnchanced, error) {
+	block, err := s.b.BlockByNumber(ctx, rpc.BlockNumber(rpc.LatestBlockNumber))
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not retrieve the latest block information")
+	}
 	return s.b.GetValidatorInformation(
-		internal_common.ParseAddr(address),
+		internal_common.ParseAddr(address), block,
 	)
 }
 
-// GetAllValidatorInformation returns information about all validators.
-// If page is -1, return all instead of `validatorsPageSize` elements.
-func (s *PublicBlockChainAPI) GetAllValidatorInformation(
-	ctx context.Context, page int,
+// GetValidatorInformationByBlockNumber returns information about a validator.
+func (s *PublicBlockChainAPI) GetValidatorInformationByBlockNumber(
+	ctx context.Context, address string, blockNr rpc.BlockNumber,
+) (*staking.ValidatorRPCEnchanced, error) {
+	block, err := s.b.BlockByNumber(ctx, rpc.BlockNumber(blockNr))
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not retrieve the block information for block number: %d", blockNr)
+	}
+	return s.b.GetValidatorInformation(
+		internal_common.ParseAddr(address), block,
+	)
+}
+
+func (s *PublicBlockChainAPI) getAllValidatorInformation(
+	ctx context.Context, page int, blockNr rpc.BlockNumber,
 ) ([]*staking.ValidatorRPCEnchanced, error) {
 	if page < -1 {
 		return nil, errors.Errorf("page given %d cannot be less than -1", page)
@@ -595,14 +610,34 @@ func (s *PublicBlockChainAPI) GetAllValidatorInformation(
 		}
 	}
 	validators := make([]*staking.ValidatorRPCEnchanced, validatorsNum)
+	block, err := s.b.BlockByNumber(ctx, rpc.BlockNumber(blockNr))
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not retrieve the block information for block number: %d", blockNr)
+	}
 	for i := start; i < start+validatorsNum; i++ {
-		information, err := s.b.GetValidatorInformation(addresses[i])
+		information, err := s.b.GetValidatorInformation(addresses[i], block)
 		if err != nil {
 			return nil, err
 		}
 		validators[i-start] = information
 	}
 	return validators, nil
+}
+
+// GetAllValidatorInformation returns information about all validators.
+// If page is -1, return all instead of `validatorsPageSize` elements.
+func (s *PublicBlockChainAPI) GetAllValidatorInformation(
+	ctx context.Context, page int,
+) ([]*staking.ValidatorRPCEnchanced, error) {
+	return s.getAllValidatorInformation(ctx, page, rpc.LatestBlockNumber)
+}
+
+// GetAllValidatorInformationByBlockNumber returns information about all validators.
+// If page is -1, return all instead of `validatorsPageSize` elements.
+func (s *PublicBlockChainAPI) GetAllValidatorInformationByBlockNumber(
+	ctx context.Context, page int, blockNr rpc.BlockNumber,
+) ([]*staking.ValidatorRPCEnchanced, error) {
+	return s.getAllValidatorInformation(ctx, page, blockNr)
 }
 
 // GetAllDelegationInformation returns delegation information about `validatorsPageSize` validators,

--- a/internal/hmyapi/apiv2/backend.go
+++ b/internal/hmyapi/apiv2/backend.go
@@ -74,7 +74,7 @@ type Backend interface {
 	SendStakingTx(ctx context.Context, newStakingTx *staking.StakingTransaction) error
 	GetElectedValidatorAddresses() []common.Address
 	GetAllValidatorAddresses() []common.Address
-	GetValidatorInformation(addr common.Address) (*staking.ValidatorRPCEnchanced, error)
+	GetValidatorInformation(addr common.Address, block *types.Block) (*staking.ValidatorRPCEnchanced, error)
 	GetDelegationsByValidator(validator common.Address) []*staking.Delegation
 	GetDelegationsByDelegator(delegator common.Address) ([]common.Address, []*staking.Delegation)
 	GetValidatorSelfDelegation(addr common.Address) *big.Int

--- a/internal/hmyapi/backend.go
+++ b/internal/hmyapi/backend.go
@@ -76,7 +76,7 @@ type Backend interface {
 	SendStakingTx(ctx context.Context, newStakingTx *staking.StakingTransaction) error
 	GetElectedValidatorAddresses() []common.Address
 	GetAllValidatorAddresses() []common.Address
-	GetValidatorInformation(addr common.Address) (*staking.ValidatorRPCEnchanced, error)
+	GetValidatorInformation(addr common.Address, block *types.Block) (*staking.ValidatorRPCEnchanced, error)
 	GetDelegationsByValidator(validator common.Address) []*staking.Delegation
 	GetDelegationsByDelegator(delegator common.Address) ([]common.Address, []*staking.Delegation)
 	GetValidatorSelfDelegation(addr common.Address) *big.Int


### PR DESCRIPTION
Added new rpc to get the validator information by block number. The existing one works as is, the new rpc GetValidatorInformationByBlockNumber requires address and hex block number as input.