### PR TITLE
Fix super committee bug and add raw-stake to per-key metrics

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2354,6 +2354,19 @@ func (bc *BlockChain) UpdateValidatorVotingPower(
 		}
 		stats.MetricsPerShard = earningWrapping
 
+		// fetch raw-stake from snapshot and update per-key metrics
+		if snapshot, err := bc.ReadValidatorSnapshotAtEpoch(
+			newEpochSuperCommittee.Epoch, key,
+		); err == nil {
+			wrapper := snapshot.Validator
+			spread := numeric.NewDecFromBigInt(wrapper.TotalDelegation()).
+				QuoInt64(int64(len(wrapper.SlotPubKeys)))
+			for i := range stats.MetricsPerShard {
+				metric := stats.MetricsPerShard[i]
+				metric.Vote.RawStake = spread
+			}
+		}
+
 		// This means it's already in staking epoch
 		if currentEpochSuperCommittee.Epoch != nil {
 			wrapper, err := state.ValidatorWrapper(key)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2359,8 +2359,11 @@ func (bc *BlockChain) UpdateValidatorVotingPower(
 			newEpochSuperCommittee.Epoch, key,
 		); err == nil {
 			wrapper := snapshot.Validator
-			spread := numeric.NewDecFromBigInt(wrapper.TotalDelegation()).
-				QuoInt64(int64(len(wrapper.SlotPubKeys)))
+			spread := numeric.ZeroDec()
+			if len(wrapper.SlotPubKeys) > 0 {
+				spread = numeric.NewDecFromBigInt(wrapper.TotalDelegation()).
+					QuoInt64(int64(len(wrapper.SlotPubKeys)))
+			}
 			for i := range stats.MetricsPerShard {
 				metric := stats.MetricsPerShard[i]
 				metric.Vote.RawStake = spread

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -602,7 +602,7 @@ func (b *APIBackend) readAndUpdateRawStakes(
 	comm shard.Committee,
 	rawStakes []effective.SlotPurchase,
 	validatorSpreads map[common.Address]numeric.Dec,
-) {
+) []effective.SlotPurchase {
 	for i := range comm.Slots {
 		slot := comm.Slots[i]
 		slotAddr := slot.EcdsaAddress
@@ -628,6 +628,7 @@ func (b *APIBackend) readAndUpdateRawStakes(
 			spread,
 		})
 	}
+	return rawStakes
 }
 
 func (b *APIBackend) getSuperCommittees() (*quorum.Transition, error) {
@@ -662,7 +663,7 @@ func (b *APIBackend) getSuperCommittees() (*quorum.Transition, error) {
 		if _, err := decider.SetVoters(&comm, prevCommittee.Epoch); err != nil {
 			return nil, err
 		}
-		b.readAndUpdateRawStakes(thenE, decider, comm, rawStakes, validatorSpreads)
+		rawStakes = b.readAndUpdateRawStakes(thenE, decider, comm, rawStakes, validatorSpreads)
 		then.Deciders[fmt.Sprintf("shard-%d", comm.ShardID)] = decider
 	}
 	then.MedianStake = effective.Median(rawStakes)
@@ -674,7 +675,7 @@ func (b *APIBackend) getSuperCommittees() (*quorum.Transition, error) {
 		if _, err := decider.SetVoters(&comm, nowCommittee.Epoch); err != nil {
 			return nil, err
 		}
-		b.readAndUpdateRawStakes(nowE, decider, comm, rawStakes, validatorSpreads)
+		rawStakes = b.readAndUpdateRawStakes(nowE, decider, comm, rawStakes, validatorSpreads)
 		now.Deciders[fmt.Sprintf("shard-%d", comm.ShardID)] = decider
 	}
 	then.MedianStake = effective.Median(rawStakes)


### PR DESCRIPTION
* fixed super-committee rpc showing zero `epos-median-stake` 
* set raw-stake in per-key metric, such that getting validator information reflects raw-stake as well