### PR TITLE
fix block proposal ordering; other offchain commits change

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -2,7 +2,6 @@ package consensus
 
 import (
 	"fmt"
-	"math/big"
 	"sync"
 	"time"
 
@@ -129,8 +128,6 @@ type Consensus struct {
 	syncNotReadyChan chan struct{}
 	// If true, this consensus will not propose view change.
 	disableViewChange bool
-	// last node block reward for metrics
-	lastBlockReward *big.Int
 	// Have a dedicated reader thread pull from this chan, like in node
 	SlashChan chan slash.Record
 }
@@ -165,11 +162,6 @@ func (consensus *Consensus) BlocksNotSynchronized() {
 // VdfSeedSize returns the number of VRFs for VDF computation
 func (consensus *Consensus) VdfSeedSize() int {
 	return int(consensus.Decider.ParticipantsCount()) * 2 / 3
-}
-
-// GetBlockReward returns last node block reward
-func (consensus *Consensus) GetBlockReward() *big.Int {
-	return consensus.lastBlockReward
 }
 
 // GetLeaderPrivateKey returns leader private key if node is the leader
@@ -229,7 +221,6 @@ func New(
 	consensus.SlashChan = make(chan slash.Record)
 	consensus.commitFinishChan = make(chan uint64)
 	consensus.ReadySignal = make(chan struct{})
-	consensus.lastBlockReward = common.Big0
 	// channel for receiving newly generated VDF
 	consensus.RndChannel = make(chan [vdfAndSeedSize]byte)
 	return &consensus, nil

--- a/core/staking_verifier.go
+++ b/core/staking_verifier.go
@@ -2,9 +2,9 @@ package core
 
 import (
 	"bytes"
+	"github.com/ethereum/go-ethereum/common"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/common/denominations"
 	"github.com/harmony-one/harmony/core/vm"
 	common2 "github.com/harmony-one/harmony/internal/common"

--- a/core/staking_verifier.go
+++ b/core/staking_verifier.go
@@ -2,8 +2,9 @@ package core
 
 import (
 	"bytes"
-	"github.com/ethereum/go-ethereum/common"
 	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/harmony-one/harmony/common/denominations"
 	"github.com/harmony-one/harmony/core/vm"

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -356,7 +356,9 @@ func (b *APIBackend) GetValidatorInformation(
 	}
 
 	now := block.Epoch()
-	inCommittee := now.Cmp(wrapper.LastEpochInCommittee) == 0
+	// At the last block of epoch, block epoch is e while val.LastEpochInCommittee
+	// is already updated to e+1. So need the >= check rather than ==
+	inCommittee := wrapper.LastEpochInCommittee.Cmp(now) >= 0
 	defaultReply := &staking.ValidatorRPCEnchanced{
 		CurrentlyInCommittee: inCommittee,
 		Wrapper:              *wrapper,

--- a/internal/chain/reward.go
+++ b/internal/chain/reward.go
@@ -74,9 +74,10 @@ func lookupVotingPower(
 	return results.(*votepower.Roster), nil
 }
 
-// AccumulateRewards credits the coinbase of the given block with the mining
+// AccumulateRewardsAndCountSigs credits the coinbase of the given block with the mining
 // reward. The total reward consists of the static block reward
-func AccumulateRewards(
+// This func also do IncrementValidatorSigningCounts for validators
+func AccumulateRewardsAndCountSigs(
 	bc engine.ChainReader, state *state.DB,
 	header *block.Header, beaconChain engine.ChainReader,
 ) (reward.Reader, error) {

--- a/staking/availability/measure.go
+++ b/staking/availability/measure.go
@@ -185,6 +185,11 @@ func ComputeCurrentSigning(
 	}
 
 	s1, s2 := numeric.NewDecFromBigInt(signed), numeric.NewDecFromBigInt(toSign)
+	if s2.IsNil() || s2.IsZero() {
+		// Shouldn't happen
+		utils.Logger().Debug().Interface("toSign", toSign).Msg("s2 is nil or zero")
+		return computed
+	}
 	computed.Percentage = s1.Quo(s2)
 	computed.IsBelowThreshold = IsBelowSigningThreshold(computed.Percentage)
 	return computed

--- a/staking/availability/measure.go
+++ b/staking/availability/measure.go
@@ -185,11 +185,6 @@ func ComputeCurrentSigning(
 	}
 
 	s1, s2 := numeric.NewDecFromBigInt(signed), numeric.NewDecFromBigInt(toSign)
-	if s2.IsNil() || s2.IsZero() {
-		// Shouldn't happen
-		utils.Logger().Debug().Interface("toSign", toSign).Msg("s2 is nil or zero")
-		return computed
-	}
 	computed.Percentage = s1.Quo(s2)
 	computed.IsBelowThreshold = IsBelowSigningThreshold(computed.Percentage)
 	return computed

--- a/staking/effective/eligible.go
+++ b/staking/effective/eligible.go
@@ -82,8 +82,8 @@ const (
 	NotBooted BootedStatus = iota
 	// LostEPoSAuction ..
 	LostEPoSAuction
-	// InsufficientUptimeDuringEpoch ..
-	InsufficientUptimeDuringEpoch
+	// TurnedInactiveOrInsufficientUptime ..
+	TurnedInactiveOrInsufficientUptime
 	// BannedForDoubleSigning ..
 	BannedForDoubleSigning
 )
@@ -92,8 +92,8 @@ func (r BootedStatus) String() string {
 	switch r {
 	case LostEPoSAuction:
 		return "lost epos auction"
-	case InsufficientUptimeDuringEpoch:
-		return "bad uptime"
+	case TurnedInactiveOrInsufficientUptime:
+		return "manually turned inactive or insufficient uptime"
 	case BannedForDoubleSigning:
 		return doubleSigningBanned
 	default:

--- a/staking/network/reward.go
+++ b/staking/network/reward.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/common/denominations"
 	"github.com/harmony-one/harmony/consensus/engine"
 	"github.com/harmony-one/harmony/consensus/reward"
@@ -31,7 +30,7 @@ var (
 		"total payout not equal to blockreward",
 	)
 	// NoReward ..
-	NoReward = common.Big0
+	NoReward = big.NewInt(0)
 	// EmptyPayout ..
 	EmptyPayout = noReward{}
 )
@@ -46,7 +45,7 @@ type noReward struct{ ignoreMissing }
 
 func (noReward) ReadRoundResult() *reward.CompletedRound {
 	return &reward.CompletedRound{
-		Total:            common.Big0,
+		Total:            big.NewInt(0),
 		BeaconchainAward: []reward.Payout{},
 		ShardChainAward:  []reward.Payout{},
 	}


### PR DESCRIPTION
Move EPoS Status check before the AccumulateRewards to be consistent with block proposal state.

Remove some dead code on delete validator snapshot.

Fix InCommittee condition check.

Add div by 0 safety guard to avoid crash.

Do no compute uptime for EPoS Booted status. It's not consistent with that for block proposal. Instead just use Inactive.

More cleanup on common.Big0 usage.