### PR TITLE
[rpc] Account for ExplorerNode with BLS keys changes for NodeMetadata

### DIFF
--- a/internal/hmyapi/apiv1/harmony.go
+++ b/internal/hmyapi/apiv1/harmony.go
@@ -72,9 +72,11 @@ func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
 		blockEpoch = &b
 	}
 
-	var blsKeys []string
-	for _, key := range cfg.ConsensusPubKey.PublicKey {
-		blsKeys = append(blsKeys, key.SerializeToHexStr())
+	blsKeys := []string{}
+	if cfg.ConsensusPubKey != nil {
+		for _, key := range cfg.ConsensusPubKey.PublicKey {
+			blsKeys = append(blsKeys, key.SerializeToHexStr())
+		}
 	}
 
 	return NodeMetadata{

--- a/internal/hmyapi/apiv2/harmony.go
+++ b/internal/hmyapi/apiv2/harmony.go
@@ -71,9 +71,11 @@ func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
 		blockEpoch = &b
 	}
 
-	var blsKeys []string
-	for _, key := range cfg.ConsensusPubKey.PublicKey {
-		blsKeys = append(blsKeys, key.SerializeToHexStr())
+	blsKeys := []string{}
+	if cfg.ConsensusPubKey != nil {
+		for _, key := range cfg.ConsensusPubKey.PublicKey {
+			blsKeys = append(blsKeys, key.SerializeToHexStr())
+		}
 	}
 
 	return NodeMetadata{


### PR DESCRIPTION
Fix nil pointer when explorer node is queried for nodeMetadata (no bls keys). Tested locally.
<img width="1088" alt="Screen Shot 2020-03-25 at 1 43 53 AM" src="https://user-
images.githubusercontent.com/56005637/77517910-25d38880-6e3a-11ea-9328-241ab4d6701e.png">

