### PR TITLE
Revert "[consensus][viewchange] fix total power of signers in IsQuorumAchieved for view change

### DIFF
--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -357,7 +357,7 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 			binary.LittleEndian.PutUint64(blockNumBytes[:], consensus.blockNum)
 			commitPayload := append(blockNumBytes[:], consensus.blockHash[:]...)
 			if _, err := consensus.Decider.SubmitVote(
-				quorum.ViewChange,
+				quorum.Commit,
 				newLeaderKey,
 				newLeaderPriKey.SignHash(commitPayload),
 				common.BytesToHash(consensus.blockHash[:]),


### PR DESCRIPTION
Reverting this change, as it should actually submit vote for commit phase and not view change phase. This is because, if the view change happened during the commit phase, the new leader still needs to submit his vote for the commit message. OnNewView, other validators will do the same (they will also send the commit message to the new leader). 

The total-power-of-signers 0.0 problem will be fixed in the next pr.