### PR TITLE
[p2p] Add libp2p_metrics into host and use bwCounter to record in/out…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/golangci/golangci-lint v1.22.2
 	github.com/gorilla/handlers v1.4.0 // indirect
 	github.com/gorilla/mux v1.7.2
-	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/harmony-ek/gencodec v0.0.0-20190215044613-e6740dbdd846
 	github.com/harmony-one/bls v0.0.6
 	github.com/harmony-one/taggedrlp v0.1.4
@@ -34,6 +33,7 @@ require (
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/karalabe/hid v1.0.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/libp2p/go-addr-util v0.0.2 // indirect
 	github.com/libp2p/go-libp2p v0.7.4
 	github.com/libp2p/go-libp2p-core v0.5.1
 	github.com/libp2p/go-libp2p-crypto v0.1.0
@@ -44,9 +44,6 @@ require (
 	github.com/libp2p/go-libp2p-peer v0.2.0
 	github.com/libp2p/go-libp2p-peerstore v0.2.3
 	github.com/libp2p/go-libp2p-pubsub v0.2.7-0.20200325112436-d3d43e32bef3
-	github.com/libp2p/go-nat v0.0.5 // indirect
-	github.com/libp2p/go-reuseport-transport v0.0.3 // indirect
-	github.com/libp2p/go-addr-util v0.0.2 // indirect
 	github.com/multiformats/go-multiaddr v0.2.1
 	github.com/multiformats/go-multiaddr-net v0.1.4
 	github.com/natefinch/lumberjack v2.0.0+incompatible
@@ -64,9 +61,9 @@ require (
 	github.com/uber/jaeger-client-go v2.20.1+incompatible // indirect
 	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
 	go.uber.org/zap v1.14.1 // indirect
+	golang.org/x/crypto v0.0.0-20200406173513-056763e48d71
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
-	golang.org/x/crypto v0.0.0-20200406173513-056763e48d71
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4 // indirect
 	golang.org/x/tools v0.0.0-20200408032209-46bd65c8538f

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -59,6 +59,13 @@ func (node *Node) processSkippedMsgTypeByteValue(
 
 // HandleMessage parses the message and dispatch the actions.
 func (node *Node) HandleMessage(content []byte, sender libp2p_peer.ID) {
+	// log in-coming metrics
+	node.host.LogRecvMessage(content)
+	utils.Logger().Info().
+		Int64("TotalIn", node.host.GetBandwidthTotals().TotalIn).
+		Float64("RateIn", node.host.GetBandwidthTotals().RateIn).
+		Msg("Record Receiving Metrics!")
+
 	msgCategory, err := proto.GetMessageCategory(content)
 	if err != nil {
 		utils.Logger().Error().
@@ -447,6 +454,10 @@ func (node *Node) PostConsensusProcessing(
 
 	// Broadcast client requested missing cross shard receipts if there is any
 	node.BroadcastMissingCXReceipts()
+
+	// Clear metrics after one consensus cycle
+	node.host.ResetMetrics()
+	utils.Logger().Info().Msg("Metrics cleared after one consensus cycle")	
 
 	// Update consensus keys at last so the change of leader status doesn't mess up normal flow
 	if len(newBlock.Header().ShardState()) > 0 {

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -457,7 +457,7 @@ func (node *Node) PostConsensusProcessing(
 
 	// Clear metrics after one consensus cycle
 	node.host.ResetMetrics()
-	utils.Logger().Info().Msg("Metrics cleared after one consensus cycle")	
+	utils.Logger().Info().Msg("Metrics cleared after one consensus cycle")
 
 	// Update consensus keys at last so the change of leader status doesn't mess up normal flow
 	if len(newBlock.Header().ShardState()) > 0 {

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -64,7 +64,7 @@ func (node *Node) HandleMessage(content []byte, sender libp2p_peer.ID) {
 	utils.Logger().Info().
 		Int64("TotalIn", node.host.GetBandwidthTotals().TotalIn).
 		Float64("RateIn", node.host.GetBandwidthTotals().RateIn).
-		Msg("Record Receiving Metrics!")
+		Msg("[metrics][p2p] traffic in in bytes")
 
 	msgCategory, err := proto.GetMessageCategory(content)
 	if err != nil {
@@ -457,7 +457,7 @@ func (node *Node) PostConsensusProcessing(
 
 	// Clear metrics after one consensus cycle
 	node.host.ResetMetrics()
-	utils.Logger().Info().Msg("Metrics cleared after one consensus cycle")
+	utils.Logger().Info().Msg("[metrics][p2p] Reset after 1 consensus cycle")
 
 	// Update consensus keys at last so the change of leader status doesn't mess up normal flow
 	if len(newBlock.Header().ShardState()) > 0 {

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -15,10 +15,10 @@ import (
 	libp2p "github.com/libp2p/go-libp2p"
 	libp2p_crypto "github.com/libp2p/go-libp2p-core/crypto"
 	libp2p_host "github.com/libp2p/go-libp2p-core/host"
+	libp2p_metrics "github.com/libp2p/go-libp2p-core/metrics"
 	libp2p_peer "github.com/libp2p/go-libp2p-core/peer"
 	libp2p_peerstore "github.com/libp2p/go-libp2p-core/peerstore"
 	libp2p_pubsub "github.com/libp2p/go-libp2p-pubsub"
-	libp2p_metrics  "github.com/libp2p/go-libp2p-core/metrics"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -38,7 +38,7 @@ type Host interface {
 
 	// libp2p.metrics related
 	GetBandwidthTotals() libp2p_metrics.Stats
-	LogRecvMessage( msg []byte )
+	LogRecvMessage(msg []byte)
 	ResetMetrics()
 }
 
@@ -243,7 +243,7 @@ func (host *HostV2) GetBandwidthTotals() libp2p_metrics.Stats {
 }
 
 // LogRecvMessage logs received message on node
-func (host *HostV2) LogRecvMessage( msg []byte ) {
+func (host *HostV2) LogRecvMessage(msg []byte) {
 	host.metrics.LogRecvMessage(int64(len(msg)))
 }
 

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -237,15 +237,17 @@ func (host *HostV2) GetPeerCount() int {
 	return host.h.Peerstore().Peers().Len()
 }
 
-// host.metrics.GetBandwidthTotals()
+// GetBandwidthTotals returns total bandwidth of a node
 func (host *HostV2) GetBandwidthTotals() libp2p_metrics.Stats {
 	return host.metrics.GetBandwidthTotals()
 }
 
+// LogRecvMessage logs received message on node
 func (host *HostV2) LogRecvMessage( msg []byte ) {
 	host.metrics.LogRecvMessage(int64(len(msg)))
 }
 
+// ResetMetrics resets metrics counters
 func (host *HostV2) ResetMetrics() {
 	host.metrics.Reset()
 }

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -180,7 +180,7 @@ func (host *HostV2) SendMessageToGroups(groups []nodeconfig.GroupID, msg []byte)
 	host.logger.Info().
 		Int64("TotalOut", host.GetBandwidthTotals().TotalOut).
 		Float64("RateOut", host.GetBandwidthTotals().RateOut).
-		Msg("Record Sending Metrics!")
+		Msg("[metrics][p2p] traffic out in bytes")
 
 	return err
 }

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -175,12 +175,12 @@ func (host *HostV2) SendMessageToGroups(groups []nodeconfig.GroupID, msg []byte)
 			continue
 		}
 		// log out-going metrics
-		host.metrics.LogSentMessage(int64(len(msg))) 
+		host.metrics.LogSentMessage(int64(len(msg)))
 	}
 	host.logger.Info().
- 		Int64("TotalOut", host.GetBandwidthTotals().TotalOut).
-                Float64("RateOut", host.GetBandwidthTotals().RateOut).
-                Msg("Record Sending Metrics!")
+		Int64("TotalOut", host.GetBandwidthTotals().TotalOut).
+		Float64("RateOut", host.GetBandwidthTotals().RateOut).
+		Msg("Record Sending Metrics!")
 
 	return err
 }

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -18,6 +18,7 @@ import (
 	libp2p_peer "github.com/libp2p/go-libp2p-core/peer"
 	libp2p_peerstore "github.com/libp2p/go-libp2p-core/peerstore"
 	libp2p_pubsub "github.com/libp2p/go-libp2p-pubsub"
+	libp2p_metrics  "github.com/libp2p/go-libp2p-core/metrics"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -34,6 +35,11 @@ type Host interface {
 	// SendMessageToGroups sends a message to one or more multicast groups.
 	SendMessageToGroups(groups []nodeconfig.GroupID, msg []byte) error
 	AllTopics() []*libp2p_pubsub.Topic
+
+	// libp2p.metrics related
+	GetBandwidthTotals() libp2p_metrics.Stats
+	LogRecvMessage( msg []byte )
+	ResetMetrics()
 }
 
 // Peer is the object for a p2p peer (node)
@@ -88,6 +94,9 @@ func NewHost(self *Peer, key libp2p_crypto.PrivKey) (Host, error) {
 
 	self.PeerID = p2pHost.ID()
 	subLogger := utils.Logger().With().Str("hostID", p2pHost.ID().Pretty()).Logger()
+
+	newMetrics := libp2p_metrics.NewBandwidthCounter()
+
 	// has to save the private key for host
 	h := &HostV2{
 		h:      p2pHost,
@@ -96,6 +105,7 @@ func NewHost(self *Peer, key libp2p_crypto.PrivKey) (Host, error) {
 		self:   *self,
 		priKey: key,
 		logger: &subLogger,
+		metrics: newMetrics,
 	}
 
 	if err != nil {
@@ -131,6 +141,8 @@ type HostV2 struct {
 	lock   sync.Mutex
 	// logger
 	logger *zerolog.Logger
+	// metrics
+	metrics *libp2p_metrics.BandwidthCounter
 }
 
 func (host *HostV2) getTopic(topic string) (*libp2p_pubsub.Topic, error) {
@@ -150,6 +162,7 @@ func (host *HostV2) getTopic(topic string) (*libp2p_pubsub.Topic, error) {
 // It returns a nil error if and only if it has succeeded to schedule the given
 // message for sending.
 func (host *HostV2) SendMessageToGroups(groups []nodeconfig.GroupID, msg []byte) (err error) {
+
 	for _, group := range groups {
 		t, e := host.getTopic(string(group))
 		if e != nil {
@@ -161,7 +174,14 @@ func (host *HostV2) SendMessageToGroups(groups []nodeconfig.GroupID, msg []byte)
 			err = e
 			continue
 		}
+		// log out-going metrics
+		host.metrics.LogSentMessage(int64(len(msg))) 
 	}
+	host.logger.Info().
+ 		Int64("TotalOut", host.GetBandwidthTotals().TotalOut).
+                Float64("RateOut", host.GetBandwidthTotals().RateOut).
+                Msg("Record Sending Metrics!")
+
 	return err
 }
 
@@ -215,6 +235,19 @@ func (host *HostV2) GetP2PHost() libp2p_host.Host {
 // GetPeerCount ...
 func (host *HostV2) GetPeerCount() int {
 	return host.h.Peerstore().Peers().Len()
+}
+
+// host.metrics.GetBandwidthTotals()
+func (host *HostV2) GetBandwidthTotals() libp2p_metrics.Stats {
+	return host.metrics.GetBandwidthTotals()
+}
+
+func (host *HostV2) LogRecvMessage( msg []byte ) {
+	host.metrics.LogRecvMessage(int64(len(msg)))
+}
+
+func (host *HostV2) ResetMetrics() {
+	host.metrics.Reset()
 }
 
 // ConnectHostPeer connects to peer host

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -99,12 +99,12 @@ func NewHost(self *Peer, key libp2p_crypto.PrivKey) (Host, error) {
 
 	// has to save the private key for host
 	h := &HostV2{
-		h:      p2pHost,
-		joiner: topicJoiner{pubsub},
-		joined: map[string]*libp2p_pubsub.Topic{},
-		self:   *self,
-		priKey: key,
-		logger: &subLogger,
+		h:       p2pHost,
+		joiner:  topicJoiner{pubsub},
+		joined:  map[string]*libp2p_pubsub.Topic{},
+		self:    *self,
+		priKey:  key,
+		logger:  &subLogger,
 		metrics: newMetrics,
 	}
 


### PR DESCRIPTION
… networking traffic in a node

## Issue

So far we don't have good visibility into what's going on in the p2p layer, to improve the performance of p2p layer, we need to have some metrics to be collected.  This is the first step, I will gradually add more metrics in more places as needed. 

The changes in the go.mod is automatically generated when I ran "make" in my workspace, I have retried a few times and it seems not harmful.  Please let me know if otherwise. Thanks.

## Test

### Unit Test Coverage

I have run go test -cover inside node directory, let me know if I need to run some other unit testing. 

Jians-MacBook-Pro:node jz$ go test -cover
PASS
coverage: 12.4% of statements
ok  	github.com/harmony-one/harmony/node	1.195s

### Test/Run Logs

Have run ./test/debug.sh and generated logs  like 

tmp_log/log-20200419-232519/zerolog-validator-127.0.0.1-9000.log, on my machine. Here I share a few examples of the generated messages in the log:

https://gist.github.com/jz0000/807652e4b0f05b91eae3319246652f6e

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

NO

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

NO

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

There could be some minor increase in the log it generated, thus disk usage might increase a bit, but don't see this an issue. 


