### PR TITLE
fix explorer node OOM for stress testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/golangci/golangci-lint v1.22.2
 	github.com/gorilla/handlers v1.4.0 // indirect
 	github.com/gorilla/mux v1.7.2
-	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/harmony-ek/gencodec v0.0.0-20190215044613-e6740dbdd846
 	github.com/harmony-one/bls v0.0.6
 	github.com/harmony-one/taggedrlp v0.1.4
@@ -34,6 +33,7 @@ require (
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/karalabe/hid v1.0.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/libp2p/go-addr-util v0.0.2 // indirect
 	github.com/libp2p/go-libp2p v0.7.4
 	github.com/libp2p/go-libp2p-core v0.5.1
 	github.com/libp2p/go-libp2p-crypto v0.1.0
@@ -44,9 +44,6 @@ require (
 	github.com/libp2p/go-libp2p-peer v0.2.0
 	github.com/libp2p/go-libp2p-peerstore v0.2.3
 	github.com/libp2p/go-libp2p-pubsub v0.2.7-0.20200325112436-d3d43e32bef3
-	github.com/libp2p/go-nat v0.0.5 // indirect
-	github.com/libp2p/go-reuseport-transport v0.0.3 // indirect
-	github.com/libp2p/go-addr-util v0.0.2 // indirect
 	github.com/multiformats/go-multiaddr v0.2.1
 	github.com/multiformats/go-multiaddr-net v0.1.4
 	github.com/natefinch/lumberjack v2.0.0+incompatible
@@ -64,9 +61,9 @@ require (
 	github.com/uber/jaeger-client-go v2.20.1+incompatible // indirect
 	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
 	go.uber.org/zap v1.14.1 // indirect
+	golang.org/x/crypto v0.0.0-20200406173513-056763e48d71
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
-	golang.org/x/crypto v0.0.0-20200406173513-056763e48d71
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4 // indirect
 	golang.org/x/tools v0.0.0-20200408032209-46bd65c8538f


### PR DESCRIPTION
Stressnet explorer nodes OOM

```
/home/ec2-user/go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20190923125748-758128399b1d/leveldb/table/reader.go:904 +0x623 fp=0xc0127dd538 sp=0xc0127dd360 pc=0x9b3123
github.com/syndtr/goleveldb/leveldb/table.(*Reader).Find(...)
        /home/ec2-user/go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20190923125748-758128399b1d/leveldb/table/reader.go:922
github.com/syndtr/goleveldb/leveldb.(*tOps).find(0xc0003eb230, 0xc00bedb2c0, 0xc00abdcc40, 0x35, 0x35, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /home/ec2-user/go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20190923125748-758128399b1d/leveldb/table.go:450 +0x13f fp=0xc0127dd5d8 sp=0xc0127dd538 pc=0x9df4ff
github.com/syndtr/goleveldb/leveldb.(*version).get.func1(0x0, 0xc00bedb2c0, 0xc00abdcc40)
        /home/ec2-user/go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20190923125748-758128399b1d/leveldb/version.go:180 +0x458 fp=0xc0127dd6e8 sp=0xc0127dd5d8 pc=0x9e9618
github.com/syndtr/goleveldb/leveldb.(*version).walkOverlapping(0xc00cbe27e0, 0x0, 0x0, 0x0, 0xc00abdcc40, 0x35, 0x35, 0xc0127dd858, 0xc0127dd828)
        /home/ec2-user/go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20190923125748-758128399b1d/leveldb/version.go:119 +0x2a8 fp=0xc0127dd7a8 sp=0xc0127dd6e8 pc=0x9e13b8
github.com/syndtr/goleveldb/leveldb.(*version).get(0xc00cbe27e0, 0x0, 0x0, 0x0, 0xc00abdcc40, 0x35, 0x35, 0x0, 0xa49f00, 0x0, ...)
        /home/ec2-user/go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20190923125748-758128399b1d/leveldb/version.go:164 +0x2dd fp=0xc0127dd900 sp=0xc0127dd7a8 pc=0x9e190d
github.com/syndtr/goleveldb/leveldb.(*DB).get(0xc0001b2380, 0x0, 0x0, 0x0, 0x0, 0xc019e01650, 0x2d, 0x30, 0x161d, 0x0, ...)
        /home/ec2-user/go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20190923125748-758128399b1d/leveldb/db.go:785 +0x381 fp=0xc0127dda18 sp=0xc0127dd900 pc=0x9bece1
github.com/syndtr/goleveldb/leveldb.(*DB).Get(0xc0001b2380, 0xc019e01650, 0x2d, 0x30, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /home/ec2-user/go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20190923125748-758128399b1d/leveldb/db.go:851 +0x13b fp=0xc0127ddac0 sp=0xc0127dda18 pc=0x9bf4cb
github.com/harmony-one/harmony/api/service/explorer.(*Storage).UpdateTxAddressStorage(0xc0003f0040, 0xc00a9e85d0, 0x2a, 0xc006f84000, 0xc00e04a8c0)
        /home/ec2-user/go/src/github.com/harmony-one/harmony/api/service/explorer/storage.go:122 +0x159 fp=0xc0127ddc08 sp=0xc0127ddac0 pc=0x100b6d9
github.com/harmony-one/harmony/api/service/explorer.(*Storage).UpdateTxAddress(0xc0003f0040, 0xc006f84000, 0xc00e04a8c0)
        /home/ec2-user/go/src/github.com/harmony-one/harmony/api/service/explorer/storage.go:105 +0xa8 fp=0xc0127ddc48 sp=0xc0127ddc08 pc=0x100b3e8
github.com/harmony-one/harmony/api/service/explorer.(*Storage).Dump(0xc0003f0040, 0xc013c36a80, 0xc2b)
        /home/ec2-user/go/src/github.com/harmony-one/harmony/api/service/explorer/storage.go:89 +0xcf fp=0xc0127ddcc8 sp=0xc0127ddc48 pc=0x100b21f
Connection to 54.245.77.197 closed by remote host.BlockForExplorer(0xc0003dcf00, 0xc013c36a80)
Connection to 54.245.77.197 closed.b.com/harmony-one/harmony/node/node_explorer.go:141 +0x12d fp=0xc0127ddd20 sp=0xc0127ddcc8 pc=0x110243You have new mail in /var/spool/mail/ec2-user
ec2-user@ip-172-31-37-52 ~ $ y/node.(*Node).ExplorerMessageHandler(0xc0003dcf00, 0xc01021e146, 0x127, 0x13a)
        /home/ec2-user/go/src/github.com/harmony-one/harmony/node/node_explorer.go:78 +0x716 fp=0xc0127dde50 sp=0xc0127ddd20 pc=0x1101e36
github.com/harmony-one/harmony/node.(*Node).HandleMessage(0xc0003dcf00, 0xc01021e145, 0x128, 0x13b, 0xc00dd9a330, 0x22)
```

Fixing OOM by using same memory pointer for the sent and received txns being saved on explorer nodes upon block dump.


-=== Test ===
```
dennis.won@Jongs-MacBook-Pro:~/harmony-one/harmony (explorer_oom) $ hmy blockchain transaction-by-hash 0x677a8273e5f395009f0007ef87f8a4db957424ee975438afae17183df45d8714
{
  "id": "1",
  "jsonrpc": "2.0",
  "result": {
    "blockHash": "0x4cf06a991c01f568ccb9d28668344065b65dcc743580b3051cad5d8b4d452436",
    "blockNumber": "0x2e",
    "from": "one1a50tun737ulcvwy0yvve0pvu5skq0kjargvhwe",
    "gas": "0xf4240",
    "gasPrice": "0x9184e72a000",
    "hash": "0x677a8273e5f395009f0007ef87f8a4db957424ee975438afae17183df45d8714",
    "input": "0x",
    "nonce": "0x2",
    "r": "0x8c354b2879061e63a48ddbf845b7482694ab3d8467d8e368ca00b3a396d0ec25",
    "s": "0x1436e5eed0aa23f5459b49dfd01d5679a05ac88331f4984564258e22ce395fa8",
    "shardID": 0,
    "timestamp": "0x5e954562",
    "to": "one1a50tun737ulcvwy0yvve0pvu5skq0kjargvhwe",
    "toShardID": 1,
    "transactionIndex": "0x0",
    "v": "0x27",
    "value": "0x8ac7230489e80000"
  }
}
```

Do see the transaction returned by the explorer node on localnet with this change