### PR TITLE
optimize leader signature collection strategy; Clean up logs

### DIFF
--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -590,6 +590,7 @@ func (ss *StateSync) UpdateBlockAndStatus(block *types.Block, bc *core.BlockChai
 		Uint64("blockHeight", block.NumberU64()).
 		Uint64("blockEpoch", block.Epoch().Uint64()).
 		Str("blockHex", block.Hash().Hex()).
+		Uint32("ShardID", block.ShardID()).
 		Msg("[SYNC] UpdateBlockAndStatus: new block added to blockchain")
 	for i, tx := range block.StakingTransactions() {
 		utils.Logger().Info().
@@ -783,7 +784,7 @@ func (ss *StateSync) SyncLoop(bc *core.BlockChain, worker *worker.Worker, isBeac
 			return
 		}
 		utils.Logger().Debug().
-			Msgf("[SYNC] Node is Not in Sync (isBeacon: %t, ShardID: %d, otherHeight: %d, currentHeight: %d)",
+			Msgf("[SYNC] Node is OUT OF SYNC (isBeacon: %t, ShardID: %d, otherHeight: %d, currentHeight: %d)",
 				isBeacon, bc.ShardID(), otherHeight, currentHeight)
 
 		startHash := bc.CurrentBlock().Hash()

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -742,6 +742,7 @@ func main() {
 		os.Exit(1)
 	}
 	currentNode := setupConsensusAndNode(nodeConfig)
+	nodeconfig.GetDefaultConfig().ShardID = nodeConfig.ShardID
 
 	// Prepare for graceful shutdown from os signals
 	osSignal := make(chan os.Signal)

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -571,8 +571,9 @@ func setupConsensusAndNode(nodeConfig *nodeconfig.ConfigType) *node.Node {
 	// update consensus information based on the blockchain
 	currentConsensus.SetMode(currentConsensus.UpdateConsensusInformation())
 
-	// Setup block period for currentConsensus.
+	// Setup block period and block due time.
 	currentConsensus.BlockPeriod = time.Duration(*blockPeriod) * time.Second
+	currentConsensus.NextBlockDue = time.Now()
 	return currentNode
 }
 

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -548,9 +548,6 @@ func setupConsensusAndNode(nodeConfig *nodeconfig.ConfigType) *node.Node {
 	currentNode.NodeConfig.ConsensusPubKey = nodeConfig.ConsensusPubKey
 	currentNode.NodeConfig.ConsensusPriKey = nodeConfig.ConsensusPriKey
 
-	// Setup block period for currentNode.
-	currentNode.BlockPeriod = time.Duration(*blockPeriod) * time.Second
-
 	// This needs to be executed after consensus setup
 	if err := currentNode.InitConsensusWithValidators(); err != nil {
 		utils.Logger().Warn().
@@ -573,6 +570,9 @@ func setupConsensusAndNode(nodeConfig *nodeconfig.ConfigType) *node.Node {
 
 	// update consensus information based on the blockchain
 	currentConsensus.SetMode(currentConsensus.UpdateConsensusInformation())
+
+	// Setup block period for currentConsensus.
+	currentConsensus.BlockPeriod = time.Duration(*blockPeriod) * time.Second
 	return currentNode
 }
 

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -128,6 +128,8 @@ type Consensus struct {
 	disableViewChange bool
 	// Have a dedicated reader thread pull from this chan, like in node
 	SlashChan chan slash.Record
+	// How long in second the leader needs to wait to propose a new block.
+	BlockPeriod time.Duration
 }
 
 // SetCommitDelay sets the commit message delay.  If set to non-zero,

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -130,6 +130,8 @@ type Consensus struct {
 	SlashChan chan slash.Record
 	// How long in second the leader needs to wait to propose a new block.
 	BlockPeriod time.Duration
+	// The time due for next block proposal
+	NextBlockDue time.Time
 }
 
 // SetCommitDelay sets the commit message delay.  If set to non-zero,

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -181,10 +181,10 @@ func (consensus *Consensus) finalizeCommits() {
 		Int("numStakingTxns", len(block.StakingTransactions())).
 		Msg("HOORAY!!!!!!! CONSENSUS REACHED!!!!!!!")
 
-	if time.Now().Before(consensus.NextBlockDue) {
+	if n := time.Now(); n.Before(consensus.NextBlockDue) {
 		// Sleep to wait for the full block time
 		consensus.getLogger().Debug().Msg("[finalizeCommits] Waiting for Block Time")
-		time.Sleep(consensus.NextBlockDue.Sub(time.Now()))
+		time.Sleep(consensus.NextBlockDue.Sub(n))
 	}
 	// Send signal to Node to propose the new block for consensus
 	consensus.ReadySignal <- struct{}{}

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -367,13 +367,13 @@ func (consensus *Consensus) Start(
 				consensus.SetViewID(consensus.ChainReader.CurrentHeader().ViewID().Uint64() + 1)
 				mode := consensus.UpdateConsensusInformation()
 				consensus.current.SetMode(mode)
-				consensus.getLogger().Info().Str("Mode", mode.String()).Msg("Node is in sync")
+				consensus.getLogger().Info().Str("Mode", mode.String()).Msg("Node is IN SYNC")
 
 			case <-consensus.syncNotReadyChan:
 				consensus.getLogger().Debug().Msg("[ConsensusMainLoop] syncNotReadyChan")
 				consensus.SetBlockNum(consensus.ChainReader.CurrentHeader().Number().Uint64() + 1)
 				consensus.current.SetMode(Syncing)
-				consensus.getLogger().Info().Msg("Node is out of sync")
+				consensus.getLogger().Info().Msg("[ConsensusMainLoop] Node is OUT OF SYNC")
 
 			case newBlock := <-blockChannel:
 				// Debug code to trigger leader change.

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -259,7 +259,11 @@ func (consensus *Consensus) onCommit(msg *msg_pb.Message) {
 	if !quorumWasMet && quorumIsMet {
 		logger.Info().Msg("[OnCommit] 2/3 Enough commits received")
 		go func(viewID uint64) {
-			time.Sleep(2 * time.Second)
+			if time.Now().Before(consensus.NextBlockDue) {
+				// Sleep to wait for the full block time
+				consensus.getLogger().Debug().Msg("[OnCommit] Starting Grace Period")
+				time.Sleep(consensus.NextBlockDue.Sub(time.Now()))
+			}
 			logger.Debug().Msg("[OnCommit] Commit Grace Period Ended")
 			consensus.commitFinishChan <- viewID
 		}(consensus.viewID)

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -267,10 +267,10 @@ func (consensus *Consensus) onCommit(msg *msg_pb.Message) {
 		consensus.msgSender.StopRetry(msg_pb.MessageType_PREPARED)
 	}
 
-	if consensus.Decider.IsRewardThresholdAchieved() {
+	if consensus.Decider.IsAllSigsCollected() {
 		go func(viewID uint64) {
 			consensus.commitFinishChan <- viewID
-			logger.Info().Msg("[OnCommit] 90% Enough commits received")
+			logger.Info().Msg("[OnCommit] 100% Enough commits received")
 		}(consensus.viewID)
 	}
 }

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -259,10 +259,10 @@ func (consensus *Consensus) onCommit(msg *msg_pb.Message) {
 	if !quorumWasMet && quorumIsMet {
 		logger.Info().Msg("[OnCommit] 2/3 Enough commits received")
 		go func(viewID uint64) {
-			if time.Now().Before(consensus.NextBlockDue) {
+			if n := time.Now(); n.Before(consensus.NextBlockDue) {
 				// Sleep to wait for the full block time
 				consensus.getLogger().Debug().Msg("[OnCommit] Starting Grace Period")
-				time.Sleep(consensus.NextBlockDue.Sub(time.Now()))
+				time.Sleep(consensus.NextBlockDue.Sub(n))
 			}
 			logger.Debug().Msg("[OnCommit] Commit Grace Period Ended")
 			consensus.commitFinishChan <- viewID

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -259,9 +259,11 @@ func (consensus *Consensus) onCommit(msg *msg_pb.Message) {
 	if !quorumWasMet && quorumIsMet {
 		logger.Info().Msg("[OnCommit] 2/3 Enough commits received")
 		go func(viewID uint64) {
+			consensus.getLogger().Debug().Msg("[OnCommit] Starting Grace Period")
+			// Always wait for 2 seconds as minimum grace period
+			time.Sleep(2 * time.Second)
 			if n := time.Now(); n.Before(consensus.NextBlockDue) {
 				// Sleep to wait for the full block time
-				consensus.getLogger().Debug().Msg("[OnCommit] Starting Grace Period")
 				time.Sleep(consensus.NextBlockDue.Sub(n))
 			}
 			logger.Debug().Msg("[OnCommit] Commit Grace Period Ended")

--- a/consensus/quorum/one-node-one-vote.go
+++ b/consensus/quorum/one-node-one-vote.go
@@ -52,9 +52,9 @@ func (v *uniformVoteWeight) QuorumThreshold() numeric.Dec {
 	return numeric.NewDec(v.TwoThirdsSignersCount())
 }
 
-// RewardThreshold ..
-func (v *uniformVoteWeight) IsRewardThresholdAchieved() bool {
-	return v.SignersCount(Commit) >= (v.ParticipantsCount() * 9 / 10)
+// IsAllSigsCollected ..
+func (v *uniformVoteWeight) IsAllSigsCollected() bool {
+	return v.SignersCount(Commit) == v.ParticipantsCount()
 }
 
 func (v *uniformVoteWeight) SetVoters(

--- a/consensus/quorum/one-node-staked-vote.go
+++ b/consensus/quorum/one-node-staked-vote.go
@@ -14,9 +14,8 @@ import (
 )
 
 var (
-	twoThird      = numeric.NewDec(2).Quo(numeric.NewDec(3))
-	ninetyPercent = numeric.MustNewDecFromStr("0.90")
-	totalShare    = numeric.MustNewDecFromStr("1.00")
+	twoThird   = numeric.NewDec(2).Quo(numeric.NewDec(3))
+	totalShare = numeric.MustNewDecFromStr("1.00")
 )
 
 // TallyResult is the result of when we calculate voting power,
@@ -137,16 +136,9 @@ func (v *stakedVoteWeight) QuorumThreshold() numeric.Dec {
 	return twoThird
 }
 
-// RewardThreshold ..
-func (v *stakedVoteWeight) IsRewardThresholdAchieved() bool {
-	reached, err := v.computeCurrentTotalPower(Commit)
-	if err != nil {
-		utils.Logger().Error().
-			AnErr("bls error", err).
-			Msg("Failure in attempt bls-key reading")
-		return false
-	}
-	return reached.GTE(ninetyPercent)
+// IsAllSigsCollected ..
+func (v *stakedVoteWeight) IsAllSigsCollected() bool {
+	return v.SignersCount(Commit) == v.ParticipantsCount()
 }
 
 var (

--- a/consensus/quorum/one-node-staked-vote_test.go
+++ b/consensus/quorum/one-node-staked-vote_test.go
@@ -161,9 +161,9 @@ func TestEvenNodes(t *testing.T) {
 			ViewChange, strconv.FormatBool(achieved))
 	}
 	// RewardThreshold
-	rewarded := stakedVote.IsRewardThresholdAchieved()
+	rewarded := stakedVote.IsAllSigsCollected()
 	if rewarded {
-		t.Errorf("[IsRewardThresholdAchieved] Got: %s, Expected: false (All Staker nodes = 32%%)",
+		t.Errorf("[IsAllSigsCollected] Got: %s, Expected: false (All Staker nodes = 32%%)",
 			strconv.FormatBool(rewarded))
 	}
 
@@ -189,9 +189,9 @@ func TestEvenNodes(t *testing.T) {
 			ViewChange, strconv.FormatBool(achieved))
 	}
 	// RewardThreshold
-	rewarded = stakedVote.IsRewardThresholdAchieved()
+	rewarded = stakedVote.IsAllSigsCollected()
 	if !rewarded {
-		t.Errorf("[IsRewardThresholdAchieved] Got: %s, Expected: true (All nodes = 100%%)",
+		t.Errorf("[IsAllSigsCollected] Got: %s, Expected: true (All nodes = 100%%)",
 			strconv.FormatBool(rewarded))
 	}
 }
@@ -228,9 +228,9 @@ func Test33HarmonyNodes(t *testing.T) {
 			ViewChange, strconv.FormatBool(achieved))
 	}
 	// RewardThreshold
-	rewarded := stakedVote.IsRewardThresholdAchieved()
+	rewarded := stakedVote.IsAllSigsCollected()
 	if rewarded {
-		t.Errorf("[IsRewardThresholdAchieved] Got: %s, Expected: false (All Harmony nodes = 68%%)",
+		t.Errorf("[IsAllSigsCollected] Got: %s, Expected: false (All Harmony nodes = 68%%)",
 			strconv.FormatBool(rewarded))
 	}
 }

--- a/consensus/quorum/quorum.go
+++ b/consensus/quorum/quorum.go
@@ -118,7 +118,7 @@ type Decider interface {
 	IsQuorumAchievedByMask(mask *bls_cosi.Mask) bool
 	QuorumThreshold() numeric.Dec
 	AmIMemberOfCommitee() bool
-	IsRewardThresholdAchieved() bool
+	IsAllSigsCollected() bool
 	ResetPrepareAndCommitVotes()
 	ResetViewChangeVotes()
 }

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -279,7 +279,7 @@ func (consensus *Consensus) onCommitted(msg *msg_pb.Message) {
 	consensus.commitBitmap = mask
 
 	if recvMsg.BlockNum-consensus.blockNum > consensusBlockNumBuffer {
-		consensus.getLogger().Debug().Uint64("MsgBlockNum", recvMsg.BlockNum).Msg("[OnCommitted] out of sync")
+		consensus.getLogger().Debug().Uint64("MsgBlockNum", recvMsg.BlockNum).Msg("[OnCommitted] OUT OF SYNC")
 		go func() {
 			select {
 			case consensus.BlockNumLowChan <- struct{}{}:

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -54,7 +54,7 @@ import (
 	"github.com/harmony-one/harmony/staking/effective"
 	"github.com/harmony-one/harmony/staking/slash"
 	staking "github.com/harmony-one/harmony/staking/types"
-	"github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/pkg/errors"
 )
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/harmony-one/harmony/internal/configs/node"
 	"io"
 	"math/big"
 	"sync"
@@ -55,7 +54,7 @@ import (
 	"github.com/harmony-one/harmony/staking/effective"
 	"github.com/harmony-one/harmony/staking/slash"
 	staking "github.com/harmony-one/harmony/staking/types"
-	lru "github.com/hashicorp/golang-lru"
+	"github.com/hashicorp/golang-lru"
 	"github.com/pkg/errors"
 )
 
@@ -1960,10 +1959,6 @@ func (bc *BlockChain) ReadPendingCrossLinks() ([]types.CrossLink, error) {
 	} else {
 		bytes, err := rawdb.ReadPendingCrossLinks(bc.db)
 		if err != nil || len(bytes) == 0 {
-			if nodeconfig.GetDefaultConfig().ShardID == shard.BeaconChainShardID {
-				// Only beacon chain worries about this
-				utils.Logger().Info().Err(err).Int("dataLen", len(bytes)).Msg("ReadPendingCrossLinks")
-			}
 			return nil, err
 		}
 	}

--- a/core/offchain.go
+++ b/core/offchain.go
@@ -2,9 +2,10 @@ package core
 
 import (
 	"bytes"
-	"github.com/harmony-one/harmony/internal/configs/node"
 	"math/big"
 	"sort"
+
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"

--- a/node/node.go
+++ b/node/node.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/accounts"
@@ -186,8 +185,7 @@ type Node struct {
 	serviceMessageChan map[service.Type]chan *msg_pb.Message
 	accountManager     *accounts.Manager
 	isFirstTime        bool // the node was started with a fresh database
-	// How long in second the leader needs to wait to propose a new block.
-	BlockPeriod time.Duration
+
 	// Last 1024 staking transaction error, only in memory
 	errorSink struct {
 		sync.Mutex


### PR DESCRIPTION
Leader sig collection strategy:

**before**: once 2/3 voting power/sig collected, wait for another 2s to collect more sigs; or if 90% reached, just commit.

**now**: 
    1. always wait for the full block time (8s) and collect as much sigs as possible. New block won't be proposed before full block time.
    2. once 2/3 voting power/sig collected, wait for another 2s or more if full block time not reached.
    3. If 100% sig collected, commit the block immediately
    4. Both 2 and 3 works under constraint of 1


This change will help improve the chance of slow node getting their signatures collected in block