### PR TITLE
adding log to print out the current view id

### DIFF
--- a/consensus/checks.go
+++ b/consensus/checks.go
@@ -242,8 +242,8 @@ func (consensus *Consensus) onViewChangeSanityCheck(recvMsg *FBFTMessage) bool {
 	if recvMsg.ViewID-consensus.current.ViewID() > MaxViewIDDiff {
 		consensus.getLogger().Debug().
 			Uint64("MsgViewID", recvMsg.ViewID).
-			Uint64("MaxViewIDDiff", MaxViewIDDiff).
-			Msg("Received viewID that is MaxViewIDDiff further from the current viewID!")
+			Uint64("CurrentViewID", consensus.current.ViewID()).
+			Msg("Received viewID that is MaxViewIDDiff (100) further from the current viewID!")
 		return false
 	}
 	return true

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -278,6 +278,7 @@ func (consensus *Consensus) verifyViewChangeSenderKey(msg *msg_pb.Message) (*bls
 // SetViewID set the viewID to the height of the blockchain
 func (consensus *Consensus) SetViewID(height uint64) {
 	consensus.viewID = height
+	consensus.current.viewID = height
 }
 
 // SetMode sets the mode of consensus


### PR DESCRIPTION
* Enhanced log to print out the consensus current view id
* Also make sure to check only if the current view id is not zero. Looks like when the consensus restarts the current view id is set to zero. 