### PR TITLE
Validator dedup on identity and bls keys

### DIFF
--- a/core/evm.go
+++ b/core/evm.go
@@ -41,6 +41,9 @@ type ChainContext interface {
 
 	// ReadValidatorSnapshot returns the snapshot of validator at the beginning of current epoch.
 	ReadValidatorSnapshot(common.Address) (*staking.ValidatorSnapshot, error)
+
+	// ReadValidatorList returns the list of all validators
+	ReadValidatorList() ([]common.Address, error)
 }
 
 // NewEVMContext creates a new context for use in the EVM.

--- a/core/staking_verifier.go
+++ b/core/staking_verifier.go
@@ -162,61 +162,26 @@ func VerifyAndDelegateFromMsg(
 	if err != nil {
 		return nil, nil, err
 	}
-	// Check for redelegation
-	for i := range wrapper.Delegations {
-		delegation := &wrapper.Delegations[i]
-		if bytes.Equal(delegation.DelegatorAddress.Bytes(), msg.DelegatorAddress.Bytes()) {
-			totalInUndelegation := delegation.TotalInUndelegation()
-			balance := stateDB.GetBalance(msg.DelegatorAddress)
-			// If the sum of normal balance and the total amount of tokens in undelegation is greater than the amount to delegate
-			if big.NewInt(0).Add(totalInUndelegation, balance).Cmp(msg.Amount) >= 0 {
-				// Check if it can use tokens in undelegation to delegate (redelegate)
-				delegateBalance := big.NewInt(0).Set(msg.Amount)
-				// Use the latest undelegated token first as it has the longest remaining locking time.
-				i := len(delegation.Undelegations) - 1
-				for ; i >= 0; i-- {
-					if delegation.Undelegations[i].Amount.Cmp(delegateBalance) <= 0 {
-						delegateBalance.Sub(delegateBalance, delegation.Undelegations[i].Amount)
-					} else {
-						delegation.Undelegations[i].Amount.Sub(
-							delegation.Undelegations[i].Amount, delegateBalance,
-						)
-						delegateBalance = big.NewInt(0)
-						break
-					}
-				}
-				delegation.Undelegations = delegation.Undelegations[:i+1]
-				delegation.Amount.Add(delegation.Amount, msg.Amount)
-				if err := wrapper.SanityCheck(
-					staking.DoNotEnforceMaxBLS,
-				); err != nil {
-					return nil, nil, err
-				}
-				if delegateBalance.Cmp(big.NewInt(0)) < 0 {
-					return nil, nil, errNegativeAmount // shouldn't really happen
-				}
-				// Return remaining balance to be deducted for delegation
-				if !CanTransfer(stateDB, msg.DelegatorAddress, delegateBalance) {
-					return nil, nil, errors.Wrapf(
-						errInsufficientBalanceForStake, "had %v, tried to stake %v",
-						stateDB.GetBalance(msg.DelegatorAddress), delegateBalance)
-				}
-				return wrapper, delegateBalance, nil
-			}
-			return nil, nil, errors.Wrapf(
-				errInsufficientBalanceForStake,
-				"total-delegated %s own-current-balance %s amount-to-delegate %s",
-				totalInUndelegation.String(),
-				balance.String(),
-				msg.Amount.String(),
-			)
-		}
-	}
-	// If no redelegation, create new delegation
+
+	// If no existing delegation, create new delegation
 	if !CanTransfer(stateDB, msg.DelegatorAddress, msg.Amount) {
 		return nil, nil, errors.Wrapf(
 			errInsufficientBalanceForStake, "had %v, tried to stake %v",
 			stateDB.GetBalance(msg.DelegatorAddress), msg.Amount)
+	}
+
+	// Check for existing delegation
+	for i := range wrapper.Delegations {
+		delegation := &wrapper.Delegations[i]
+		if bytes.Equal(delegation.DelegatorAddress.Bytes(), msg.DelegatorAddress.Bytes()) {
+			delegation.Amount.Add(delegation.Amount, msg.Amount)
+			if err := wrapper.SanityCheck(
+				staking.DoNotEnforceMaxBLS,
+			); err != nil {
+				return nil, nil, err
+			}
+			return wrapper, msg.Amount, nil
+		}
 	}
 	wrapper.Delegations = append(
 		wrapper.Delegations, staking.NewDelegation(

--- a/core/staking_verifier.go
+++ b/core/staking_verifier.go
@@ -163,7 +163,7 @@ func VerifyAndDelegateFromMsg(
 		return nil, nil, err
 	}
 
-	// If no existing delegation, create new delegation
+	// Check if there is enough liquid token to delegate
 	if !CanTransfer(stateDB, msg.DelegatorAddress, msg.Amount) {
 		return nil, nil, errors.Wrapf(
 			errInsufficientBalanceForStake, "had %v, tried to stake %v",
@@ -183,6 +183,8 @@ func VerifyAndDelegateFromMsg(
 			return wrapper, msg.Amount, nil
 		}
 	}
+
+	// Add new delegation
 	wrapper.Delegations = append(
 		wrapper.Delegations, staking.NewDelegation(
 			msg.DelegatorAddress, msg.Amount,

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -46,7 +46,6 @@ var (
 	errCommissionRateChangeTooHigh = errors.New("commission rate can not be higher than maximum commission rate")
 	errNoRewardsToCollect          = errors.New("no rewards to collect")
 	errNegativeAmount              = errors.New("amount can not be negative")
-	errDupName                     = errors.New("validator name exists")
 	errDupIdentity                 = errors.New("validator identity exists")
 	errDupBlsKey                   = errors.New("BLS key exists")
 )
@@ -389,13 +388,12 @@ func (st *StateTransition) StakingTransitionDb() (usedGas uint64, err error) {
 	return st.gasUsed(), err
 }
 
-func (st *StateTransition) checkDuplicateFields(validator common.Address, name, identity string, blsKeys []shard.BLSPublicKey) error {
+func (st *StateTransition) checkDuplicateFields(validator common.Address, identity string, blsKeys []shard.BLSPublicKey) error {
 	addrs, err := st.bc.ReadValidatorList()
 	if err != nil {
 		return err
 	}
 
-	checkName := name != ""
 	checkIdentity := identity != ""
 	checkBlsKeys := len(blsKeys) != 0
 
@@ -412,9 +410,6 @@ func (st *StateTransition) checkDuplicateFields(validator common.Address, name, 
 				return err
 			}
 
-			if checkName && wrapper.Name == name {
-				return errDupName
-			}
 			if checkIdentity && wrapper.Identity == identity {
 				return errDupIdentity
 			}
@@ -435,7 +430,6 @@ func (st *StateTransition) verifyAndApplyCreateValidatorTx(
 ) error {
 	if err := st.checkDuplicateFields(
 		createValidator.ValidatorAddress,
-		createValidator.Name,
 		createValidator.Identity,
 		createValidator.SlotPubKeys); err != nil {
 		return err
@@ -463,7 +457,6 @@ func (st *StateTransition) verifyAndApplyEditValidatorTx(
 	}
 	if err := st.checkDuplicateFields(
 		editValidator.ValidatorAddress,
-		editValidator.Name,
 		editValidator.Identity,
 		newBlsKeys); err != nil {
 		return err

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -403,7 +403,7 @@ func (st *StateTransition) checkDuplicateFields(validator common.Address, identi
 	}
 
 	for _, addr := range addrs {
-		if bytes.Compare(validator.Bytes(), addr.Bytes()) != 0 {
+		if !bytes.Equal(validator.Bytes(), addr.Bytes()) {
 			wrapper, err := st.state.ValidatorWrapperCopy(addr)
 
 			if err != nil {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -18,9 +18,10 @@ package core
 
 import (
 	"bytes"
-	"github.com/harmony-one/harmony/shard"
 	"math"
 	"math/big"
+
+	"github.com/harmony-one/harmony/shard"
 
 	staking2 "github.com/harmony-one/harmony/staking"
 	"github.com/harmony-one/harmony/staking/network"

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -411,12 +411,12 @@ func (st *StateTransition) checkDuplicateFields(validator common.Address, identi
 			}
 
 			if checkIdentity && wrapper.Identity == identity {
-				return errDupIdentity
+				return errors.Wrapf(errDupIdentity, "duplicate identity %s", identity)
 			}
 			if checkBlsKeys {
 				for _, existingKey := range wrapper.SlotPubKeys {
 					if _, ok := blsKeyMap[existingKey]; ok {
-						return errDupBlsKey
+						return errors.Wrapf(errDupBlsKey, "duplicate bls key %x", existingKey)
 					}
 				}
 			}


### PR DESCRIPTION
Add the dedup feature for validator identifying fields including identity and bls keys.

Fail the staking txn if dups are detected and return corresponding errors.