### PR TITLE
do snapshot for validators at last block of epoch

### DIFF
--- a/core/offchain.go
+++ b/core/offchain.go
@@ -94,7 +94,7 @@ func (bc *BlockChain) CommitOffChainData(
 
 	// Do bookkeeping for new staking txns
 	newVals, err := bc.UpdateStakingMetaData(
-		batch, block.StakingTransactions(), state, epoch,
+		batch, block.StakingTransactions(), state, epoch, isNewEpoch,
 	)
 	if err != nil {
 		utils.Logger().Err(err).Msg("UpdateStakingMetaData failed")


### PR DESCRIPTION
Need to do snapshot for new validators at last block of an epoch for the new epoch.