### PR TITLE
[node.sh] Remove msg when no trace file given, default behavior shoul…

### DIFF
--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -866,7 +866,7 @@ do
       ;;
    esac
    case "${TRACEFILE}" in
-      "") msg "not enabling p2p trace" ;;
+      "") ;;
       *) msg "WARN: enabled p2p tracefile: $TRACEFILE. Be aware of the file size."
          export P2P_TRACEFILE=${TRACEFILE} ;;
    esac


### PR DESCRIPTION
The default behavior is causing a message printed that is new to the volunteers group and so the API of "is everything working correctly" changed. This is causing new overhead in onboarding and repeated explanations that the default message is fine, not an error/issue.