### PR TITLE
Explorer node dump opt

### DIFF
--- a/api/service/explorer/structs.go
+++ b/api/service/explorer/structs.go
@@ -25,6 +25,13 @@ const (
 	Sent     = "SENT"
 )
 
+// TxRecord ...
+type TxRecord struct {
+	Hash      string
+	Type      string
+	Timestamp string
+}
+
 // Data ...
 type Data struct {
 	Addresses []string `json:"Addresses"`
@@ -32,10 +39,10 @@ type Data struct {
 
 // Address ...
 type Address struct {
-	ID         string                `json:"id"`
-	Balance    *big.Int              `json:"balance"`
-	TXs        []*Transaction        `json:"txs"`
-	StakingTXs []*StakingTransaction `json:"staking_txs"`
+	ID         string      `json:"id"`
+	Balance    *big.Int    `json:"balance"`
+	TXs        []*TxRecord `json:"txs"`
+	StakingTXs []*TxRecord `json:"staking_txs"`
 }
 
 // Transaction ...

--- a/node/node_explorer.go
+++ b/node/node_explorer.go
@@ -172,7 +172,7 @@ func (node *Node) GetTransactionsHistory(address, txType, order string) ([]commo
 	hashes := make([]common.Hash, 0)
 	for _, tx := range addressData.TXs {
 		if txType == "" || txType == "ALL" || txType == tx.Type {
-			hash := common.HexToHash(tx.ID)
+			hash := common.HexToHash(tx.Hash)
 			hashes = append(hashes, hash)
 		}
 	}
@@ -204,7 +204,7 @@ func (node *Node) GetStakingTransactionsHistory(address, txType, order string) (
 	hashes := make([]common.Hash, 0)
 	for _, tx := range addressData.StakingTXs {
 		if txType == "" || txType == "ALL" || txType == tx.Type {
-			hash := common.HexToHash(tx.ID)
+			hash := common.HexToHash(tx.Hash)
 			hashes = append(hashes, hash)
 		}
 	}


### PR DESCRIPTION
## Issue

related https://github.com/harmony-one/harmony/issues/2831

This PR optimizes the block dump process in terms of memory usage during dump and also the disk storage size of transactions history. Both transaction and staking transactions.

### Unit Test Coverage

```
dennis.won@Jongs-MacBook-Pro:~/harmony-one/harmony (explorer_node_dump_opt) $ go test ./api/service/explorer/
ok  	github.com/harmony-one/harmony/api/service/explorer	0.785s
dennis.won@Jongs-MacBook-Pro:~/harmony-one/harmony (explorer_node_dump_opt) $ go test ./node/node
node.go               node_cross_link.go    node_explorer.go      node_handler.go       node_newblock.go      node_test.go
node.md               node_cross_shard.go   node_genesis.go       node_handler_test.go  node_syncing.go       node_utils.go
dennis.won@Jongs-MacBook-Pro:~/harmony-one/harmony (explorer_node_dump_opt) $ go test ./node
ok  	github.com/harmony-one/harmony/node	1.408s
dennis.won@Jongs-MacBook-Pro:~/harmony-one/harmony (explorer_node_dump_opt) $
```
