### PR TITLE
[rpc] separate transaction counts rpc into regular vs staking

### DIFF
--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -241,26 +241,22 @@ func (b *APIBackend) GetBalance(ctx context.Context, address common.Address, blo
 
 // GetTransactionsHistory returns list of transactions hashes of address.
 func (b *APIBackend) GetTransactionsHistory(address, txType, order string) ([]common.Hash, error) {
-	hashes, err := b.hmy.nodeAPI.GetTransactionsHistory(address, txType, order)
-	return hashes, err
+	return b.hmy.nodeAPI.GetTransactionsHistory(address, txType, order)
 }
 
 // GetStakingTransactionsHistory returns list of staking transactions hashes of address.
 func (b *APIBackend) GetStakingTransactionsHistory(address, txType, order string) ([]common.Hash, error) {
-	hashes, err := b.hmy.nodeAPI.GetStakingTransactionsHistory(address, txType, order)
-	return hashes, err
+	return b.hmy.nodeAPI.GetStakingTransactionsHistory(address, txType, order)
 }
 
 // GetTransactionsCount returns the number of regular transactions of address.
 func (b *APIBackend) GetTransactionsCount(address, txType string) (uint64, error) {
-	count, err := b.hmy.nodeAPI.GetTransactionsCount(address, txType)
-	return count, err
+	return b.hmy.nodeAPI.GetTransactionsCount(address, txType)
 }
 
 // GetStakingTransactionsCount returns the number of staking transactions of address.
 func (b *APIBackend) GetStakingTransactionsCount(address, txType string) (uint64, error) {
-	count, err := b.hmy.nodeAPI.GetStakingTransactionsCount(address, txType)
-	return count, err
+	return b.hmy.nodeAPI.GetStakingTransactionsCount(address, txType)
 }
 
 // NetVersion returns net version

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -251,15 +251,15 @@ func (b *APIBackend) GetStakingTransactionsHistory(address, txType, order string
 	return hashes, err
 }
 
-// GetTransactionCount returns the number of regular transactions of address.
-func (b *APIBackend) GetTransactionCount(address, txType string) (uint64, error) {
-	count, err := b.hmy.nodeAPI.GetTransactionCount(address, txType)
+// GetTransactionsCount returns the number of regular transactions of address.
+func (b *APIBackend) GetTransactionsCount(address, txType string) (uint64, error) {
+	count, err := b.hmy.nodeAPI.GetTransactionsCount(address, txType)
 	return count, err
 }
 
-// GetStakingTransactionCount returns the number of staking transactions of address.
-func (b *APIBackend) GetStakingTransactionCount(address, txType string) (uint64, error) {
-	count, err := b.hmy.nodeAPI.GetStakingTransactionCount(address, txType)
+// GetStakingTransactionsCount returns the number of staking transactions of address.
+func (b *APIBackend) GetStakingTransactionsCount(address, txType string) (uint64, error) {
+	count, err := b.hmy.nodeAPI.GetStakingTransactionsCount(address, txType)
 	return count, err
 }
 

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -220,6 +220,16 @@ func (b *APIBackend) GetPoolTransactions() (types.PoolTransactions, error) {
 	return txs, nil
 }
 
+// GetAccountNonce returns the nonce value of the given address for the given block number
+func (b *APIBackend) GetAccountNonce(
+	ctx context.Context, address common.Address, blockNr rpc.BlockNumber) (uint64, error) {
+	state, _, err := b.StateAndHeaderByNumber(ctx, blockNr)
+	if state == nil || err != nil {
+		return 0, err
+	}
+	return state.GetNonce(address), state.Error()
+}
+
 // GetBalance returns balance of an given address.
 func (b *APIBackend) GetBalance(ctx context.Context, address common.Address, blockNr rpc.BlockNumber) (*big.Int, error) {
 	state, _, err := b.StateAndHeaderByNumber(ctx, blockNr)
@@ -239,6 +249,18 @@ func (b *APIBackend) GetTransactionsHistory(address, txType, order string) ([]co
 func (b *APIBackend) GetStakingTransactionsHistory(address, txType, order string) ([]common.Hash, error) {
 	hashes, err := b.hmy.nodeAPI.GetStakingTransactionsHistory(address, txType, order)
 	return hashes, err
+}
+
+// GetTransactionCount returns the number of regular transactions of address.
+func (b *APIBackend) GetTransactionCount(address, txType string) (uint64, error) {
+	count, err := b.hmy.nodeAPI.GetTransactionCount(address, txType)
+	return count, err
+}
+
+// GetStakingTransactionCount returns the number of staking transactions of address.
+func (b *APIBackend) GetStakingTransactionCount(address, txType string) (uint64, error) {
+	count, err := b.hmy.nodeAPI.GetStakingTransactionCount(address, txType)
+	return count, err
 }
 
 // NetVersion returns net version

--- a/hmy/backend.go
+++ b/hmy/backend.go
@@ -46,6 +46,8 @@ type NodeAPI interface {
 	GetNonceOfAddress(address common.Address) uint64
 	GetTransactionsHistory(address, txType, order string) ([]common.Hash, error)
 	GetStakingTransactionsHistory(address, txType, order string) ([]common.Hash, error)
+	GetTransactionCount(address, txType string) (uint64, error)
+	GetStakingTransactionCount(address, txType string) (uint64, error)
 	IsCurrentlyLeader() bool
 	ErroredStakingTransactionSink() []staking.RPCTransactionError
 	ErroredTransactionSink() []types.RPCTransactionError

--- a/hmy/backend.go
+++ b/hmy/backend.go
@@ -46,8 +46,8 @@ type NodeAPI interface {
 	GetNonceOfAddress(address common.Address) uint64
 	GetTransactionsHistory(address, txType, order string) ([]common.Hash, error)
 	GetStakingTransactionsHistory(address, txType, order string) ([]common.Hash, error)
-	GetTransactionCount(address, txType string) (uint64, error)
-	GetStakingTransactionCount(address, txType string) (uint64, error)
+	GetTransactionsCount(address, txType string) (uint64, error)
+	GetStakingTransactionsCount(address, txType string) (uint64, error)
 	IsCurrentlyLeader() bool
 	ErroredStakingTransactionSink() []staking.RPCTransactionError
 	ErroredTransactionSink() []types.RPCTransactionError

--- a/internal/hmyapi/README.md
+++ b/internal/hmyapi/README.md
@@ -44,8 +44,8 @@
 * [x] hmy_getTransactionByBlockNumberAndIndex - get transaction object of block by block number and index number
 * [ ] hmy_sign - sign message using node specific sign method.
 * [ ] hmy_pendingTransactions - returns the pending transactions list.
-* [ ] hmy_getTransactionCount - returns the number of confirmed (not pending) transactions count for the account
-* [ ] hmy_getStakingTransactionCount - returns the number of confirmed (not pending) staking transactions count for the account
+* [ ] hmy_getTransactionsCount - returns the number of confirmed (not pending) transactions count for the account
+* [ ] hmy_getStakingTransactionsCount - returns the number of confirmed (not pending) staking transactions count for the account
 
 
 ### Contract related

--- a/internal/hmyapi/README.md
+++ b/internal/hmyapi/README.md
@@ -22,7 +22,7 @@
 * [ ] hmy_getUncleByBlockNumberAndIndex - get uncle by block number and index number
 * [ ] hmy_getUncleCountByBlockHash - get uncle count by block hash
 * [ ] hmy_getUncleCountByBlockNumber - get uncle count by block number
-* [ ] hmy_syncing - Returns an object with data about the sync status 
+* [ ] hmy_syncing - Returns an object with data about the sync status
 * [ ] hmy_coinbase - return coinbase address
 * [ ] hmy_mining - return if mining client is mining
 * [ ] hmy_hashrate - return current hash rate for blockchain
@@ -30,7 +30,7 @@
 
 ### Account related
 * [x] hmy_getBalance - get balance for account address
-* [x] hmy_getTransactionCount - get nonce for account address
+* [x] hmy_getAccountNonce - get nonce for account address
 * [ ] hmy_accounts - return accounts that lives in node
 
 ### Transactions related
@@ -44,10 +44,13 @@
 * [x] hmy_getTransactionByBlockNumberAndIndex - get transaction object of block by block number and index number
 * [ ] hmy_sign - sign message using node specific sign method.
 * [ ] hmy_pendingTransactions - returns the pending transactions list.
+* [ ] hmy_getTransactionCount - returns the number of confirmed (not pending) transactions count for the account
+* [ ] hmy_getStakingTransactionCount - returns the number of confirmed (not pending) staking transactions count for the account
+
 
 ### Contract related
-* [ ] hmy_call - call contract method 
-* [x] hmy_getCode - get deployed contract's byte code 
+* [ ] hmy_call - call contract method
+* [x] hmy_getCode - get deployed contract's byte code
 * [x] hmy_getStorageAt - get storage position at a given address
 * ~~[ ] hmy_getCompilers~~ - DEPRECATED
 * ~~[ ] hmy_compileLLL~~ - DEPRECATED

--- a/internal/hmyapi/apiv1/backend.go
+++ b/internal/hmyapi/apiv1/backend.go
@@ -50,6 +50,8 @@ type Backend interface {
 	GetPoolTransactions() (types.PoolTransactions, error)
 	GetPoolTransaction(txHash common.Hash) types.PoolTransaction
 	GetPoolNonce(ctx context.Context, addr common.Address) (uint64, error)
+	// Get account nonce
+	GetAccountNonce(ctx context.Context, address common.Address, blockNr rpc.BlockNumber) (uint64, error)
 	// Stats() (pending int, queued int)
 	// TxPoolContent() (map[common.Address]types.Transactions, map[common.Address]types.Transactions)
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
@@ -60,10 +62,10 @@ type Backend interface {
 	// Get validators for a particular epoch
 	GetValidators(epoch *big.Int) (*shard.Committee, error)
 	GetShardID() uint32
-	// Get transactions history for an address
 	GetTransactionsHistory(address, txType, order string) ([]common.Hash, error)
-	// Get staking transactions history for an address
 	GetStakingTransactionsHistory(address, txType, order string) ([]common.Hash, error)
+	GetTransactionCount(address, txType string) (uint64, error)
+	GetStakingTransactionCount(address, txType string) (uint64, error)
 	// retrieve the blockHash using txID and add blockHash to CxPool for resending
 	ResendCx(ctx context.Context, txID common.Hash) (uint64, bool)
 	IsLeader() bool

--- a/internal/hmyapi/apiv1/backend.go
+++ b/internal/hmyapi/apiv1/backend.go
@@ -64,8 +64,8 @@ type Backend interface {
 	GetShardID() uint32
 	GetTransactionsHistory(address, txType, order string) ([]common.Hash, error)
 	GetStakingTransactionsHistory(address, txType, order string) ([]common.Hash, error)
-	GetTransactionCount(address, txType string) (uint64, error)
-	GetStakingTransactionCount(address, txType string) (uint64, error)
+	GetTransactionsCount(address, txType string) (uint64, error)
+	GetStakingTransactionsCount(address, txType string) (uint64, error)
 	// retrieve the blockHash using txID and add blockHash to CxPool for resending
 	ResendCx(ctx context.Context, txID common.Hash) (uint64, bool)
 	IsLeader() bool

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -388,6 +388,12 @@ func (s *PublicBlockChainAPI) GetBalanceByBlockNumber(ctx context.Context, addre
 	return (*hexutil.Big)(balance), err
 }
 
+// GetAccountNonce returns the nonce value of the given address for the given block number
+func (s *PublicBlockChainAPI) GetAccountNonce(ctx context.Context, address string, blockNr rpc.BlockNumber) (uint64, error) {
+	addr := internal_common.ParseAddr(address)
+	return s.b.GetAccountNonce(ctx, addr, rpc.BlockNumber(blockNr))
+}
+
 // GetBalance returns the amount of Nano for the given address in the state of the
 // given block number. The rpc.LatestBlockNumber and rpc.PendingBlockNumber meta
 // block numbers are also allowed.

--- a/internal/hmyapi/apiv1/transactionpool.go
+++ b/internal/hmyapi/apiv1/transactionpool.go
@@ -184,8 +184,7 @@ func (s *PublicTransactionPoolAPI) GetTransactionsCount(ctx context.Context, add
 			return 0, err
 		}
 	}
-	count, err := s.b.GetTransactionsCount(address, txType)
-	return count, err
+	return s.b.GetTransactionsCount(address, txType)
 }
 
 // GetStakingTransactionsCount returns the number of staking transactions from genesis of input type ("SENT", "RECEIVED", "ALL")
@@ -198,8 +197,7 @@ func (s *PublicTransactionPoolAPI) GetStakingTransactionsCount(ctx context.Conte
 			return 0, err
 		}
 	}
-	count, err := s.b.GetStakingTransactionsCount(address, txType)
-	return count, err
+	return s.b.GetStakingTransactionsCount(address, txType)
 }
 
 // SendRawStakingTransaction will add the signed transaction to the transaction pool.

--- a/internal/hmyapi/apiv1/transactionpool.go
+++ b/internal/hmyapi/apiv1/transactionpool.go
@@ -152,26 +152,6 @@ func (s *PublicTransactionPoolAPI) GetStakingTransactionByBlockHashAndIndex(ctx 
 	return nil
 }
 
-// GetTransactionCount returns the number of transactions the given address has sent for the given block number
-func (s *PublicTransactionPoolAPI) GetTransactionCount(ctx context.Context, addr string, blockNr rpc.BlockNumber) (*hexutil.Uint64, error) {
-	address := internal_common.ParseAddr(addr)
-	// Ask transaction pool for the nonce which includes pending transactions
-	if blockNr == rpc.PendingBlockNumber {
-		nonce, err := s.b.GetPoolNonce(ctx, address)
-		if err != nil {
-			return nil, err
-		}
-		return (*hexutil.Uint64)(&nonce), nil
-	}
-	// Resolve block number and use its state to ask for the nonce
-	state, _, err := s.b.StateAndHeaderByNumber(ctx, blockNr)
-	if state == nil || err != nil {
-		return nil, err
-	}
-	nonce := state.GetNonce(address)
-	return (*hexutil.Uint64)(&nonce), state.Error()
-}
-
 // SendRawStakingTransaction will add the signed transaction to the transaction pool.
 // The sender is responsible for signing the transaction and using the correct nonce.
 func (s *PublicTransactionPoolAPI) SendRawStakingTransaction(

--- a/internal/hmyapi/apiv2/backend.go
+++ b/internal/hmyapi/apiv2/backend.go
@@ -50,6 +50,7 @@ type Backend interface {
 	GetPoolTransactions() (types.PoolTransactions, error)
 	GetPoolTransaction(txHash common.Hash) types.PoolTransaction
 	GetPoolNonce(ctx context.Context, addr common.Address) (uint64, error)
+	GetAccountNonce(ctx context.Context, addr common.Address, blockNr rpc.BlockNumber) (uint64, error)
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
 	ChainConfig() *params.ChainConfig
 	CurrentBlock() *types.Block
@@ -59,6 +60,8 @@ type Backend interface {
 	GetShardID() uint32
 	GetTransactionsHistory(address, txType, order string) ([]common.Hash, error)
 	GetStakingTransactionsHistory(address, txType, order string) ([]common.Hash, error)
+	GetTransactionCount(address, txType string) (uint64, error)
+	GetStakingTransactionCount(address, txType string) (uint64, error)
 	ResendCx(ctx context.Context, txID common.Hash) (uint64, bool)
 	IsLeader() bool
 	SendStakingTx(ctx context.Context, newStakingTx *staking.StakingTransaction) error

--- a/internal/hmyapi/apiv2/backend.go
+++ b/internal/hmyapi/apiv2/backend.go
@@ -60,8 +60,8 @@ type Backend interface {
 	GetShardID() uint32
 	GetTransactionsHistory(address, txType, order string) ([]common.Hash, error)
 	GetStakingTransactionsHistory(address, txType, order string) ([]common.Hash, error)
-	GetTransactionCount(address, txType string) (uint64, error)
-	GetStakingTransactionCount(address, txType string) (uint64, error)
+	GetTransactionsCount(address, txType string) (uint64, error)
+	GetStakingTransactionsCount(address, txType string) (uint64, error)
 	ResendCx(ctx context.Context, txID common.Hash) (uint64, bool)
 	IsLeader() bool
 	SendStakingTx(ctx context.Context, newStakingTx *staking.StakingTransaction) error

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -352,6 +352,12 @@ func (s *PublicBlockChainAPI) GetBalanceByBlockNumber(ctx context.Context, addre
 	return s.b.GetBalance(ctx, addr, rpc.BlockNumber(blockNr))
 }
 
+// GetAccountNonce returns the nonce value of the given address for the given block number
+func (s *PublicBlockChainAPI) GetAccountNonce(ctx context.Context, address string, blockNr rpc.BlockNumber) (uint64, error) {
+	addr := internal_common.ParseAddr(address)
+	return s.b.GetAccountNonce(ctx, addr, rpc.BlockNumber(blockNr))
+}
+
 // GetBalance returns the amount of Nano for the given address in the state of the
 // given block number. The rpc.LatestBlockNumber and rpc.PendingBlockNumber meta
 // block numbers are also allowed.

--- a/internal/hmyapi/apiv2/transactionpool.go
+++ b/internal/hmyapi/apiv2/transactionpool.go
@@ -210,8 +210,7 @@ func (s *PublicTransactionPoolAPI) GetTransactionsCount(ctx context.Context, add
 			return 0, err
 		}
 	}
-	count, err := s.b.GetTransactionsCount(address, txType)
-	return count, err
+	return s.b.GetTransactionsCount(address, txType)
 }
 
 // GetStakingTransactionsCount returns the number of staking transactions from genesis of input type ("SENT", "RECEIVED", "ALL")
@@ -224,8 +223,7 @@ func (s *PublicTransactionPoolAPI) GetStakingTransactionsCount(ctx context.Conte
 			return 0, err
 		}
 	}
-	count, err := s.b.GetStakingTransactionsCount(address, txType)
-	return count, err
+	return s.b.GetStakingTransactionsCount(address, txType)
 }
 
 // SendRawStakingTransaction will add the signed transaction to the transaction pool.

--- a/internal/hmyapi/apiv2/transactionpool.go
+++ b/internal/hmyapi/apiv2/transactionpool.go
@@ -200,8 +200,8 @@ func (s *PublicTransactionPoolAPI) GetStakingTransactionByHash(ctx context.Conte
 	return nil
 }
 
-// GetTransactionCount returns the number of regular transactions from genesis of input type ("SENT", "RECEIVED", "ALL")
-func (s *PublicTransactionPoolAPI) GetTransactionCount(ctx context.Context, address, txType string) (uint64, error) {
+// GetTransactionsCount returns the number of regular transactions from genesis of input type ("SENT", "RECEIVED", "ALL")
+func (s *PublicTransactionPoolAPI) GetTransactionsCount(ctx context.Context, address, txType string) (uint64, error) {
 	var err error
 	if !strings.HasPrefix(address, "one1") {
 		addr := internal_common.ParseAddr(address)
@@ -210,12 +210,12 @@ func (s *PublicTransactionPoolAPI) GetTransactionCount(ctx context.Context, addr
 			return 0, err
 		}
 	}
-	count, err := s.b.GetTransactionCount(address, txType)
+	count, err := s.b.GetTransactionsCount(address, txType)
 	return count, err
 }
 
-// GetStakingTransactionCount returns the number of staking transactions from genesis of input type ("SENT", "RECEIVED", "ALL")
-func (s *PublicTransactionPoolAPI) GetStakingTransactionCount(ctx context.Context, address, txType string) (uint64, error) {
+// GetStakingTransactionsCount returns the number of staking transactions from genesis of input type ("SENT", "RECEIVED", "ALL")
+func (s *PublicTransactionPoolAPI) GetStakingTransactionsCount(ctx context.Context, address, txType string) (uint64, error) {
 	var err error
 	if !strings.HasPrefix(address, "one1") {
 		addr := internal_common.ParseAddr(address)
@@ -224,7 +224,7 @@ func (s *PublicTransactionPoolAPI) GetStakingTransactionCount(ctx context.Contex
 			return 0, err
 		}
 	}
-	count, err := s.b.GetStakingTransactionCount(address, txType)
+	count, err := s.b.GetStakingTransactionsCount(address, txType)
 	return count, err
 }
 

--- a/internal/hmyapi/apiv2/transactionpool.go
+++ b/internal/hmyapi/apiv2/transactionpool.go
@@ -200,28 +200,32 @@ func (s *PublicTransactionPoolAPI) GetStakingTransactionByHash(ctx context.Conte
 	return nil
 }
 
-// GetTransactionCount returns the number of transactions the given address has sent from genesis to the input block number
-// NOTE: unlike other txn apis where staking vs. regular txns are separate,
-// the transaction count here includes the count of both regular and staking txns
-func (s *PublicTransactionPoolAPI) GetTransactionCount(
-	ctx context.Context, addr string, blockNr uint64,
-) (uint64, error) {
-	address := internal_common.ParseAddr(addr)
-	// Ask transaction pool for the nonce which includes pending transactions
-	if rpc.BlockNumber(blockNr) == rpc.PendingBlockNumber {
-		nonce, err := s.b.GetPoolNonce(ctx, address)
+// GetTransactionCount returns the number of regular transactions from genesis of input type ("SENT", "RECEIVED", "ALL")
+func (s *PublicTransactionPoolAPI) GetTransactionCount(ctx context.Context, address, txType string) (uint64, error) {
+	var err error
+	if !strings.HasPrefix(address, "one1") {
+		addr := internal_common.ParseAddr(address)
+		address, err = internal_common.AddressToBech32(addr)
 		if err != nil {
 			return 0, err
 		}
-		return nonce, nil
 	}
-	// Resolve block number and use its state to ask for the nonce
-	state, _, err := s.b.StateAndHeaderByNumber(ctx, rpc.BlockNumber(blockNr))
-	if state == nil || err != nil {
-		return 0, err
+	count, err := s.b.GetTransactionCount(address, txType)
+	return count, err
+}
+
+// GetStakingTransactionCount returns the number of staking transactions from genesis of input type ("SENT", "RECEIVED", "ALL")
+func (s *PublicTransactionPoolAPI) GetStakingTransactionCount(ctx context.Context, address, txType string) (uint64, error) {
+	var err error
+	if !strings.HasPrefix(address, "one1") {
+		addr := internal_common.ParseAddr(address)
+		address, err = internal_common.AddressToBech32(addr)
+		if err != nil {
+			return 0, err
+		}
 	}
-	nonce := state.GetNonce(address)
-	return nonce, state.Error()
+	count, err := s.b.GetStakingTransactionCount(address, txType)
+	return count, err
 }
 
 // SendRawStakingTransaction will add the signed transaction to the transaction pool.

--- a/internal/hmyapi/backend.go
+++ b/internal/hmyapi/backend.go
@@ -45,6 +45,7 @@ type Backend interface {
 	GetPoolTransactions() (types.PoolTransactions, error)
 	GetPoolTransaction(txHash common.Hash) types.PoolTransaction
 	GetPoolNonce(ctx context.Context, addr common.Address) (uint64, error)
+	GetAccountNonce(ctx context.Context, address common.Address, blockNr rpc.BlockNumber) (uint64, error)
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
 	ChainConfig() *params.ChainConfig
 	CurrentBlock() *types.Block
@@ -53,6 +54,8 @@ type Backend interface {
 	GetShardID() uint32
 	GetTransactionsHistory(address, txType, order string) ([]common.Hash, error)
 	GetStakingTransactionsHistory(address, txType, order string) ([]common.Hash, error)
+	GetTransactionCount(address, txType string) (uint64, error)
+	GetStakingTransactionCount(address, txType string) (uint64, error)
 	ResendCx(ctx context.Context, txID common.Hash) (uint64, bool)
 	IsLeader() bool
 	SendStakingTx(ctx context.Context, newStakingTx *staking.StakingTransaction) error

--- a/internal/hmyapi/backend.go
+++ b/internal/hmyapi/backend.go
@@ -54,8 +54,8 @@ type Backend interface {
 	GetShardID() uint32
 	GetTransactionsHistory(address, txType, order string) ([]common.Hash, error)
 	GetStakingTransactionsHistory(address, txType, order string) ([]common.Hash, error)
-	GetTransactionCount(address, txType string) (uint64, error)
-	GetStakingTransactionCount(address, txType string) (uint64, error)
+	GetTransactionsCount(address, txType string) (uint64, error)
+	GetStakingTransactionsCount(address, txType string) (uint64, error)
 	ResendCx(ctx context.Context, txID common.Hash) (uint64, bool)
 	IsLeader() bool
 	SendStakingTx(ctx context.Context, newStakingTx *staking.StakingTransaction) error

--- a/node/node_explorer.go
+++ b/node/node_explorer.go
@@ -210,3 +210,49 @@ func (node *Node) GetStakingTransactionsHistory(address, txType, order string) (
 	}
 	return hashes, nil
 }
+
+// GetTransactionCount returns the number of regular transactions hashes of address for input type.
+func (node *Node) GetTransactionCount(address, txType string) (uint64, error) {
+	addressData := &explorer.Address{}
+	key := explorer.GetAddressKey(address)
+	bytes, err := explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port, false).GetDB().Get([]byte(key), nil)
+	if err != nil {
+		utils.Logger().Error().Err(err).Msg("[Explorer] Cannot get storage db instance")
+		return 0, nil
+	}
+	if err = rlp.DecodeBytes(bytes, &addressData); err != nil {
+		utils.Logger().Error().Err(err).Msg("[Explorer] Cannot convert address data from DB")
+		return 0, err
+	}
+
+	count := uint64(0)
+	for _, tx := range addressData.TXs {
+		if txType == "" || txType == "ALL" || txType == tx.Type {
+			count++
+		}
+	}
+	return count, nil
+}
+
+// GetStakingTransactionCount returns the number of staking transactions hashes of address for input type.
+func (node *Node) GetStakingTransactionCount(address, txType string) (uint64, error) {
+	addressData := &explorer.Address{}
+	key := explorer.GetAddressKey(address)
+	bytes, err := explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port, false).GetDB().Get([]byte(key), nil)
+	if err != nil {
+		utils.Logger().Error().Err(err).Msg("[Explorer] Cannot get storage db instance")
+		return 0, nil
+	}
+	if err = rlp.DecodeBytes(bytes, &addressData); err != nil {
+		utils.Logger().Error().Err(err).Msg("[Explorer] Cannot convert address data from DB")
+		return 0, err
+	}
+
+	count := uint64(0)
+	for _, tx := range addressData.StakingTXs {
+		if txType == "" || txType == "ALL" || txType == tx.Type {
+			count++
+		}
+	}
+	return count, nil
+}

--- a/node/node_explorer.go
+++ b/node/node_explorer.go
@@ -211,8 +211,8 @@ func (node *Node) GetStakingTransactionsHistory(address, txType, order string) (
 	return hashes, nil
 }
 
-// GetTransactionCount returns the number of regular transactions hashes of address for input type.
-func (node *Node) GetTransactionCount(address, txType string) (uint64, error) {
+// GetTransactionsCount returns the number of regular transactions hashes of address for input type.
+func (node *Node) GetTransactionsCount(address, txType string) (uint64, error) {
 	addressData := &explorer.Address{}
 	key := explorer.GetAddressKey(address)
 	bytes, err := explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port, false).GetDB().Get([]byte(key), nil)
@@ -234,8 +234,8 @@ func (node *Node) GetTransactionCount(address, txType string) (uint64, error) {
 	return count, nil
 }
 
-// GetStakingTransactionCount returns the number of staking transactions hashes of address for input type.
-func (node *Node) GetStakingTransactionCount(address, txType string) (uint64, error) {
+// GetStakingTransactionsCount returns the number of staking transactions hashes of address for input type.
+func (node *Node) GetStakingTransactionsCount(address, txType string) (uint64, error) {
 	addressData := &explorer.Address{}
 	key := explorer.GetAddressKey(address)
 	bytes, err := explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port, false).GetDB().Get([]byte(key), nil)

--- a/scripts/api_test.sh
+++ b/scripts/api_test.sh
@@ -547,8 +547,8 @@ function API_getStorageAt_test() {
 
 function API_getAccountNonce_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
-	echo "POST API_getAccountNonce test:"
-	response_test ${RESPONSES[API_getAccountNonce]}
+	echo "POST hmy_getAccountNonce test:"
+	response_test ${RESPONSES[hmy_getAccountNonce]}
 	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 	echo
 }

--- a/scripts/api_test.sh
+++ b/scripts/api_test.sh
@@ -26,7 +26,7 @@ function response_test() {
 }
 
 function isHashTest() {
-	if [ "$TRANSACTION" != "null" ]; then	
+	if [ "$TRANSACTION" != "null" ]; then
 		if [[ "$TRANSACTION_HASH" =~ ^0x[0-9a-f]{64}$ ]]; then
 			echo ${green}TRANSACTION HASH VALID${reset}
 			echo
@@ -38,7 +38,7 @@ function isHashTest() {
 }
 
 function isHexTest() {
-	if [ "$1" != "null" ]; then	
+	if [ "$1" != "null" ]; then
 		if [[ "$1" =~ ^0x[0-9a-f]+$ ]]; then
 			echo ${green}VALID HEX RECIEVED${reset}
 			echo
@@ -60,7 +60,7 @@ while getopts "lbvp" OPTION; do
 			  --data "{\"jsonrpc\":\"2.0\",\"method\":\"hmy_getBlockByNumber\",\"params\":[\"0x1\", true],\"id\":1}" | jq -r '.result.hash')
 		echo "BLOCK0HASH:"
 		echo "$BLOCK_0_HASH"
-		
+
 		SIGNED_RAW_TRANSACTION=$(node ../dapp-examples/nodejs/apiTestSign.js)
 		echo "RAWTX"
 		echo "$SIGNED_RAW_TRANSACTION"
@@ -80,7 +80,7 @@ while getopts "lbvp" OPTION; do
 		TRANSACTION_BLOCK_HASH=$(echo $TRANSACTION | jq -r '.result.blockHash')
 		TRANSACTION_BLOCK_NUMBER=$(echo $TRANSACTION | jq -r '.result.blockNumber')
 		TRANSACTION_INDEX=$(echo $TRANSACTION | jq -r '.result.transactionIndex')  #Needs to be get transaction Index
-		
+
 
 		TRANSACTION_BLOCK_ID=$(( $TRANSACTION_BLOCK_NUMBER ))
 		echo TRANSACTION_BLOCK_ID
@@ -104,7 +104,7 @@ while getopts "lbvp" OPTION; do
 
 		echo "BLOCK0HASH:"
 		echo "$BLOCK_0_HASH"
-		
+
 		SIGNED_RAW_TRANSACTION=$(node ../dapp-examples/nodejs/apiTestSign.js localnet)
 		echo "RAWTX"
 		echo "$SIGNED_RAW_TRANSACTION"
@@ -123,7 +123,7 @@ while getopts "lbvp" OPTION; do
 
 		TRANSACTION_BLOCK_HASH=$(echo $TRANSACTION | jq -r '.result.blockHash')
 		TRANSACTION_BLOCK_NUMBER=$(echo $TRANSACTION | jq -r '.result.blockNumber')
-		TRANSACTION_INDEX=$(echo $TRANSACTION | jq -r '.result.transactionIndex')  
+		TRANSACTION_INDEX=$(echo $TRANSACTION | jq -r '.result.transactionIndex')
 
 		TRANSACTION_BLOCK_ID=$(( $TRANSACTION_BLOCK_NUMBER ))
 		echo TRANSACTION_BLOCK_ID
@@ -165,7 +165,7 @@ if [ "$NETWORK" == "localnet" ]; then
 	POSTDATA[net_peerCount]="net_peerCount\",\"params\":[]"
 	POSTDATA[hmy_getBalance]="hmy_getBalance\",\"params\":[\"one18t4yj4fuutj83uwqckkvxp9gfa0568uc48ggj7\", \"latest\"]"
 	POSTDATA[hmy_getStorageAt]="hmy_getStorageAt\",\"params\":[\"0xD7Ff41CA29306122185A07d04293DdB35F24Cf2d\", \"0\", \"latest\"]"
-	POSTDATA[hmy_getTransactionCount]="hmy_getTransactionCount\",\"params\":[\"0x806171f95C5a74371a19e8a312c9e5Cb4E1D24f6\", \"latest\"]" # what is this
+	POSTDATA[hmy_getAccountNonce]="hmy_getAccountNonce\",\"params\":[\"0x806171f95C5a74371a19e8a312c9e5Cb4E1D24f6\", \"latest\"]"
 	POSTDATA[hmy_sendRawTransaction]="hmy_sendRawTransaction\",\"params\":[\"$SIGNED_RAW_TRANSACTION\"]"
 	POSTDATA[hmy_getLogs]="hmy_getLogs\", \"params\":[{\"BlockHash\": \"$TRANSACTION_BLOCK_HASH\"}]"
 	POSTDATA[hmy_getFilterChanges]="hmy_getFilterChanges\", \"params\":[\"0x58010795a282878ed0d61da72a14b8b0\"]"
@@ -193,7 +193,7 @@ if [ "$NETWORK" == "betanet" ]; then
 	POSTDATA[net_peerCount]="net_peerCount\",\"params\":[]"
 	POSTDATA[hmy_getBalance]="hmy_getBalance\",\"params\":[\"one18t4yj4fuutj83uwqckkvxp9gfa0568uc48ggj7\", \"latest\"]"
 	POSTDATA[hmy_getStorageAt]="hmy_getStorageAt\",\"params\":[\"0xD7Ff41CA29306122185A07d04293DdB35F24Cf2d\", \"0\", \"latest\"]"
-	POSTDATA[hmy_getTransactionCount]="hmy_getTransactionCount\",\"params\":[\"0x806171f95C5a74371a19e8a312c9e5Cb4E1D24f6\", \"latest\"]" # what is this
+	POSTDATA[hmy_getAccountNonce]="hmy_getAccountNonce\",\"params\":[\"0x806171f95C5a74371a19e8a312c9e5Cb4E1D24f6\", \"latest\"]"
 	POSTDATA[hmy_sendRawTransaction]="hmy_sendRawTransaction\",\"params\":[\"$SIGNED_RAW_TRANSACTION\"]"
 	POSTDATA[hmy_getLogs]="hmy_getLogs\", \"params\":[{\"BlockHash\": \"$TRANSACTION_BLOCK_HASH\"}]"
 	POSTDATA[hmy_getFilterChanges]="hmy_getFilterChanges\", \"params\":[\"0x58010795a282878ed0d61da72a14b8b0\"]"
@@ -228,7 +228,7 @@ RESPONSES[hmy_syncing]=""
 RESPONSES[net_peerCount]=""
 RESPONSES[hmy_getBalance]=""
 RESPONSES[hmy_getStorageAt]=""
-RESPONSES[hmy_getTransactionCount]=""
+RESPONSES[hmy_getAccountNonce]=""
 RESPONSES[hmy_sendRawTransaction]=""
 RESPONSES[hmy_getLogs]=""
 RESPONSES[hmy_getFilterChanges]=""
@@ -243,7 +243,7 @@ RESPONSES[hmy_protocolVersion]=""
 
 ### Processes GET requests and stores reponses in RESPONSES ###
 function GET_requests() {
-	for K in "${!GETDATA[@]}"; 
+	for K in "${!GETDATA[@]}";
 	do
 		RESPONSES[$K]=$(curl -s --location --request GET "${PORT[GET]}${GETDATA[$K]}" \
 	  		--header "Content-Type: application/json" \
@@ -253,8 +253,8 @@ function GET_requests() {
 
 ### Processes POST requests and stores reponses in RESPONSES ###
 function POST_requests() {
-	for K in "${!POSTDATA[@]}"; 
-	do	
+	for K in "${!POSTDATA[@]}";
+	do
 		RESPONSES[$K]="$(curl -s --location --request POST "${PORT[POST]}" \
 	  		--header "Content-Type: application/json" \
 			--data "{\"jsonrpc\":\"2.0\",\"method\":\"${POSTDATA[$K]},\"id\":1}")"
@@ -262,7 +262,7 @@ function POST_requests() {
 }
 
 function log_API_responses() {
-	for K in "${!GETDATA[@]}"; 
+	for K in "${!GETDATA[@]}";
 	do
 		echo "${yellow}$K"
 		echo "${blue}REQUEST:"
@@ -272,8 +272,8 @@ function log_API_responses() {
 		echo
 		echo
 	done
-	for K in "${!POSTDATA[@]}"; 
-	do 
+	for K in "${!POSTDATA[@]}";
+	do
 		echo "${yellow}$K"
 		echo "${blue}REQUEST:"
 		echo "${white}${POSTDATA[$K]}"
@@ -291,10 +291,10 @@ POST_requests
 function Explorer_getBlock_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "GET blocks(explorer) test:"
-	response_test ${RESPONSES[GET_blocks]}	
-	if [ "$?"  == "1" ]; then 
+	response_test ${RESPONSES[GET_blocks]}
+	if [ "$?"  == "1" ]; then
 		BLOCKBYIDHASH=$(echo ${RESPONSES[GET_blocks]} | jq -r .[0].id)
-		if [ "$BLOCKBYIDHASH" != "null" ]; then		
+		if [ "$BLOCKBYIDHASH" != "null" ]; then
 			if [ "$BLOCKBYIDHASH" == "$TRANSACTION_BLOCK_HASH" ]; then
 				TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 				echo ${green}BLOCK HASH MATCHES TX${reset}
@@ -312,9 +312,9 @@ function Explorer_getTx_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "GET tx(explorer) test:"
 	response_test ${RESPONSES[GET_tx]}
-	if [ "$?" == "1" ]; then 
+	if [ "$?" == "1" ]; then
 		TX_HASH=$(echo ${RESPONSES[GET_tx]} | jq -r .id) # fix agrs to jq
-		if [ "$TX_HASH" != "null" ]; then		
+		if [ "$TX_HASH" != "null" ]; then
 			if [ "$TX_HASH" == "$TX_HASH" ]; then
 				TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 				echo ${green}BLOCK HASH MATCHES TX${reset}
@@ -331,7 +331,7 @@ function Explorer_getExplorerNodeAdress_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "GET address(explorer) test:"
 	response_test ${RESPONSES[GET_address]}
-	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 )) 
+	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 	echo
 }
 
@@ -352,15 +352,15 @@ function Explorer_getShard_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "GET shard(explorer) test:"
 	response_test ${RESPONSES[GET_shard]}
-	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 )) 
+	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 	echo
 }
 
-function Explorer_getCommitte_test() {	
+function Explorer_getCommitte_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "GET committe(explorer) test:"
 	response_test ${RESPONSES[GET_committee]}
-	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 )) 
+	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 	echo
 }
 
@@ -371,8 +371,8 @@ function API_getBlockByNumber_test() {
 	echo "POST hmy_getBlockByNumber test:"
 	response_test ${RESPONSES[hmy_getBlockByNumber]}
 	BLOCKBYNUMBERHASH=$(echo ${RESPONSES[hmy_getBlockByNumber]} | jq -r '.result.hash')
-	
-	if [ "$BLOCKBLOCKBYNUMBERHASH" != "null" ]; then		
+
+	if [ "$BLOCKBLOCKBYNUMBERHASH" != "null" ]; then
 		if [ "$BLOCKBYNUMBERHASH" == "$TRANSACTION_BLOCK_HASH" ]; then
 			TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 			echo ${green}BLOCK HASH MATCHES TX${reset}
@@ -389,8 +389,8 @@ function API_getBlockByHash_test() {
 	echo "POST hmy_getBlockByHash test:"
 	response_test ${RESPONSES[hmy_getBlockByHash]}
 	BLOCKBYHASHHASH=$(echo ${RESPONSES[hmy_getBlockByHash]} | jq -r '.result.hash')
-	if [ "$BLOCKBYHASHBYHASH" != "null" ]; then	
-		if [ "$BLOCKBYHASHHASH" == "$TRANSACTION_BLOCK_HASH" ]; then	
+	if [ "$BLOCKBYHASHBYHASH" != "null" ]; then
+		if [ "$BLOCKBYHASHHASH" == "$TRANSACTION_BLOCK_HASH" ]; then
 			TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 			echo ${green}BLOCK HASH MATCHES TX${reset}
 			echo
@@ -407,8 +407,8 @@ function API_getBlockTransactionCountByHash_test() {
 	response_test ${RESPONSES[hmy_getBlockTransactionCountByHash]}
 	TRANSACTIONCOUNTBYHASH=$(echo ${RESPONSES[hmy_getBlockTransactionCountByHash]} | jq -r '.result')
 	TRANSACTIONCOUNTBYHASH=$(( TRANSACTIONCOUNTBYHASH ))
-	if [ "$TRANSACTIONCOUNTBYHASH" != "null" ]; then	
-		if [ $TRANSACTIONCOUNTBYHASH -gt 0 ]; then	
+	if [ "$TRANSACTIONCOUNTBYHASH" != "null" ]; then
+		if [ $TRANSACTIONCOUNTBYHASH -gt 0 ]; then
 			TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 			echo ${green}NON ZERO TRANSACTION COUNT IN BLOCK${reset}
 			echo
@@ -419,13 +419,13 @@ function API_getBlockTransactionCountByHash_test() {
 	echo
 }
 
-function API_getBlockTransactionCountByNumber_test() {	
+function API_getBlockTransactionCountByNumber_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "POST hmy_getBlockTransactionCountByNumber test:"
 	response_test ${RESPONSES[hmy_getBlockTransactionCountByNumber]}
 	TRANSACTIONCOUNTBYNUMBER=$(echo ${RESPONSES[hmy_getBlockTransactionCountByNumber]} | jq -r '.result')
 	TRANSACTIONCOUNTBYNUMBER=$(( TRANSACTIONCOUNTBYNUMBER ))
-	if [ "$BLOCKBYHASH" != "null" ]; then		
+	if [ "$BLOCKBYHASH" != "null" ]; then
 		if [ $TRANSACTIONCOUNTBYNUMBER -gt 0 ]; then
 			TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 			echo ${green}NON ZERO TRANSACTION COUNT IN BLOCK${reset}
@@ -441,7 +441,7 @@ function API_getCode_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "POST hmy_getCode test:"
 	response_test ${RESPONSES[hmy_getCode]}
-	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 )) 
+	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 	echo
 }
 
@@ -450,8 +450,8 @@ function API_getTransactionByBlockHashAndIndex_test() {
 	echo "POST hmy_getTransactionByBlockHashAndIndex test:"
 	response_test ${RESPONSES[hmy_getTransactionByBlockHashAndIndex]}
 	TRANSACTIONHASHBYHASHANDINDEX=$(echo ${RESPONSES[hmy_getTransactionByBlockHashAndIndex]} | jq -r '.result.hash')
-	if [ "$TRANSACTIONHASHBYHASHANDINDEX" != "null" ]; then	
-		if [ "$TRANSACTIONHASHBYHASHANDINDEX" == "$TRANSACTION_HASH" ]; then	
+	if [ "$TRANSACTIONHASHBYHASHANDINDEX" != "null" ]; then
+		if [ "$TRANSACTIONHASHBYHASHANDINDEX" == "$TRANSACTION_HASH" ]; then
 			TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 			echo ${green}TRANSACTION FROM BLOCKHASH AND INDEX MATCH${reset}
 			echo
@@ -467,7 +467,7 @@ function API_getTransactionByBlockNumberAndIndex_test() {
 	echo "POST hmy_getTransactionByBlockNumberAndIndex test:"
 	response_test ${RESPONSES[hmy_getTransactionByBlockNumberAndIndex]}
 	TRANSACTIONHASHBYNUMBERANDINDEX=$(echo ${RESPONSES[hmy_getTransactionByBlockNumberAndIndex]} | jq -r '.result.hash')
-	if [ "$TRANSACTIONHASHBYNUMBERANDINDEX" != "null" ]; then	
+	if [ "$TRANSACTIONHASHBYNUMBERANDINDEX" != "null" ]; then
 		if [ "$TRANSACTIONHASHBYNUMBERANDINDEX" == "$TRANSACTION_HASH" ]; then
 			TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 			echo ${green}TRANSACTION FROM BLOCKNUMBER AND INDEX MATCH${reset}
@@ -479,12 +479,12 @@ function API_getTransactionByBlockNumberAndIndex_test() {
 	echo
 }
 
-function API_getTransactionByHash_test() {	
-	TESTS_RAN=$(( TESTS_RAN + 1 ))	
+function API_getTransactionByHash_test() {
+	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "POST hmy_getTransactionByHash test:"
 	TX_HASH=$(echo ${RESPONSES[hmy_getTransactionByHash]} | jq -r '.result.hash')
-	response_test ${RESPONSES[hmy_getTransactionByHash]} 
-	if [ "$TX_HASH" != "null" ]; then	
+	response_test ${RESPONSES[hmy_getTransactionByHash]}
+	if [ "$TX_HASH" != "null" ]; then
 		if [ "$TX_HASH" == "$TRANSACTION_HASH" ]; then
 			TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 			echo ${green}TRANSACTION HASH MATCH${reset}
@@ -497,11 +497,11 @@ function API_getTransactionByHash_test() {
 }
 
 function API_getTransactionReceipt_test() {
-	TESTS_RAN=$(( TESTS_RAN + 1 ))	
+	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "POST hmy_getTransactionReceipt test:"
 	TX_HASH=$(echo ${RESPONSES[hmy_getTransactionReceipt]} | jq -r '.result.transactionHash')
-	response_test ${RESPONSES[hmy_getTransactionReceipt]} 
-	if [ "$TX_HASH" != "null" ]; then	
+	response_test ${RESPONSES[hmy_getTransactionReceipt]}
+	if [ "$TX_HASH" != "null" ]; then
 		if [ "$TX_HASH" == "$TRANSACTION_HASH" ]; then
 			TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 			echo ${green}TRANSACTION HASH MATCH${reset}
@@ -517,15 +517,15 @@ function API_syncing_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "POST hmy_syncing test:"
 	response_test ${RESPONSES[hmy_syncing]}
-	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 )) 
+	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 	echo
 }
 
 function API_netPeerCount_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "POST net_peerCount test:"
-	response_test ${RESPONSES[net_peerCount]}	
-	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 )) 
+	response_test ${RESPONSES[net_peerCount]}
+	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 	echo
 }
 
@@ -533,7 +533,7 @@ function API_getBalance_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "POST hmy_getBalance test:"
 	response_test ${RESPONSES[hmy_getBalance]}
-	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 )) 
+	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 	echo
 }
 
@@ -541,15 +541,15 @@ function API_getStorageAt_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "POST hmy_getStorageAt test:"
 	response_test ${RESPONSES[hmy_getStorageAt]}
-	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 )) 
+	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 	echo
 }
 
-function API_getTransactionCount_test() {
+function API_getAccountNonce_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
-	echo "POST hmy_getTransactionCount test:"
-	response_test ${RESPONSES[hmy_getTransactionCount]}
-	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 )) 
+	echo "POST API_getAccountNonce test:"
+	response_test ${RESPONSES[API_getAccountNonce]}
+	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 	echo
 }
 
@@ -557,7 +557,7 @@ function API_sendRawTransaction_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "POST hmy_sendRawTransaction test:"
 	response_test ${RESPONSES[hmy_sendRawTransaction]}
-	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 )) 
+	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 	echo
 }
 
@@ -565,15 +565,15 @@ function API_getLogs_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "POST hmy_getLogs test:"
 	response_test ${RESPONSES[hmy_getLogs]}
-	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 )) 
+	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 	echo
 }
 
 function API_getFilterChanges_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "POST hmy_getFilterChanges test:"
