### PR TITLE
[rpc] delegations by block & error checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ based library dependencies (`libbls` and `mcl`) setup correctly for you. You can
 versions easily, an example:
 
 ```
-$ eval $(gimme 1.13.6)
+$ eval $(gimme 1.14.1)
 ```
 
 Note that changing the go version might mean that dependencies won't work out right when trying to
@@ -129,7 +129,7 @@ brew install openssl
 
 ## Dev Environment Setup
 
-The required go version is: **go1.13.6**
+The required go version is: **go1.14.1**
 
 ```bash
 export GOPATH=$HOME/<path_of_your_choice>

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2471,7 +2471,7 @@ func (bc *BlockChain) ReadDelegationsByDelegator(
 	return m, nil
 }
 
-// ReadDelegationsByDelegator reads the addresses of validators delegated by a delegator
+// ReadDelegationsByDelegatorAt reads the addresses of validators delegated by a delegator at a given block
 func (bc *BlockChain) ReadDelegationsByDelegatorAt(
 	delegator common.Address, blockNum *big.Int,
 ) (m staking.DelegationIndexes, err error) {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2471,6 +2471,33 @@ func (bc *BlockChain) ReadDelegationsByDelegator(
 	return m, nil
 }
 
+// ReadDelegationsByDelegator reads the addresses of validators delegated by a delegator
+func (bc *BlockChain) ReadDelegationsByDelegatorAt(
+	delegator common.Address, blockNum *big.Int,
+) (m staking.DelegationIndexes, err error) {
+	rawResult := staking.DelegationIndexes{}
+	if cached, ok := bc.validatorListByDelegatorCache.Get(string(delegator.Bytes())); ok {
+		by := cached.([]byte)
+		if err := rlp.DecodeBytes(by, &rawResult); err != nil {
+			return nil, err
+		}
+	} else {
+		if rawResult, err = rawdb.ReadDelegationsByDelegator(bc.db, delegator); err != nil {
+			return nil, err
+		}
+	}
+	for _, index := range rawResult {
+		if index.BlockNum.Cmp(blockNum) <= 0 {
+			m = append(m, index)
+		} else {
+			// Filter out index that's created beyond current height of chain.
+			// This only happens when there is a chain rollback.
+			utils.Logger().Warn().Msgf("Future delegation index encountered. Skip: %+v", index)
+		}
+	}
+	return m, nil
+}
+
 // writeDelegationsByDelegator writes the list of validator addresses to database
 func (bc *BlockChain) writeDelegationsByDelegator(
 	batch rawdb.DatabaseWriter,

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -531,19 +531,19 @@ func (b *APIBackend) GetDelegationsByValidator(validator common.Address) []*stak
 }
 
 // GetDelegationsByDelegator returns all delegation information of a delegator
-func (b *APIBackend) GetDelegationsByDelegator(
-	delegator common.Address,
+func (b *APIBackend) GetDelegationsByDelegatorAt(
+	delegator common.Address, block *types.Block,
 ) ([]common.Address, []*staking.Delegation) {
 	addresses := []common.Address{}
 	delegations := []*staking.Delegation{}
-	delegationIndexes, err := b.hmy.BlockChain().ReadDelegationsByDelegator(delegator)
+	delegationIndexes, err := b.hmy.BlockChain().ReadDelegationsByDelegatorAt(delegator, block.Number())
 	if err != nil {
 		return nil, nil
 	}
 
 	for i := range delegationIndexes {
-		wrapper, err := b.hmy.BlockChain().ReadValidatorInformation(
-			delegationIndexes[i].ValidatorAddress,
+		wrapper, err := b.hmy.BlockChain().ReadValidatorInformationAt(
+			delegationIndexes[i].ValidatorAddress, block.Root(),
 		)
 		if err != nil || wrapper == nil {
 			return nil, nil
@@ -557,6 +557,14 @@ func (b *APIBackend) GetDelegationsByDelegator(
 		addresses = append(addresses, delegationIndexes[i].ValidatorAddress)
 	}
 	return addresses, delegations
+}
+
+// GetDelegationsByDelegator returns all delegation information of a delegator
+func (b *APIBackend) GetDelegationsByDelegator(
+	delegator common.Address,
+) ([]common.Address, []*staking.Delegation) {
+	block := b.hmy.BlockChain().CurrentBlock()
+	return b.GetDelegationsByDelegatorAt(delegator, block)
 }
 
 // GetValidatorSelfDelegation returns the amount of staking after applying all delegated stakes

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -530,13 +530,14 @@ func (b *APIBackend) GetDelegationsByValidator(validator common.Address) []*stak
 	return delegations
 }
 
-// GetDelegationsByDelegator returns all delegation information of a delegator
-func (b *APIBackend) GetDelegationsByDelegatorAt(
+// GetDelegationsByDelegatorByBlockNumber returns all delegation information of a delegator
+func (b *APIBackend) GetDelegationsByDelegatorByBlockNumber(
 	delegator common.Address, block *types.Block,
 ) ([]common.Address, []*staking.Delegation) {
 	addresses := []common.Address{}
 	delegations := []*staking.Delegation{}
-	delegationIndexes, err := b.hmy.BlockChain().ReadDelegationsByDelegatorAt(delegator, block.Number())
+	delegationIndexes, err := b.hmy.BlockChain().
+		ReadDelegationsByDelegatorAt(delegator, block.Number())
 	if err != nil {
 		return nil, nil
 	}
@@ -564,7 +565,7 @@ func (b *APIBackend) GetDelegationsByDelegator(
 	delegator common.Address,
 ) ([]common.Address, []*staking.Delegation) {
 	block := b.hmy.BlockChain().CurrentBlock()
-	return b.GetDelegationsByDelegatorAt(delegator, block)
+	return b.GetDelegationsByDelegatorByBlockNumber(delegator, block)
 }
 
 // GetValidatorSelfDelegation returns the amount of staking after applying all delegated stakes

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -530,8 +530,8 @@ func (b *APIBackend) GetDelegationsByValidator(validator common.Address) []*stak
 	return delegations
 }
 
-// GetDelegationsByDelegatorByBlockNumber returns all delegation information of a delegator
-func (b *APIBackend) GetDelegationsByDelegatorByBlockNumber(
+// GetDelegationsByDelegatorByBlock returns all delegation information of a delegator
+func (b *APIBackend) GetDelegationsByDelegatorByBlock(
 	delegator common.Address, block *types.Block,
 ) ([]common.Address, []*staking.Delegation) {
 	addresses := []common.Address{}
@@ -565,7 +565,7 @@ func (b *APIBackend) GetDelegationsByDelegator(
 	delegator common.Address,
 ) ([]common.Address, []*staking.Delegation) {
 	block := b.hmy.BlockChain().CurrentBlock()
-	return b.GetDelegationsByDelegatorByBlockNumber(delegator, block)
+	return b.GetDelegationsByDelegatorByBlock(delegator, block)
 }
 
 // GetValidatorSelfDelegation returns the amount of staking after applying all delegated stakes

--- a/internal/hmyapi/apiv1/backend.go
+++ b/internal/hmyapi/apiv1/backend.go
@@ -77,7 +77,7 @@ type Backend interface {
 	GetValidatorInformation(addr common.Address, block *types.Block) (*staking.ValidatorRPCEnchanced, error)
 	GetDelegationsByValidator(validator common.Address) []*staking.Delegation
 	GetDelegationsByDelegator(delegator common.Address) ([]common.Address, []*staking.Delegation)
-	GetDelegationsByDelegatorByBlockNumber(delegator common.Address, block *types.Block) ([]common.Address, []*staking.Delegation)
+	GetDelegationsByDelegatorByBlock(delegator common.Address, block *types.Block) ([]common.Address, []*staking.Delegation)
 	GetValidatorSelfDelegation(addr common.Address) *big.Int
 	GetShardState() (*shard.State, error)
 	GetCurrentStakingErrorSink() []staking.RPCTransactionError

--- a/internal/hmyapi/apiv1/backend.go
+++ b/internal/hmyapi/apiv1/backend.go
@@ -77,7 +77,7 @@ type Backend interface {
 	GetValidatorInformation(addr common.Address, block *types.Block) (*staking.ValidatorRPCEnchanced, error)
 	GetDelegationsByValidator(validator common.Address) []*staking.Delegation
 	GetDelegationsByDelegator(delegator common.Address) ([]common.Address, []*staking.Delegation)
-	GetDelegationsByDelegatorAt(delegator common.Address, block *types.Block) ([]common.Address, []*staking.Delegation)
+	GetDelegationsByDelegatorByBlockNumber(delegator common.Address, block *types.Block) ([]common.Address, []*staking.Delegation)
 	GetValidatorSelfDelegation(addr common.Address) *big.Int
 	GetShardState() (*shard.State, error)
 	GetCurrentStakingErrorSink() []staking.RPCTransactionError

--- a/internal/hmyapi/apiv1/backend.go
+++ b/internal/hmyapi/apiv1/backend.go
@@ -77,6 +77,7 @@ type Backend interface {
 	GetValidatorInformation(addr common.Address, block *types.Block) (*staking.ValidatorRPCEnchanced, error)
 	GetDelegationsByValidator(validator common.Address) []*staking.Delegation
 	GetDelegationsByDelegator(delegator common.Address) ([]common.Address, []*staking.Delegation)
+	GetDelegationsByDelegatorAt(delegator common.Address, block *types.Block) ([]common.Address, []*staking.Delegation)
 	GetValidatorSelfDelegation(addr common.Address) *big.Int
 	GetShardState() (*shard.State, error)
 	GetCurrentStakingErrorSink() []staking.RPCTransactionError

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -812,7 +812,7 @@ func (s *PublicBlockChainAPI) GetDelegationsByDelegatorByBlockNumber(
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not retrieve the block information for block number: %d", blockNum)
 	}
-	validators, delegations := s.b.GetDelegationsByDelegatorByBlockNumber(delegatorAddress, block)
+	validators, delegations := s.b.GetDelegationsByDelegatorByBlock(delegatorAddress, block)
 	result := []*RPCDelegation{}
 	for i := range delegations {
 		delegation := delegations[i]

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -953,7 +953,7 @@ func (s *PublicBlockChainAPI) GetCurrentUtilityMetrics() (*network.UtilityMetric
 	if err := s.isBeaconShard(); err != nil {
 		return nil, err
 	}
-		return s.b.GetCurrentUtilityMetrics()
+	return s.b.GetCurrentUtilityMetrics()
 }
 
 // GetSuperCommittees ..
@@ -961,7 +961,7 @@ func (s *PublicBlockChainAPI) GetSuperCommittees() (*quorum.Transition, error) {
 	if err := s.isBeaconShard(); err != nil {
 		return nil, err
 	}
-		return s.b.GetSuperCommittees()
+	return s.b.GetSuperCommittees()
 }
 
 // GetCurrentBadBlocks ..
@@ -1007,5 +1007,5 @@ func (s *PublicBlockChainAPI) GetLastCrossLinks() ([]*types.CrossLink, error) {
 	if err := s.isBeaconShard(); err != nil {
 		return nil, err
 	}
-		return s.b.GetLastCrossLinks()
+	return s.b.GetLastCrossLinks()
 }

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -813,27 +813,27 @@ func (s *PublicBlockChainAPI) GetDelegationsByDelegatorByBlockNumber(
 		return nil, errors.Wrapf(err, "could not retrieve the block information for block number: %d", blockNum)
 	}
 	validators, delegations := s.b.GetDelegationsByDelegatorByBlock(delegatorAddress, block)
-	result := []*RPCDelegation{}
+	result := make([]*RPCDelegation, len(delegations))
 	for i := range delegations {
 		delegation := delegations[i]
 
 		undelegations := make([]RPCUndelegation, len(delegation.Undelegations))
 
 		for j := range delegation.Undelegations {
-			undelegations = append(undelegations, RPCUndelegation{
+			undelegations[j] = RPCUndelegation{
 				delegation.Undelegations[j].Amount,
 				delegation.Undelegations[j].Epoch,
-			})
+			}
 		}
 		valAddr, _ := internal_common.AddressToBech32(validators[i])
 		delAddr, _ := internal_common.AddressToBech32(delegatorAddress)
-		result = append(result, &RPCDelegation{
+		result[i] = &RPCDelegation{
 			valAddr,
 			delAddr,
 			delegation.Amount,
 			delegation.Reward,
 			undelegations,
-		})
+		}
 	}
 	return result, nil
 }

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -765,7 +765,7 @@ func (s *PublicBlockChainAPI) GetDelegationsByDelegator(ctx context.Context, add
 	for i := range delegations {
 		delegation := delegations[i]
 
-		undelegations := []RPCUndelegation{}
+		undelegations := make([]RPCUndelegation, len(delegation.Undelegations))
 
 		for j := range delegation.Undelegations {
 			undelegations = append(undelegations, RPCUndelegation{
@@ -806,7 +806,7 @@ func (s *PublicBlockChainAPI) GetDelegationsByDelegatorByBlockNumber(
 	for i := range delegations {
 		delegation := delegations[i]
 
-		undelegations := []RPCUndelegation{}
+		undelegations := make([]RPCUndelegation, len(delegation.Undelegations))
 
 		for j := range delegation.Undelegations {
 			undelegations = append(undelegations, RPCUndelegation{

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -206,7 +206,7 @@ func (s *PublicBlockChainAPI) EpochLastBlock(epoch uint64) (uint64, error) {
 
 // GetBlockSigners returns signers for a particular block.
 func (s *PublicBlockChainAPI) GetBlockSigners(ctx context.Context, blockNr rpc.BlockNumber) ([]string, error) {
-	if uint64(blockNr) == 0 || uint64(blockNr) >= uint64(s.BlockNumber()) {
+	if uint64(blockNr) == 0 {
 		return []string{}, nil
 	}
 	block, err := s.b.BlockByNumber(ctx, blockNr)
@@ -757,8 +757,10 @@ func (s *PublicBlockChainAPI) GetDelegationsByDelegator(ctx context.Context, add
 	return result, nil
 }
 
-// GetDelegationsByDelegatorAt returns list of delegations for a delegator address at given block number
-func (s *PublicBlockChainAPI) GetDelegationsByDelegatorAt(ctx context.Context, address string, blockNum rpc.BlockNumber) ([]*RPCDelegation, error) {
+// GetDelegationsByDelegatorByBlockNumber returns list of delegations for a delegator address at given block number
+func (s *PublicBlockChainAPI) GetDelegationsByDelegatorByBlockNumber(
+	ctx context.Context, address string, blockNum rpc.BlockNumber,
+) ([]*RPCDelegation, error) {
 	if err := s.isBeaconShard(); err != nil {
 		return nil, err
 	}
@@ -767,7 +769,7 @@ func (s *PublicBlockChainAPI) GetDelegationsByDelegatorAt(ctx context.Context, a
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not retrieve the block information for block number: %d", blockNum)
 	}
-	validators, delegations := s.b.GetDelegationsByDelegatorAt(delegatorAddress, block)
+	validators, delegations := s.b.GetDelegationsByDelegatorByBlockNumber(delegatorAddress, block)
 	result := []*RPCDelegation{}
 	for i := range delegations {
 		delegation := delegations[i]

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -58,6 +58,20 @@ type BlockArgs struct {
 	InclStaking bool     `json:"inclStaking"`
 }
 
+func (s *PublicBlockChainAPI) isBeaconShard() error {
+	if s.b.GetShardID() != shard.BeaconChainShardID {
+		return ErrNotBeaconShard
+	}
+	return nil
+}
+
+func (s *PublicBlockChainAPI) isBlockGreaterThanLatest(blockNum rpc.BlockNumber) error {
+	if uint64(blockNum) > s.b.CurrentBlock().NumberU64() {
+		return ErrRequestedBlockTooHigh
+	}
+	return nil
+}
+
 // GetBlockByNumber returns the requested block. When blockNr is -1 the chain head is returned. When fullTx is true all
 // transactions in the block are returned in full detail, otherwise only the transaction hash is returned.
 func (s *PublicBlockChainAPI) GetBlockByNumber(ctx context.Context, blockNr rpc.BlockNumber, fullTx bool) (map[string]interface{}, error) {

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -449,9 +449,6 @@ func (s *PublicBlockChainAPI) ResendCx(ctx context.Context, txID common.Hash) (b
 // Call executes the given transaction on the state for the given block number.
 // It doesn't make and changes in the state/blockchain and is useful to execute and retrieve values.
 func (s *PublicBlockChainAPI) Call(ctx context.Context, args CallArgs, blockNr rpc.BlockNumber) (hexutil.Bytes, error) {
-	if err := s.isBlockGreaterThanLatest(blockNr); err != nil {
-		return nil, err
-	}
 	result, _, _, err := doCall(ctx, s.b, args, blockNr, vm.Config{}, 5*time.Second, s.b.RPCGasCap())
 	return (hexutil.Bytes)(result), err
 }

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -724,6 +724,39 @@ func (s *PublicBlockChainAPI) GetDelegationsByDelegator(ctx context.Context, add
 	return result, nil
 }
 
+// GetDelegationsByDelegatorAt returns list of delegations for a delegator address at given block number
+func (s *PublicBlockChainAPI) GetDelegationsByDelegatorAt(ctx context.Context, address string, blockNum rpc.BlockNumber) ([]*RPCDelegation, error) {
+	delegatorAddress := internal_common.ParseAddr(address)
+	block, err := s.b.BlockByNumber(ctx, rpc.BlockNumber(blockNum))
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not retrieve the block information for block number: %d", blockNum)
+	}
+	validators, delegations := s.b.GetDelegationsByDelegatorAt(delegatorAddress, block)
+	result := []*RPCDelegation{}
+	for i := range delegations {
+		delegation := delegations[i]
+
+		undelegations := []RPCUndelegation{}
+
+		for j := range delegation.Undelegations {
+			undelegations = append(undelegations, RPCUndelegation{
+				delegation.Undelegations[j].Amount,
+				delegation.Undelegations[j].Epoch,
+			})
+		}
+		valAddr, _ := internal_common.AddressToBech32(validators[i])
+		delAddr, _ := internal_common.AddressToBech32(delegatorAddress)
+		result = append(result, &RPCDelegation{
+			valAddr,
+			delAddr,
+			delegation.Amount,
+			delegation.Reward,
+			undelegations,
+		})
+	}
+	return result, nil
+}
+
 // GetDelegationsByValidator returns list of delegations for a validator address.
 func (s *PublicBlockChainAPI) GetDelegationsByValidator(ctx context.Context, address string) ([]*RPCDelegation, error) {
 	validatorAddress := internal_common.ParseAddr(address)

--- a/internal/hmyapi/apiv1/debug.go
+++ b/internal/hmyapi/apiv1/debug.go
@@ -2,7 +2,6 @@ package apiv1
 
 import (
 	"context"
-	"errors"
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/harmony-one/harmony/internal/utils"
@@ -23,7 +22,7 @@ func NewDebugAPI(b Backend) *DebugAPI {
 //  curl -H "Content-Type: application/json" -d '{"method":"debug_setLogVerbosity","params":[0],"id":1}' http://localhost:9123
 func (*DebugAPI) SetLogVerbosity(ctx context.Context, level int) (map[string]interface{}, error) {
 	if level < int(log.LvlCrit) || level > int(log.LvlTrace) {
-		return nil, errors.New("invalid log level")
+		return nil, ErrInvalidLogLevel
 	}
 
 	verbosity := log.Lvl(level)

--- a/internal/hmyapi/apiv1/error.go
+++ b/internal/hmyapi/apiv1/error.go
@@ -3,6 +3,7 @@ package apiv1
 import (
 	"errors"
 
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/harmony-one/harmony/shard"
 )
 
@@ -15,11 +16,20 @@ var (
 	ErrInvalidChainID = errors.New("invalid chain id for signer")
 	// ErrNotBeaconChainShard when rpc is called on not beacon chain node
 	ErrNotBeaconShard = errors.New("cannot call this rpc on non beaconchain node")
+	// ErrRequestedBlockTooHigh when given block is greater than latest block number
+	ErrRequestedBlockTooHigh = errors.New("requested block number greater than current block number")
 )
 
 func (s *PublicBlockChainAPI) isBeaconShard() error {
 	if s.b.GetShardID() != shard.BeaconChainShardID {
 		return ErrNotBeaconShard
+	}
+	return nil
+}
+
+func (s *PublicBlockChainAPI) isBlockGreaterThanLatest(blockNum rpc.BlockNumber) error {
+	if uint64(blockNum) >= uint64(s.BlockNumber()) {
+		return ErrRequestedBlockTooHigh
 	}
 	return nil
 }

--- a/internal/hmyapi/apiv1/error.go
+++ b/internal/hmyapi/apiv1/error.go
@@ -3,6 +3,12 @@ package apiv1
 import "errors"
 
 var (
-	// ErrIncorrectChainID is an incorrect chain ID.
-	ErrIncorrectChainID = errors.New("incorrect chain ID")
+	// ErrInvalidLogLevel when invalid log level is provided
+	ErrInvalidLogLevel = errors.New("invalid log level")
+	// ErrIncorrectChainID when ChainID does not match running node
+	ErrIncorrectChainID = errors.New("incorrect chain id")
+	// ErrInvalidChainID when ChainID of signer does not match that of running node
+	ErrInvalidChainID = errors.New("invalid chain id for signer")
+	// ErrNotBeaconChainShard when rpc is called on not beacon chain node
+	ErrNotBeaconChainShard = errors.New("cannot call this rpc on non beaconchain node")
 )

--- a/internal/hmyapi/apiv1/error.go
+++ b/internal/hmyapi/apiv1/error.go
@@ -14,7 +14,7 @@ var (
 	ErrIncorrectChainID = errors.New("incorrect chain id")
 	// ErrInvalidChainID when ChainID of signer does not match that of running node
 	ErrInvalidChainID = errors.New("invalid chain id for signer")
-	// ErrNotBeaconChainShard when rpc is called on not beacon chain node
+	// ErrNotBeaconShard when rpc is called on not beacon chain node
 	ErrNotBeaconShard = errors.New("cannot call this rpc on non beaconchain node")
 	// ErrRequestedBlockTooHigh when given block is greater than latest block number
 	ErrRequestedBlockTooHigh = errors.New("requested block number greater than current block number")

--- a/internal/hmyapi/apiv1/error.go
+++ b/internal/hmyapi/apiv1/error.go
@@ -28,7 +28,7 @@ func (s *PublicBlockChainAPI) isBeaconShard() error {
 }
 
 func (s *PublicBlockChainAPI) isBlockGreaterThanLatest(blockNum rpc.BlockNumber) error {
-	if uint64(blockNum) >= uint64(s.BlockNumber()) {
+	if uint64(blockNum) > uint64(s.BlockNumber()) {
 		return ErrRequestedBlockTooHigh
 	}
 	return nil

--- a/internal/hmyapi/apiv1/error.go
+++ b/internal/hmyapi/apiv1/error.go
@@ -2,9 +2,6 @@ package apiv1
 
 import (
 	"errors"
-
-	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/harmony-one/harmony/shard"
 )
 
 var (
@@ -19,17 +16,3 @@ var (
 	// ErrRequestedBlockTooHigh when given block is greater than latest block number
 	ErrRequestedBlockTooHigh = errors.New("requested block number greater than current block number")
 )
-
-func (s *PublicBlockChainAPI) isBeaconShard() error {
-	if s.b.GetShardID() != shard.BeaconChainShardID {
-		return ErrNotBeaconShard
-	}
-	return nil
-}
-
-func (s *PublicBlockChainAPI) isBlockGreaterThanLatest(blockNum rpc.BlockNumber) error {
-	if uint64(blockNum) > s.b.CurrentBlock().NumberU64() {
-		return ErrRequestedBlockTooHigh
-	}
-	return nil
-}

--- a/internal/hmyapi/apiv1/error.go
+++ b/internal/hmyapi/apiv1/error.go
@@ -1,6 +1,10 @@
 package apiv1
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/harmony-one/harmony/shard"
+)
 
 var (
 	// ErrInvalidLogLevel when invalid log level is provided
@@ -10,5 +14,12 @@ var (
 	// ErrInvalidChainID when ChainID of signer does not match that of running node
 	ErrInvalidChainID = errors.New("invalid chain id for signer")
 	// ErrNotBeaconChainShard when rpc is called on not beacon chain node
-	ErrNotBeaconChainShard = errors.New("cannot call this rpc on non beaconchain node")
+	ErrNotBeaconShard = errors.New("cannot call this rpc on non beaconchain node")
 )
+
+func (s *PublicBlockChainAPI) isBeaconShard() error {
+	if s.b.GetShardID() != shard.BeaconChainShardID {
+		return ErrNotBeaconShard
+	}
+	return nil
+}

--- a/internal/hmyapi/apiv1/error.go
+++ b/internal/hmyapi/apiv1/error.go
@@ -28,7 +28,7 @@ func (s *PublicBlockChainAPI) isBeaconShard() error {
 }
 
 func (s *PublicBlockChainAPI) isBlockGreaterThanLatest(blockNum rpc.BlockNumber) error {
-	if uint64(blockNum) > uint64(s.BlockNumber()) {
+	if uint64(blockNum) > s.b.CurrentBlock().NumberU64() {
 		return ErrRequestedBlockTooHigh
 	}
 	return nil

--- a/internal/hmyapi/apiv1/transactionpool.go
+++ b/internal/hmyapi/apiv1/transactionpool.go
@@ -16,11 +16,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-var (
-	// ErrInvalidChainID when ChainID of signer does not match that of running node
-	errInvalidChainID = errors.New("invalid chain id for signer")
-)
-
 // TxHistoryArgs is struct to make GetTransactionsHistory request
 type TxHistoryArgs struct {
 	Address   string `json:"address"`
@@ -216,7 +211,7 @@ func (s *PublicTransactionPoolAPI) SendRawStakingTransaction(
 	c := s.b.ChainConfig().ChainID
 	if id := tx.ChainID(); id.Cmp(c) != 0 {
 		return common.Hash{}, errors.Wrapf(
-			errInvalidChainID, "blockchain chain id:%s, given %s", c.String(), id.String(),
+			ErrInvalidChainID, "blockchain chain id:%s, given %s", c.String(), id.String(),
 		)
 	}
 	return SubmitStakingTransaction(ctx, s.b, tx)
@@ -238,7 +233,7 @@ func (s *PublicTransactionPoolAPI) SendRawTransaction(
 	c := s.b.ChainConfig().ChainID
 	if id := tx.ChainID(); id.Cmp(c) != 0 {
 		return common.Hash{}, errors.Wrapf(
-			errInvalidChainID, "blockchain chain id:%s, given %s", c.String(), id.String(),
+			ErrInvalidChainID, "blockchain chain id:%s, given %s", c.String(), id.String(),
 		)
 	}
 	return SubmitTransaction(ctx, s.b, tx)

--- a/internal/hmyapi/apiv2/backend.go
+++ b/internal/hmyapi/apiv2/backend.go
@@ -72,7 +72,7 @@ type Backend interface {
 	GetValidatorInformation(addr common.Address, block *types.Block) (*staking.ValidatorRPCEnchanced, error)
 	GetDelegationsByValidator(validator common.Address) []*staking.Delegation
 	GetDelegationsByDelegator(delegator common.Address) ([]common.Address, []*staking.Delegation)
-	GetDelegationsByDelegatorByBlockNumber(delegator common.Address, block *types.Block) ([]common.Address, []*staking.Delegation)
+	GetDelegationsByDelegatorByBlock(delegator common.Address, block *types.Block) ([]common.Address, []*staking.Delegation)
 	GetValidatorSelfDelegation(addr common.Address) *big.Int
 	GetShardState() (*shard.State, error)
 	GetCurrentStakingErrorSink() []staking.RPCTransactionError

--- a/internal/hmyapi/apiv2/backend.go
+++ b/internal/hmyapi/apiv2/backend.go
@@ -72,7 +72,7 @@ type Backend interface {
 	GetValidatorInformation(addr common.Address, block *types.Block) (*staking.ValidatorRPCEnchanced, error)
 	GetDelegationsByValidator(validator common.Address) []*staking.Delegation
 	GetDelegationsByDelegator(delegator common.Address) ([]common.Address, []*staking.Delegation)
-	GetDelegationsByDelegatorAt(delegator common.Address, block *types.Block) ([]common.Address, []*staking.Delegation)
+	GetDelegationsByDelegatorByBlockNumber(delegator common.Address, block *types.Block) ([]common.Address, []*staking.Delegation)
 	GetValidatorSelfDelegation(addr common.Address) *big.Int
 	GetShardState() (*shard.State, error)
 	GetCurrentStakingErrorSink() []staking.RPCTransactionError

--- a/internal/hmyapi/apiv2/backend.go
+++ b/internal/hmyapi/apiv2/backend.go
@@ -72,6 +72,7 @@ type Backend interface {
 	GetValidatorInformation(addr common.Address, block *types.Block) (*staking.ValidatorRPCEnchanced, error)
 	GetDelegationsByValidator(validator common.Address) []*staking.Delegation
 	GetDelegationsByDelegator(delegator common.Address) ([]common.Address, []*staking.Delegation)
+	GetDelegationsByDelegatorAt(delegator common.Address, block *types.Block) ([]common.Address, []*staking.Delegation)
 	GetValidatorSelfDelegation(addr common.Address) *big.Int
 	GetShardState() (*shard.State, error)
 	GetCurrentStakingErrorSink() []staking.RPCTransactionError

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -716,8 +716,10 @@ func (s *PublicBlockChainAPI) GetDelegationsByDelegator(ctx context.Context, add
 	return result, nil
 }
 
-// GetDelegationsByDelegatorAt returns list of delegations for a delegator address at given block number
-func (s *PublicBlockChainAPI) GetDelegationsByDelegatorAt(ctx context.Context, address string, blockNum rpc.BlockNumber) ([]*RPCDelegation, error) {
+// GetDelegationsByDelegatorByBlockNumber returns list of delegations for a delegator address at given block number
+func (s *PublicBlockChainAPI) GetDelegationsByDelegatorByBlockNumber(
+	ctx context.Context, address string, blockNum rpc.BlockNumber,
+) ([]*RPCDelegation, error) {
 	if err := s.isBeaconShard(); err != nil {
 		return nil, err
 	}
@@ -726,7 +728,7 @@ func (s *PublicBlockChainAPI) GetDelegationsByDelegatorAt(ctx context.Context, a
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not retrieve the block information for block number: %d", blockNum)
 	}
-	validators, delegations := s.b.GetDelegationsByDelegatorAt(delegatorAddress, block)
+	validators, delegations := s.b.GetDelegationsByDelegatorByBlockNumber(delegatorAddress, block)
 	result := []*RPCDelegation{}
 	for i := range delegations {
 		delegation := delegations[i]

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -57,6 +57,20 @@ type BlockArgs struct {
 	InclStaking bool     `json:"inclStaking"`
 }
 
+func (s *PublicBlockChainAPI) isBeaconShard() error {
+	if s.b.GetShardID() != shard.BeaconChainShardID {
+		return ErrNotBeaconShard
+	}
+	return nil
+}
+
+func (s *PublicBlockChainAPI) isBlockGreaterThanLatest(blockNum uint64) error {
+	if blockNum > s.b.CurrentBlock().NumberU64() {
+		return ErrRequestedBlockTooHigh
+	}
+	return nil
+}
+
 // GetBlockByNumber returns the requested block. When fullTx in blockArgs is true all transactions in the block are returned in full detail,
 // otherwise only the transaction hash is returned. When withSigners in BlocksArgs is true it shows block signers for this block in list of one addresses.
 func (s *PublicBlockChainAPI) GetBlockByNumber(ctx context.Context, blockNr uint64, blockArgs BlockArgs) (map[string]interface{}, error) {

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -722,7 +722,7 @@ func (s *PublicBlockChainAPI) GetDelegationsByDelegator(ctx context.Context, add
 	for i := range delegations {
 		delegation := delegations[i]
 
-		undelegations := []RPCUndelegation{}
+		undelegations := make([]RPCUndelegation, len(delegation.Undelegations))
 
 		for j := range delegation.Undelegations {
 			undelegations = append(undelegations, RPCUndelegation{
@@ -763,7 +763,7 @@ func (s *PublicBlockChainAPI) GetDelegationsByDelegatorByBlockNumber(
 	for i := range delegations {
 		delegation := delegations[i]
 
-		undelegations := []RPCUndelegation{}
+		undelegations := make([]RPCUndelegation, len(delegation.Undelegations))
 
 		for j := range delegation.Undelegations {
 			undelegations = append(undelegations, RPCUndelegation{

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -159,7 +159,7 @@ func (s *PublicBlockChainAPI) IsLastBlock(blockNum uint64) (bool, error) {
 	if s.b.GetShardID() == shard.BeaconChainShardID {
 		return shard.Schedule.IsLastBlock(blockNum), nil
 	}
-	return false, errNotBeaconChainShard
+	return false, ErrNotBeaconChainShard
 }
 
 // EpochLastBlock returns epoch last block.
@@ -167,13 +167,13 @@ func (s *PublicBlockChainAPI) EpochLastBlock(epoch uint64) (uint64, error) {
 	if s.b.GetShardID() == shard.BeaconChainShardID {
 		return shard.Schedule.EpochLastBlock(epoch), nil
 	}
-	return 0, errNotBeaconChainShard
+	return 0, ErrNotBeaconChainShard
 }
 
 // GetBlockSigners returns signers for a particular block.
 func (s *PublicBlockChainAPI) GetBlockSigners(ctx context.Context, blockNr uint64) ([]string, error) {
 	if blockNr == 0 || blockNr >= uint64(s.BlockNumber()) {
-		return make([]string, 0), nil
+		return []string{}, nil
 	}
 	block, err := s.b.BlockByNumber(ctx, rpc.BlockNumber(blockNr))
 	if err != nil {
@@ -192,22 +192,22 @@ func (s *PublicBlockChainAPI) GetBlockSigners(ctx context.Context, blockNr uint6
 		pubkeys[i] = new(bls.PublicKey)
 		validator.BLSPublicKey.ToLibBLSPublicKey(pubkeys[i])
 	}
-	result := make([]string, 0)
 	mask, err := internal_bls.NewMask(pubkeys, nil)
 	if err != nil {
-		return result, err
+		return nil, err
 	}
 	if err != nil {
-		return result, err
+		return nil, err
 	}
 	err = mask.SetMask(blockWithSigners.Header().LastCommitBitmap())
 	if err != nil {
-		return result, err
+		return nil, err
 	}
+	result := []string{}
 	for _, validator := range committee.Slots {
 		oneAddress, err := internal_common.AddressToBech32(validator.EcdsaAddress)
 		if err != nil {
-			return result, err
+			return nil, err
 		}
 		blsPublicKey := new(bls.PublicKey)
 		validator.BLSPublicKey.ToLibBLSPublicKey(blsPublicKey)
@@ -491,17 +491,13 @@ func (s *PublicBlockChainAPI) LatestHeader(ctx context.Context) *HeaderInformati
 	return newHeaderInformation(header)
 }
 
-var (
-	errNotBeaconChainShard = errors.New("cannot call this rpc on non beaconchain node")
-)
-
 // GetTotalStaking returns total staking by validators, only meant to be called on beaconchain
 // explorer node
 func (s *PublicBlockChainAPI) GetTotalStaking() (*big.Int, error) {
 	if s.b.GetShardID() == shard.BeaconChainShardID {
 		return s.b.GetTotalStakingSnapshot(), nil
 	}
-	return nil, errNotBeaconChainShard
+	return nil, ErrNotBeaconChainShard
 }
 
 // GetMedianRawStakeSnapshot returns the raw median stake, only meant to be called on beaconchain
@@ -512,7 +508,7 @@ func (s *PublicBlockChainAPI) GetMedianRawStakeSnapshot() (
 	if s.b.GetShardID() == shard.BeaconChainShardID {
 		return s.b.GetMedianRawStakeSnapshot()
 	}
-	return nil, errNotBeaconChainShard
+	return nil, ErrNotBeaconChainShard
 }
 
 // GetAllValidatorAddresses returns all validator addresses.
@@ -816,7 +812,7 @@ func (s *PublicBlockChainAPI) GetCurrentUtilityMetrics() (*network.UtilityMetric
 	if s.b.GetShardID() == shard.BeaconChainShardID {
 		return s.b.GetCurrentUtilityMetrics()
 	}
-	return nil, errNotBeaconChainShard
+	return nil, ErrNotBeaconChainShard
 }
 
 // GetSuperCommittees ..
@@ -824,7 +820,7 @@ func (s *PublicBlockChainAPI) GetSuperCommittees() (*quorum.Transition, error) {
 	if s.b.GetShardID() == shard.BeaconChainShardID {
 		return s.b.GetSuperCommittees()
 	}
-	return nil, errNotBeaconChainShard
+	return nil, ErrNotBeaconChainShard
 }
 
 // GetCurrentBadBlocks ..
@@ -848,7 +844,7 @@ func (s *PublicBlockChainAPI) GetStakingNetworkInfo(
 	ctx context.Context,
 ) (*StakingNetworkInfo, error) {
 	if s.b.GetShardID() != shard.BeaconChainShardID {
-		return nil, errNotBeaconChainShard
+		return nil, ErrNotBeaconChainShard
 	}
 	totalStaking, _ := s.GetTotalStaking()
 	round, _ := s.GetMedianRawStakeSnapshot()
@@ -870,5 +866,5 @@ func (s *PublicBlockChainAPI) GetLastCrossLinks() ([]*types.CrossLink, error) {
 	if s.b.GetShardID() == shard.BeaconChainShardID {
 		return s.b.GetLastCrossLinks()
 	}
-	return nil, errNotBeaconChainShard
+	return nil, ErrNotBeaconChainShard
 }

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -408,9 +408,6 @@ func (s *PublicBlockChainAPI) ResendCx(ctx context.Context, txID common.Hash) (b
 // Call executes the given transaction on the state for the given block number.
 // It doesn't make and changes in the state/blockchain and is useful to execute and retrieve values.
 func (s *PublicBlockChainAPI) Call(ctx context.Context, args CallArgs, blockNr uint64) (hexutil.Bytes, error) {
-	if err := s.isBlockGreaterThanLatest(blockNr); err != nil {
-		return nil, err
-	}
 	result, _, _, err := doCall(ctx, s.b, args, rpc.BlockNumber(blockNr), vm.Config{}, 5*time.Second, s.b.RPCGasCap())
 	return (hexutil.Bytes)(result), err
 }

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -769,7 +769,7 @@ func (s *PublicBlockChainAPI) GetDelegationsByDelegatorByBlockNumber(
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not retrieve the block information for block number: %d", blockNum)
 	}
-	validators, delegations := s.b.GetDelegationsByDelegatorByBlockNumber(delegatorAddress, block)
+	validators, delegations := s.b.GetDelegationsByDelegatorByBlock(delegatorAddress, block)
 	result := []*RPCDelegation{}
 	for i := range delegations {
 		delegation := delegations[i]

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -770,27 +770,27 @@ func (s *PublicBlockChainAPI) GetDelegationsByDelegatorByBlockNumber(
 		return nil, errors.Wrapf(err, "could not retrieve the block information for block number: %d", blockNum)
 	}
 	validators, delegations := s.b.GetDelegationsByDelegatorByBlock(delegatorAddress, block)
-	result := []*RPCDelegation{}
+	result := make([]*RPCDelegation, len(delegations))
 	for i := range delegations {
 		delegation := delegations[i]
 
 		undelegations := make([]RPCUndelegation, len(delegation.Undelegations))
 
 		for j := range delegation.Undelegations {
-			undelegations = append(undelegations, RPCUndelegation{
+			undelegations[j] = RPCUndelegation{
 				delegation.Undelegations[j].Amount,
 				delegation.Undelegations[j].Epoch,
-			})
+			}
 		}
 		valAddr, _ := internal_common.AddressToBech32(validators[i])
 		delAddr, _ := internal_common.AddressToBech32(delegatorAddress)
-		result = append(result, &RPCDelegation{
+		result[i] = &RPCDelegation{
 			valAddr,
 			delAddr,
 			delegation.Amount,
 			delegation.Reward,
 			undelegations,
-		})
+		}
 	}
 	return result, nil
 }

--- a/internal/hmyapi/apiv2/debug.go
+++ b/internal/hmyapi/apiv2/debug.go
@@ -2,7 +2,6 @@ package apiv2
 
 import (
 	"context"
-	"errors"
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/harmony-one/harmony/internal/utils"
@@ -23,7 +22,7 @@ func NewDebugAPI(b Backend) *DebugAPI {
 //  curl -H "Content-Type: application/json" -d '{"method":"debug_setLogVerbosity","params":[0],"id":1}' http://localhost:9123
 func (*DebugAPI) SetLogVerbosity(ctx context.Context, level int) (map[string]interface{}, error) {
 	if level < int(log.LvlCrit) || level > int(log.LvlTrace) {
-		return nil, errors.New("invalid log level")
+		return nil, ErrInvalidLogLevel
 	}
 
 	verbosity := log.Lvl(level)

--- a/internal/hmyapi/apiv2/error.go
+++ b/internal/hmyapi/apiv2/error.go
@@ -1,6 +1,10 @@
 package apiv2
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/harmony-one/harmony/shard"
+)
 
 var (
 	// ErrInvalidLogLevel when invalid log level is provided
@@ -10,5 +14,12 @@ var (
 	// ErrInvalidChainID when ChainID of signer does not match that of running node
 	ErrInvalidChainID = errors.New("invalid chain id for signer")
 	// ErrNotBeaconChainShard when rpc is called on not beacon chain node
-	ErrNotBeaconChainShard = errors.New("cannot call this rpc on non beaconchain node")
+	ErrNotBeaconShard = errors.New("cannot call this rpc on non beaconchain node")
 )
+
+func (s *PublicBlockChainAPI) isBeaconShard() error {
+	if s.b.GetShardID() != shard.BeaconChainShardID {
+		return ErrNotBeaconShard
+	}
+	return nil
+}

--- a/internal/hmyapi/apiv2/error.go
+++ b/internal/hmyapi/apiv2/error.go
@@ -13,7 +13,7 @@ var (
 	ErrIncorrectChainID = errors.New("incorrect chain id")
 	// ErrInvalidChainID when ChainID of signer does not match that of running node
 	ErrInvalidChainID = errors.New("invalid chain id for signer")
-	// ErrNotBeaconChainShard when rpc is called on not beacon chain node
+	// ErrNotBeaconShard when rpc is called on not beacon chain node
 	ErrNotBeaconShard = errors.New("cannot call this rpc on non beaconchain node")
 	// ErrRequestedBlockTooHigh when given block is greater than latest block number
 	ErrRequestedBlockTooHigh = errors.New("requested block number greater than current block number")

--- a/internal/hmyapi/apiv2/error.go
+++ b/internal/hmyapi/apiv2/error.go
@@ -3,6 +3,12 @@ package apiv2
 import "errors"
 
 var (
-	// ErrIncorrectChainID is an incorrect chain ID.
-	ErrIncorrectChainID = errors.New("Incorrect chain ID")
+	// ErrInvalidLogLevel when invalid log level is provided
+	ErrInvalidLogLevel = errors.New("invalid log level")
+	// ErrIncorrectChainID when ChainID does not match running node
+	ErrIncorrectChainID = errors.New("incorrect chain id")
+	// ErrInvalidChainID when ChainID of signer does not match that of running node
+	ErrInvalidChainID = errors.New("invalid chain id for signer")
+	// ErrNotBeaconChainShard when rpc is called on not beacon chain node
+	ErrNotBeaconChainShard = errors.New("cannot call this rpc on non beaconchain node")
 )

--- a/internal/hmyapi/apiv2/error.go
+++ b/internal/hmyapi/apiv2/error.go
@@ -2,8 +2,6 @@ package apiv2
 
 import (
 	"errors"
-
-	"github.com/harmony-one/harmony/shard"
 )
 
 var (
@@ -18,17 +16,3 @@ var (
 	// ErrRequestedBlockTooHigh when given block is greater than latest block number
 	ErrRequestedBlockTooHigh = errors.New("requested block number greater than current block number")
 )
-
-func (s *PublicBlockChainAPI) isBeaconShard() error {
-	if s.b.GetShardID() != shard.BeaconChainShardID {
-		return ErrNotBeaconShard
-	}
-	return nil
-}
-
-func (s *PublicBlockChainAPI) isBlockGreaterThanLatest(blockNum uint64) error {
-	if blockNum > s.b.CurrentBlock().NumberU64() {
-		return ErrRequestedBlockTooHigh
-	}
-	return nil
-}

--- a/internal/hmyapi/apiv2/error.go
+++ b/internal/hmyapi/apiv2/error.go
@@ -27,7 +27,7 @@ func (s *PublicBlockChainAPI) isBeaconShard() error {
 }
 
 func (s *PublicBlockChainAPI) isBlockGreaterThanLatest(blockNum uint64) error {
-	if blockNum >= uint64(s.BlockNumber()) {
+	if blockNum > uint64(s.BlockNumber()) {
 		return ErrRequestedBlockTooHigh
 	}
 	return nil

--- a/internal/hmyapi/apiv2/error.go
+++ b/internal/hmyapi/apiv2/error.go
@@ -15,11 +15,20 @@ var (
 	ErrInvalidChainID = errors.New("invalid chain id for signer")
 	// ErrNotBeaconChainShard when rpc is called on not beacon chain node
 	ErrNotBeaconShard = errors.New("cannot call this rpc on non beaconchain node")
+	// ErrRequestedBlockTooHigh when given block is greater than latest block number
+	ErrRequestedBlockTooHigh = errors.New("requested block number greater than current block number")
 )
 
 func (s *PublicBlockChainAPI) isBeaconShard() error {
 	if s.b.GetShardID() != shard.BeaconChainShardID {
 		return ErrNotBeaconShard
+	}
+	return nil
+}
+
+func (s *PublicBlockChainAPI) isBlockGreaterThanLatest(blockNum uint64) error {
+	if blockNum >= uint64(s.BlockNumber()) {
+		return ErrRequestedBlockTooHigh
 	}
 	return nil
 }

--- a/internal/hmyapi/apiv2/error.go
+++ b/internal/hmyapi/apiv2/error.go
@@ -27,7 +27,7 @@ func (s *PublicBlockChainAPI) isBeaconShard() error {
 }
 
 func (s *PublicBlockChainAPI) isBlockGreaterThanLatest(blockNum uint64) error {
-	if blockNum > uint64(s.BlockNumber()) {
+	if blockNum > s.b.CurrentBlock().NumberU64() {
 		return ErrRequestedBlockTooHigh
 	}
 	return nil

--- a/internal/hmyapi/apiv2/transactionpool.go
+++ b/internal/hmyapi/apiv2/transactionpool.go
@@ -16,11 +16,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-var (
-	// ErrInvalidChainID when ChainID of signer does not match that of running node
-	errInvalidChainID = errors.New("invalid chain id for signer")
-)
-
 // TxHistoryArgs is struct to make GetTransactionsHistory request
 type TxHistoryArgs struct {
 	Address   string `json:"address"`
@@ -242,7 +237,7 @@ func (s *PublicTransactionPoolAPI) SendRawStakingTransaction(
 	c := s.b.ChainConfig().ChainID
 	if id := tx.ChainID(); id.Cmp(c) != 0 {
 		return common.Hash{}, errors.Wrapf(
-			errInvalidChainID, "blockchain chain id:%s, given %s", c.String(), id.String(),
+			ErrInvalidChainID, "blockchain chain id:%s, given %s", c.String(), id.String(),
 		)
 	}
 	return SubmitStakingTransaction(ctx, s.b, tx)
@@ -262,7 +257,7 @@ func (s *PublicTransactionPoolAPI) SendRawTransaction(ctx context.Context, encod
 	c := s.b.ChainConfig().ChainID
 	if id := tx.ChainID(); id.Cmp(c) != 0 {
 		return common.Hash{}, errors.Wrapf(
-			errInvalidChainID, "blockchain chain id:%s, given %s", c.String(), id.String(),
+			ErrInvalidChainID, "blockchain chain id:%s, given %s", c.String(), id.String(),
 		)
 	}
 	return SubmitTransaction(ctx, s.b, tx)

--- a/internal/hmyapi/backend.go
+++ b/internal/hmyapi/backend.go
@@ -66,7 +66,7 @@ type Backend interface {
 	GetValidatorInformation(addr common.Address, block *types.Block) (*staking.ValidatorRPCEnchanced, error)
 	GetDelegationsByValidator(validator common.Address) []*staking.Delegation
 	GetDelegationsByDelegator(delegator common.Address) ([]common.Address, []*staking.Delegation)
-	GetDelegationsByDelegatorAt(delegator common.Address, block *types.Block) ([]common.Address, []*staking.Delegation)
+	GetDelegationsByDelegatorByBlockNumber(delegator common.Address, block *types.Block) ([]common.Address, []*staking.Delegation)
 	GetValidatorSelfDelegation(addr common.Address) *big.Int
 	GetShardState() (*shard.State, error)
 	GetCurrentStakingErrorSink() []staking.RPCTransactionError

--- a/internal/hmyapi/backend.go
+++ b/internal/hmyapi/backend.go
@@ -66,6 +66,7 @@ type Backend interface {
 	GetValidatorInformation(addr common.Address, block *types.Block) (*staking.ValidatorRPCEnchanced, error)
 	GetDelegationsByValidator(validator common.Address) []*staking.Delegation
 	GetDelegationsByDelegator(delegator common.Address) ([]common.Address, []*staking.Delegation)
+	GetDelegationsByDelegatorAt(delegator common.Address, block *types.Block) ([]common.Address, []*staking.Delegation)
 	GetValidatorSelfDelegation(addr common.Address) *big.Int
 	GetShardState() (*shard.State, error)
 	GetCurrentStakingErrorSink() []staking.RPCTransactionError

--- a/internal/hmyapi/backend.go
+++ b/internal/hmyapi/backend.go
@@ -66,7 +66,7 @@ type Backend interface {
 	GetValidatorInformation(addr common.Address, block *types.Block) (*staking.ValidatorRPCEnchanced, error)
 	GetDelegationsByValidator(validator common.Address) []*staking.Delegation
 	GetDelegationsByDelegator(delegator common.Address) ([]common.Address, []*staking.Delegation)
-	GetDelegationsByDelegatorByBlockNumber(delegator common.Address, block *types.Block) ([]common.Address, []*staking.Delegation)
+	GetDelegationsByDelegatorByBlock(delegator common.Address, block *types.Block) ([]common.Address, []*staking.Delegation)
 	GetValidatorSelfDelegation(addr common.Address) *big.Int
 	GetShardState() (*shard.State, error)
 	GetCurrentStakingErrorSink() []staking.RPCTransactionError


### PR DESCRIPTION
Add `GetDelegationsByDelegatorAtBlock`
Return error when calling staking RPCs on not beacon chain nodes
Return error when requesting information from block that is greater than current chain height

Tested on localnet.
<img width="674" alt="Screen Shot 2020-04-29 at 4 30 31 AM" src="https://user-images.githubusercontent.com/56005637/80608585-d6114f80-89eb-11ea-9f8e-a965501608af.png">
