### PR TITLE
[slashing][audit] Refactor slashing code and fix audit todos

### DIFF
--- a/consensus/checks.go
+++ b/consensus/checks.go
@@ -92,22 +92,6 @@ func (consensus *Consensus) isRightBlockNumAndViewID(recvMsg *FBFTMessage,
 	return true
 }
 
-func (consensus *Consensus) couldThisBeADoubleSigner(
-	recvMsg *FBFTMessage,
-) bool {
-	num, hash, now := consensus.blockNum, recvMsg.BlockHash, consensus.blockNum
-	suspicious := !consensus.FBFTLog.HasMatchingAnnounce(num, hash) ||
-		!consensus.FBFTLog.HasMatchingPrepared(num, hash)
-	if suspicious {
-		consensus.getLogger().Debug().
-			Str("message", recvMsg.String()).
-			Uint64("block-on-consensus", now).
-			Msg("possible double signer")
-		return true
-	}
-	return false
-}
-
 func (consensus *Consensus) onAnnounceSanityChecks(recvMsg *FBFTMessage) bool {
 	logMsgs := consensus.FBFTLog.GetMessagesByTypeSeqView(
 		msg_pb.MessageType_ANNOUNCE, recvMsg.BlockNum, recvMsg.ViewID,

--- a/consensus/double_sign.go
+++ b/consensus/double_sign.go
@@ -105,13 +105,13 @@ func (consensus *Consensus) checkDoubleSign(recvMsg *FBFTMessage) {
 func (consensus *Consensus) couldThisBeADoubleSigner(
 	recvMsg *FBFTMessage,
 ) bool {
-	num, hash, now := consensus.blockNum, recvMsg.BlockHash, consensus.blockNum
+	num, hash := consensus.blockNum, recvMsg.BlockHash
 	suspicious := !consensus.FBFTLog.HasMatchingAnnounce(num, hash) ||
 		!consensus.FBFTLog.HasMatchingPrepared(num, hash)
 	if suspicious {
 		consensus.getLogger().Debug().
 			Str("message", recvMsg.String()).
-			Uint64("block-on-consensus", now).
+			Uint64("block-on-consensus", num).
 			Msg("possible double signer")
 		return true
 	}

--- a/consensus/double_sign.go
+++ b/consensus/double_sign.go
@@ -1,0 +1,119 @@
+package consensus
+
+import (
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/harmony-one/bls/ffi/go/bls"
+	"github.com/harmony-one/harmony/consensus/quorum"
+	"github.com/harmony-one/harmony/consensus/votepower"
+	"github.com/harmony-one/harmony/shard"
+	"github.com/harmony-one/harmony/staking/slash"
+)
+
+// Check for double sign and if any, send it out to beacon chain for slashing.
+func (consensus *Consensus) checkDoubleSign(recvMsg *FBFTMessage) {
+	if consensus.couldThisBeADoubleSigner(recvMsg) {
+		if alreadyCastBallot := consensus.Decider.ReadBallot(
+			quorum.Commit, recvMsg.SenderPubkey,
+		); alreadyCastBallot != nil {
+			firstPubKey := bls.PublicKey{}
+			alreadyCastBallot.SignerPubKey.ToLibBLSPublicKey(&firstPubKey)
+			if recvMsg.SenderPubkey.IsEqual(&firstPubKey) {
+				for _, blk := range consensus.FBFTLog.GetBlocksByNumber(recvMsg.BlockNum) {
+					firstSignedBlock := blk.Header()
+					areHeightsEqual := firstSignedBlock.Number().Uint64() == recvMsg.BlockNum
+					areViewIDsEqual := firstSignedBlock.ViewID().Uint64() == recvMsg.ViewID
+					areHeadersEqual := firstSignedBlock.Hash() == recvMsg.BlockHash
+
+					// If signer already firstSignedBlock, and the block height is the same
+					// and the viewID is the same, then we need to verify the block
+					// hash, and if block hash is different, then that is a clear
+					// case of double signing
+					if areHeightsEqual && areViewIDsEqual && !areHeadersEqual {
+						var doubleSign bls.Sign
+						if err := doubleSign.Deserialize(recvMsg.Payload); err != nil {
+							consensus.getLogger().Err(err).Str("msg", recvMsg.String()).
+								Msg("could not deserialize potential double signer")
+							return
+						}
+
+						curHeader := consensus.ChainReader.CurrentHeader()
+						committee, err := consensus.ChainReader.ReadShardState(curHeader.Epoch())
+						if err != nil {
+							consensus.getLogger().Err(err).
+								Uint32("shard", consensus.ShardID).
+								Uint64("epoch", curHeader.Epoch().Uint64()).
+								Msg("could not read shard state")
+							return
+						}
+						offender := *shard.FromLibBLSPublicKeyUnsafe(recvMsg.SenderPubkey)
+						subComm, err := committee.FindCommitteeByID(
+							consensus.ShardID,
+						)
+						if err != nil {
+							consensus.getLogger().Err(err).
+								Str("msg", recvMsg.String()).
+								Msg("could not find subcommittee for bls key")
+							return
+						}
+
+						addr, err := subComm.AddressForBLSKey(offender)
+
+						if err != nil {
+							consensus.getLogger().Err(err).Str("msg", recvMsg.String()).
+								Msg("could not find address for bls key")
+							return
+						}
+
+						now := big.NewInt(time.Now().UnixNano())
+
+						go func(reporter common.Address) {
+							evid := slash.Evidence{
+								ConflictingBallots: slash.ConflictingBallots{
+									AlreadyCastBallot: *alreadyCastBallot,
+									DoubleSignedBallot: votepower.Ballot{
+										SignerPubKey:    offender,
+										BlockHeaderHash: recvMsg.BlockHash,
+										Signature:       common.Hex2Bytes(doubleSign.SerializeToHexStr()),
+										Height:          recvMsg.BlockNum,
+										ViewID:          recvMsg.ViewID,
+									}},
+								Moment: slash.Moment{
+									Epoch:        curHeader.Epoch(),
+									ShardID:      consensus.ShardID,
+									TimeUnixNano: now,
+								},
+							}
+							proof := slash.Record{
+								Evidence: evid,
+								Reporter: reporter,
+								Offender: *addr,
+							}
+							consensus.SlashChan <- proof
+						}(consensus.SelfAddresses[consensus.LeaderPubKey.SerializeToHexStr()])
+						return
+					}
+				}
+			}
+		}
+		return
+	}
+}
+
+func (consensus *Consensus) couldThisBeADoubleSigner(
+	recvMsg *FBFTMessage,
+) bool {
+	num, hash, now := consensus.blockNum, recvMsg.BlockHash, consensus.blockNum
+	suspicious := !consensus.FBFTLog.HasMatchingAnnounce(num, hash) ||
+		!consensus.FBFTLog.HasMatchingPrepared(num, hash)
+	if suspicious {
+		consensus.getLogger().Debug().
+			Str("message", recvMsg.String()).
+			Uint64("block-on-consensus", now).
+			Msg("possible double signer")
+		return true
+	}
+	return false
+}

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -1,9 +1,7 @@
 package consensus
 
 import (
-	"bytes"
 	"encoding/binary"
-	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -11,12 +9,9 @@ import (
 	"github.com/harmony-one/bls/ffi/go/bls"
 	msg_pb "github.com/harmony-one/harmony/api/proto/message"
 	"github.com/harmony-one/harmony/consensus/quorum"
-	"github.com/harmony-one/harmony/consensus/votepower"
 	"github.com/harmony-one/harmony/core/types"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/p2p/host"
-	"github.com/harmony-one/harmony/shard"
-	"github.com/harmony-one/harmony/staking/slash"
 )
 
 func (consensus *Consensus) announce(block *types.Block) {
@@ -195,7 +190,6 @@ func (consensus *Consensus) onPrepare(msg *msg_pb.Message) {
 
 func (consensus *Consensus) onCommit(msg *msg_pb.Message) {
 	recvMsg, err := ParseFBFTMessage(msg)
-	log := consensus.getLogger()
 	if err != nil {
 		consensus.getLogger().Debug().Err(err).Msg("[OnCommit] Parse pbft message failed")
 		return
@@ -208,95 +202,6 @@ func (consensus *Consensus) onCommit(msg *msg_pb.Message) {
 
 	consensus.mutex.Lock()
 	defer consensus.mutex.Unlock()
-
-	// TODO(audit): refactor into a new func
-	if key := (bls.PublicKey{}); consensus.couldThisBeADoubleSigner(recvMsg) {
-		if alreadyCastBallot := consensus.Decider.ReadBallot(
-			quorum.Commit, recvMsg.SenderPubkey,
-		); alreadyCastBallot != nil {
-			for _, blk := range consensus.FBFTLog.GetBlocksByNumber(recvMsg.BlockNum) {
-				alreadyCastBallot.SignerPubKey.ToLibBLSPublicKey(&key)
-				if recvMsg.SenderPubkey.IsEqual(&key) {
-					signed := blk.Header()
-					areHeightsEqual := signed.Number().Uint64() == recvMsg.BlockNum
-					areViewIDsEqual := signed.ViewID().Uint64() == recvMsg.ViewID
-					areHeadersEqual := bytes.Compare(
-						signed.Hash().Bytes(), recvMsg.BlockHash.Bytes(),
-					) == 0
-					// If signer already signed, and the block height is the same
-					// and the viewID is the same, then we need to verify the block
-					// hash, and if block hash is different, then that is a clear
-					// case of double signing
-					if areHeightsEqual && areViewIDsEqual && !areHeadersEqual {
-						var doubleSign bls.Sign
-						if err := doubleSign.Deserialize(recvMsg.Payload); err != nil {
-							log.Err(err).Str("msg", recvMsg.String()).
-								Msg("could not deserialize potential double signer")
-							return
-						}
-
-						curHeader := consensus.ChainReader.CurrentHeader()
-						committee, err := consensus.ChainReader.ReadShardState(curHeader.Epoch())
-						if err != nil {
-							log.Err(err).
-								Uint32("shard", consensus.ShardID).
-								Uint64("epoch", curHeader.Epoch().Uint64()).
-								Msg("could not read shard state")
-							return
-						}
-						offender := *shard.FromLibBLSPublicKeyUnsafe(recvMsg.SenderPubkey)
-						subComm, err := committee.FindCommitteeByID(
-							consensus.ShardID,
-						)
-						if err != nil {
-							log.Err(err).
-								Str("msg", recvMsg.String()).
-								Msg("could not find subcommittee for bls key")
-							return
-						}
-
-						addr, err := subComm.AddressForBLSKey(offender)
-
-						if err != nil {
-							log.Err(err).Str("msg", recvMsg.String()).
-								Msg("could not find address for bls key")
-							return
-						}
-
-						now := big.NewInt(time.Now().UnixNano())
-
-						go func(reporter common.Address) {
-							evid := slash.Evidence{
-								ConflictingBallots: slash.ConflictingBallots{
-									*alreadyCastBallot,
-									votepower.Ballot{
-										SignerPubKey:    offender,
-										BlockHeaderHash: recvMsg.BlockHash,
-										Signature:       common.Hex2Bytes(doubleSign.SerializeToHexStr()),
-										Height:          recvMsg.BlockNum,
-										ViewID:          recvMsg.ViewID,
-									}},
-								Moment: slash.Moment{
-									Epoch:        curHeader.Epoch(),
-									ShardID:      consensus.ShardID,
-									TimeUnixNano: now,
-								},
-								ProposalHeader: signed,
-							}
-							proof := slash.Record{
-								Evidence: evid,
-								Reporter: reporter,
-								Offender: *addr,
-							}
-							consensus.SlashChan <- proof
-						}(consensus.SelfAddresses[consensus.LeaderPubKey.SerializeToHexStr()])
-						return
-					}
-				}
-			}
-		}
-		return
-	}
 
 	validatorPubKey, commitSig, commitBitmap :=
 		recvMsg.SenderPubkey, recvMsg.Payload, consensus.commitBitmap
@@ -325,6 +230,9 @@ func (consensus *Consensus) onCommit(msg *msg_pb.Message) {
 		logger.Error().Msg("[OnCommit] Cannot verify commit message")
 		return
 	}
+
+	// Check for potential double signing
+	consensus.checkDoubleSign(recvMsg)
 
 	logger = logger.With().
 		Int64("numReceivedSoFar", consensus.Decider.SignersCount(quorum.Commit)).

--- a/consensus/votepower/roster.go
+++ b/consensus/votepower/roster.go
@@ -3,9 +3,10 @@ package votepower
 import (
 	"encoding/hex"
 	"encoding/json"
-	"github.com/harmony-one/harmony/internal/utils"
 	"math/big"
 	"sort"
+
+	"github.com/harmony-one/harmony/internal/utils"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/bls/ffi/go/bls"

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2056,7 +2056,7 @@ func (bc *BlockChain) AddPendingSlashingCandidates(
 			errExceedMaxPendingSlashes, "current %d with-additional %d", c, l,
 		)
 	}
-	bc.pendingSlashes = pendingSlashes
+	bc.pendingSlashes = valid
 	return bc.writeSlashes(bc.pendingSlashes)
 }
 

--- a/shard/committee/assignment.go
+++ b/shard/committee/assignment.go
@@ -292,7 +292,7 @@ func eposStakedCommittee(
 		}
 	}
 
-	// TODO: make sure external validator BLS key are also not duplicate to Harmony's keys
+	// TODO(audit): make sure external validator BLS key are also not duplicate to Harmony's keys
 	completedEPoSRound, err := NewEPoSRound(stakerReader)
 
 	if err != nil {

--- a/staking/apr/compute.go
+++ b/staking/apr/compute.go
@@ -1,9 +1,10 @@
 package apr
 
 import (
+	"math/big"
+
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/shard"
-	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/block"

--- a/staking/slash/double-sign.go
+++ b/staking/slash/double-sign.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/harmony-one/bls/ffi/go/bls"
-	"github.com/harmony-one/harmony/block"
 	"github.com/harmony-one/harmony/consensus/votepower"
 	"github.com/harmony-one/harmony/core/state"
 	"github.com/harmony-one/harmony/core/types"
@@ -68,7 +67,6 @@ type Moment struct {
 type Evidence struct {
 	Moment
 	ConflictingBallots
-	ProposalHeader *block.Header `json:"header"`
 }
 
 // ConflictingBallots ..
@@ -101,8 +99,7 @@ func (e Evidence) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Moment
 		ConflictingBallots
-		ProposalHeader *block.Header `json:"header"`
-	}{e.Moment, e.ConflictingBallots, e.ProposalHeader})
+	}{e.Moment, e.ConflictingBallots})
 }
 
 // Records ..

--- a/staking/slash/double-sign_test.go
+++ b/staking/slash/double-sign_test.go
@@ -397,7 +397,6 @@ func defaultSlashRecord() Record {
 				TimeUnixNano: big.NewInt(doubleSignUnixNano),
 				ShardID:      doubleSignShardID,
 			},
-			ProposalHeader: &header,
 		},
 		Reporter: reporterAddr,
 		Offender: offenderAddr,


### PR DESCRIPTION
Refactor slash detection code.

Fix previous audit todos:
 1. Group slash records by blocks and apply separately.
 2. Use the epoch at double sign rather than at current epoch.