### PR TITLE
-is_genesis is no longer used

### DIFF
--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -825,7 +825,6 @@ do
       -bootnodes "${BN_MA}"
       -ip "${PUB_IP}"
       -port "${NODE_PORT}"
-      -is_genesis
       -network_type="${network_type}"
       -dns_zone="${dns_zone}"
       -blacklist="${blacklist}"


### PR DESCRIPTION
## Issue

`-is-genesis` is no longer part of cmd/harmony/main.go - so need to remove it

E.g:
```
node.sh: ############### Running Harmony Process ###############
flag provided but not defined: -is_genesis
```
