### PR TITLE
[rpc] Hide confusing num-beacon-blocks-until-next-epoch

### DIFF
--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -96,7 +96,7 @@ type ValidatorWrapper struct {
 type Computed struct {
 	Signed            *big.Int    `json:"current-epoch-signed"`
 	ToSign            *big.Int    `json:"current-epoch-to-sign"`
-	BlocksLeftInEpoch uint64      `json:"num-beacon-blocks-until-next-epoch"`
+	BlocksLeftInEpoch uint64      `json:"-"`
 	Percentage        numeric.Dec `json:"current-epoch-signing-percentage"`
 	IsBelowThreshold  bool        `json:"-"`
 }


### PR DESCRIPTION
Fixes https://github.com/harmony-one/harmony/issues/2797

TODO, remove this field proper and remove parameters/logic threaded through ad-hoc just to satisfy this field creation 