### PR TITLE
Fix potential nil pointer when validator is first created

### DIFF
--- a/staking/types/delegation.go
+++ b/staking/types/delegation.go
@@ -113,6 +113,7 @@ func NewDelegation(delegatorAddr common.Address,
 	return Delegation{
 		DelegatorAddress: delegatorAddr,
 		Amount:           amount,
+		Reward:           big.NewInt(0),
 	}
 }
 

--- a/test/chain/reward/main.go
+++ b/test/chain/reward/main.go
@@ -101,6 +101,8 @@ func main() {
 		})
 	}
 
+	statedb.UpdateValidatorWrapper(msg.ValidatorAddress, validator)
+
 	startTime := time.Now()
 	validator, _ = statedb.ValidatorWrapper(msg.ValidatorAddress)
 	endTime := time.Now()


### PR DESCRIPTION
Since we are using the in-memory version of validatorWrapper, the nil big.Int will have trouble.

Need to avoid nils in the validatorWrapper.