### PR TITLE
port the fix from go-ethereum for interface conversion panic

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -200,6 +200,9 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 	if bc.genesisBlock == nil {
 		return nil, ErrNoGenesis
 	}
+	var nilBlock *types.Block
+	bc.currentBlock.Store(nilBlock)
+	bc.currentFastBlock.Store(nilBlock)
 	if err := bc.loadLastState(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fixes https://github.com/harmony-one/harmony/issues/2808

problem is also observed in go-ethereum: https://github.com/ethereum/go-ethereum/issues/19286

this pr is simply porting their fix. basically, just make a nil pointer and initialize the `currentBlock` and `currentFastBlock` atomic with it.