### PR TITLE
[rpc] Return public BLSKeys as a list from getNodeMetadata

### DIFF
--- a/internal/hmyapi/apiv1/harmony.go
+++ b/internal/hmyapi/apiv1/harmony.go
@@ -47,7 +47,7 @@ func (s *PublicHarmonyAPI) GasPrice(ctx context.Context) (*hexutil.Big, error) {
 
 // NodeMetadata captures select metadata of the RPC answering node
 type NodeMetadata struct {
-	BLSPublicKey   string             `json:"blskey"`
+	BLSPublicKey   []string           `json:"blskey"`
 	Version        string             `json:"version"`
 	NetworkType    string             `json:"network"`
 	ChainConfig    params.ChainConfig `json:"chain-config"`
@@ -72,8 +72,13 @@ func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
 		blockEpoch = &b
 	}
 
+	var blsKeys []string
+	for _, key := range cfg.ConsensusPubKey.PublicKey {
+		blsKeys = append(blsKeys, key.SerializeToHexStr())
+	}
+
 	return NodeMetadata{
-		cfg.ConsensusPubKey.SerializeToHexStr(),
+		blsKeys,
 		nodeconfig.GetVersion(),
 		string(cfg.GetNetworkType()),
 		*s.b.ChainConfig(),

--- a/internal/hmyapi/apiv2/harmony.go
+++ b/internal/hmyapi/apiv2/harmony.go
@@ -46,7 +46,7 @@ func (s *PublicHarmonyAPI) GasPrice(ctx context.Context) (*big.Int, error) {
 
 // NodeMetadata captures select metadata of the RPC answering node
 type NodeMetadata struct {
-	BLSPublicKey   string             `json:"blskey"`
+	BLSPublicKey   []string           `json:"blskey"`
 	Version        string             `json:"version"`
 	NetworkType    string             `json:"network"`
 	ChainConfig    params.ChainConfig `json:"chain-config"`
@@ -71,8 +71,13 @@ func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
 		blockEpoch = &b
 	}
 
+	var blsKeys []string
+	for _, key := range cfg.ConsensusPubKey.PublicKey {
+		blsKeys = append(blsKeys, key.SerializeToHexStr())
+	}
+
 	return NodeMetadata{
-		cfg.ConsensusPubKey.SerializeToHexStr(),
+		blsKeys,
 		nodeconfig.GetVersion(),
 		string(cfg.GetNetworkType()),
 		*s.b.ChainConfig(),


### PR DESCRIPTION
<img width="962" alt="Screen Shot 2020-03-24 at 6 59 01 PM" src="https://user-images.githubusercontent.com/56005637/77493901-94482480-6e01-11ea-8676-99030152e29e.png">

Need downstream for TUI & Watchdog.