### PR TITLE
[rpc] Account for ExplorerNode with BLS keys changes for NodeMetadata for s3

### DIFF
--- a/internal/hmyapi/apiv1/harmony.go
+++ b/internal/hmyapi/apiv1/harmony.go
@@ -59,9 +59,11 @@ type NodeMetadata struct {
 func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
 	cfg := nodeconfig.GetDefaultConfig()
 
-	var blsKeys []string
-	for _, key := range cfg.ConsensusPubKey.PublicKey {
-		blsKeys = append(blsKeys, key.SerializeToHexStr())
+	blsKeys := []string{}
+	if cfg.ConsensusPubKey != nil {
+		for _, key := range cfg.ConsensusPubKey.PublicKey {
+			blsKeys = append(blsKeys, key.SerializeToHexStr())
+		}
 	}
 
 	return NodeMetadata{

--- a/internal/hmyapi/apiv2/harmony.go
+++ b/internal/hmyapi/apiv2/harmony.go
@@ -58,9 +58,11 @@ type NodeMetadata struct {
 func (s *PublicHarmonyAPI) GetNodeMetadata() NodeMetadata {
 	cfg := nodeconfig.GetDefaultConfig()
 
-	var blsKeys []string
-	for _, key := range cfg.ConsensusPubKey.PublicKey {
-		blsKeys = append(blsKeys, key.SerializeToHexStr())
+	blsKeys := []string{}
+	if cfg.ConsensusPubKey != nil {
+		for _, key := range cfg.ConsensusPubKey.PublicKey {
+			blsKeys = append(blsKeys, key.SerializeToHexStr())
+		}
 	}
 
 	return NodeMetadata{


### PR DESCRIPTION
Cherry-pick to S3. Tested locally again.