### PR TITLE
[consensus][viewchange] fix total power of signers in IsQuorumAchieved for view change

### DIFF
--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -357,7 +357,7 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 			binary.LittleEndian.PutUint64(blockNumBytes[:], consensus.blockNum)
 			commitPayload := append(blockNumBytes[:], consensus.blockHash[:]...)
 			if _, err := consensus.Decider.SubmitVote(
-				quorum.Commit,
+				quorum.ViewChange,
 				newLeaderKey,
 				newLeaderPriKey.SignHash(commitPayload),
 				common.BytesToHash(consensus.blockHash[:]),


### PR DESCRIPTION
fixes https://github.com/harmony-one/harmony/issues/2741

didn't want to completely get rid of quorum.ViewChange, as signers total voting power information could be useful. Further, removing the option  quorum.ViewChange may lead to regression.