### PR TITLE
booted-status to show booted for elected/signing validator, not booted for never elected

### DIFF
--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -415,6 +415,9 @@ func (b *APIBackend) GetValidatorInformation(
 
 	stats, err := bc.ReadValidatorStats(addr)
 	if err != nil {
+		// when validator has no stats, default boot-status to not booted
+		notBooted := effective.NotBooted.String()
+		defaultReply.BootedStatus = &notBooted
 		return defaultReply, nil
 	}
 

--- a/staking/effective/eligible.go
+++ b/staking/effective/eligible.go
@@ -78,8 +78,10 @@ func ValidatorStatus(currentlyInCommittee bool, status Eligibility) Candidacy {
 type BootedStatus byte
 
 const (
+	// Booted ..
+	Booted BootedStatus = iota
 	// NotBooted ..
-	NotBooted BootedStatus = iota
+	NotBooted
 	// LostEPoSAuction ..
 	LostEPoSAuction
 	// TurnedInactiveOrInsufficientUptime ..
@@ -90,6 +92,8 @@ const (
 
 func (r BootedStatus) String() string {
 	switch r {
+	case Booted:
+		return "booted"
 	case LostEPoSAuction:
 		return "lost epos auction"
 	case TurnedInactiveOrInsufficientUptime:

--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -127,7 +127,7 @@ func NewEmptyStats() *ValidatorStats {
 		numeric.ZeroDec(),
 		numeric.ZeroDec(),
 		[]VoteWithCurrentEpochEarning{},
-		effective.NotBooted,
+		effective.Booted,
 	}
 }
 


### PR DESCRIPTION
Fixing: https://github.com/harmony-one/harmony/issues/2851
* for a validator who is never elected and part of committee, will have no validator stats and needs booted status set to not booted.
* also, it does not make sense to show booted-status: none, for a validator who is currently elected and signing, hence added a new status "booted".