### PR TITLE
burn all transaction fees after staking.

### DIFF
--- a/core/evm.go
+++ b/core/evm.go
@@ -19,6 +19,8 @@ package core
 import (
 	"math/big"
 
+	"github.com/harmony-one/harmony/internal/params"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/block"
 	consensus_engine "github.com/harmony-one/harmony/consensus/engine"
@@ -41,6 +43,9 @@ type ChainContext interface {
 
 	// ReadValidatorSnapshot returns the snapshot of validator at the beginning of current epoch.
 	ReadValidatorSnapshot(common.Address) (*staking.ValidatorWrapper, error)
+
+	// Config of the blockchain
+	Config() *params.ChainConfig
 }
 
 // NewEVMContext creates a new context for use in the EVM.

--- a/core/evm.go
+++ b/core/evm.go
@@ -19,8 +19,6 @@ package core
 import (
 	"math/big"
 
-	"github.com/harmony-one/harmony/internal/params"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/block"
 	consensus_engine "github.com/harmony-one/harmony/consensus/engine"
@@ -43,9 +41,6 @@ type ChainContext interface {
 
 	// ReadValidatorSnapshot returns the snapshot of validator at the beginning of current epoch.
 	ReadValidatorSnapshot(common.Address) (*staking.ValidatorWrapper, error)
-
-	// Config of the blockchain
-	Config() *params.ChainConfig
 }
 
 // NewEVMContext creates a new context for use in the EVM.

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -253,9 +253,12 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 		}
 	}
 	st.refundGas()
-	// Burn Txn Fees
-	//txFee := new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice)
-	//st.state.AddBalance(st.evm.Coinbase, txFee)
+
+	// Burn Txn Fees after staking epoch
+	if !st.evm.ChainConfig().IsStaking(st.evm.EpochNumber) {
+		txFee := new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice)
+		st.state.AddBalance(st.evm.Coinbase, txFee)
+	}
 
 	return ret, st.gasUsed(), vmerr != nil, err
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -253,8 +253,9 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 		}
 	}
 	st.refundGas()
-	txFee := new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice)
-	st.state.AddBalance(st.evm.Coinbase, txFee)
+	// Burn Txn Fees
+	//txFee := new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice)
+	//st.state.AddBalance(st.evm.Coinbase, txFee)
 
 	return ret, st.gasUsed(), vmerr != nil, err
 }
@@ -372,8 +373,9 @@ func (st *StateTransition) StakingTransitionDb() (usedGas uint64, err error) {
 	}
 	st.refundGas()
 
-	txFee := new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice)
-	st.state.AddBalance(st.evm.Coinbase, txFee)
+	// Burn Txn Fees
+	//txFee := new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice)
+	//st.state.AddBalance(st.evm.Coinbase, txFee)
 
 	return st.gasUsed(), err
 }


### PR DESCRIPTION
To better conform with the new economic model. We need to burn all transactions fees after staking epoch.