### PR TITLE
fix explorer storage for transactions and staking transactions

### DIFF
--- a/api/service/explorer/storage.go
+++ b/api/service/explorer/storage.go
@@ -19,10 +19,9 @@ import (
 
 // Constants for storage.
 const (
-	AddressPrefix        = "ad"
-	CheckpointPrefix     = "dc"
-	PrefixLen            = 3
-	AdddressTxnsInitSize = 10
+	AddressPrefix    = "ad"
+	CheckpointPrefix = "dc"
+	PrefixLen        = 3
 )
 
 // GetAddressKey ...
@@ -110,7 +109,7 @@ func (storage *Storage) Dump(block *types.Block, height uint64) {
 }
 
 // UpdateTxAddressStorage updates specific addr tx Address.
-func (storage *Storage) UpdateTxAddressStorage(addr string, txRecords []*TxRecord, isStaking bool) {
+func (storage *Storage) UpdateTxAddressStorage(addr string, txRecords TxRecords, isStaking bool) {
 	var address Address
 	key := GetAddressKey(addr)
 	if data, err := storage.GetDB().Get([]byte(key), nil); err == nil {
@@ -119,6 +118,7 @@ func (storage *Storage) UpdateTxAddressStorage(addr string, txRecords []*TxRecor
 				Bool("isStaking", isStaking).Err(err).Msg("Failed due to error")
 		}
 	}
+
 	address.ID = addr
 	if isStaking {
 		address.StakingTXs = append(address.StakingTXs, txRecords...)
@@ -160,11 +160,11 @@ func (storage *Storage) GetAddresses(size int, prefix string) ([]string, error) 
 
 func computeAccountsTransactionsMapForBlock(
 	block *types.Block,
-) (map[string][]*TxRecord, map[string][]*TxRecord) {
+) (map[string]TxRecords, map[string]TxRecords) {
 	// mapping from account address to TxRecords for txns in the block
-	var acntsTxns map[string][]*TxRecord
+	var acntsTxns map[string]TxRecords = make(map[string]TxRecords)
 	// mapping from account address to TxRecords for staking txns in the block
-	var acntsStakingTxns map[string][]*TxRecord
+	var acntsStakingTxns map[string]TxRecords = make(map[string]TxRecords)
 
 	// Store txs
 	for _, tx := range block.Transactions() {
@@ -183,9 +183,10 @@ func computeAccountsTransactionsMapForBlock(
 		}
 		acntTxns, ok := acntsTxns[explorerTransaction.From]
 		if !ok {
-			acntTxns = make([]*TxRecord, AdddressTxnsInitSize)
+			acntTxns = make(TxRecords, 0)
 		}
 		acntTxns = append(acntTxns, txRecord)
+		acntsTxns[explorerTransaction.From] = acntTxns
 
 		// store as received transaction with to address
 		txRecord = &TxRecord{
@@ -195,9 +196,10 @@ func computeAccountsTransactionsMapForBlock(
 		}
 		acntTxns, ok = acntsTxns[explorerTransaction.To]
 		if !ok {
-			acntTxns = make([]*TxRecord, AdddressTxnsInitSize)
+			acntTxns = make(TxRecords, 0)
 		}
 		acntTxns = append(acntTxns, txRecord)
+		acntsTxns[explorerTransaction.To] = acntTxns
 	}
 
 	// Store staking txns
@@ -217,9 +219,10 @@ func computeAccountsTransactionsMapForBlock(
 		}
 		acntStakingTxns, ok := acntsStakingTxns[explorerTransaction.From]
 		if !ok {
-			acntStakingTxns = make([]*TxRecord, AdddressTxnsInitSize)
+			acntStakingTxns = make(TxRecords, 0)
 		}
 		acntStakingTxns = append(acntStakingTxns, txRecord)
+		acntsStakingTxns[explorerTransaction.From] = acntStakingTxns
 
 		// For delegate/undelegate, also store as received staking transaction with to address
 		txRecord = &TxRecord{
@@ -229,9 +232,10 @@ func computeAccountsTransactionsMapForBlock(
 		}
 		acntStakingTxns, ok = acntsStakingTxns[explorerTransaction.To]
 		if !ok {
-			acntStakingTxns = make([]*TxRecord, AdddressTxnsInitSize)
+			acntStakingTxns = make(TxRecords, 0)
 		}
 		acntStakingTxns = append(acntStakingTxns, txRecord)
+		acntsStakingTxns[explorerTransaction.To] = acntStakingTxns
 	}
 
 	return acntsTxns, acntsStakingTxns

--- a/api/service/explorer/structs.go
+++ b/api/service/explorer/structs.go
@@ -32,6 +32,9 @@ type TxRecord struct {
 	Timestamp string
 }
 
+// TxRecords ...
+type TxRecords []*TxRecord
+
 // Data ...
 type Data struct {
 	Addresses []string `json:"Addresses"`
@@ -39,10 +42,10 @@ type Data struct {
 
 // Address ...
 type Address struct {
-	ID         string      `json:"id"`
-	Balance    *big.Int    `json:"balance"`
-	TXs        []*TxRecord `json:"txs"`
-	StakingTXs []*TxRecord `json:"staking_txs"`
+	ID         string    `json:"id"`
+	Balance    *big.Int  `json:"balance"`
+	TXs        TxRecords `json:"txs"`
+	StakingTXs TxRecords `json:"staking_txs"`
 }
 
 // Transaction ...


### PR DESCRIPTION
## Issue

Explorer node fails to save transaction records to its storage, returning empty transaction history.

### Unit Test Coverage
```
dennis.won@Jongs-MacBook-Pro:~/harmony-one/harmony (fix_explorer_node) $ go test ./api/service/explorer/
ok  	github.com/harmony-one/harmony/api/service/explorer	0.490s
```

### Test/Run Logs
checked the logs for txs are correctly saved on storage for each block during dump.

...
{"level":"info","port":"9099","ip":"127.0.0.1","addr":"one1a50tun737ulcvwy0yvve0pvu5skq0kjargvhwe","**num TXs":2,**"caller":"/Users/dennis.won/go/src/github.com/harmony-one/harmony/api/service/explorer/storage.go:139","time":"2020-04-        29T19:12:21.27235-07:00","message":"UpdateTxAddressStorage"}

 235 {"level":"info","port":"9099","ip":"127.0.0.1","addr":"one1a50tun737ulcvwy0yvve0pvu5skq0kjargvhwe",**"num TXs":3,**"caller":"/Users/dennis.won/go/src/github.com/harmony-one/harmony/api/service/explorer/storage.go:139","time":"2020-04-        29T19:12:21.273101-07:00","message":"UpdateTxAddressStorage"}
 236 {"level":"info","port":"9099","ip":"127.0.0.1","addr":"one1uyshu2jgv8w465yc8kkny36thlt2wvel89tcmg",**"num TXs":1**,"caller":"/Users/dennis.won/go/src/github.com/harmony-one/harmony/api/service/explorer/storage.go:139","time":"2020-04-        29T19:12:21.273117-07:00","message":"UpdateTxAddressStorage"}

 241 {"level":"info","port":"9099","ip":"127.0.0.1","addr":"one1a50tun737ulcvwy0yvve0pvu5skq0kjargvhwe"**,"num TXs"**:4,"caller":"/Users/dennis.won/go/src/github.com/harmony-one/harmony/api/service/explorer/storage.go:139","time":"2020-04-        29T19:12:21.273949-07:00","message":"UpdateTxAddressStorage"}
 242 {"level":"info","port":"9099","ip":"127.0.0.1","addr":"one1uyshu2jgv8w465yc8kkny36thlt2wvel89tcmg","**num TXs"**:2,"caller":"/Users/dennis.won/go/src/github.com/harmony-one/harmony/api/service/explorer/storage.go:139","time":"2020-04-        29T19:12:21.273968-07:00","message":"UpdateTxAddressStorage"}

 248 {"level":"info","port":"9099","ip":"127.0.0.1","addr":"one1uyshu2jgv8w465yc8kkny36thlt2wvel89tcmg",**"num TXs":3**,"caller":"/Users/dennis.won/go/src/github.com/harmony-one/harmony/api/service/explorer/storage.go:139","time":"2020-04-        29T19:12:21.274862-07:00","message":"UpdateTxAddressStorage"}
...

Also: Go Playground demo of code correctness: https://play.golang.org/p/VAq3DxJTcdx

Then finally, checked that transactions return correctly:

```
dennis.won@Jongs-MacBook-Pro:~/harmony-one/harmony (fix_explorer_node) $ hmy blockchain account-history one1a50tun737ulcvwy0yvve0pvu5skq0kjargvhwe --node="http://localhost:9599"
{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "transactions": [
      {
        "blockHash": "0xadb1e33baf7499a5aadf5b73d2b20957f0c3c717042bea029f9ad13ac891e54c",
        "blockNumber": "0x3",
        "from": "one1a50tun737ulcvwy0yvve0pvu5skq0kjargvhwe",
        "gas": "0x5208",
        "gasPrice": "0x3b9aca00",
        "hash": "0x470cb13a2249f88e291b079a4a59bf9b32640e0cd62f5152a4e53d191f8b94d3",
        "input": "0x",
        "nonce": "0x0",
        "r": "0xf54f5a5f75b0b59fe613779fe13766afa3607ba05e17334f6c16510e1153df92",
        "s": "0x14c96201486470a32a1872c1a21cf13d0064823ee3fd1385ea0901e21daac190",
        "shardID": 0,
        "timestamp": "0x5eaa3718",
        "to": "one1a50tun737ulcvwy0yvve0pvu5skq0kjargvhwe",
        "toShardID": 0,
        "transactionIndex": "0x0",
        "v": "0x27",
        "value": "0xde0b6b3a7640000"
      },
      {
        "blockHash": "0xadb1e33baf7499a5aadf5b73d2b20957f0c3c717042bea029f9ad13ac891e54c",
        "blockNumber": "0x3",
        "from": "one1a50tun737ulcvwy0yvve0pvu5skq0kjargvhwe",
        "gas": "0x5208",
        "gasPrice": "0x3b9aca00",
        "hash": "0x470cb13a2249f88e291b079a4a59bf9b32640e0cd62f5152a4e53d191f8b94d3",
        "input": "0x",
        "nonce": "0x0",
        "r": "0xf54f5a5f75b0b59fe613779fe13766afa3607ba05e17334f6c16510e1153df92",
        "s": "0x14c96201486470a32a1872c1a21cf13d0064823ee3fd1385ea0901e21daac190",
        "shardID": 0,
        "timestamp": "0x5eaa3718",
        "to": "one1a50tun737ulcvwy0yvve0pvu5skq0kjargvhwe",
        "toShardID": 0,
        "transactionIndex": "0x0",
        "v": "0x27",
        "value": "0xde0b6b3a7640000"
      },
      {
        "blockHash": "0xea6a946781bee680906676cc7678ae1eabc21f51446c4da1cee484a3c3eecfe5",
        "blockNumber": "0x4",
        "from": "one1a50tun737ulcvwy0yvve0pvu5skq0kjargvhwe",
        "gas": "0x5208",
        "gasPrice": "0x3b9aca00",
        "hash": "0xee71ca2ca3ef4abd10691c90ef4a945a0302156d06aaa19eb8a737fe1d4442e7",
        "input": "0x",
        "nonce": "0x1",
        "r": "0x6b1e63f20694c24b0954bb8ef305b320f68f50a1015ff4d0b0837a8009d6adc7",
        "s": "0x8420176d02367305227a6e9f58e0044b353f8046af935a204b7c3e72b7d1210",
        "shardID": 0,
        "timestamp": "0x5eaa3720",
        "to": "one1uyshu2jgv8w465yc8kkny36thlt2wvel89tcmg",
        "toShardID": 0,
        "transactionIndex": "0x0",
        "v": "0x28",
        "value": "0xde0b6b3a7640000"
      },
      {
        "blockHash": "0x4b006f6c7d5e5e90be45aa6a6de8ff76ff4e954a2c5e86b2c66c9392bac4ab44",
        "blockNumber": "0x5",
        "from": "one1a50tun737ulcvwy0yvve0pvu5skq0kjargvhwe",
        "gas": "0x5208",
        "gasPrice": "0x3b9aca00",
        "hash": "0xc6298aa0fcab961cd1580266be76ff2dd8740ba2df40398a8720acbbd2fbb772",
        "input": "0x",
        "nonce": "0x2",
        "r": "0x47c218b57599f3529c6c6f558086d56e6841f4e2f0f12180916b06da72bfdcc2",
        "s": "0x65dbf6a20a96738877f181a58406bfb24ec98fff0d83ce2e7863cf12c95ec4ae",
        "shardID": 0,
        "timestamp": "0x5eaa3728",
        "to": "one1uyshu2jgv8w465yc8kkny36thlt2wvel89tcmg",
        "toShardID": 0,
        "transactionIndex": "0x0",
        "v": "0x27",
        "value": "0xde0b6b3a7640000"
      },
      {
        "blockHash": "0x18f3cf9886556f771686472b544780d4a8e00f341f70848a91cfa358ba8c4dfc",
        "blockNumber": "0x6",
        "from": "one1a50tun737ulcvwy0yvve0pvu5skq0kjargvhwe",
        "gas": "0x5208",
        "gasPrice": "0x3b9aca00",
        "hash": "0x3d0415b2e8d75644b83a53e655510a20bb354b01c445e95e8f4107886762c9fc",
        "input": "0x",
        "nonce": "0x3",
        "r": "0x86f5453aef6a495759033c443795febfce848b3c464bb49336806b61c3fe6092",
        "s": "0x6b98c184c4e6febdc1dda36542163f258e57ee61018da5e8c10a1bb9fe15c09f",
        "shardID": 0,
        "timestamp": "0x5eaa3730",
        "to": "one1a50tun737ulcvwy0yvve0pvu5skq0kjargvhwe",
        "toShardID": 0,
        "transactionIndex": "0x0",
        "v": "0x27",
        "value": "0xde0b6b3a7640000"
      },
      {
        "blockHash": "0x18f3cf9886556f771686472b544780d4a8e00f341f70848a91cfa358ba8c4dfc",
        "blockNumber": "0x6",
        "from": "one1a50tun737ulcvwy0yvve0pvu5skq0kjargvhwe",
        "gas": "0x5208",
        "gasPrice": "0x3b9aca00",
        "hash": "0x3d0415b2e8d75644b83a53e655510a20bb354b01c445e95e8f4107886762c9fc",
        "input": "0x",
        "nonce": "0x3",
        "r": "0x86f5453aef6a495759033c443795febfce848b3c464bb49336806b61c3fe6092",
        "s": "0x6b98c184c4e6febdc1dda36542163f258e57ee61018da5e8c10a1bb9fe15c09f",
        "shardID": 0,
        "timestamp": "0x5eaa3730",
        "to": "one1a50tun737ulcvwy0yvve0pvu5skq0kjargvhwe",
        "toShardID": 0,
        "transactionIndex": "0x0",
        "v": "0x27",
        "value": "0xde0b6b3a7640000"
      }
    ]
  }
}
```