### PR TITLE
fix super committee median for current committee and raw-stake assignment

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2365,8 +2365,7 @@ func (bc *BlockChain) UpdateValidatorVotingPower(
 					QuoInt64(int64(len(wrapper.SlotPubKeys)))
 			}
 			for i := range stats.MetricsPerShard {
-				metric := stats.MetricsPerShard[i]
-				metric.Vote.RawStake = spread
+				stats.MetricsPerShard[i].Vote.RawStake = spread
 			}
 		}
 

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -718,7 +718,7 @@ func (b *APIBackend) getSuperCommittees() (*quorum.Transition, error) {
 		rawStakes = b.readAndUpdateRawStakes(nowE, decider, comm, rawStakes, validatorSpreads)
 		now.Deciders[fmt.Sprintf("shard-%d", comm.ShardID)] = decider
 	}
-	then.MedianStake = effective.Median(rawStakes)
+	now.MedianStake = effective.Median(rawStakes)
 
 	return &quorum.Transition{then, now}, nil
 }


### PR DESCRIPTION
* fix super committee bug that was overwriting previous median instead of current
* read from validator wrapper to update raw-stake instead of snapshot, as snapshot is still in batch and not flushed.