### PR TITLE
Add viewID to block signed content

### DIFF
--- a/api/proto/node/node.go
+++ b/api/proto/node/node.go
@@ -198,8 +198,7 @@ func ConstructCrossLinkMessage(bc engine.ChainReader, headers []*block.Header) [
 		if parentHeader == nil {
 			continue
 		}
-		epoch := parentHeader.Epoch()
-		crosslinks = append(crosslinks, types.NewCrossLink(header, epoch))
+		crosslinks = append(crosslinks, types.NewCrossLink(header, parentHeader))
 	}
 	crosslinksData, _ := rlp.EncodeToBytes(crosslinks)
 	byteBuffer.Write(crosslinksData)

--- a/api/proto/node/node.go
+++ b/api/proto/node/node.go
@@ -189,7 +189,7 @@ func ConstructSlashMessage(witnesses slash.Records) []byte {
 // ConstructCrossLinkMessage constructs cross link message to send to beacon chain
 func ConstructCrossLinkMessage(bc engine.ChainReader, headers []*block.Header) []byte {
 	byteBuffer := bytes.NewBuffer(crossLinkH)
-	crosslinks := []types.CrossLink{}
+	crosslinks := []*types.CrossLink{}
 	for _, header := range headers {
 		if header.Number().Uint64() <= 1 || !bc.Config().IsCrossLink(header.Epoch()) {
 			continue

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -1,7 +1,8 @@
 package consensus
 
 import (
-	"encoding/binary"
+	"encoding/hex"
+	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -9,8 +10,10 @@ import (
 	"github.com/harmony-one/bls/ffi/go/bls"
 	msg_pb "github.com/harmony-one/harmony/api/proto/message"
 	"github.com/harmony-one/harmony/consensus/quorum"
+	"github.com/harmony-one/harmony/consensus/signature"
 	"github.com/harmony-one/harmony/core/types"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
+	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 )
 
@@ -222,10 +225,14 @@ func (consensus *Consensus) onCommit(msg *msg_pb.Message) {
 		return
 	}
 
-	// TODO(audit): verify signature on hash+blockNum+viewID (add a hard fork)
-	blockNumHash := make([]byte, 8)
-	binary.LittleEndian.PutUint64(blockNumHash, recvMsg.BlockNum)
-	commitPayload := append(blockNumHash, recvMsg.BlockHash[:]...)
+	commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
+		new(big.Int).SetUint64(consensus.epoch), recvMsg.BlockHash, recvMsg.BlockNum, consensus.viewID)
+	// TODO: remove debug msg after STN testing
+	utils.Logger().Debug().
+		Uint64("epoch", consensus.epoch).
+		Uint64("block-number", recvMsg.BlockNum).
+		Uint64("view-id", recvMsg.ViewID).
+		Msgf("[COMMIT-PAYLOAD] onCommitted %v", hex.EncodeToString(commitPayload))
 	logger = logger.With().
 		Uint64("MsgViewID", recvMsg.ViewID).
 		Uint64("MsgBlockNum", recvMsg.BlockNum).

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -1,7 +1,6 @@
 package consensus
 
 import (
-	"encoding/hex"
 	"math/big"
 	"time"
 
@@ -13,7 +12,6 @@ import (
 	"github.com/harmony-one/harmony/consensus/signature"
 	"github.com/harmony-one/harmony/core/types"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
-	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 )
 
@@ -227,12 +225,6 @@ func (consensus *Consensus) onCommit(msg *msg_pb.Message) {
 
 	commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
 		new(big.Int).SetUint64(consensus.epoch), recvMsg.BlockHash, recvMsg.BlockNum, consensus.viewID)
-	// TODO: remove debug msg after STN testing
-	utils.Logger().Debug().
-		Uint64("epoch", consensus.epoch).
-		Uint64("block-number", recvMsg.BlockNum).
-		Uint64("view-id", recvMsg.ViewID).
-		Msgf("[COMMIT-PAYLOAD] onCommitted %v", hex.EncodeToString(commitPayload))
 	logger = logger.With().
 		Uint64("MsgViewID", recvMsg.ViewID).
 		Uint64("MsgBlockNum", recvMsg.BlockNum).

--- a/consensus/signature/signature.go
+++ b/consensus/signature/signature.go
@@ -1,0 +1,27 @@
+package signature
+
+import (
+	"encoding/binary"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/harmony-one/harmony/internal/params"
+)
+
+type configChainReader interface {
+	Config() *params.ChainConfig
+}
+
+// ConstructCommitPayload returns the commit payload for consensus signatures.
+func ConstructCommitPayload(
+	chain configChainReader, blockHash common.Hash, epoch, blockNum, viewID uint64,
+) []byte {
+	blockNumBytes := make([]byte, 8)
+	viewIDBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(blockNumBytes, blockNum)
+	binary.LittleEndian.PutUint64(viewIDBytes, viewID)
+	if chain.Config().IsStaking(new(big.Int).SetUint64(epoch)) {
+		return append(blockNumBytes, append(viewIDBytes, blockHash.Bytes()...)...)
+	}
+	return append(blockNumBytes, blockHash.Bytes()...)
+}

--- a/consensus/threshold.go
+++ b/consensus/threshold.go
@@ -1,11 +1,13 @@
 package consensus
 
 import (
-	"encoding/binary"
+	"encoding/hex"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	msg_pb "github.com/harmony-one/harmony/api/proto/message"
 	"github.com/harmony-one/harmony/consensus/quorum"
+	"github.com/harmony-one/harmony/consensus/signature"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
@@ -37,10 +39,14 @@ func (consensus *Consensus) didReachPrepareQuorum() error {
 	consensus.aggregatedPrepareSig = aggSig
 	consensus.FBFTLog.AddMessage(FBFTMsg)
 	// Leader add commit phase signature
-	// TODO(audit): sign signature on hash+blockNum+viewID (add a hard fork)
-	blockNumHash := [8]byte{}
-	binary.LittleEndian.PutUint64(blockNumHash[:], consensus.blockNum)
-	commitPayload := append(blockNumHash[:], consensus.blockHash[:]...)
+	commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
+		new(big.Int).SetUint64(consensus.epoch), consensus.blockHash, consensus.blockNum, consensus.viewID)
+	// TODO: remove debug msg after STN testing
+	utils.Logger().Debug().
+		Uint64("epoch", consensus.epoch).
+		Uint64("block-number", consensus.blockNum).
+		Uint64("view-id", consensus.viewID).
+		Msgf("[COMMIT-PAYLOAD] didReachPrepareQuorum %v", hex.EncodeToString(commitPayload))
 
 	// so by this point, everyone has committed to the blockhash of this block
 	// in prepare and so this is the actual block.

--- a/consensus/threshold.go
+++ b/consensus/threshold.go
@@ -1,7 +1,6 @@
 package consensus
 
 import (
-	"encoding/hex"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -41,12 +40,6 @@ func (consensus *Consensus) didReachPrepareQuorum() error {
 	// Leader add commit phase signature
 	commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
 		new(big.Int).SetUint64(consensus.epoch), consensus.blockHash, consensus.blockNum, consensus.viewID)
-	// TODO: remove debug msg after STN testing
-	utils.Logger().Debug().
-		Uint64("epoch", consensus.epoch).
-		Uint64("block-number", consensus.blockNum).
-		Uint64("view-id", consensus.viewID).
-		Msgf("[COMMIT-PAYLOAD] didReachPrepareQuorum %v", hex.EncodeToString(commitPayload))
 
 	// so by this point, everyone has committed to the blockhash of this block
 	// in prepare and so this is the actual block.

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -12,7 +12,6 @@ import (
 	"github.com/harmony-one/harmony/consensus/signature"
 	"github.com/harmony-one/harmony/core/types"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
-	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 )
 
@@ -205,12 +204,6 @@ func (consensus *Consensus) onPrepared(msg *msg_pb.Message) {
 	// local viewID may not be constant with other, so use received msg viewID.
 	commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
 		new(big.Int).SetUint64(consensus.epoch), consensus.blockHash, consensus.blockNum, recvMsg.ViewID)
-	// TODO: remove debug msg after STN testing
-	utils.Logger().Debug().
-		Uint64("epoch", consensus.epoch).
-		Uint64("block-number", consensus.blockNum).
-		Uint64("view-id", consensus.viewID).
-		Msgf("[COMMIT-PAYLOAD] onPrepared %v", hex.EncodeToString(commitPayload))
 	groupID := []nodeconfig.GroupID{
 		nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(consensus.ShardID)),
 	}
@@ -268,12 +261,6 @@ func (consensus *Consensus) onCommitted(msg *msg_pb.Message) {
 	// Received msg must be about same epoch, otherwise it's invalid anyways.
 	commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
 		new(big.Int).SetUint64(consensus.epoch), recvMsg.BlockHash, recvMsg.BlockNum, recvMsg.ViewID)
-	// TODO: remove debug msg after STN testing
-	utils.Logger().Debug().
-		Uint64("epoch", consensus.epoch).
-		Uint64("block-number", recvMsg.BlockNum).
-		Uint64("view-id", recvMsg.ViewID).
-		Msgf("[COMMIT-PAYLOAD] onCommitted %v", hex.EncodeToString(commitPayload))
 	if !aggSig.VerifyHash(mask.AggregatePublic, commitPayload) {
 		consensus.getLogger().Error().
 			Uint64("MsgBlockNum", recvMsg.BlockNum).

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -3,7 +3,6 @@ package consensus
 import (
 	"bytes"
 	"encoding/binary"
-	"encoding/hex"
 	"math/big"
 	"sync"
 	"time"
@@ -366,12 +365,6 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 			// Leader sign and add commit message
 			commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
 				new(big.Int).SetUint64(consensus.epoch), consensus.blockHash, consensus.blockNum, recvMsg.ViewID)
-			// TODO: remove debug msg after STN testing
-			utils.Logger().Debug().
-				Uint64("epoch", consensus.epoch).
-				Uint64("block-number", consensus.blockNum).
-				Uint64("view-id", recvMsg.ViewID).
-				Msgf("[COMMIT-PAYLOAD] onViewChange %v", hex.EncodeToString(commitPayload))
 			for i, key := range consensus.PubKey.PublicKey {
 				priKey := consensus.priKey.PrivateKey[i]
 				if _, err := consensus.Decider.SubmitVote(
@@ -542,12 +535,6 @@ func (consensus *Consensus) onNewView(msg *msg_pb.Message) {
 		// Construct and send the commit message
 		commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
 			new(big.Int).SetUint64(consensus.epoch), consensus.blockHash, consensus.blockNum, consensus.viewID)
-		// TODO: remove debug msg after STN testing
-		utils.Logger().Debug().
-			Uint64("epoch", consensus.epoch).
-			Uint64("block-number", consensus.blockNum).
-			Uint64("view-id", consensus.viewID).
-			Msgf("[COMMIT-PAYLOAD] onNewView %v", hex.EncodeToString(commitPayload))
 		groupID := []nodeconfig.GroupID{
 			nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(consensus.ShardID))}
 		for i, key := range consensus.PubKey.PublicKey {

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -3,6 +3,8 @@ package consensus
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/hex"
+	"math/big"
 	"sync"
 	"time"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/harmony-one/bls/ffi/go/bls"
 	msg_pb "github.com/harmony-one/harmony/api/proto/message"
 	"github.com/harmony-one/harmony/consensus/quorum"
+	"github.com/harmony-one/harmony/consensus/signature"
 	bls_cosi "github.com/harmony-one/harmony/crypto/bls"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
@@ -361,10 +364,14 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 			consensus.aggregatedPrepareSig = aggSig
 			consensus.prepareBitmap = mask
 			// Leader sign and add commit message
-			// TODO(audit): verify signature on hash+blockNum+viewID (add a hard fork)
-			blockNumBytes := [8]byte{}
-			binary.LittleEndian.PutUint64(blockNumBytes[:], consensus.blockNum)
-			commitPayload := append(blockNumBytes[:], consensus.blockHash[:]...)
+			commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
+				new(big.Int).SetUint64(consensus.epoch), consensus.blockHash, consensus.blockNum, recvMsg.ViewID)
+			// TODO: remove debug msg after STN testing
+			utils.Logger().Debug().
+				Uint64("epoch", consensus.epoch).
+				Uint64("block-number", consensus.blockNum).
+				Uint64("view-id", recvMsg.ViewID).
+				Msgf("[COMMIT-PAYLOAD] onViewChange %v", hex.EncodeToString(commitPayload))
 			for i, key := range consensus.PubKey.PublicKey {
 				priKey := consensus.priKey.PrivateKey[i]
 				if _, err := consensus.Decider.SubmitVote(
@@ -533,14 +540,20 @@ func (consensus *Consensus) onNewView(msg *msg_pb.Message) {
 	// TODO: check magic number 32
 	if len(recvMsg.Payload) > 32 {
 		// Construct and send the commit message
-		blockNumHash := make([]byte, 8)
-		binary.LittleEndian.PutUint64(blockNumHash, consensus.blockNum)
+		commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
+			new(big.Int).SetUint64(consensus.epoch), consensus.blockHash, consensus.blockNum, consensus.viewID)
+		// TODO: remove debug msg after STN testing
+		utils.Logger().Debug().
+			Uint64("epoch", consensus.epoch).
+			Uint64("block-number", consensus.blockNum).
+			Uint64("view-id", consensus.viewID).
+			Msgf("[COMMIT-PAYLOAD] onNewView %v", hex.EncodeToString(commitPayload))
 		groupID := []nodeconfig.GroupID{
 			nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(consensus.ShardID))}
 		for i, key := range consensus.PubKey.PublicKey {
 			network, err := consensus.construct(
 				msg_pb.MessageType_COMMIT,
-				append(blockNumHash, consensus.blockHash[:]...),
+				commitPayload,
 				key, consensus.priKey.PrivateKey[i],
 			)
 			if err != nil {

--- a/core/types/crosslink.go
+++ b/core/types/crosslink.go
@@ -13,12 +13,13 @@ import (
 
 // CrossLink is only used on beacon chain to store the hash links from other shards
 // signature and bitmap correspond to |blockNumber|parentHash| byte array
-// Captial to enable rlp encoding
+// Capital to enable rlp encoding
 // Here we replace header to signatures only, the basic assumption is the committee will not be
 // corrupted during one epoch, which is the same as consensus assumption
 type CrossLink struct {
 	HashF        common.Hash
 	BlockNumberF *big.Int
+	ViewIDF      *big.Int
 	SignatureF   [96]byte //aggregated signature
 	BitmapF      []byte   //corresponding bitmap mask for agg signature
 	ShardIDF     uint32   //will be verified with signature on |blockNumber|blockHash| is correct
@@ -26,14 +27,24 @@ type CrossLink struct {
 }
 
 // NewCrossLink returns a new cross link object
-// epoch is the parentHeader's epoch
-func NewCrossLink(header *block.Header, epoch *big.Int) CrossLink {
+func NewCrossLink(header *block.Header, parentHeader *block.Header) CrossLink {
 	parentBlockNum := big.NewInt(0)
-	if header.Number().Uint64() == 0 { // should not happend, just to be defensive
-		return CrossLink{header.ParentHash(), parentBlockNum, header.LastCommitSignature(), header.LastCommitBitmap(), header.ShardID(), epoch}
+	parentViewID := big.NewInt(0)
+	parentEpoch := big.NewInt(0)
+	if parentHeader != nil { // Should always happen, default values to be defensive.
+		parentBlockNum = parentHeader.Number()
+		parentViewID = parentHeader.ViewID()
+		parentEpoch = parentHeader.Epoch()
 	}
-	parentBlockNum.Sub(header.Number(), big.NewInt(1))
-	return CrossLink{header.ParentHash(), parentBlockNum, header.LastCommitSignature(), header.LastCommitBitmap(), header.ShardID(), epoch}
+	return CrossLink{
+		HashF:        header.ParentHash(),
+		BlockNumberF: parentBlockNum,
+		ViewIDF:      parentViewID,
+		SignatureF:   header.LastCommitSignature(),
+		BitmapF:      header.LastCommitBitmap(),
+		ShardIDF:     header.ShardID(),
+		EpochF:       parentEpoch,
+	}
 }
 
 // ShardID returns shardID
@@ -44,6 +55,11 @@ func (cl CrossLink) ShardID() uint32 {
 // Number returns blockNum with big.Int format
 func (cl CrossLink) Number() *big.Int {
 	return cl.BlockNumberF
+}
+
+// ViewID returns viewID with big.Int format
+func (cl CrossLink) ViewID() *big.Int {
+	return cl.ViewIDF
 }
 
 // Epoch returns epoch with big.Int format
@@ -76,6 +92,7 @@ func (cl CrossLink) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Hash        common.Hash `json:"hash"`
 		BlockNumber *big.Int    `json:"block-number"`
+		ViewID      *big.Int    `json:"view-id"`
 		Signature   string      `json:"signature"`
 		Bitmap      string      `json:"signature-bitmap"`
 		ShardID     uint32      `json:"shard-id"`
@@ -83,6 +100,7 @@ func (cl CrossLink) MarshalJSON() ([]byte, error) {
 	}{
 		cl.HashF,
 		cl.BlockNumberF,
+		cl.ViewIDF,
 		hex.EncodeToString(cl.SignatureF[:]),
 		hex.EncodeToString(cl.BitmapF),
 		cl.ShardIDF,
@@ -109,16 +127,20 @@ func DeserializeCrossLink(bytes []byte) (*CrossLink, error) {
 // CrossLinks is a collection of cross links
 type CrossLinks []CrossLink
 
-// Sort crosslinks by shardID and then by blockNum
+// Sort crosslinks by shardID and then tie break by blockNum then by viewID
 func (cls CrossLinks) Sort() {
 	sort.Slice(cls, func(i, j int) bool {
-		return cls[i].ShardID() < cls[j].ShardID() || (cls[i].ShardID() == cls[j].ShardID() && cls[i].Number().Cmp(cls[j].Number()) < 0)
+		return cls[i].ShardID() < cls[j].ShardID() ||
+			(cls[i].ShardID() == cls[j].ShardID() && cls[i].Number().Cmp(cls[j].Number()) < 0) ||
+			(cls[i].ShardID() == cls[j].ShardID() && cls[i].Number() == cls[j].Number() && cls[i].ViewID().Cmp(cls[j].ViewID()) < 0)
 	})
 }
 
 // IsSorted checks whether the cross links are sorted
 func (cls CrossLinks) IsSorted() bool {
 	return sort.SliceIsSorted(cls, func(i, j int) bool {
-		return cls[i].ShardID() < cls[j].ShardID() || (cls[i].ShardID() == cls[j].ShardID() && cls[i].Number().Cmp(cls[j].Number()) < 0)
+		return cls[i].ShardID() < cls[j].ShardID() ||
+			(cls[i].ShardID() == cls[j].ShardID() && cls[i].Number().Cmp(cls[j].Number()) < 0) ||
+			(cls[i].ShardID() == cls[j].ShardID() && cls[i].Number() == cls[j].Number() && cls[i].ViewID().Cmp(cls[j].ViewID()) < 0)
 	})
 }

--- a/core/types/crosslink.go
+++ b/core/types/crosslink.go
@@ -27,7 +27,7 @@ type CrossLink struct {
 }
 
 // NewCrossLink returns a new cross link object
-func NewCrossLink(header *block.Header, parentHeader *block.Header) CrossLink {
+func NewCrossLink(header *block.Header, parentHeader *block.Header) *CrossLink {
 	parentBlockNum := big.NewInt(0)
 	parentViewID := big.NewInt(0)
 	parentEpoch := big.NewInt(0)
@@ -36,7 +36,7 @@ func NewCrossLink(header *block.Header, parentHeader *block.Header) CrossLink {
 		parentViewID = parentHeader.ViewID()
 		parentEpoch = parentHeader.Epoch()
 	}
-	return CrossLink{
+	return &CrossLink{
 		HashF:        header.ParentHash(),
 		BlockNumberF: parentBlockNum,
 		ViewIDF:      parentViewID,
@@ -48,47 +48,47 @@ func NewCrossLink(header *block.Header, parentHeader *block.Header) CrossLink {
 }
 
 // ShardID returns shardID
-func (cl CrossLink) ShardID() uint32 {
+func (cl *CrossLink) ShardID() uint32 {
 	return cl.ShardIDF
 }
 
 // Number returns blockNum with big.Int format
-func (cl CrossLink) Number() *big.Int {
+func (cl *CrossLink) Number() *big.Int {
 	return cl.BlockNumberF
 }
 
 // ViewID returns viewID with big.Int format
-func (cl CrossLink) ViewID() *big.Int {
+func (cl *CrossLink) ViewID() *big.Int {
 	return cl.ViewIDF
 }
 
 // Epoch returns epoch with big.Int format
-func (cl CrossLink) Epoch() *big.Int {
+func (cl *CrossLink) Epoch() *big.Int {
 	return cl.EpochF
 }
 
 // BlockNum returns blockNum
-func (cl CrossLink) BlockNum() uint64 {
+func (cl *CrossLink) BlockNum() uint64 {
 	return cl.BlockNumberF.Uint64()
 }
 
 // Hash returns hash
-func (cl CrossLink) Hash() common.Hash {
+func (cl *CrossLink) Hash() common.Hash {
 	return cl.HashF
 }
 
 // Bitmap returns bitmap
-func (cl CrossLink) Bitmap() []byte {
+func (cl *CrossLink) Bitmap() []byte {
 	return cl.BitmapF
 }
 
 // Signature returns aggregated signature
-func (cl CrossLink) Signature() [96]byte {
+func (cl *CrossLink) Signature() [96]byte {
 	return cl.SignatureF
 }
 
 // MarshalJSON ..
-func (cl CrossLink) MarshalJSON() ([]byte, error) {
+func (cl *CrossLink) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Hash        common.Hash `json:"hash"`
 		BlockNumber *big.Int    `json:"block-number"`
@@ -109,7 +109,7 @@ func (cl CrossLink) MarshalJSON() ([]byte, error) {
 }
 
 // Serialize returns bytes of cross link rlp-encoded content
-func (cl CrossLink) Serialize() []byte {
+func (cl *CrossLink) Serialize() []byte {
 	bytes, _ := rlp.EncodeToBytes(cl)
 	return bytes
 }

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -548,7 +548,7 @@ func (e *engineImpl) VerifyHeaderWithSignature(chain engine.ChainReader, header 
 		}
 	}
 	commitPayload := signature.ConstructCommitPayload(chain,
-		header.Epoch(), header.Hash(), header.Epoch().Uint64(), header.ViewID().Uint64())
+		header.Epoch(), header.Hash(), header.Number().Uint64(), header.ViewID().Uint64())
 	// TODO: remove debug msg after STN testing
 	utils.Logger().Debug().
 		Uint64("epoch", header.Epoch().Uint64()).

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -228,13 +228,14 @@ func (e *engineImpl) VerifySeal(chain engine.ChainReader, header *block.Header) 
 		}
 	}
 
-	lastCommitPayload := signature.ConstructCommitPayload(e.Beaconchain(),
-		parentHeader.Hash(), parentHeader.Epoch().Uint64(), parentHeader.Number().Uint64(), parentHeader.ViewID().Uint64())
-	utils.Logger().Debug(). // TODO: remove debug msg after STN testing
-				Uint64("epoch", parentHeader.Epoch().Uint64()).
-				Uint64("block-number", parentHeader.Number().Uint64()).
-				Uint64("view-id", parentHeader.ViewID().Uint64()).
-				Msgf("[COMMIT-PAYLOAD] VerifySeal %v", hex.EncodeToString(lastCommitPayload))
+	lastCommitPayload := signature.ConstructCommitPayload(chain,
+		parentHeader.Epoch(), parentHeader.Hash(), parentHeader.Number().Uint64(), parentHeader.ViewID().Uint64())
+	// TODO: remove debug msg after STN testing
+	utils.Logger().Debug().
+		Uint64("epoch", parentHeader.Epoch().Uint64()).
+		Uint64("block-number", parentHeader.Number().Uint64()).
+		Uint64("view-id", parentHeader.ViewID().Uint64()).
+		Msgf("[COMMIT-PAYLOAD] VerifySeal %v", hex.EncodeToString(lastCommitPayload))
 	if !aggSig.VerifyHash(mask.AggregatePublic, lastCommitPayload) {
 		const msg = "[VerifySeal] Unable to verify aggregated signature from last block"
 		return errors.New(msg)
@@ -546,13 +547,14 @@ func (e *engineImpl) VerifyHeaderWithSignature(chain engine.ChainReader, header 
 			)
 		}
 	}
-	commitPayload := signature.ConstructCommitPayload(e.Beaconchain(),
-		header.Hash(), header.Epoch().Uint64(), header.Number().Uint64(), header.ViewID().Uint64())
-	utils.Logger().Debug(). // TODO: remove debug msg after STN testing
-				Uint64("epoch", header.Epoch().Uint64()).
-				Uint64("block-number", header.Number().Uint64()).
-				Uint64("view-id", header.ViewID().Uint64()).
-				Msgf("[COMMIT-PAYLOAD] VerifyHeaderWithSignature %v", hex.EncodeToString(commitPayload))
+	commitPayload := signature.ConstructCommitPayload(chain,
+		header.Epoch(), header.Hash(), header.Epoch().Uint64(), header.ViewID().Uint64())
+	// TODO: remove debug msg after STN testing
+	utils.Logger().Debug().
+		Uint64("epoch", header.Epoch().Uint64()).
+		Uint64("block-number", header.Number().Uint64()).
+		Uint64("view-id", header.ViewID().Uint64()).
+		Msgf("[COMMIT-PAYLOAD] VerifyHeaderWithSignature %v", hex.EncodeToString(commitPayload))
 
 	if !aggSig.VerifyHash(mask.AggregatePublic, commitPayload) {
 		return errors.New("[VerifySeal] Unable to verify aggregated signature for block")

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -2,7 +2,6 @@ package chain
 
 import (
 	"bytes"
-	"encoding/hex"
 	"math/big"
 	"sort"
 
@@ -230,12 +229,6 @@ func (e *engineImpl) VerifySeal(chain engine.ChainReader, header *block.Header) 
 
 	lastCommitPayload := signature.ConstructCommitPayload(chain,
 		parentHeader.Epoch(), parentHeader.Hash(), parentHeader.Number().Uint64(), parentHeader.ViewID().Uint64())
-	// TODO: remove debug msg after STN testing
-	utils.Logger().Debug().
-		Uint64("epoch", parentHeader.Epoch().Uint64()).
-		Uint64("block-number", parentHeader.Number().Uint64()).
-		Uint64("view-id", parentHeader.ViewID().Uint64()).
-		Msgf("[COMMIT-PAYLOAD] VerifySeal %v", hex.EncodeToString(lastCommitPayload))
 	if !aggSig.VerifyHash(mask.AggregatePublic, lastCommitPayload) {
 		const msg = "[VerifySeal] Unable to verify aggregated signature from last block"
 		return errors.New(msg)
@@ -549,12 +542,6 @@ func (e *engineImpl) VerifyHeaderWithSignature(chain engine.ChainReader, header 
 	}
 	commitPayload := signature.ConstructCommitPayload(chain,
 		header.Epoch(), header.Hash(), header.Number().Uint64(), header.ViewID().Uint64())
-	// TODO: remove debug msg after STN testing
-	utils.Logger().Debug().
-		Uint64("epoch", header.Epoch().Uint64()).
-		Uint64("block-number", header.Number().Uint64()).
-		Uint64("view-id", header.ViewID().Uint64()).
-		Msgf("[COMMIT-PAYLOAD] VerifyHeaderWithSignature %v", hex.EncodeToString(commitPayload))
 
 	if !aggSig.VerifyHash(mask.AggregatePublic, commitPayload) {
 		return errors.New("[VerifySeal] Unable to verify aggregated signature for block")

--- a/node/node_cross_link.go
+++ b/node/node_cross_link.go
@@ -145,6 +145,6 @@ func (node *Node) VerifyCrossLink(cl types.CrossLink) error {
 	}
 
 	return verify.AggregateSigForCommittee(
-		committee, aggSig, cl.Hash(), cl.BlockNum(), cl.Epoch(), cl.Bitmap(),
+		node.Blockchain(), committee, aggSig, cl.Hash(), cl.BlockNum(), cl.ViewID().Uint64(), cl.Epoch(), cl.Bitmap(),
 	)
 }

--- a/node/node_explorer.go
+++ b/node/node_explorer.go
@@ -1,7 +1,6 @@
 package node
 
 import (
-	"encoding/hex"
 	"sort"
 	"sync"
 
@@ -65,12 +64,6 @@ func (node *Node) ExplorerMessageHandler(payload []byte) {
 
 		commitPayload := signature.ConstructCommitPayload(node.Blockchain(),
 			block.Epoch(), block.Hash(), block.Number().Uint64(), block.Header().ViewID().Uint64())
-		// TODO: remove debug msg after STN testing
-		utils.Logger().Debug().
-			Uint64("epoch", block.Epoch().Uint64()).
-			Uint64("block-number", block.Number().Uint64()).
-			Uint64("view-id", block.Header().ViewID().Uint64()).
-			Msgf("[COMMIT-PAYLOAD] ExplorerMessageHandler %v", hex.EncodeToString(commitPayload))
 		if !aggSig.VerifyHash(mask.AggregatePublic, commitPayload) {
 			utils.Logger().
 				Error().Err(err).

--- a/node/node_explorer.go
+++ b/node/node_explorer.go
@@ -1,7 +1,7 @@
 package node
 
 import (
-	"encoding/binary"
+	"encoding/hex"
 	"sort"
 	"sync"
 
@@ -11,6 +11,7 @@ import (
 	msg_pb "github.com/harmony-one/harmony/api/proto/message"
 	"github.com/harmony-one/harmony/api/service/explorer"
 	"github.com/harmony-one/harmony/consensus"
+	"github.com/harmony-one/harmony/consensus/signature"
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/internal/utils"
 )
@@ -52,18 +53,6 @@ func (node *Node) ExplorerMessageHandler(payload []byte) {
 			return
 		}
 
-		// TODO(audit): verify signature on hash+blockNum+viewID (add a hard fork)
-		blockNumHash := make([]byte, 8)
-		binary.LittleEndian.PutUint64(blockNumHash, recvMsg.BlockNum)
-		commitPayload := append(blockNumHash, recvMsg.BlockHash[:]...)
-		if !aggSig.VerifyHash(mask.AggregatePublic, commitPayload) {
-			utils.Logger().
-				Error().Err(err).
-				Uint64("msgBlock", recvMsg.BlockNum).
-				Msg("[Explorer] Failed to verify the multi signature for commit phase")
-			return
-		}
-
 		block := node.Consensus.FBFTLog.GetBlockByHash(recvMsg.BlockHash)
 
 		if block == nil {
@@ -71,6 +60,22 @@ func (node *Node) ExplorerMessageHandler(payload []byte) {
 				Uint64("msgBlock", recvMsg.BlockNum).
 				Msg("[Explorer] Haven't received the block before the committed msg")
 			node.Consensus.FBFTLog.AddMessage(recvMsg)
+			return
+		}
+
+		commitPayload := signature.ConstructCommitPayload(node.Blockchain(),
+			block.Epoch(), block.Hash(), block.Number().Uint64(), block.Header().ViewID().Uint64())
+		// TODO: remove debug msg after STN testing
+		utils.Logger().Debug().
+			Uint64("epoch", block.Epoch().Uint64()).
+			Uint64("block-number", block.Number().Uint64()).
+			Uint64("view-id", block.Header().ViewID().Uint64()).
+			Msgf("[COMMIT-PAYLOAD] ExplorerMessageHandler %v", hex.EncodeToString(commitPayload))
+		if !aggSig.VerifyHash(mask.AggregatePublic, commitPayload) {
+			utils.Logger().
+				Error().Err(err).
+				Uint64("msgBlock", recvMsg.BlockNum).
+				Msg("[Explorer] Failed to verify the multi signature for commit phase")
 			return
 		}
 

--- a/staking/slash/double-sign_test.go
+++ b/staking/slash/double-sign_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/harmony-one/harmony/core/state"
 	"github.com/harmony-one/harmony/core/types"
 	common2 "github.com/harmony-one/harmony/internal/common"
+	"github.com/harmony-one/harmony/internal/params"
 	"github.com/harmony-one/harmony/numeric"
 	"github.com/harmony-one/harmony/shard"
 	"github.com/harmony-one/harmony/staking/effective"
@@ -399,7 +400,7 @@ func (mockOutChainReader) ReadShardState(epoch *big.Int) (*shard.State, error) {
 	return &shard.State{
 		Epoch: doubleSignEpochBig,
 		Shards: []shard.Committee{
-			shard.Committee{
+			{
 				ShardID: doubleSignShardID,
 				Slots: shard.SlotList{
 					shard.Slot{
@@ -411,6 +412,10 @@ func (mockOutChainReader) ReadShardState(epoch *big.Int) (*shard.State, error) {
 			},
 		},
 	}, nil
+}
+
+func (mockOutChainReader) Config() *params.ChainConfig {
+	return params.TestChainConfig
 }
 
 func TestVerify(t *testing.T) {

--- a/staking/verify/verify.go
+++ b/staking/verify/verify.go
@@ -1,7 +1,6 @@
 package verify
 
 import (
-	"encoding/hex"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -10,7 +9,6 @@ import (
 	"github.com/harmony-one/harmony/consensus/signature"
 	"github.com/harmony-one/harmony/core"
 	bls_cosi "github.com/harmony-one/harmony/crypto/bls"
-	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/multibls"
 	"github.com/harmony-one/harmony/shard"
 	"github.com/pkg/errors"
@@ -57,12 +55,6 @@ func AggregateSigForCommittee(
 	}
 
 	commitPayload := signature.ConstructCommitPayload(chain, epoch, hash, blockNum, viewID)
-	// TODO: remove debug msg after STN testing
-	utils.Logger().Debug().
-		Uint64("epoch", epoch.Uint64()).
-		Uint64("block-number", blockNum).
-		Uint64("view-id", viewID).
-		Msgf("[COMMIT-PAYLOAD] AggregateSigForCommittee %v", hex.EncodeToString(commitPayload))
 	if !aggSignature.VerifyHash(mask.AggregatePublic, commitPayload) {
 		return errAggregateSigFail
 	}


### PR DESCRIPTION
## Issue

This closes #2630 

### Unit Test Coverage

Before:

```
PASS
coverage: 7.4% of statements
ok  	github.com/harmony-one/harmony/consensus	1.380s
```
```
PASS
coverage: 21.5% of statements
ok  	github.com/harmony-one/harmony/core	6.803s
```
```
PASS
coverage: 47.3% of statements
ok  	github.com/harmony-one/harmony/staking/slash	0.243s
```

After:

```
PASS
coverage: 7.5% of statements
ok      github.com/harmony-one/harmony/consensus        1.265s
```
```
PASS
coverage: 21.7% of statements
ok      github.com/harmony-one/harmony/core     6.865s
```
```
PASS
coverage: 47.2% of statements
ok      github.com/harmony-one/harmony/staking/slash    0.304s
```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

   At the staking epoch fork, signing and verification will be done with the addition of the viewID in which the block is going to be/was committed.

3. **Describe how the plan was tested.**

   Tested on localnet and it works, got well past staking epoch. Tested on STN: got past staking epoch with external validator signing and earning. 


7. **What should node operators know about this planned change?**

   Nothing new other than what is needed for staking launch.

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**
