### PR TITLE
Fixes-#2558: Allow validator to withdraw all their stake if they want to quit

### DIFF
--- a/core/staking_verifier.go
+++ b/core/staking_verifier.go
@@ -10,6 +10,7 @@ import (
 	common2 "github.com/harmony-one/harmony/internal/common"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/shard"
+	"github.com/harmony-one/harmony/staking/effective"
 	staking "github.com/harmony-one/harmony/staking/types"
 	"github.com/pkg/errors"
 )
@@ -264,7 +265,13 @@ func VerifyAndUndelegateFromMsg(
 			if err := wrapper.SanityCheck(
 				staking.DoNotEnforceMaxBLS,
 			); err != nil {
-				return nil, err
+				// allow self delegation to go below min self delegation
+				// but set the status to inactive
+				if errors.Cause(err) == staking.ErrInvalidSelfDelegation {
+					wrapper.Status = effective.Inactive
+				} else {
+					return nil, err
+				}
 			}
 			return wrapper, nil
 		}

--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -31,8 +31,9 @@ const (
 )
 
 var (
-	errAddressNotMatch       = errors.New("Validator key not match")
-	errInvalidSelfDelegation = errors.New(
+	errAddressNotMatch = errors.New("validator key not match")
+	// ErrInvalidSelfDelegation ..
+	ErrInvalidSelfDelegation = errors.New(
 		"self delegation can not be less than min_self_delegation",
 	)
 	errInvalidTotalDelegation = errors.New(
@@ -325,16 +326,18 @@ func (w *ValidatorWrapper) SanityCheck(
 	switch len(w.Delegations) {
 	case 0:
 		return errors.Wrapf(
-			errInvalidSelfDelegation, "no self delegation given at all",
+			ErrInvalidSelfDelegation, "no self delegation given at all",
 		)
 	default:
 		if w.Status != effective.Banned &&
 			w.Delegations[0].Amount.Cmp(w.Validator.MinSelfDelegation) < 0 {
-			return errors.Wrapf(
-				errInvalidSelfDelegation,
-				"min_self_delegation %s, amount %s",
-				w.Validator.MinSelfDelegation, w.Delegations[0].Amount.String(),
-			)
+			if w.Status == effective.Active {
+				return errors.Wrapf(
+					ErrInvalidSelfDelegation,
+					"min_self_delegation %s, amount %s",
+					w.Validator.MinSelfDelegation, w.Delegations[0].Amount.String(),
+				)
+			}
 		}
 	}
 	totalDelegation := w.TotalDelegation()

--- a/staking/types/validator_test.go
+++ b/staking/types/validator_test.go
@@ -282,7 +282,7 @@ func TestValidatorWrapperSanityCheck(t *testing.T) {
 	// no delegation must fail
 	wrapper := createNewValidatorWrapper(createNewValidator())
 	if err := wrapper.SanityCheck(DoNotEnforceMaxBLS); err == nil {
-		t.Error("expected", errInvalidSelfDelegation, "got", err)
+		t.Error("expected", ErrInvalidSelfDelegation, "got", err)
 	}
 
 	// valid self delegation must not fail
@@ -297,13 +297,13 @@ func TestValidatorWrapperSanityCheck(t *testing.T) {
 	valDel = NewDelegation(validatorAddr, big.NewInt(1e18))
 	wrapper.Delegations = []Delegation{valDel}
 	if err := wrapper.SanityCheck(DoNotEnforceMaxBLS); err == nil {
-		t.Error("expected", errInvalidSelfDelegation, "got", err)
+		t.Error("expected", ErrInvalidSelfDelegation, "got", err)
 	}
 
 	// invalid self delegation of less than 10K ONE must fail
 	valDel = NewDelegation(validatorAddr, big.NewInt(1e18))
 	if err := wrapper.SanityCheck(DoNotEnforceMaxBLS); err == nil {
-		t.Error("expected", errInvalidSelfDelegation, "got", err)
+		t.Error("expected", ErrInvalidSelfDelegation, "got", err)
 	}
 }
 


### PR DESCRIPTION
Local test output: 
1. Create validator with 10K stake
```
./hmy blockchain validator information one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy
{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "current-epoch-performance": null,
    "currently-in-committee": true,
    "epos-status": "currently elected and signing enough blocks to be eligible for election next epoch",
    "lifetime": {
      "apr": "0.000000000000000000",
      "blocks": {
        "signed": 1,
        "to-sign": 2
      },
      "reward-accumulated": 0
    },
    "metrics": null,
    "total-delegation": 1e+22,
    "validator": {
      "address": "one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy",
      "bls-public-keys": [
        "65f55eb3052f9e9f632b2923be594ba77c55543f5c58ee1454b9cfd658d25e06373b0f7d42a19c84768139ea294f6204"
      ],
      "creation-height": 19,
      "delegations": [
        {
          "amount": 1e+22,
          "delegator-address": "one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy",
          "reward": 0,
          "undelegations": []
        }
      ],
      "details": "Ganesh the validator",
      "identity": "ganesh",
      "last-epoch-in-committee": 4,
      "max-change-rate": "0.050000000000000000",
      "max-rate": "0.500000000000000000",
      "max-total-delegation": 1e+23,
      "min-self-delegation": 1e+22,
      "name": "Ganesh",
      "rate": "0.100000000000000000",
      "security-contact": "Alex",
      "update-height": 19,
      "website": "ganesh@harmony.one"
    }
  }
}
```

2. Self Undelegate all 10K stake, allowed to withdraw full stake, status set to inactive
```
./hmy blockchain validator information one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "current-epoch-performance": null,
    "currently-in-committee": false,
    **"epos-status": "not eligible to be elected next epoch",**
    "lifetime": {
      "apr": "0.000000000000000000",
      "blocks": {
        "signed": 5,
        "to-sign": 10
      },
      "reward-accumulated": 0
    },
    "metrics": null,
    "total-delegation": 0,
    "validator": {
      "address": "one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy",
      "bls-public-keys": [
        "65f55eb3052f9e9f632b2923be594ba77c55543f5c58ee1454b9cfd658d25e06373b0f7d42a19c84768139ea294f6204"
      ],
      "creation-height": 19,
      "delegations": [
        {
          "amount": 0,
          "delegator-address": "one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy",
          "reward": 0,
          **"undelegations": [
            {
              "amount": 1e+22,
              "epoch": 5
            }**
          ]
        }
      ],
      "details": "Ganesh the validator",
      "identity": "ganesh",
      "last-epoch-in-committee": 4,
      "max-change-rate": "0.050000000000000000",
      "max-rate": "0.500000000000000000",
      "max-total-delegation": 1e+23,
      "min-self-delegation": 1e+22,
      "name": "Ganesh",
      "rate": "0.100000000000000000",
      "security-contact": "Alex",
      "update-height": 19,
      "website": "ganesh@harmony.one"
    }
  }
}
```

3. Undelegation paid out after 7 epochs, validator is still inactive
```
./hmy blockchain validator information one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy
{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "current-epoch-performance": null,
    "currently-in-committee": false,
    **"epos-status": "not eligible to be elected next epoch",**
    "lifetime": {
      "apr": "0.000000000000000000",
      "blocks": {
        "signed": 5,
        "to-sign": 10
      },
      "reward-accumulated": 0
    },
    "metrics": null,
    "total-delegation": 0,
    "validator": {
      "address": "one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy",
      "bls-public-keys": [
        "65f55eb3052f9e9f632b2923be594ba77c55543f5c58ee1454b9cfd658d25e06373b0f7d42a19c84768139ea294f6204"
      ],
      "creation-height": 19,
      **"delegations": [
        {
          "amount": 0,
          "delegator-address": "one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy",
          "reward": 0,
          "undelegations": []
        }**
      ],
      "details": "Ganesh the validator",
      "identity": "ganesh",
      "last-epoch-in-committee": 4,
      "max-change-rate": "0.050000000000000000",
      "max-rate": "0.500000000000000000",
      "max-total-delegation": 1e+23,
      "min-self-delegation": 1e+22,
      "name": "Ganesh",
      "rate": "0.100000000000000000",
      "security-contact": "Alex",
      "update-height": 19,
      "website": "ganesh@harmony.one"
    }
  }
}
```