### PR TITLE
[node] move self address to node, make it updatable every epoch

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -451,12 +451,6 @@ func setupConsensusAndNode(nodeConfig *nodeconfig.ConfigType) *node.Node {
 		return currentConsensus.PubKey, nil
 	})
 
-	// staking validator doesn't have to specify ECDSA address
-	currentConsensus.SelfAddresses = map[string]ethCommon.Address{}
-	for _, initialAccount := range initialAccounts {
-		currentConsensus.SelfAddresses[initialAccount.BLSPublicKey] = common.ParseAddr(initialAccount.Address)
-	}
-
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Error :%v \n", err)
 		os.Exit(1)

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/bls/ffi/go/bls"
 	"github.com/harmony-one/harmony/consensus/quorum"
 	"github.com/harmony-one/harmony/core"
@@ -79,8 +78,6 @@ type Consensus struct {
 	// private/public keys of current node
 	priKey *multibls.PrivateKey
 	PubKey *multibls.PublicKey
-	// TODO(audit): SelfAddresses doesn't have the ECDSA address for external validators. Don't use it that way.
-	SelfAddresses map[string]common.Address
 	// the publickey of leader
 	LeaderPubKey *bls.PublicKey
 	viewID       uint64

--- a/consensus/double_sign.go
+++ b/consensus/double_sign.go
@@ -54,6 +54,7 @@ func (consensus *Consensus) checkDoubleSign(recvMsg *FBFTMessage) bool {
 							consensus.getLogger().Error().
 								Str("msg", recvMsg.String()).
 								Msg("could not get shard key from sender's key")
+							return true
 						}
 						subComm, err := committee.FindCommitteeByID(
 							consensus.ShardID,
@@ -79,6 +80,7 @@ func (consensus *Consensus) checkDoubleSign(recvMsg *FBFTMessage) bool {
 							consensus.getLogger().Error().
 								Str("msg", recvMsg.String()).
 								Msg("could not get shard key from leader's key")
+							return true
 						}
 						leaderAddr, err := subComm.AddressForBLSKey(*leaderShardKey)
 						if err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -712,8 +712,6 @@ func (node *Node) ShutDown() {
 
 func (node *Node) populateSelfAddresses(epoch *big.Int) {
 	// reset the self addresses
-	node.keysToAddrsMutex.Lock()
-	defer node.keysToAddrsMutex.Unlock()
 	node.KeysToAddrs = map[string]common.Address{}
 	node.keysToAddrsEpoch = epoch
 
@@ -769,6 +767,8 @@ func (node *Node) populateSelfAddresses(epoch *big.Int) {
 // GetAddressForBLSKey retrieves the ECDSA address associated with bls key for epoch
 func (node *Node) GetAddressForBLSKey(blskey *bls.PublicKey, epoch *big.Int) common.Address {
 	// populate if first time setting or new epoch
+	node.keysToAddrsMutex.Lock()
+	defer node.keysToAddrsMutex.Unlock()
 	if node.keysToAddrsEpoch == nil || epoch.Cmp(node.keysToAddrsEpoch) != 0 {
 		node.populateSelfAddresses(epoch)
 	}
@@ -783,6 +783,8 @@ func (node *Node) GetAddressForBLSKey(blskey *bls.PublicKey, epoch *big.Int) com
 // GetAddresses retrieves all ECDSA addresses of the bls keys for epoch
 func (node *Node) GetAddresses(epoch *big.Int) map[string]common.Address {
 	// populate if first time setting or new epoch
+	node.keysToAddrsMutex.Lock()
+	defer node.keysToAddrsMutex.Unlock()
 	if node.keysToAddrsEpoch == nil || epoch.Cmp(node.keysToAddrsEpoch) != 0 {
 		node.populateSelfAddresses(epoch)
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -780,7 +780,7 @@ func (node *Node) GetAddressForBLSKey(blskey *bls.PublicKey, epoch *big.Int) com
 	return addr
 }
 
-// GetSelfAddresses retrieves all ECDSA addresses of the bls keys for epoch
+// GetAddresses retrieves all ECDSA addresses of the bls keys for epoch
 func (node *Node) GetAddresses(epoch *big.Int) map[string]common.Address {
 	// populate if first time setting or new epoch
 	if node.keysToAddrsEpoch == nil || epoch.Cmp(node.keysToAddrsEpoch) != 0 {

--- a/node/node.go
+++ b/node/node.go
@@ -755,19 +755,21 @@ func (node *Node) populateSelfAddresses(epoch *big.Int) {
 	}
 }
 
+// GetAddressForBLSKey retrieves the ECDSA address associated with bls key for epoch
 func (node *Node) GetAddressForBLSKey(blskey *bls.PublicKey, epoch *big.Int) common.Address {
 	// populate if first time setting or new epoch
 	if node.selfAddressEpoch == nil || epoch.Cmp(node.selfAddressEpoch) != 0 {
 		node.populateSelfAddresses(epoch)
 	}
 	blsStr := blskey.SerializeToHexStr()
-	if addr, ok := node.SelfAddresses[blsStr]; !ok {
+	addr, ok := node.SelfAddresses[blsStr]
+	if !ok {
 		return common.Address{}
-	} else {
-		return addr
 	}
+	return addr
 }
 
+// GetSelfAddresses retrieves all ECDSA addresses of the bls keys for epoch
 func (node *Node) GetSelfAddresses(epoch *big.Int) map[string]common.Address {
 	// populate if first time setting or new epoch
 	if node.selfAddressEpoch == nil || epoch.Cmp(node.selfAddressEpoch) != 0 {

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -494,7 +494,7 @@ func (node *Node) PostConsensusProcessing(
 	}
 	if h := node.NodeConfig.WebHooks.Hooks; h != nil {
 		if h.Availability != nil {
-			for _, addr := range node.Consensus.SelfAddresses {
+			for _, addr := range node.GetSelfAddresses(newBlock.Epoch()) {
 				wrapper, err := node.Beaconchain().ReadValidatorInformation(addr)
 				if err != nil {
 					return
@@ -506,7 +506,8 @@ func (node *Node) PostConsensusProcessing(
 				computed := availability.ComputeCurrentSigning(
 					snapshot, wrapper,
 				)
-				beaconChainBlocks := uint64(node.Beaconchain().CurrentBlock().Header().Number().Int64()) % shard.Schedule.BlocksPerEpoch()
+				beaconChainBlocks := uint64(node.Beaconchain().CurrentBlock().Header().Number().Int64()) %
+					shard.Schedule.BlocksPerEpoch()
 				computed.BlocksLeftInEpoch = shard.Schedule.BlocksPerEpoch() - beaconChainBlocks
 
 				if err != nil && computed.IsBelowThreshold {

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -494,7 +494,7 @@ func (node *Node) PostConsensusProcessing(
 	}
 	if h := node.NodeConfig.WebHooks.Hooks; h != nil {
 		if h.Availability != nil {
-			for _, addr := range node.GetSelfAddresses(newBlock.Epoch()) {
+			for _, addr := range node.GetAddresses(newBlock.Epoch()) {
 				wrapper, err := node.Beaconchain().ReadValidatorInformation(addr)
 				if err != nil {
 					return

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -80,15 +80,15 @@ func (node *Node) proposeNewBlock() (*types.Block, error) {
 
 	node.Worker.UpdateCurrent()
 
+	header := node.Worker.GetCurrentHeader()
 	// Update worker's current header and
 	// state data in preparation to propose/process new transactions
 	var (
-		coinbase    = node.Consensus.SelfAddresses[node.Consensus.LeaderPubKey.SerializeToHexStr()]
+		coinbase    = node.GetAddressForBLSKey(node.Consensus.LeaderPubKey, header.Epoch())
 		beneficiary = coinbase
 		err         error
 	)
 
-	header := node.Worker.GetCurrentHeader()
 	// After staking, all coinbase will be the address of bls pub key
 	if node.Blockchain().Config().IsStaking(header.Epoch()) {
 		blsPubKeyBytes := node.Consensus.LeaderPubKey.GetAddress()


### PR DESCRIPTION
* Remove self address assignment while starting node
* Move the self address out of consensus to node
* Get the self addresses for bls keys run by the node using shard state 
* Updates the self address every epoch