### PR TITLE
[build] fix the release action for static build

### DIFF
--- a/scripts/go_executable_build.sh
+++ b/scripts/go_executable_build.sh
@@ -13,7 +13,7 @@ PUBBUCKET=pub.harmony.one
 REL=
 GOOS=linux
 GOARCH=amd64
-FOLDER=/${WHOAMI:-$USER}
+FOLDER=${WHOAMI:-$USER}
 RACE=
 VERBOSE=
 GO_GCFLAGS="all=-c 2"
@@ -170,7 +170,7 @@ function upload
    if [ "$STATIC" != "true" ]; then
       for lib in "${!LIB[@]}"; do
          if [ -e ${LIB[$lib]} ]; then
-            $AWSCLI s3 cp ${LIB[$lib]} s3://${BUCKET}$FOLDER/$lib --acl public-read
+            $AWSCLI s3 cp ${LIB[$lib]} s3://${BUCKET}/$FOLDER/$lib --acl public-read
          else
             echo "!! MISSING ${LIB[$lib]} !!"
          fi
@@ -180,11 +180,11 @@ function upload
    fi
 
    for bin in "${!SRC[@]}"; do
-      [ -e $BINDIR/$bin ] && $AWSCLI s3 cp $BINDIR/$bin s3://${BUCKET}$FOLDER/$bin --acl public-read
+      [ -e $BINDIR/$bin ] && $AWSCLI s3 cp $BINDIR/$bin s3://${BUCKET}/$FOLDER/$bin --acl public-read
    done
 
 
-   [ -e $BINDIR/md5sum.txt ] && $AWSCLI s3 cp $BINDIR/md5sum.txt s3://${BUCKET}$FOLDER/md5sum.txt --acl public-read
+   [ -e $BINDIR/md5sum.txt ] && $AWSCLI s3 cp $BINDIR/md5sum.txt s3://${BUCKET}/$FOLDER/md5sum.txt --acl public-read
 }
 
 function release

--- a/scripts/go_executable_build.sh
+++ b/scripts/go_executable_build.sh
@@ -207,14 +207,6 @@ function release
          return ;;
    esac
 
-   for bin in "${!SRC[@]}"; do
-      if [ -e $BINDIR/$bin ]; then
-         $AWSCLI s3 cp $BINDIR/$bin s3://${PUBBUCKET}/$FOLDER/$bin --acl public-read
-      else
-         echo "!! MISSGING $bin !!"
-      fi
-   done
-
    if [ "$STATIC" != "true" ]; then
       for lib in "${!LIB[@]}"; do
          if [ -e ${LIB[$lib]} ]; then
@@ -223,7 +215,17 @@ function release
             echo "!! MISSING ${LIB[$lib]} !!"
          fi
       done
+   else
+      FOLDER+='/static'
    fi
+
+   for bin in "${!SRC[@]}"; do
+      if [ -e $BINDIR/$bin ]; then
+         $AWSCLI s3 cp $BINDIR/$bin s3://${PUBBUCKET}/$FOLDER/$bin --acl public-read
+      else
+         echo "!! MISSGING $bin !!"
+      fi
+   done
 
    [ -e $BINDIR/md5sum.txt ] && $AWSCLI s3 cp $BINDIR/md5sum.txt s3://${PUBBUCKET}/$FOLDER/md5sum.txt --acl public-read
 }


### PR DESCRIPTION
```
make linux_static
./scripts/go_executable_build.sh -s -N pangaea release
```

@john-harmony , this is how I manually release OSTN binaries to public bucket.