-	response_test ${RESPONSES[hmy_getFilterChanges]}	
-	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 )) 
+	response_test ${RESPONSES[hmy_getFilterChanges]}
+	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 	echo
 }
 
@@ -581,7 +581,7 @@ function API_newPendingTransactionFilter_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "POST hmy_sendRawTransaction test:"
 	response_test ${RESPONSES[hmy_newPendingTransactionFilter]}
-	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 )) 
+	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 	echo
 }
 
@@ -589,7 +589,7 @@ function API_newBlockFilter_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "POST hmy_newBlockFilter test:"
 	response_test ${RESPONSES[hmy_newBlockFilter]}
-	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 )) 
+	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 	echo
 }
 
@@ -597,7 +597,7 @@ function API_newFilter_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "POST hmy_newFilter test:"
 	response_test ${RESPONSES[hmy_newFilter]}
-	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 )) 
+	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 	echo
 }
 
@@ -605,7 +605,7 @@ function API_call_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "POST hmy_call test:"
 	response_test ${RESPONSES[hmy_call]}
-	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 )) 
+	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 	echo
 }
 
@@ -616,7 +616,7 @@ function API_gasPrice_test() {
 	if [ "$?" == "1" ]; then
 		RESULT=$(echo ${RESPONSES[hmy_gasPrice]} | jq -r '.result')
 		isHexTest $RESULT
-		[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 )) 
+		[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 	fi
 }
 
