### PR TITLE
[rpc] Account for ExplorerNode with BLS keys changes for NodeMetadata on t3

### DIFF
--- a/internal/hmyapi/apiv1/harmony.go
+++ b/internal/hmyapi/apiv1/harmony.go
@@ -72,9 +72,11 @@ func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
 		blockEpoch = &b
 	}
 
-	var blsKeys []string
-	for _, key := range cfg.ConsensusPubKey.PublicKey {
-		blsKeys = append(blsKeys, key.SerializeToHexStr())
+	blsKeys := []string{}
+	if cfg.ConsensusPubKey != nil {
+		for _, key := range cfg.ConsensusPubKey.PublicKey {
+			blsKeys = append(blsKeys, key.SerializeToHexStr())
+		}
 	}
 
 	return NodeMetadata{

--- a/internal/hmyapi/apiv2/harmony.go
+++ b/internal/hmyapi/apiv2/harmony.go
@@ -71,9 +71,11 @@ func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
 		blockEpoch = &b
 	}
 
-	var blsKeys []string
-	for _, key := range cfg.ConsensusPubKey.PublicKey {
-		blsKeys = append(blsKeys, key.SerializeToHexStr())
+	blsKeys := []string{}
+	if cfg.ConsensusPubKey != nil {
+		for _, key := range cfg.ConsensusPubKey.PublicKey {
+			blsKeys = append(blsKeys, key.SerializeToHexStr())
+		}
 	}
 
 	return NodeMetadata{


### PR DESCRIPTION
Cherry-pick to t3. Tested locally again.