### PR TITLE
fix issue2689 error loading blspass

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -152,6 +152,9 @@ func initSetup() {
 	// maybe request passphrase for bls key.
 	if *cmkEncryptedBLSKey == "" {
 		passphraseForBLS()
+	} else {
+		// Get aws credentials from stdin prompt
+		awsSettingString, _ = blsgen.Readln(1 * time.Second)
 	}
 
 	// Configure log parameters
@@ -656,9 +659,6 @@ func main() {
 	// notes one line 66,67 of https://golang.org/src/net/net.go that say can make the decision at
 	// build time.
 	os.Setenv("GODEBUG", "netdns=go")
-
-	// Get aws credentials from prompt timeout 1 second if there's no input
-	awsSettingString, _ = blsgen.Readln(1 * time.Second)
 
 	flag.Var(&p2putils.BootNodes, "bootnodes", "a list of bootnode multiaddress (delimited by ,)")
 	flag.Parse()

--- a/internal/blsgen/lib.go
+++ b/internal/blsgen/lib.go
@@ -163,7 +163,6 @@ func LoadAwsCMKEncryptedBLSKey(fileName, awsSettingString string) (*ffi_bls.Secr
 
 	// Create KMS service client
 	svc := kms.New(sess, &aws.Config{
-		//Region: aws.String("us-east-1"),
 		Region:      aws.String(awsConfig.Region),
 		Credentials: credentials.NewStaticCredentials(awsConfig.AccessKey, awsConfig.SecretKey, ""),
 	})


### PR DESCRIPTION
## Issue

This is a fix for issue https://github.com/harmony-one/harmony/issues/2689. The reason is that the blspass read from stdin when "-blspass std" is specified and it conflict with aws setting (which also read from stdin)  reading required for aws encrypted bls key. 

## Test

Tested both "-blspass std" and "--aws_blskey " works.  Note that only one way of reading from stdin is supported. Either for blspass or for aws credentials. 
 
