### PR TITLE
Fix view change message level and early return for non-leader

### DIFF
--- a/consensus/checks.go
+++ b/consensus/checks.go
@@ -184,10 +184,17 @@ func (consensus *Consensus) viewChangeSanityCheck(msg *msg_pb.Message) bool {
 		Msg("[viewChangeSanityCheck] Checking new message")
 	senderKey, err := consensus.verifyViewChangeSenderKey(msg)
 	if err != nil {
-		consensus.getLogger().Error().Err(err).Msgf(
-			"[%s] VerifySenderKey Failed",
-			msg.GetType().String(),
-		)
+		if err == shard.ErrValidNotInCommittee {
+			consensus.getLogger().Info().Msgf(
+				"[%s] sender key not in this slot's subcommittee",
+				msg.GetType().String(),
+			)
+		} else {
+			consensus.getLogger().Error().Err(err).Msgf(
+				"[%s] VerifySenderKey Failed",
+				msg.GetType().String(),
+			)
+		}
 		return false
 	}
 	if err := verifyMessageSig(senderKey, msg); err != nil {

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -152,6 +152,12 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 		consensus.getLogger().Warn().Msg("[onViewChange] Unable To Parse Viewchange Message")
 		return
 	}
+	// if not leader, noop
+	newLeaderKey := recvMsg.LeaderPubkey
+	newLeaderPriKey, err := consensus.GetLeaderPrivateKey(newLeaderKey)
+	if err != nil {
+		return
+	}
 
 	if consensus.Decider.IsQuorumAchieved(quorum.ViewChange) {
 		consensus.getLogger().Debug().
@@ -167,11 +173,6 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 	}
 
 	senderKey := recvMsg.SenderPubkey
-	newLeaderKey := recvMsg.LeaderPubkey
-	newLeaderPriKey, err := consensus.GetLeaderPrivateKey(newLeaderKey)
-	if err != nil {
-		return
-	}
 
 	consensus.vcLock.Lock()
 	defer consensus.vcLock.Unlock()


### PR DESCRIPTION
Fixes:
* Follows other validation checks to only info level message if the sender is not part of the slot committee (earlier this was error)
* Move leader check to much earlier before even new view sanity check