### PR TITLE
change explorer node storage folder

### DIFF
--- a/api/service/explorer/storage.go
+++ b/api/service/explorer/storage.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/harmony-one/harmony/core/types"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
 	staking "github.com/harmony-one/harmony/staking/types"
 	"github.com/syndtr/goleveldb/leveldb"
@@ -46,7 +47,7 @@ func GetStorageInstance(ip, port string, remove bool) *Storage {
 
 // Init initializes the block update.
 func (storage *Storage) Init(ip, port string, remove bool) {
-	dbFileName := "/tmp/explorer_storage_" + ip + "_" + port
+	dbFileName := nodeconfig.GetDefaultConfig().DBDir + "/explorer_storage_" + ip + "_" + port
 	var err error
 	if remove {
 		var err = os.RemoveAll(dbFileName)

--- a/api/service/explorer/storage_test.go
+++ b/api/service/explorer/storage_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,6 +15,7 @@ func TestGetAddressKey(t *testing.T) {
 
 // TestInit ..
 func TestInit(t *testing.T) {
+	nodeconfig.GetDefaultConfig().DBDir = "/tmp"
 	ins := GetStorageInstance("1.1.1.1", "3333", true)
 	if err := ins.GetDB().Put([]byte{1}, []byte{2}, nil); err != nil {
 		t.Fatal("(*LDBDatabase).Put failed:", err)

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -523,6 +523,7 @@ func setupConsensusAndNode(nodeConfig *nodeconfig.ConfigType) *node.Node {
 		nodeconfig.NewGroupIDByShardID(shard.BeaconChainShardID),
 	)
 
+	nodeconfig.GetDefaultConfig().DBDir = nodeConfig.DBDir
 	switch *nodeType {
 	case "explorer":
 		nodeconfig.SetDefaultRole(nodeconfig.ExplorerNode)


### PR DESCRIPTION
## Issue

Current explorer node storage folder starts with /tmp and this causes losing db unexpectedly.

## Test

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
