### PR TITLE
disallow duplicate bls keys as internal keys

### DIFF
--- a/core/staking_verifier.go
+++ b/core/staking_verifier.go
@@ -52,7 +52,7 @@ func VerifyAndCreateValidatorFromMsg(
 	if !CanTransfer(stateDB, msg.ValidatorAddress, msg.Amount) {
 		return nil, errInsufficientBalanceForStake
 	}
-	v, err := staking.CreateValidatorFromNewMsg(msg, blockNum)
+	v, err := staking.CreateValidatorFromNewMsg(msg, blockNum, epoch)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func VerifyAndEditValidatorFromMsg(
 	if err != nil {
 		return nil, err
 	}
-	if err := staking.UpdateValidatorFromEditMsg(&wrapper.Validator, msg); err != nil {
+	if err := staking.UpdateValidatorFromEditMsg(&wrapper.Validator, msg, epoch); err != nil {
 		return nil, err
 	}
 	newRate := wrapper.Validator.Rate

--- a/staking/types/validator_test.go
+++ b/staking/types/validator_test.go
@@ -400,7 +400,7 @@ func TestCreateValidatorFromNewMsg(t *testing.T) {
 		Amount:           big.NewInt(1e18),
 	}
 	blockNum := big.NewInt(1000)
-	_, err := CreateValidatorFromNewMsg(&v, blockNum)
+	_, err := CreateValidatorFromNewMsg(&v, blockNum, new(big.Int))
 	if err != nil {
 		t.Errorf("CreateValidatorFromNewMsg failed")
 	}
@@ -413,7 +413,7 @@ func TestUpdateValidatorFromEditMsg(t *testing.T) {
 		MinSelfDelegation:  tenK,
 		MaxTotalDelegation: twelveK,
 	}
-	UpdateValidatorFromEditMsg(&validator, &ev)
+	UpdateValidatorFromEditMsg(&validator, &ev, new(big.Int))
 
 	if validator.MinSelfDelegation.Cmp(tenK) != 0 {
 		t.Errorf("UpdateValidatorFromEditMsg failed")


### PR DESCRIPTION
Duplicate bls keys as internal harmony node shouldn't be allowed. #2587

Output from local testing:
1. Create validator using internal key 
```
./hmy staking create-validator --validator-addr one1tpxl87y4g8ecsm6ceqay49qxyl5vs94jjyfvd9 --name Ganesh --identity ganesh --website ganesh@harmony.one --security-contact Alex --details "Ganesh the validator" --rate 0.1 --max-rate 0.5 --max-change-rate 0.05 --min-self-delegation 10000 --max-total-delegation 100000 --bls-pubkeys 65f55eb3052f9e9f632b2923be594ba77c55543f5c58ee1454b9cfd658d25e06373b0f7d42a19c84768139ea294f6204 --amount 10000
Enter the bls passphrase:
[CreateValidator] slot key "65f55eb3052f9e9f632b2923be594ba77c55543f5c58ee1454b9cfd658d25e06373b0f7d42a19c84768139ea294f6204" conflicts with internal keys: slot keys can not have duplicates -- 2020-03-30 07:13:59 -0700 PDT
commit: v335-9043f22-dirty, error: staking transaction error
check hmy cookbook for valid examples or try adding a `--help` flag
```

2. Create validator from non-existing key
```
./hmy staking create-validator --validator-addr one1tpxl87y4g8ecsm6ceqay49qxyl5vs94jjyfvd9 --name Ganesh --identity ganesh --website ganesh@harmony.one --security-contact Alex --details "Ganesh the validator" --rate 0.1 --max-rate 0.5 --max-change-rate 0.05 --min-self-delegation 10000 --max-total-delegation 100000 --bls-pubkeys 7ab21e88f5d17712e30dfc9a7acdb7e0e784fabf2bf76d5f83d8a0269dd47f38d8f454cb7ece5921027a9b68d806578f --amount 10000
Enter the bls passphrase:
{
  "id": "18",
  "jsonrpc": "2.0",
  "result": {
    "blockHash": "0x7c82aa67f60fcef364c1871316f68d99802eed6a5dd4877b77f5d0fff34ce874",
    "blockNumber": "0x1a",
    "contractAddress": null,
    "cumulativeGasUsed": "0x512b48",
    "gasUsed": "0x512b48",
    "logs": [],
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "sender": "one1tpxl87y4g8ecsm6ceqay49qxyl5vs94jjyfvd9",
    "status": "0x1",
    "transactionHash": "0x00b536d5f406a5beaa700153ab7d0e9662bc26c5da8298db7c4a12b237fbfe68",
    "transactionIndex": "0x0",
    "type": 0
  }
}
```

4. Edit validator using existing internal key 
```
./hmy staking edit-validator --validator-addr one1tpxl87y4g8ecsm6ceqay49qxyl5vs94jjyfvd9 --add-bls-key 65f55eb3052f9e9f632b2923be594ba77c55543f5c58ee1454b9cfd658d25e06373b0f7d42a19c84768139ea294f6204
Enter the bls passphrase:
[EditValidator] slot key "65f55eb3052f9e9f632b2923be594ba77c55543f5c58ee1454b9cfd658d25e06373b0f7d42a19c84768139ea294f6204" conflicts with internal keys: slot keys can not have duplicates -- 2020-03-30 07:15:34 -0700 PDT
commit: v335-9043f22-dirty, error: staking transaction error
check hmy cookbook for valid examples or try adding a `--help` flag
```

4. Edit validator using non-existing key
```
./hmy staking edit-validator --validator-addr one1tpxl87y4g8ecsm6ceqay49qxyl5vs94jjyfvd9 --add-bls-key 5d8ecf58a9ac04bfcff7b7e0aaf2e6250c2599613958fc3dc5e92864796ea68fa99b92ab98803dd7898900ab79c2f516
Enter the bls passphrase:
{
  "id": "15",
  "jsonrpc": "2.0",
  "result": {
    "blockHash": "0x17a4ea8a6acada936585e14e859382fadc475c6427de560706b590513cde74c2",
    "blockNumber": "0x3b",
    "contractAddress": null,
    "cumulativeGasUsed": "0x81dc",
    "gasUsed": "0x81dc",
    "logs": [],
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "sender": "one1tpxl87y4g8ecsm6ceqay49qxyl5vs94jjyfvd9",
    "status": "0x1",
    "transactionHash": "0x54041ce0429c221a02f3f1c7c5bdeaa7db695f3d30008bffd0d1866d350f1541",
    "transactionIndex": "0x0",
    "type": 1
  }
}
```