### PR TITLE
Squashed commit of the following:

### DIFF
--- a/core/offchain.go
+++ b/core/offchain.go
@@ -93,9 +93,10 @@ func (bc *BlockChain) CommitOffChainData(
 	//}
 
 	// Do bookkeeping for new staking txns
-	if err := bc.UpdateStakingMetaData(
+	newVals, err := bc.UpdateStakingMetaData(
 		batch, block.StakingTransactions(), state, epoch,
-	); err != nil {
+	)
+	if err != nil {
 		utils.Logger().Err(err).Msg("UpdateStakingMetaData failed")
 		return NonStatTy, err
 	}
@@ -129,7 +130,7 @@ func (bc *BlockChain) CommitOffChainData(
 	if isBeaconChain && shard.Schedule.IsLastBlock(header.Number().Uint64()+1) {
 		// Update snapshots for all validators
 		epoch := new(big.Int).Add(header.Epoch(), common.Big1)
-		if err := bc.UpdateValidatorSnapshots(batch, epoch, state); err != nil {
+		if err := bc.UpdateValidatorSnapshots(batch, epoch, state, newVals); err != nil {
 			return NonStatTy, err
 		}
 	}


### PR DESCRIPTION
commit f2524a888d6133e7d729ee22031d198695e8ce5f
Author: Rongjian Lan <rongjian.lan@gmail.com>
Date:   Sun Apr 5 12:33:35 2020 -0700

    Make validator snapshot on new validator too (#2733)

commit 350b7a0bb45c68889547ac5b9521f46dcd97ced8
Author: Rongjian Lan <rongjian.lan@gmail.com>
Date:   Sat Apr 4 23:41:19 2020 -0700

    fix validator snapshot cache

commit 8f5f287c749c62209f2dd08bfc0dbfc88df7b225
Author: Leo Chen <leo@harmony.one>
Date:   Sat Apr 4 19:09:38 2020 -0700

    [node.sh] use rclone to fast sync harmony_db_0 (#2709)

    Signed-off-by: Leo Chen <leo@harmony.one>

commit 05f2e20a39e3472ee1ff506aa8b974a988a9a970
Author: Rongjian Lan <rongjian.lan@gmail.com>
Date:   Sat Apr 4 19:00:28 2020 -0700

    make validator snapshot consistent with election (#2726)

    * make validator snapshot consistent with election

    * fix condition with only beacon chain

    * Fix epoch number

    * Fix stats update nil epoch issue

commit 24a17feecdbd91b8bc3c8a758be6e2f0c2e2b973
Author: Edgar Aroutiounian <edgar.factorial@gmail.com>
Date:   Sat Apr 4 16:38:12 2020 -0700

    [state] ValidatorWrapper div zero panic fix -  (#2724)

    * [state] Error on div zero

    * [state] Do not pay out commit when commit is 0%

    * [state] Put whole commission in guarded block

    * [core] Reward cannot be zero

    * [state] return nil, not hard error

commit 1f83ebf6a6f2853d9df2b18fd658a82a32c4f530
Author: Minh Doan <40258599+mikedoan@users.noreply.github.com>
Date:   Sat Apr 4 14:38:55 2020 -0700

    change explorer node storage folder (#2720)

commit 3aa08e9e3b4f17423eda01138b2900e0abf6f0c0
Author: Edgar Aroutiounian <edgar.factorial@gmail.com>
Date:   Sat Apr 4 10:21:51 2020 -0700

    [rpc] Show both latest header of beacon chain and shard chain (#2714)

commit 1a2c23ada524e4cadc89001bec60f9b5147885b8
Author: Edgar Aroutiounian <edgar.factorial@gmail.com>
Date:   Fri Apr 3 17:49:24 2020 -0700

    [validator] Hide one field from JSON (#2705)

## Issue

<!-- link to the issue number or description of the issue -->

## Test

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
