### PR TITLE
Not update status for banned validators

### DIFF
--- a/staking/availability/measure.go
+++ b/staking/availability/measure.go
@@ -215,6 +215,10 @@ func ComputeAndMutateEPOSStatus(
 	if err != nil {
 		return err
 	}
+	if wrapper.Status == effective.Banned {
+		utils.Logger().Debug().Msg("Can't update EPoS status on a banned validator")
+		return nil
+	}
 
 	snapshot, err := bc.ReadValidatorSnapshot(wrapper.Address)
 	if err != nil {


### PR DESCRIPTION
The bug has caused leader failure to propose new blocks once there is a slashed validator in current epoch:

{"level":"error","port":"9000","ip":"34.209.133.63","error":"cannot finalize block: [ComputeAndMutateEPOSStatus] failed update validator info: have 9800000000000000000000 want 10000000000000000000000: self delegation can not be less than min_self_delegation","caller":"/home/ec2-user/harmony/node/node_newblock.go:78","time":"2020-03-28T06:04:59.350967974Z","message":"!!!!!!!!!Failed Proposing New Block!!!!!!!!!"}