### PR TITLE
moving delay out of loop

### DIFF
--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -184,6 +184,12 @@ func (consensus *Consensus) onPrepared(msg *msg_pb.Message) {
 		return
 	}
 
+	// TODO: genesis account node delay for 1 second,
+	// this is a temp fix for allows FN nodes to earning reward
+	if consensus.delayCommit > 0 {
+		time.Sleep(consensus.delayCommit)
+	}
+
 	// add preparedSig field
 	consensus.aggregatedPrepareSig = aggSig
 	consensus.prepareBitmap = mask
@@ -203,11 +209,6 @@ func (consensus *Consensus) onPrepared(msg *msg_pb.Message) {
 			append(blockNumBytes, consensus.blockHash[:]...),
 			key, consensus.priKey.PrivateKey[i],
 		)
-		// TODO: genesis account node delay for 1 second,
-		// this is a temp fix for allows FN nodes to earning reward
-		if consensus.delayCommit > 0 {
-			time.Sleep(consensus.delayCommit)
-		}
 
 		if consensus.current.Mode() != Listening {
 			if err := consensus.msgSender.SendWithoutRetry(


### PR DESCRIPTION
commit delay of `delayCommit` was applied inside the loop that iterates through nodes multi-bls keys before sending commit message. taking it outside of the loop with this fix.