### PR TITLE
[rpc] Return public BLSKeys as a list from getNodeMetadata

### DIFF
--- a/internal/hmyapi/apiv1/harmony.go
+++ b/internal/hmyapi/apiv1/harmony.go
@@ -45,21 +45,27 @@ func (s *PublicHarmonyAPI) GasPrice(ctx context.Context) (*hexutil.Big, error) {
 
 // NodeMetadata captures select metadata of the RPC answering node
 type NodeMetadata struct {
-	BLSPublicKey string `json:"blskey"`
-	Version      string `json:"version"`
-	NetworkType  string `json:"network"`
-	ChainID      string `json:"chainid"`
-	IsLeader     bool   `json:"is-leader"`
-	ShardID      uint32 `json:"shard-id"`
-	Role         string `json:"role"`
-	Archival     bool   `json:"is-archival"`
+	BLSPublicKey []string `json:"blskey"`
+	Version      string   `json:"version"`
+	NetworkType  string   `json:"network"`
+	ChainID      string   `json:"chainid"`
+	IsLeader     bool     `json:"is-leader"`
+	ShardID      uint32   `json:"shard-id"`
+	Role         string   `json:"role"`
+	Archival     bool     `json:"is-archival"`
 }
 
 // GetNodeMetadata produces a NodeMetadata record, data is from the answering RPC node
 func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
 	cfg := nodeconfig.GetDefaultConfig()
+
+	var blsKeys []string
+	for _, key := range cfg.ConsensusPubKey.PublicKey {
+		blsKeys = append(blsKeys, key.SerializeToHexStr())
+	}
+
 	return NodeMetadata{
-		cfg.ConsensusPubKey.SerializeToHexStr(),
+		blsKeys,
 		nodeconfig.GetVersion(),
 		string(cfg.GetNetworkType()),
 		s.b.ChainConfig().ChainID.String(),

--- a/internal/hmyapi/apiv2/harmony.go
+++ b/internal/hmyapi/apiv2/harmony.go
@@ -44,21 +44,27 @@ func (s *PublicHarmonyAPI) GasPrice(ctx context.Context) (*big.Int, error) {
 
 // NodeMetadata captures select metadata of the RPC answering node
 type NodeMetadata struct {
-	BLSPublicKey string `json:"blskey"`
-	Version      string `json:"version"`
-	NetworkType  string `json:"network"`
-	ChainID      string `json:"chainid"`
-	IsLeader     bool   `json:"is-leader"`
-	ShardID      uint32 `json:"shard-id"`
-	Role         string `json:"role"`
-	Archival     bool   `json:"is-archival"`
+	BLSPublicKey []string `json:"blskey"`
+	Version      string   `json:"version"`
+	NetworkType  string   `json:"network"`
+	ChainID      string   `json:"chainid"`
+	IsLeader     bool     `json:"is-leader"`
+	ShardID      uint32   `json:"shard-id"`
+	Role         string   `json:"role"`
+	Archival     bool     `json:"is-archival"`
 }
 
 // GetNodeMetadata produces a NodeMetadata record, data is from the answering RPC node
 func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
 	cfg := nodeconfig.GetDefaultConfig()
+
+	var blsKeys []string
+	for _, key := range cfg.ConsensusPubKey.PublicKey {
+		blsKeys = append(blsKeys, key.SerializeToHexStr())
+	}
+
 	return NodeMetadata{
-		cfg.ConsensusPubKey.SerializeToHexStr(),
+		blsKeys,
 		nodeconfig.GetVersion(),
 		string(cfg.GetNetworkType()),
 		s.b.ChainConfig().ChainID.String(),


### PR DESCRIPTION
Cherry-pick to S3. Tested locally.