### PR TITLE
support config file and environment variable by the viper lib

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/harmony-one/harmony/internal/common"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	shardingconfig "github.com/harmony-one/harmony/internal/configs/sharding"
+	viperconfig "github.com/harmony-one/harmony/internal/configs/viper"
 	"github.com/harmony-one/harmony/internal/genesis"
 	hmykey "github.com/harmony-one/harmony/internal/keystore"
 	"github.com/harmony-one/harmony/internal/memprofiling"
@@ -543,6 +544,68 @@ func setupBlacklist() (map[ethCommon.Address]struct{}, error) {
 	return addrMap, nil
 }
 
+func setupViperConfig() {
+
+	// read from environment
+	envViper := viperconfig.CreateEnvViper()
+
+	//read from config file
+	configFileViper := viperconfig.CreateConfFileViper("./.hmy", "nodeconfig", "json")
+
+	viperconfig.ResetConfString(ip, envViper, configFileViper, "", "ip")
+	viperconfig.ResetConfString(port, envViper, configFileViper, "", "port")
+	viperconfig.ResetConfString(logFolder, envViper, configFileViper, "", "log_folder")
+	viperconfig.ResetConfInt(logMaxSize, envViper, configFileViper, "", "log_max_size")
+	viperconfig.ResetConfBool(freshDB, envViper, configFileViper, "", "fresh_db")
+	viperconfig.ResetConfBool(profile, envViper, configFileViper, "", "profile")
+	viperconfig.ResetConfString(metricsReportURL, envViper, configFileViper, "", "metrics_report_url")
+	viperconfig.ResetConfString(pprof, envViper, configFileViper, "", "pprof")
+
+	viperconfig.ResetConfBool(versionFlag, envViper, configFileViper, "", "version")
+	viperconfig.ResetConfBool(onlyLogTps, envViper, configFileViper, "", "only_log_tps")
+	viperconfig.ResetConfString(dnsZone, envViper, configFileViper, "", "dns_zone")
+	viperconfig.ResetConfBool(dnsFlag, envViper, configFileViper, "", "dns")
+	viperconfig.ResetConfInt(minPeers, envViper, configFileViper, "", "min_peers")
+	viperconfig.ResetConfString(keyFile, envViper, configFileViper, "", "key")
+	viperconfig.ResetConfBool(isGenesis, envViper, configFileViper, "", "is_genesis")
+	viperconfig.ResetConfBool(isArchival, envViper, configFileViper, "", "is_archival")
+	viperconfig.ResetConfString(delayCommit, envViper, configFileViper, "", "delay_commit")
+	viperconfig.ResetConfString(nodeType, envViper, configFileViper, "", "node_type")
+	viperconfig.ResetConfString(networkType, envViper, configFileViper, "", "network_type")
+
+	viperconfig.ResetConfInt(syncFreq, envViper, configFileViper, "", "sync_freq")
+	viperconfig.ResetConfInt(beaconSyncFreq, envViper, configFileViper, "", "beacon_sync_freq")
+	viperconfig.ResetConfInt(blockPeriod, envViper, configFileViper, "", "block_period")
+	viperconfig.ResetConfBool(leaderOverride, envViper, configFileViper, "", "leader_override")
+	viperconfig.ResetConfBool(stakingFlag, envViper, configFileViper, "", "staking")
+	viperconfig.ResetConfInt(shardID, envViper, configFileViper, "", "shard_id")
+	viperconfig.ResetConfBool(enableMemProfiling, envViper, configFileViper, "", "enableMemProfiling")
+	viperconfig.ResetConfBool(enableGC, envViper, configFileViper, "", "enableGC")
+	viperconfig.ResetConfString(blsKeyFile, envViper, configFileViper, "", "blskey_file")
+	viperconfig.ResetConfString(blsFolder, envViper, configFileViper, "", "blsfolder")
+	viperconfig.ResetConfString(blsPass, envViper, configFileViper, "", "blsPass")
+	viperconfig.ResetConfUInt(devnetNumShards, envViper, configFileViper, "", "dn_num_shards")
+	viperconfig.ResetConfInt(devnetShardSize, envViper, configFileViper, "", "dn_shard_size")
+	viperconfig.ResetConfInt(devnetHarmonySize, envViper, configFileViper, "", "dn_hmy_size")
+
+	viperconfig.ResetConfBool(logConn, envViper, configFileViper, "", "log_conn")
+	viperconfig.ResetConfString(keystoreDir, envViper, configFileViper, "", "keystore")
+	viperconfig.ResetConfBool(logP2P, envViper, configFileViper, "", "log_p2p")
+	viperconfig.ResetConfInt(verbosity, envViper, configFileViper, "", "verbosity")
+	viperconfig.ResetConfString(dbDir, envViper, configFileViper, "", "db_dir")
+	viperconfig.ResetConfBool(disableViewChange, envViper, configFileViper, "", "disable_view_change")
+	viperconfig.ResetConfBool(metricsFlag, envViper, configFileViper, "", "metrics")
+	viperconfig.ResetConfString(pushgatewayIP, envViper, configFileViper, "", "pushgateway_ip")
+	viperconfig.ResetConfString(pushgatewayPort, envViper, configFileViper, "", "pushgateway_port")
+	viperconfig.ResetConfBool(publicRPC, envViper, configFileViper, "", "public_rpc")
+	viperconfig.ResetConfInt(doRevertBefore, envViper, configFileViper, "", "do_revert_before")
+	viperconfig.ResetConfInt(revertTo, envViper, configFileViper, "", "revert_to")
+	viperconfig.ResetConfBool(revertBeacon, envViper, configFileViper, "", "revert_beacon")
+	viperconfig.ResetConfString(blacklistPath, envViper, configFileViper, "", "blacklist")
+	viperconfig.ResetConfString(webHookYamlPath, envViper, configFileViper, "", "webhook_yaml")
+
+}
+
 func main() {
 	// HACK Force usage of go implementation rather than the C based one. Do the right way, see the
 	// notes one line 66,67 of https://golang.org/src/net/net.go that say can make the decision at
@@ -596,6 +659,8 @@ func main() {
 		_, _ = fmt.Fprintf(os.Stderr, "invalid network type: %#v\n", *networkType)
 		os.Exit(2)
 	}
+
+	setupViperConfig()
 
 	initSetup()
 

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/rs/zerolog v1.18.0
 	github.com/shirou/gopsutil v2.18.12+incompatible
 	github.com/spf13/cobra v0.0.5
+	github.com/spf13/viper v1.6.1
 	github.com/stretchr/testify v1.4.0
 	github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965
 	github.com/uber/jaeger-client-go v2.20.1+incompatible // indirect

--- a/internal/configs/viper/viper_config.go
+++ b/internal/configs/viper/viper_config.go
@@ -1,0 +1,115 @@
+package viperconfig
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/spf13/viper"
+)
+
+// CreateEnvViper creates viper to read variables from system enviroment
+func CreateEnvViper() *viper.Viper {
+	envViper := viper.New()
+	envViper.SetEnvPrefix("HMY") // will be uppercased automatically
+	envViper.AutomaticEnv()
+
+	return envViper
+}
+
+// CreateConfFileViper creates viper to read from config file
+// Now the config file is JSON type, name is "config.json"
+func CreateConfFileViper(filePath, confName, confType string) *viper.Viper {
+	configFileViper := viper.New()
+	configFileViper.SetConfigName(confName) // name of config file (without extension)
+	configFileViper.SetConfigType(confType) // REQUIRED if the config file does not have the extension in the name
+	configFileViper.AddConfigPath(filePath) // look for the file in filePath
+	configFileViper.AddConfigPath(".")      // or look for config in the working directory
+
+	if err := configFileViper.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			panic(fmt.Errorf("fatal error config file: %s", err))
+		}
+	}
+	return configFileViper
+}
+
+func getEnvName(sectionName string, flagName string) string {
+	var buffer bytes.Buffer
+	if sectionName != "" {
+		buffer.WriteString("_")
+		buffer.WriteString(sectionName)
+	}
+	buffer.WriteString("_")
+	buffer.WriteString(flagName)
+	return buffer.String()
+}
+
+func getConfName(sectionName string, flagName string) string {
+	var buffer bytes.Buffer
+	if sectionName != "" {
+		buffer.WriteString(sectionName)
+		buffer.WriteString(".")
+	}
+	buffer.WriteString(flagName)
+	return buffer.String()
+}
+
+// ResetConfUInt resets UInt value to value from config files and system environment variable
+func ResetConfUInt(value *uint, envViper *viper.Viper, configFileViper *viper.Viper, sectionName string, flagName string) {
+	var confRet = configFileViper.GetInt(getConfName(sectionName, flagName))
+	if confRet != 0 {
+		*value = uint(confRet)
+		return
+	}
+
+	var envRet = envViper.GetInt(getEnvName(sectionName, flagName))
+	if envRet != 0 {
+		*value = uint(envRet)
+		return
+	}
+}
+
+// ResetConfInt resets INT value to value from config files and system environment variable
+func ResetConfInt(value *int, envViper *viper.Viper, configFileViper *viper.Viper, sectionName string, flagName string) {
+	var confRet = configFileViper.GetInt(getConfName(sectionName, flagName))
+	if confRet != 0 {
+		*value = confRet
+		return
+	}
+
+	var envRet = envViper.GetInt(getEnvName(sectionName, flagName))
+	if envRet != 0 {
+		*value = envRet
+		return
+	}
+}
+
+// ResetConfBool resets Bool value to value from config files and system environment variable
+func ResetConfBool(value *bool, envViper *viper.Viper, configFileViper *viper.Viper, sectionName string, flagName string) {
+	var confRet = configFileViper.GetBool(getConfName(sectionName, flagName))
+	if confRet != false {
+		*value = confRet
+		return
+	}
+
+	var envRet = envViper.GetBool(getEnvName(sectionName, flagName))
+	if envRet != false {
+		*value = envRet
+		return
+	}
+}
+
+// ResetConfString resets String value to value from config files and system environment variable
+func ResetConfString(value *string, envViper *viper.Viper, configFileViper *viper.Viper, sectionName string, flagName string) {
+	var confRet = configFileViper.GetString(getConfName(sectionName, flagName))
+	if confRet != "" {
+		*value = confRet
+		return
+	}
+
+	var envRet = envViper.GetString(getEnvName(sectionName, flagName))
+	if envRet != "" {
+		*value = envRet
+		return
+	}
+}


### PR DESCRIPTION
## Issue
#2494  : harmony node program use basic flag to define command line option support. We need to revamp it using latest library https://github.com/spf13/viper to support both command line option, plus configuration, and all kinds of configuration options.

Currently, it supports 1) config file like "config.json" to read and overwrite the command line options, also support config sections. 2) environment variables(ENV) to overwrite the command line options, the format is like "HMY_SECTION_FLAG".

Please notice the order of precedence: ENV > config_file value >  command line option > default value. The config value will be _0/ false/ ""_ if the config file or ENV is missing.


### TODO
add more test cases
