### PR TITLE
Added aws encrypted bls key support

### DIFF
--- a/internal/blsgen/lib.go
+++ b/internal/blsgen/lib.go
@@ -1,21 +1,34 @@
 package blsgen
 
 import (
+	"bufio"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/md5"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"time"
+	"errors"
 
 	ffi_bls "github.com/harmony-one/bls/ffi/go/bls"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/harmony-one/harmony/crypto/bls"
 )
+
+type AwsConfiguration struct {
+	AccessKey string `json:"aws_access_key_id"`
+	SecretKey string `json:"aws_secret_access_key"`
+	Region    string `json:"aws_region"`
+}
 
 func toISO8601(t time.Time) string {
 	var tz string
@@ -91,6 +104,84 @@ func LoadBlsKeyWithPassPhrase(fileName, passphrase string) (*ffi_bls.SecretKey, 
 
 	priKey := &ffi_bls.SecretKey{}
 	priKey.DeserializeHexStr(string(decryptedBytes))
+	return priKey, nil
+}
+
+// Readln reads aws configuratoin from prompt with a timeout
+func Readln(timeout time.Duration) (string, error) {
+	s := make(chan string)
+	e := make(chan error)
+
+	go func() {
+		reader := bufio.NewReader(os.Stdin)
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			e <- err
+		} else {
+			s <- line
+		}
+		close(s)
+		close(e)
+	}()
+
+	select {
+	case line := <-s:
+		return line, nil
+	case err := <-e:
+		return "", err
+	case <-time.After(timeout):
+		return "", errors.New("Timeout")
+	}
+}
+
+// LoadBlsKeyWithPassPhrase loads bls key with passphrase.
+func LoadAwsCMKEncryptedBlsKey(fileName, awsSettingString string) (*ffi_bls.SecretKey, error) {
+	if (awsSettingString == "") {
+		return nil, errors.New("aws credential is not set")
+	}
+
+	var awsConfig AwsConfiguration
+	err := json.Unmarshal([]byte(awsSettingString), &awsConfig)
+	if err != nil {
+		return nil, errors.New(awsSettingString +  " is not a valid JSON string for setting aws configuration.")
+	}
+
+	// Initialize a session that the aws SDK uses to load
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
+
+	// Create KMS service client
+	svc := kms.New(sess, &aws.Config{
+		//Region: aws.String("us-east-1"),
+		Region: aws.String(awsConfig.Region),
+		Credentials: credentials.NewStaticCredentials(awsConfig.AccessKey, awsConfig.SecretKey, ""),
+	})
+
+	encryptedPrivateKeyBytes, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return nil, err
+	}
+
+	unhexed := make([]byte, hex.DecodedLen(len(encryptedPrivateKeyBytes)))
+	_, err = hex.Decode(unhexed, encryptedPrivateKeyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	clearKey, err := svc.Decrypt(&kms.DecryptInput{
+		CiphertextBlob: unhexed,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	priKey := &ffi_bls.SecretKey{}
+	priKey.DeserializeHexStr(hex.EncodeToString(clearKey.Plaintext))
+
+	fmt.Println(hex.EncodeToString(priKey.GetPublicKey().Serialize()))
+
 	return priKey, nil
 }
 


### PR DESCRIPTION
Added support for using AWS encrypted BLS key files... There are two ways to use it:

1) use command line option :  -aws_encrypted_blskey  [BLS_KEY_FILE]
2) put all bls key files (*.bls) under .hmy/blskeys/*.bls and use multi bls key

Also the aws credentials are needed to use aws CMK to decrypt the bls key files.  Aws credentials are a JSON string passed through stdin when the program runs, like below: 
``` 
 echo "{\"aws_access_key_id\":\"AKIAZRWVEKULJHTOQ45I\", \"aws_secret_access_key\":\"xxxxxxxxxxxxxxxxxxxxxxxxxxxx\", \"aws_region\":\"us-east-1\"}"
 |  ./bin/harmony -aws_encrypted_blskey 812db0d4ca7c74b587eddf11ae820d9909f0783b8ad17f40d828e0017ad35fe9f194564927e1819bfc682e25099e7f83.bls
``` 
or put all bls key files under .hmy/blskeys/
``` 
ls .hmy/blskeys/
04c892ac4d7fcc447187f66a8ca2cbd507d2b60d789029e1653758619cb8296731f344eda5275419e4f34e4ed3e9ea82.bls
812db0d4ca7c74b587eddf11ae820d9909f0783b8ad17f40d828e0017ad35fe9f194564927e1819bfc682e25099e7f83.bls
``` 
