### PR TITLE
Add raw stake and median to shard state and roster

### DIFF
--- a/consensus/quorum/quorum.go
+++ b/consensus/quorum/quorum.go
@@ -11,6 +11,7 @@ import (
 	"github.com/harmony-one/harmony/multibls"
 	"github.com/harmony-one/harmony/numeric"
 	"github.com/harmony-one/harmony/shard"
+	"github.com/harmony-one/harmony/staking/effective"
 	"github.com/pkg/errors"
 )
 
@@ -125,13 +126,15 @@ type Decider interface {
 
 // Registry ..
 type Registry struct {
-	Deciders      map[string]Decider `json:"quorum-deciders"`
-	ExternalCount int                `json:"external-slot-count"`
+	Deciders      map[string]Decider       `json:"quorum-deciders"`
+	ExternalCount int                      `json:"external-slot-count"`
+	MedianStake   numeric.Dec              `json:"epos-median-stake"`
+	SlotPurchases []effective.SlotPurchase `json:"slot-purchases"`
 }
 
 // NewRegistry ..
 func NewRegistry(extern int) Registry {
-	return Registry{map[string]Decider{}, extern}
+	return Registry{map[string]Decider{}, extern, numeric.NewDec(0), nil}
 }
 
 // Transition  ..

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -587,6 +587,18 @@ func (b *APIBackend) GetSuperCommittees() (*quorum.Transition, error) {
 		quorum.NewRegistry(stakedSlotsThen),
 		quorum.NewRegistry(stakedSlotsNow)
 
+	then.MedianStake, then.SlotPurchases =
+		committee.ComputeMedianRawStakeForShardCommittee(
+			b.hmy.BlockChain(),
+			prevCommittee.StakedValidators().Addrs,
+		)
+
+	now.MedianStake, now.SlotPurchases =
+		committee.ComputeMedianRawStakeForShardCommittee(
+			b.hmy.BlockChain(),
+			nowCommittee.StakedValidators().Addrs,
+		)
+
 	for _, comm := range prevCommittee.Shards {
 		decider := quorum.NewDecider(quorum.SuperMajorityStake, comm.ShardID)
 		if _, err := decider.SetVoters(&comm, prevCommittee.Epoch); err != nil {

--- a/shard/committee/assignment.go
+++ b/shard/committee/assignment.go
@@ -84,13 +84,14 @@ func ComputeMedianRawStakeForShardCommittee(
 	if err != nil {
 		return numeric.NewDec(0), nil
 	}
+
 	maxExternalSlots := shard.ExternalSlotsAvailableForEpoch(
 		stakedReader.CurrentBlock().Epoch(),
 	)
-	median, winners := effective.Apply(
+
+	return effective.Apply(
 		candidateSlotOrders, maxExternalSlots,
 	)
-	return median, winners
 }
 
 // NewEPoSRound runs a fresh computation of EPoS using


### PR DESCRIPTION
reuse all the code from `GetMedianRawStakeSnapshot`, but only work with validator snapshot to recompute the results of previous election. the format of the rpc result is same as `GetMedianRawStakeSnapshot`.