### PR TITLE
[#2588] Fix failed edit-validator tx fetch

### DIFF
--- a/internal/hmyapi/apiv1/types.go
+++ b/internal/hmyapi/apiv1/types.go
@@ -206,47 +206,61 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 // newRPCStakingTransaction returns a transaction that will serialize to the RPC
 // representation, with the given location metadata set (if available).
 func newRPCStakingTransaction(tx *types2.StakingTransaction, blockHash common.Hash, blockNumber uint64, timestamp uint64, index uint64) *RPCStakingTransaction {
-	from, _ := tx.SenderAddress()
+	from, err := tx.SenderAddress()
+	if err != nil {
+		return nil
+	}
 	v, r, s := tx.RawSignatureValues()
 
-	stakingTxType := tx.StakingType().String()
+	stakingTxType := tx.StakingType()
 	message := tx.StakingMessage()
 	fields := make(map[string]interface{}, 0)
 
 	switch stakingTxType {
-	case "CreateValidator":
-		msg := message.(types2.CreateValidator)
+	case types2.DirectiveCreateValidator:
+		msg, ok := message.(types2.CreateValidator)
+		if !ok {
+			return nil
+		}
 		validatorAddress, err := internal_common.AddressToBech32(msg.ValidatorAddress)
 		if err != nil {
 			return nil
 		}
 		fields = map[string]interface{}{
 			"validatorAddress":   validatorAddress,
-			"name":               msg.Description.Name,
 			"commissionRate":     (*hexutil.Big)(msg.CommissionRates.Rate.Int),
 			"maxCommissionRate":  (*hexutil.Big)(msg.CommissionRates.MaxRate.Int),
 			"maxChangeRate":      (*hexutil.Big)(msg.CommissionRates.MaxChangeRate.Int),
 			"minSelfDelegation":  (*hexutil.Big)(msg.MinSelfDelegation),
 			"maxTotalDelegation": (*hexutil.Big)(msg.MaxTotalDelegation),
 			"amount":             (*hexutil.Big)(msg.Amount),
+			"name":               msg.Description.Name,
 			"website":            msg.Description.Website,
 			"identity":           msg.Description.Identity,
 			"securityContact":    msg.Description.SecurityContact,
 			"details":            msg.Description.Details,
 			"slotPubKeys":        msg.SlotPubKeys,
 		}
-	case "EditValidator":
-		msg := message.(types2.EditValidator)
+	case types2.DirectiveEditValidator:
+		msg, ok := message.(types2.EditValidator)
+		if !ok {
+			return nil
+		}
 		validatorAddress, err := internal_common.AddressToBech32(msg.ValidatorAddress)
 		if err != nil {
 			return nil
 		}
+		// Edit validators txs need not have commission rates to edit
+		commissionRate := &hexutil.Big{}
+		if msg.CommissionRate != nil {
+			commissionRate = (*hexutil.Big)(msg.CommissionRate.Int)
+		}
 		fields = map[string]interface{}{
 			"validatorAddress":   validatorAddress,
-			"commisionRate":      (*hexutil.Big)(msg.CommissionRate.Int),
-			"name":               msg.Description.Name,
+			"commisionRate":      commissionRate,
 			"minSelfDelegation":  (*hexutil.Big)(msg.MinSelfDelegation),
 			"maxTotalDelegation": (*hexutil.Big)(msg.MaxTotalDelegation),
+			"name":               msg.Description.Name,
 			"website":            msg.Description.Website,
 			"identity":           msg.Description.Identity,
 			"securityContact":    msg.Description.SecurityContact,
@@ -254,8 +268,11 @@ func newRPCStakingTransaction(tx *types2.StakingTransaction, blockHash common.Ha
 			"slotPubKeyToAdd":    msg.SlotKeyToAdd,
 			"slotPubKeyToRemove": msg.SlotKeyToRemove,
 		}
-	case "CollectRewards":
-		msg := message.(types2.CollectRewards)
+	case types2.DirectiveCollectRewards:
+		msg, ok := message.(types2.CollectRewards)
+		if !ok {
+			return nil
+		}
 		delegatorAddress, err := internal_common.AddressToBech32(msg.DelegatorAddress)
 		if err != nil {
 			return nil
@@ -263,8 +280,11 @@ func newRPCStakingTransaction(tx *types2.StakingTransaction, blockHash common.Ha
 		fields = map[string]interface{}{
 			"delegatorAddress": delegatorAddress,
 		}
-	case "Delegate":
-		msg := message.(types2.Delegate)
+	case types2.DirectiveDelegate:
+		msg, ok := message.(types2.Delegate)
+		if !ok {
+			return nil
+		}
 		delegatorAddress, err := internal_common.AddressToBech32(msg.DelegatorAddress)
 		if err != nil {
 			return nil
@@ -278,8 +298,11 @@ func newRPCStakingTransaction(tx *types2.StakingTransaction, blockHash common.Ha
 			"validatorAddress": validatorAddress,
 			"amount":           (*hexutil.Big)(msg.Amount),
 		}
-	case "Undelegate":
-		msg := message.(types2.Undelegate)
+	case types2.DirectiveUndelegate:
+		msg, ok := message.(types2.Undelegate)
+		if !ok {
+			return nil
+		}
 		delegatorAddress, err := internal_common.AddressToBech32(msg.DelegatorAddress)
 		if err != nil {
 			return nil
@@ -304,7 +327,7 @@ func newRPCStakingTransaction(tx *types2.StakingTransaction, blockHash common.Ha
 		V:         (*hexutil.Big)(v),
 		R:         (*hexutil.Big)(r),
 		S:         (*hexutil.Big)(s),
-		Type:      stakingTxType,
+		Type:      stakingTxType.String(),
 		Msg:       fields,
 	}
 	if blockHash != (common.Hash{}) {


### PR DESCRIPTION
## Issue

This PR closes #2588. The reason why some block numbers failed to respond was that the RPC tried to dereference the commission rate of an edit validator transaction (which can be absent). 

### Unit Test Coverage

No unit tests

### Test/Run Logs

I wrote a script to fetch all the blocks of a blockchain given the endpoint: https://github.com/harmony-one/harmony-ops/pull/518. I ran this script on an archival node connected to OSTN. 

Prior to my fix, I got the following:

```
$ python3 get_blockchain.py http://localhost:9500/  --stats
Fetched 37558/37559 blocks
Total bad loads with number: 926

=== Stats for fetched blocks ===

Total Blocks Fetched: 37559
Total tx count: 1521
Plain tx count: 1015
Total amount sent via plain tx: 5428149538.02
Staking tx count: 506
Staking tx type breakdown: {
    "CollectRewards": 71,
    "CreateValidator": 72,
    "Delegate": 286,
    "Undelegate": 63,
    "EditValidator": 14
}
```

After my fix, I got the following:
```
$ python3 get_blockchain.py http://localhost:9500/  --stats
Fetched 37585/37586 blocks
Total bad loads with number: 0

=== Stats for fetched blocks ===

Total Blocks Fetched: 37586
Total tx count: 2032
Plain tx count: 1037
Total amount sent via plain tx: 5430074538.02
Staking tx count: 995
Staking tx type breakdown: {
    "CollectRewards": 72,
    "CreateValidator": 86,
    "EditValidator": 487,
    "Delegate": 287,
    "Undelegate": 63
}
```

Note that I also edited the script to check for the `hmyv2` version of the RPC and got same error as above.

## Misc

Note that I also added some extra checks to `newRPCStakingTransaction` that should not affect performance.

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**
