### PR TITLE
[rpc] Show both latest header of beacon chain and shard chain

### DIFF
--- a/block/header.go
+++ b/block/header.go
@@ -24,6 +24,12 @@ type Header struct {
 	blockif.Header
 }
 
+// HeaderPair ..
+type HeaderPair struct {
+	BeaconHeader *Header `json:"beacon-chain-header"`
+	ShardHeader  *Header `json:"shard-chain-header"`
+}
+
 var (
 	// ErrHeaderIsNil ..
 	ErrHeaderIsNil = errors.New("cannot encode nil header receiver")

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -421,6 +421,14 @@ func (b *APIBackend) GetMedianRawStakeSnapshot() (
 	return committee.NewEPoSRound(b.hmy.BlockChain())
 }
 
+// GetLatestChainHeaders ..
+func (b *APIBackend) GetLatestChainHeaders() *block.HeaderPair {
+	return &block.HeaderPair{
+		BeaconHeader: b.hmy.BeaconChain().CurrentHeader(),
+		ShardHeader:  b.hmy.BlockChain().CurrentHeader(),
+	}
+}
+
 // GetTotalStakingSnapshot ..
 func (b *APIBackend) GetTotalStakingSnapshot() *big.Int {
 	b.TotalStakingCache.Lock()
@@ -439,7 +447,9 @@ func (b *APIBackend) GetTotalStakingSnapshot() *big.Int {
 	for i := range candidates {
 		snapshot, _ := b.hmy.BlockChain().ReadValidatorSnapshot(candidates[i])
 		validator, _ := b.hmy.BlockChain().ReadValidatorInformation(candidates[i])
-		if !committee.IsEligibleForEPoSAuction(snapshot, validator, b.hmy.BlockChain().CurrentBlock().Epoch()) {
+		if !committee.IsEligibleForEPoSAuction(
+			snapshot, validator, b.hmy.BlockChain().CurrentBlock().Epoch(),
+		) {
 			continue
 		}
 		for i := range validator.Delegations {

--- a/hmy/backend.go
+++ b/hmy/backend.go
@@ -33,8 +33,6 @@ type Harmony struct {
 	nodeAPI      NodeAPI
 	// aka network version, which is used to identify which network we are using
 	networkID uint64
-	// TODO(ricl): put this into config object
-	// TODO(ricl): this is never set. Will result in nil pointer bug
 	// RPCGasCap is the global gas cap for eth-call variants.
 	RPCGasCap *big.Int `toml:",omitempty"`
 	shardID   uint32

--- a/internal/hmyapi/apiv1/backend.go
+++ b/internal/hmyapi/apiv1/backend.go
@@ -27,9 +27,8 @@ import (
 // implementations:
 //   * hmy/api_backend.go
 type Backend interface {
-	// NOTE(ricl): this is not in ETH Backend inteface. They put it directly in eth object.
 	NetVersion() uint64
-	// General Ethereum API
+
 	// Downloader() *downloader.Downloader
 	ProtocolVersion() int
 	// SuggestPrice(ctx context.Context) (*big.Int, error)
@@ -38,14 +37,13 @@ type Backend interface {
 	AccountManager() *accounts.Manager
 	// ExtRPCEnabled() bool
 	RPCGasCap() *big.Int // global gas cap for hmy_call over rpc: DoS protection
-	// BlockChain API
-	// SetHead(number uint64)
+
 	HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*block.Header, error)
 	BlockByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Block, error)
 	StateAndHeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*state.DB, *block.Header, error)
 	GetBlock(ctx context.Context, blockHash common.Hash) (*types.Block, error)
 	GetReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error)
-	// GetTd(blockHash common.Hash) *big.Int
+
 	GetEVM(ctx context.Context, msg core.Message, state *state.DB, header *block.Header) (*vm.EVM, func() error, error)
 	SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription
 	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription
@@ -90,4 +88,5 @@ type Backend interface {
 	GetTotalStakingSnapshot() *big.Int
 	GetCurrentBadBlocks() []core.BadBlock
 	GetLastCrossLinks() ([]*types.CrossLink, error)
+	GetLatestChainHeaders() *block.HeaderPair
 }

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/harmony-one/bls/ffi/go/bls"
+	"github.com/harmony-one/harmony/block"
 	"github.com/harmony-one/harmony/common/denominations"
 	"github.com/harmony-one/harmony/consensus/quorum"
 	"github.com/harmony-one/harmony/consensus/reward"
@@ -542,6 +543,11 @@ func (s *PublicBlockChainAPI) GetMedianRawStakeSnapshot() (
 		return s.b.GetMedianRawStakeSnapshot()
 	}
 	return nil, errNotBeaconChainShard
+}
+
+// GetLatestChainHeaders ..
+func (s *PublicBlockChainAPI) GetLatestChainHeaders() *block.HeaderPair {
+	return s.b.GetLatestChainHeaders()
 }
 
 // GetAllValidatorAddresses returns all validator addresses.

--- a/internal/hmyapi/apiv2/backend.go
+++ b/internal/hmyapi/apiv2/backend.go
@@ -90,4 +90,5 @@ type Backend interface {
 	GetTotalStakingSnapshot() *big.Int
 	GetCurrentBadBlocks() []core.BadBlock
 	GetLastCrossLinks() ([]*types.CrossLink, error)
+	GetLatestChainHeaders() *block.HeaderPair
 }

--- a/internal/hmyapi/backend.go
+++ b/internal/hmyapi/backend.go
@@ -31,17 +31,11 @@ import (
 type Backend interface {
 	// NOTE(ricl): this is not in ETH Backend inteface. They put it directly in eth object.
 	NetVersion() uint64
-	// General Ethereum API
-	// Downloader() *downloader.Downloader
 	ProtocolVersion() int
-	// SuggestPrice(ctx context.Context) (*big.Int, error)
 	ChainDb() ethdb.Database
 	EventMux() *event.TypeMux
 	AccountManager() *accounts.Manager
-	// ExtRPCEnabled() bool
 	RPCGasCap() *big.Int // global gas cap for hmy_call over rpc: DoS protection
-	// BlockChain API
-	// SetHead(number uint64)
 	HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*block.Header, error)
 	BlockByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Block, error)
 	StateAndHeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*state.DB, *block.Header, error)
@@ -92,6 +86,7 @@ type Backend interface {
 	GetTotalStakingSnapshot() *big.Int
 	GetCurrentBadBlocks() []core.BadBlock
 	GetLastCrossLinks() ([]*types.CrossLink, error)
+	GetLatestChainHeaders() *block.HeaderPair
 }
 
 // GetAPIs returns all the APIs.


### PR DESCRIPTION
Fast RPC to show headers. Deviates from `hmy blockchain latest-header` because that one uses an ad-hoc data structure and going forward the default for the RPC is to prefer using existing data structures. 

Please @janet-harmony add the corresponding CLI call in hmy cli 


```
curl --location \
--request POST 'http://localhost:9511' \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc": "2.0",
    "method": "hmy_getLatestChainHeaders",
    "params": [],
    "id": 2
}'
```

```json
{
  "jsonrpc": "2.0",
  "id": 2,
  "result": {
    "beacon-chain-header": {
      "shard-id": 0,
      "block-header-hash": "0x6c7fb0c15673f7819ae01e885b5e646aa854b0eba68cf63040ca42f7bcef6e0f",
      "block-number": 29,
      "view-id": 29,
      "epoch": 4
    },
    "shard-chain-header": {
      "shard-id": 1,
      "block-header-hash": "0xb9126c1816fb4411f30d23b0376e4d08eb8802a582127ae0df4cb9da9ba37075",
      "block-number": 29,
      "view-id": 29,
      "epoch": 4
    }
  }
}
```