### PR TITLE
make validator snapshot consistent with election

### DIFF
--- a/core/offchain.go
+++ b/core/offchain.go
@@ -122,7 +122,11 @@ func (bc *BlockChain) CommitOffChainData(
 		); err != nil {
 			return NonStatTy, err
 		}
+	}
 
+	// Snapshot for all validators at the second to last block
+	// This snapshot of the state is consistent with the state used for election
+	if shard.Schedule.IsLastBlock(header.Number().Uint64() + 1) {
 		// Update snapshots for all validators
 		if err := bc.UpdateValidatorSnapshots(batch, epoch, state); err != nil {
 			return NonStatTy, err

--- a/core/offchain.go
+++ b/core/offchain.go
@@ -126,8 +126,9 @@ func (bc *BlockChain) CommitOffChainData(
 
 	// Snapshot for all validators at the second to last block
 	// This snapshot of the state is consistent with the state used for election
-	if isBeaconChain && shard.Schedule.IsLastBlock(header.Number().Uint64() + 1) {
+	if isBeaconChain && shard.Schedule.IsLastBlock(header.Number().Uint64()+1) {
 		// Update snapshots for all validators
+		epoch := new(big.Int).Add(header.Epoch(), common.Big1)
 		if err := bc.UpdateValidatorSnapshots(batch, epoch, state); err != nil {
 			return NonStatTy, err
 		}

--- a/core/offchain.go
+++ b/core/offchain.go
@@ -126,7 +126,7 @@ func (bc *BlockChain) CommitOffChainData(
 
 	// Snapshot for all validators at the second to last block
 	// This snapshot of the state is consistent with the state used for election
-	if shard.Schedule.IsLastBlock(header.Number().Uint64() + 1) {
+	if isBeaconChain && shard.Schedule.IsLastBlock(header.Number().Uint64() + 1) {
 		// Update snapshots for all validators
 		if err := bc.UpdateValidatorSnapshots(batch, epoch, state); err != nil {
 			return NonStatTy, err


### PR DESCRIPTION
Previously the snapshot is taken after the last block is confirmed, while the election is taken on the state before the last block is executed.

So the two things are not consistent, you could have a validator elected but snapshotted with 0 delegation if that validator undelegate all its token right at that last block of epoch.