@@ -627,7 +627,7 @@ function API_blockNumber_test() {
 	if [ "$?" == "1" ]; then
 		RESULT=$(echo ${RESPONSES[hmy_blockNumber]} | jq -r '.result')
 		isHexTest $RESULT
-		[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 )) 
+		[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 	fi
 }
 
@@ -635,7 +635,7 @@ function API_net_version_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "POST net_version test:"
 	response_test ${RESPONSES[net_version]}
-	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 )) 
+	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 	echo
 }
 
@@ -643,7 +643,7 @@ function API_protocolVersion_test() {
 	TESTS_RAN=$(( TESTS_RAN + 1 ))
 	echo "POST hmy_protocolVersion test:"
 	response_test ${RESPONSES[hmy_protocolVersion]}
-	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 )) 
+	[ "$?" == "1" ] && TESTS_PASSED=$(( TESTS_PASSED + 1 ))
 	echo
 }
 
@@ -670,7 +670,7 @@ function run_tests() {
 	API_netPeerCount_test
 	API_getBalance_test
 	API_getStorageAt_test
-	API_getTransactionCount_test
+	API_getAccountNonce_test
 	API_sendRawTransaction_test
 	API_getLogs_test
 	API_getFilterChanges_test


### PR DESCRIPTION
## Issue

https://github.com/harmony-one/harmony/issues/2759

## Test

launched local network, sent staking and regular txns using hmy cli, from shard 0 with bls key in shard 0. then, saw hmy_getAccountNonce, hmy_getTransactionCount, hmy_getStakingTransactionCount all works correctly. 

```
curl --location --request POST 'http://localhost:9500' --header 'Content-Type: application/json' --data-raw '{
    "jsonrpc": "2.0",
    "method": "hmyv2_getStakingTransactionCount",
    "params": ["one1grlw2qw7t9ulhms38w4ea0gssz0dk8vvsl7jum", "ALL"}],
    "id": 1
}'

curl --location --request POST 'http://localhost:9500' --header 'Content-Type: application/json' --data-raw '{
    "jsonrpc": "2.0",
    "method": "hmyv2_getTransactionCount",
    "params": ["one1grlw2qw7t9ulhms38w4ea0gssz0dk8vvsl7jum", "ALL"}],
    "id": 1
}'

curl --location --request POST 'http://localhost:9500' --header 'Content-Type: application/json' --data-raw '{
    "jsonrpc": "2.0",
    "method": "hmyv2_getAccountNonce",
    "params": ["one1grlw2qw7t9ulhms38w4ea0gssz0dk8vvsl7jum", "latest"}],
    "id": 1
}'
```

```
dennis.won@Jongs-MacBook-Pro:~/harmony-one/harmony (txs_count) $ go test ./node
ok  	github.com/harmony-one/harmony/node	1.674s
```