### PR TITLE
Added support for using AWS encrypted BLS key files

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -107,6 +107,7 @@ var (
 	shardID            = flag.Int("shard_id", -1, "the shard ID of this node")
 	enableMemProfiling = flag.Bool("enableMemProfiling", false, "Enable memsize logging.")
 	enableGC           = flag.Bool("enableGC", true, "Enable calling garbage collector manually .")
+	cmkEncryptedBLSKey = flag.String("aws_blskey", "", "The aws CMK encrypted bls private key file.")
 	blsKeyFile         = flag.String("blskey_file", "", "The encrypted file of bls serialized private key by passphrase.")
 	blsFolder          = flag.String("blsfolder", ".hmy/blskeys", "The folder that stores the bls keys and corresponding passphrases; e.g. <blskey>.key and <blskey>.pass; all bls keys mapped to same shard")
 	blsPass            = flag.String("blspass", "", "The file containing passphrase to decrypt the encrypted bls file.")
@@ -144,6 +145,8 @@ var (
 	webHookYamlPath = flag.String(
 		"webhook_yaml", "", "path for yaml config reporting double signing",
 	)
+	// aws credentials
+	awsSettingString = ""
 )
 
 func initSetup() {
@@ -154,7 +157,9 @@ func initSetup() {
 	}
 
 	// maybe request passphrase for bls key.
-	passphraseForBLS()
+	if *cmkEncryptedBLSKey == "" {
+		passphraseForBLS()
+	}
 
 	// Configure log parameters
 	utils.SetLogContext(*port, *ip)
@@ -278,6 +283,8 @@ func setupStakingNodeAccount() error {
 func readMultiBLSKeys(consensusMultiBLSPriKey *multibls.PrivateKey, consensusMultiBLSPubKey *multibls.PublicKey) error {
 	keyPasses := map[string]string{}
 	blsKeyFiles := []os.FileInfo{}
+	awsEncryptedBLSKeyFiles := []os.FileInfo{}
+
 	if err := filepath.Walk(*blsFolder, func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() {
 			return nil
@@ -294,9 +301,11 @@ func readMultiBLSKeys(consensusMultiBLSPriKey *multibls.PrivateKey, consensusMul
 			}
 			name := fullName[:len(fullName)-len(ext)]
 			keyPasses[name] = passphrase
+		} else if ext == ".bls" {
+			awsEncryptedBLSKeyFiles = append(awsEncryptedBLSKeyFiles, info)
 		} else {
 			return errors.Errorf(
-				"[Multi-BLS] found file: %s that does not have .key or .pass file extension",
+				"[Multi-BLS] found file: %s that does not have .bls, .key or .pass file extension",
 				path,
 			)
 		}
@@ -309,29 +318,51 @@ func readMultiBLSKeys(consensusMultiBLSPriKey *multibls.PrivateKey, consensusMul
 		)
 		os.Exit(100)
 	}
-	if len(blsKeyFiles) > *maxBLSKeysPerNode {
-		fmt.Fprintf(os.Stderr,
-			"[Multi-BLS] maximum number of bls keys per node is %d, found: %d\n",
-			*maxBLSKeysPerNode,
-			len(blsKeyFiles),
-		)
-		os.Exit(100)
-	}
-	for _, blsKeyFile := range blsKeyFiles {
-		fullName := blsKeyFile.Name()
-		ext := filepath.Ext(fullName)
-		name := fullName[:len(fullName)-len(ext)]
-		if val, ok := keyPasses[name]; ok {
-			blsPassphrase = val
+
+	if len(awsEncryptedBLSKeyFiles) > 0 {
+		if len(awsEncryptedBLSKeyFiles) > *maxBLSKeysPerNode {
+			fmt.Fprintf(os.Stderr,
+				"[Multi-BLS] maximum number of bls keys per node is %d, found: %d\n",
+				*maxBLSKeysPerNode,
+				len(awsEncryptedBLSKeyFiles),
+			)
+			os.Exit(100)
 		}
-		blsKeyFilePath := path.Join(*blsFolder, blsKeyFile.Name())
-		consensusPriKey, err := blsgen.LoadBLSKeyWithPassPhrase(blsKeyFilePath, blsPassphrase)
-		if err != nil {
-			return err
+		for _, blsKeyFile := range awsEncryptedBLSKeyFiles {
+			blsKeyFilePath := path.Join(*blsFolder, blsKeyFile.Name())
+			consensusPriKey, err := blsgen.LoadAwsCMKEncryptedBLSKey(blsKeyFilePath, awsSettingString)
+			if err != nil {
+				return err
+			}
+			// TODO: assumes order between public/private key pairs
+			multibls.AppendPriKey(consensusMultiBLSPriKey, consensusPriKey)
+			multibls.AppendPubKey(consensusMultiBLSPubKey, consensusPriKey.GetPublicKey())
 		}
-		// TODO: assumes order between public/private key pairs
-		multibls.AppendPriKey(consensusMultiBLSPriKey, consensusPriKey)
-		multibls.AppendPubKey(consensusMultiBLSPubKey, consensusPriKey.GetPublicKey())
+	} else {
+		if len(blsKeyFiles) > *maxBLSKeysPerNode {
+			fmt.Fprintf(os.Stderr,
+				"[Multi-BLS] maximum number of bls keys per node is %d, found: %d\n",
+				*maxBLSKeysPerNode,
+				len(blsKeyFiles),
+			)
+			os.Exit(100)
+		}
+		for _, blsKeyFile := range blsKeyFiles {
+			fullName := blsKeyFile.Name()
+			ext := filepath.Ext(fullName)
+			name := fullName[:len(fullName)-len(ext)]
+			if val, ok := keyPasses[name]; ok {
+				blsPassphrase = val
+			}
+			blsKeyFilePath := path.Join(*blsFolder, blsKeyFile.Name())
+			consensusPriKey, err := blsgen.LoadBLSKeyWithPassPhrase(blsKeyFilePath, blsPassphrase)
+			if err != nil {
+				return err
+			}
+			// TODO: assumes order between public/private key pairs
+			multibls.AppendPriKey(consensusMultiBLSPriKey, consensusPriKey)
+			multibls.AppendPubKey(consensusMultiBLSPubKey, consensusPriKey.GetPublicKey())
+		}
 	}
 
 	return nil
@@ -347,6 +378,15 @@ func setupConsensusKey(nodeConfig *nodeconfig.ConfigType) multibls.PublicKey {
 			fmt.Fprintf(os.Stderr, "ERROR when loading bls key, err :%v\n", err)
 			os.Exit(100)
 		}
+		multibls.AppendPriKey(consensusMultiPriKey, consensusPriKey)
+		multibls.AppendPubKey(consensusMultiPubKey, consensusPriKey.GetPublicKey())
+	} else if *cmkEncryptedBLSKey != "" {
+		consensusPriKey, err := blsgen.LoadAwsCMKEncryptedBLSKey(*cmkEncryptedBLSKey, awsSettingString)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR when loading aws CMK encrypted bls key, err :%v\n", err)
+			os.Exit(100)
+		}
+
 		multibls.AppendPriKey(consensusMultiPriKey, consensusPriKey)
 		multibls.AppendPubKey(consensusMultiPubKey, consensusPriKey.GetPublicKey())
 	} else {
@@ -649,6 +689,9 @@ func main() {
 	// notes one line 66,67 of https://golang.org/src/net/net.go that say can make the decision at
 	// build time.
 	os.Setenv("GODEBUG", "netdns=go")
+
+	// Get aws credentials from prompt timeout 1 second if there's no input
+	awsSettingString, _ = blsgen.Readln(1 * time.Second)
 
 	flag.Var(&p2putils.BootNodes, "bootnodes", "a list of bootnode multiaddress (delimited by ,)")
 	flag.Parse()

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Workiva/go-datastructures v1.0.50
 	github.com/allegro/bigcache v1.2.1 // indirect
 	github.com/aristanetworks/goarista v0.0.0-20190607111240-52c2a7864a08 // indirect
+	github.com/aws/aws-sdk-go v1.30.1
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d
 	github.com/cespare/cp v1.1.1
@@ -45,7 +46,7 @@ require (
 	github.com/multiformats/go-multiaddr-net v0.1.2
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/pborman/uuid v1.2.0
-	github.com/pkg/errors v0.8.1
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v0.9.3
 	github.com/prometheus/common v0.4.1 // indirect
 	github.com/prometheus/procfs v0.0.3 // indirect
@@ -55,7 +56,7 @@ require (
 	github.com/shirou/gopsutil v2.18.12+incompatible
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.6.1
-	github.com/stretchr/testify v1.4.0
+	github.com/stretchr/testify v1.5.1
 	github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965
 	github.com/uber/jaeger-client-go v2.20.1+incompatible // indirect
 	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect


### PR DESCRIPTION
Added support for using AWS encrypted BLS key files... There are two ways to use it:

1) use command line option :  -aws_encrypted_blskey  [BLS_KEY_FILE]
2) put all bls key files (*.bls) under .hmy/blskeys/*.bls and use multi bls key

Also the aws credentials are needed to use aws CMK to decrypt the bls key files.  Aws credentials are a JSON string passed through stdin when the program runs, like below: 
``` 
 echo "{\"aws-access-key-id\":\"AKIAZRWVEKULJHTOQ45I\", \"aws-secret-access-key\":\"xxxxxxxxxxxxxxxxxxxxxxxxxxxx\", \"aws-region\":\"us-east-1\"}"
 |  ./bin/harmony -aws_blskey 812db0d4ca7c74b587eddf11ae820d9909f0783b8ad17f40d828e0017ad35fe9f194564927e1819bfc682e25099e7f83.bls
``` 
or put all bls key files under .hmy/blskeys/
``` 
ls .hmy/blskeys/
04c892ac4d7fcc447187f66a8ca2cbd507d2b60d789029e1653758619cb8296731f344eda5275419e4f34e4ed3e9ea82.bls
812db0d4ca7c74b587eddf11ae820d9909f0783b8ad17f40d828e0017ad35fe9f194564927e1819bfc682e25099e7f83.bls
``` 
