### PR TITLE
Optimize delegation reward distribution with caching

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2187,14 +2187,14 @@ func (bc *BlockChain) ReadValidatorInformation(
 func (bc *BlockChain) ReadValidatorSnapshotAtEpoch(
 	epoch *big.Int,
 	addr common.Address,
-) (*staking.ValidatorWrapper, error) {
+) (*staking.ValidatorSnapshot, error) {
 	return rawdb.ReadValidatorSnapshot(bc.db, addr, epoch)
 }
 
 // ReadValidatorSnapshot reads the snapshot staking information of given validator address
 func (bc *BlockChain) ReadValidatorSnapshot(
 	addr common.Address,
-) (*staking.ValidatorWrapper, error) {
+) (*staking.ValidatorSnapshot, error) {
 	epoch := bc.CurrentBlock().Epoch()
 	if cached, ok := bc.validatorCache.Get("validator-snapshot-" + string(addr.Bytes()) + epoch.String()); ok {
 		by := cached.([]byte)
@@ -2202,7 +2202,8 @@ func (bc *BlockChain) ReadValidatorSnapshot(
 		if err := rlp.DecodeBytes(by, &v); err != nil {
 			return nil, err
 		}
-		return &v, nil
+		s := staking.ValidatorSnapshot{&v, epoch}
+		return &s, nil
 	}
 	return rawdb.ReadValidatorSnapshot(bc.db, addr, epoch)
 }

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -275,12 +275,12 @@ func (cr *fakeChainReader) ReadValidatorInformation(
 }
 func (cr *fakeChainReader) ReadValidatorSnapshot(
 	addr common.Address,
-) (*staking.ValidatorWrapper, error) {
+) (*staking.ValidatorSnapshot, error) {
 	return nil, nil
 }
 func (cr *fakeChainReader) ReadValidatorSnapshotAtEpoch(
 	epoch *big.Int, addr common.Address,
-) (*staking.ValidatorWrapper, error) {
+) (*staking.ValidatorSnapshot, error) {
 	return nil, nil
 }
 

--- a/core/evm.go
+++ b/core/evm.go
@@ -40,7 +40,7 @@ type ChainContext interface {
 	ReadDelegationsByDelegator(common.Address) (staking.DelegationIndexes, error)
 
 	// ReadValidatorSnapshot returns the snapshot of validator at the beginning of current epoch.
-	ReadValidatorSnapshot(common.Address) (*staking.ValidatorWrapper, error)
+	ReadValidatorSnapshot(common.Address) (*staking.ValidatorSnapshot, error)
 }
 
 // NewEVMContext creates a new context for use in the EVM.

--- a/core/rawdb/accessors_offchain.go
+++ b/core/rawdb/accessors_offchain.go
@@ -171,7 +171,7 @@ func DeleteCXReceiptsProofSpent(db DatabaseDeleter, shardID uint32, number uint6
 // ReadValidatorSnapshot retrieves validator's snapshot by its address
 func ReadValidatorSnapshot(
 	db DatabaseReader, addr common.Address, epoch *big.Int,
-) (*staking.ValidatorWrapper, error) {
+) (*staking.ValidatorSnapshot, error) {
 	data, err := db.Get(validatorSnapshotKey(addr, epoch))
 	if err != nil || len(data) == 0 {
 		utils.Logger().Info().Err(err).Msg("ReadValidatorSnapshot")
@@ -184,7 +184,8 @@ func ReadValidatorSnapshot(
 			Msg("Unable to decode validator snapshot from database")
 		return nil, err
 	}
-	return &v, nil
+	s := staking.ValidatorSnapshot{&v, epoch}
+	return &s, nil
 }
 
 // WriteValidatorSnapshot stores validator's snapshot by its address

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -19,6 +19,8 @@ package vm
 import (
 	"math/big"
 
+	"github.com/harmony-one/harmony/numeric"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/core/types"
 	staking "github.com/harmony-one/harmony/staking/types"
@@ -45,7 +47,7 @@ type StateDB interface {
 	SetValidatorFlag(common.Address)
 	UnsetValidatorFlag(common.Address)
 	IsValidator(common.Address) bool
-	AddReward(*staking.ValidatorWrapper, *big.Int) error
+	AddReward(*staking.ValidatorWrapper, *big.Int, map[common.Address]numeric.Dec) error
 
 	AddRefund(uint64)
 	SubRefund(uint64)

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -406,7 +406,7 @@ func (b *APIBackend) GetValidatorInformation(
 	}
 
 	computed := availability.ComputeCurrentSigning(
-		snapshot, wrapper,
+		snapshot.Validator, wrapper,
 	)
 	beaconChainBlocks := uint64(
 		b.hmy.BeaconChain().CurrentBlock().Header().Number().Int64(),
@@ -470,7 +470,7 @@ func (b *APIBackend) GetTotalStakingSnapshot() *big.Int {
 		snapshot, _ := b.hmy.BlockChain().ReadValidatorSnapshot(candidates[i])
 		validator, _ := b.hmy.BlockChain().ReadValidatorInformation(candidates[i])
 		if !committee.IsEligibleForEPoSAuction(
-			snapshot, validator, b.hmy.BlockChain().CurrentBlock().Epoch(),
+			snapshot, validator,
 		) {
 			continue
 		}

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -444,7 +444,7 @@ func applySlashes(
 		// Apply the slashes, invariant: assume been verified as legit slash by this point
 		var slashApplied *slash.Application
 		votingPower, err := lookupVotingPower(
-			header.Epoch(), new(big.Int).SetUint64(key.epoch), subComm,
+			big.NewInt(int64(key.epoch)), subComm,
 		)
 		if err != nil {
 			return errors.Wrapf(err, "could not lookup cached voting power in slash application")

--- a/internal/chain/reward.go
+++ b/internal/chain/reward.go
@@ -5,6 +5,9 @@ import (
 	"math/big"
 	"sort"
 
+	"github.com/harmony-one/harmony/numeric"
+	types2 "github.com/harmony-one/harmony/staking/types"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/harmony-one/harmony/block"
@@ -42,11 +45,12 @@ func ballotResultBeaconchain(
 }
 
 var (
-	votingPowerCache singleflight.Group
+	votingPowerCache   singleflight.Group
+	delegateShareCache singleflight.Group
 )
 
 func lookupVotingPower(
-	epoch, beaconCurrentEpoch *big.Int, subComm *shard.Committee,
+	epoch *big.Int, subComm *shard.Committee,
 ) (*votepower.Roster, error) {
 	key := fmt.Sprintf("%s-%d", epoch.String(), subComm.ShardID)
 	results, err, _ := votingPowerCache.Do(
@@ -55,6 +59,12 @@ func lookupVotingPower(
 			if err != nil {
 				return nil, err
 			}
+
+			// For new calc, remove old data from 3 epochs ago
+			deleteEpoch := big.NewInt(0).Sub(epoch, big.NewInt(3))
+			deleteKey := fmt.Sprintf("%s-%d", deleteEpoch.String(), subComm.ShardID)
+			votingPowerCache.Forget(deleteKey)
+
 			return votingPower, nil
 		},
 	)
@@ -62,14 +72,49 @@ func lookupVotingPower(
 		return nil, err
 	}
 
-	// TODO consider if this is the best way to clear the cache
-	if new(big.Int).Sub(beaconCurrentEpoch, epoch).Cmp(common.Big3) == 1 {
-		go func() {
-			votingPowerCache.Forget(key)
-		}()
+	return results.(*votepower.Roster), nil
+}
+
+// Lookup or compute the shares of stake for all delegators in a validator
+func lookupDelegatorShares(
+	snapshot *types2.ValidatorSnapshot,
+) (map[common.Address]numeric.Dec, error) {
+	epoch := snapshot.Epoch
+	validatorSnapshot := snapshot.Validator
+	key := fmt.Sprintf("%s-%s", epoch.String(), validatorSnapshot.Address.Hex())
+
+	shares, err, _ := delegateShareCache.Do(
+		key, func() (interface{}, error) {
+			result := map[common.Address]numeric.Dec{}
+
+			totalDelegationDec := numeric.NewDecFromBigInt(validatorSnapshot.TotalDelegation())
+			if totalDelegationDec.IsZero() {
+				utils.Logger().Info().
+					RawJSON("validator-snapshot", []byte(validatorSnapshot.String())).
+					Msg("zero total delegation during AddReward delegation payout")
+				return result, nil
+			}
+
+			for i := range validatorSnapshot.Delegations {
+				delegation := validatorSnapshot.Delegations[i]
+				// NOTE percentage = <this_delegator_amount>/<total_delegation>
+				percentage := numeric.NewDecFromBigInt(delegation.Amount).Quo(totalDelegationDec)
+				result[delegation.DelegatorAddress] = percentage
+			}
+
+			// For new calc, remove old data from 3 epochs ago
+			deleteEpoch := big.NewInt(0).Sub(epoch, big.NewInt(3))
+			deleteKey := fmt.Sprintf("%s-%d", deleteEpoch.String(), validatorSnapshot.Address.Hex())
+			votingPowerCache.Forget(deleteKey)
+
+			return result, nil
+		},
+	)
+	if err != nil {
+		return nil, err
 	}
 
-	return results.(*votepower.Roster), nil
+	return shares.(map[common.Address]numeric.Dec), nil
 }
 
 // AccumulateRewardsAndCountSigs credits the coinbase of the given block with the mining
@@ -91,6 +136,7 @@ func AccumulateRewardsAndCountSigs(
 	if bc.Config().IsStaking(header.Epoch()) &&
 		bc.CurrentHeader().ShardID() != shard.BeaconChainShardID {
 		return network.EmptyPayout, nil
+
 	}
 
 	// After staking
@@ -142,9 +188,8 @@ func AccumulateRewardsAndCountSigs(
 		); err != nil {
 			return network.EmptyPayout, err
 		}
-		beaconCurrentEpoch := beaconChain.CurrentHeader().Epoch()
 		votingPower, err := lookupVotingPower(
-			headerE, beaconCurrentEpoch, &subComm,
+			headerE, &subComm,
 		)
 		if err != nil {
 			return network.EmptyPayout, err
@@ -167,7 +212,12 @@ func AccumulateRewardsAndCountSigs(
 					voter.OverallPercent.Quo(beaconExternalShare),
 				).RoundInt()
 				newRewards.Add(newRewards, due)
-				if err := state.AddReward(snapshot, due); err != nil {
+
+				shares, err := lookupDelegatorShares(snapshot)
+				if err != nil {
+					return network.EmptyPayout, err
+				}
+				if err := state.AddReward(snapshot.Validator, due, shares); err != nil {
 					return network.EmptyPayout, err
 				}
 				beaconP = append(beaconP, reward.Payout{
@@ -237,7 +287,7 @@ func AccumulateRewardsAndCountSigs(
 				}
 
 				votingPower, err := lookupVotingPower(
-					epoch, beaconCurrentEpoch, subComm,
+					epoch, subComm,
 				)
 
 				if err != nil {
@@ -303,7 +353,12 @@ func AccumulateRewardsAndCountSigs(
 					}
 					due := resultsHandle[bucket][payThem].payout
 					newRewards.Add(newRewards, due)
-					if err := state.AddReward(snapshot, due); err != nil {
+
+					shares, err := lookupDelegatorShares(snapshot)
+					if err != nil {
+						return network.EmptyPayout, err
+					}
+					if err := state.AddReward(snapshot.Validator, due, shares); err != nil {
 						return network.EmptyPayout, err
 					}
 					shardP = append(shardP, reward.Payout{

--- a/internal/chain/reward.go
+++ b/internal/chain/reward.go
@@ -104,7 +104,7 @@ func lookupDelegatorShares(
 
 			// For new calc, remove old data from 3 epochs ago
 			deleteEpoch := big.NewInt(0).Sub(epoch, big.NewInt(3))
-			deleteKey := fmt.Sprintf("%s-%d", deleteEpoch.String(), validatorSnapshot.Address.Hex())
+			deleteKey := fmt.Sprintf("%s-%s", deleteEpoch.String(), validatorSnapshot.Address.Hex())
 			votingPowerCache.Forget(deleteKey)
 
 			return result, nil

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -464,7 +464,7 @@ func (node *Node) PostConsensusProcessing(
 					return
 				}
 				computed := availability.ComputeCurrentSigning(
-					snapshot, wrapper,
+					snapshot.Validator, wrapper,
 				)
 				beaconChainBlocks := uint64(node.Beaconchain().CurrentBlock().Header().Number().Int64()) %
 					shard.Schedule.BlocksPerEpoch()

--- a/staking/apr/compute.go
+++ b/staking/apr/compute.go
@@ -33,7 +33,7 @@ type Reader interface {
 	ReadValidatorSnapshotAtEpoch(
 		epoch *big.Int,
 		addr common.Address,
-	) (*staking.ValidatorWrapper, error)
+	) (*staking.ValidatorSnapshot, error)
 }
 
 const (
@@ -121,7 +121,7 @@ func ComputeForValidator(
 
 	estimatedRewardPerYear, err := expectedRewardPerYear(
 		block.Header(), headerOneEpochAgo,
-		validatorNow, oneSnapshotAgo,
+		validatorNow, oneSnapshotAgo.Validator,
 	)
 
 	if err != nil {

--- a/staking/availability/measure.go
+++ b/staking/availability/measure.go
@@ -137,7 +137,7 @@ func IncrementValidatorSigningCounts(
 type Reader interface {
 	ReadValidatorSnapshot(
 		addr common.Address,
-	) (*staking.ValidatorWrapper, error)
+	) (*staking.ValidatorSnapshot, error)
 }
 
 // ComputeCurrentSigning returns (signed, toSign, quotient, error)
@@ -210,7 +210,7 @@ func ComputeAndMutateEPOSStatus(
 		return err
 	}
 
-	computed := ComputeCurrentSigning(snapshot, wrapper)
+	computed := ComputeCurrentSigning(snapshot.Validator, wrapper)
 
 	utils.Logger().
 		Info().Msg("check if signing percent is meeting required threshold")

--- a/staking/slash/double-sign.go
+++ b/staking/slash/double-sign.go
@@ -460,7 +460,7 @@ func Apply(
 		// stake, rest are external delegations.
 		// Bottom line: everyone will be slashed under the same rule.
 		if err := delegatorSlashApply(
-			snapshot, current, rate, state,
+			snapshot.Validator, current, rate, state,
 			slash.Reporter, slash.Evidence.Epoch, slashDiff,
 		); err != nil {
 			return nil, err
@@ -474,7 +474,7 @@ func Apply(
 			Msg("about to update staking info for a validator after a slash")
 
 		if err := state.UpdateValidatorWrapper(
-			snapshot.Address, current,
+			snapshot.Validator.Address, current,
 		); err != nil {
 			return nil, err
 		}

--- a/staking/slash/double-sign_test.go
+++ b/staking/slash/double-sign_test.go
@@ -448,7 +448,7 @@ func testScenario(
 	// state looks like as of this point
 
 	slashResult, err := Apply(
-		mockOutSnapshotReader{*s.snapshot},
+		mockOutSnapshotReader{staking.ValidatorSnapshot{s.snapshot, big.NewInt(0)}},
 		stateHandle,
 		slashes,
 		numeric.MustNewDecFromStr(

--- a/staking/slash/double-sign_test.go
+++ b/staking/slash/double-sign_test.go
@@ -377,13 +377,13 @@ func exampleSlashRecords() Records {
 }
 
 type mockOutSnapshotReader struct {
-	snapshot staking.ValidatorWrapper
+	snapshot staking.ValidatorSnapshot
 }
 
 func (m mockOutSnapshotReader) ReadValidatorSnapshotAtEpoch(
 	epoch *big.Int,
 	addr common.Address,
-) (*staking.ValidatorWrapper, error) {
+) (*staking.ValidatorSnapshot, error) {
 	return &m.snapshot, nil
 }
 

--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -69,7 +69,7 @@ type ValidatorSnapshotReader interface {
 	ReadValidatorSnapshotAtEpoch(
 		epoch *big.Int,
 		addr common.Address,
-	) (*ValidatorWrapper, error)
+	) (*ValidatorSnapshot, error)
 }
 
 type counters struct {
@@ -89,6 +89,12 @@ type ValidatorWrapper struct {
 	Counters counters `json:"-"`
 	// All the rewarded accumulated so far
 	BlockReward *big.Int `json:"-"`
+}
+
+// ValidatorSnapshot contains validator snapshot and the corresponding epoch
+type ValidatorSnapshot struct {
+	Validator *ValidatorWrapper
+	Epoch     *big.Int
 }
 
 // Computed represents current epoch


### PR DESCRIPTION
1. Make validator snapshot tied with the epoch with a new struct ValidatorSnapshot
2. Use caching for the calculation of shares of delegators in the reward distribution time. This will save around 1/3 of the time in AddReward()
3. Fix the cache cleanup logic to always cleanup data 3 epochs ago.

Did more scalability testing, it turns out the loading (rlp decode) of the validator takes similar amount of time of calculating the shares of all its delegators.

```
Time required to read validator: 0.057869 seconds
Time required to calc percentage 100001 delegations: 0.064249 seconds
Time required to reward a validator with 100001 delegations: 0.122621 seconds
```

So we should next optimize the code to avoid reading and writing validator repeated for different operations.