### PR TITLE
Fix the validator auction eligibility condition

### DIFF
--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -414,7 +414,7 @@ func (b *APIBackend) GetTotalStakingSnapshot() *big.Int {
 	for i := range candidates {
 		snapshot, _ := b.hmy.BlockChain().ReadValidatorSnapshot(candidates[i])
 		validator, _ := b.hmy.BlockChain().ReadValidatorInformation(candidates[i])
-		if !committee.IsEligibleForEPoSAuction(snapshot, validator) {
+		if !committee.IsEligibleForEPoSAuction(snapshot, validator, b.hmy.BlockChain().CurrentBlock().Epoch()) {
 			continue
 		}
 		for i := range validator.Delegations {


### PR DESCRIPTION
This original condition to check whether a validator is in last committee depends on whether the counter of NumBlocksToSign increased in last epoch. This condition is not stable because cross-links may arrive after the epoch ends and it still gets counted into the NumBlocksToSign, making this condition to be true after the new epoch even when the validator is actually not in committee.