### PR TITLE
Msg copy fix

### DIFF
--- a/numeric/decimal.go
+++ b/numeric/decimal.go
@@ -191,6 +191,9 @@ func MustNewDecFromStr(s string) Dec {
 
 // Copy makes a deep copy of the dec
 func (d Dec) Copy() Dec {
+	if d.IsNil() {
+		return Dec{}
+	}
 	return Dec{
 		new(big.Int).Set(d.Int),
 	}

--- a/numeric/decimal.go
+++ b/numeric/decimal.go
@@ -189,6 +189,13 @@ func MustNewDecFromStr(s string) Dec {
 	return dec
 }
 
+// Copy makes a deep copy of the dec
+func (d Dec) Copy() Dec {
+	return Dec{
+		new(big.Int).Set(d.Int),
+	}
+}
+
 // IsNil ...
 func (d Dec) IsNil() bool { return d.Int == nil } // is decimal nil
 // IsZero ...

--- a/numeric/decimal_test.go
+++ b/numeric/decimal_test.go
@@ -77,12 +77,18 @@ func TestDec_Copy(t *testing.T) {
 	tests := []struct {
 		d Dec
 	}{
+		{},
 		{NewDec(0)},
 		{NewDec(1)},
 		{NewDecWithPrec(12340, 4)},
 	}
 	for tcIndex, tc := range tests {
 		cp := tc.d.Copy()
+
+		assert.True(t, tc.d.IsNil() == cp.IsNil(), "IsNil not equal, tc %v", tcIndex)
+		if tc.d.IsNil() {
+			continue
+		}
 		assert.True(t, tc.d.Equal(cp), "equality was incorrect, res %v, exp %v, tc %v", cp, tc.d, tcIndex)
 		assert.False(t, tc.d == cp, "deepcopy return the original pointer %p, tc %v", cp, tcIndex)
 	}

--- a/numeric/decimal_test.go
+++ b/numeric/decimal_test.go
@@ -73,6 +73,21 @@ func TestNewDecFromStr(t *testing.T) {
 	}
 }
 
+func TestDec_Copy(t *testing.T) {
+	tests := []struct {
+		d Dec
+	}{
+		{NewDec(0)},
+		{NewDec(1)},
+		{NewDecWithPrec(12340, 4)},
+	}
+	for tcIndex, tc := range tests {
+		cp := tc.d.Copy()
+		assert.True(t, tc.d.Equal(cp), "equality was incorrect, res %v, exp %v, tc %v", cp, tc.d, tcIndex)
+		assert.False(t, tc.d == cp, "deepcopy return the original pointer %p, tc %v", cp, tcIndex)
+	}
+}
+
 func TestDecString(t *testing.T) {
 	tests := []struct {
 		d    Dec

--- a/staking/types/commission.go
+++ b/staking/types/commission.go
@@ -24,3 +24,7 @@ type (
 		MaxChangeRate numeric.Dec `json:"max-change-rate"`
 	}
 )
+
+func (cr CommissionRates) Copy() CommissionRates {
+
+}

--- a/staking/types/commission.go
+++ b/staking/types/commission.go
@@ -25,6 +25,11 @@ type (
 	}
 )
 
+// Copy makes a deep copy of the CommissionRates
 func (cr CommissionRates) Copy() CommissionRates {
-
+	return CommissionRates{
+		Rate:          cr.Rate.Copy(),
+		MaxRate:       cr.MaxRate.Copy(),
+		MaxChangeRate: cr.MaxChangeRate.Copy(),
+	}
 }

--- a/staking/types/commission_test.go
+++ b/staking/types/commission_test.go
@@ -1,0 +1,57 @@
+package types
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/harmony-one/harmony/numeric"
+)
+
+var (
+	zeroDec     = numeric.ZeroDec()
+	oneThirdDec = numeric.NewDecWithPrec(33, 2)
+	halfDec     = numeric.NewDecWithPrec(5, 1)
+	twoThirdDec = numeric.NewDecWithPrec(66, 2)
+	oneDec      = numeric.OneDec()
+)
+
+func TestCommissionRates_Copy(t *testing.T) {
+	tests := []struct {
+		cr CommissionRates
+	}{
+		{CommissionRates{zeroDec, halfDec, oneDec}},
+		{CommissionRates{zeroDec, oneThirdDec, twoThirdDec}},
+		{CommissionRates{oneThirdDec, twoThirdDec, oneDec}},
+	}
+	for i, test := range tests {
+		cp := test.cr.Copy()
+
+		if err := assertCommissionRatesDeepCopy(test.cr, cp); err != nil {
+			t.Errorf("Test %v: %v", i, err)
+		}
+	}
+}
+
+func assertCommissionRatesDeepCopy(cr1, cr2 CommissionRates) error {
+	if err := assertDecCopy(cr1.Rate, cr2.Rate); err != nil {
+		return fmt.Errorf("rate: %v", err)
+	}
+	if err := assertDecCopy(cr1.MaxRate, cr2.MaxRate); err != nil {
+		return fmt.Errorf("maxRate: %v", err)
+	}
+	if err := assertDecCopy(cr1.MaxChangeRate, cr2.MaxChangeRate); err != nil {
+		return fmt.Errorf("maxChangeRate: %v", err)
+	}
+	return nil
+}
+
+func assertDecCopy(d1, d2 numeric.Dec) error {
+	if !d1.Equal(d2) {
+		return errors.New("value not equal")
+	}
+	if d1 == d2 {
+		return errors.New("same address")
+	}
+	return nil
+}

--- a/staking/types/commission_test.go
+++ b/staking/types/commission_test.go
@@ -20,6 +20,7 @@ func TestCommissionRates_Copy(t *testing.T) {
 	tests := []struct {
 		cr CommissionRates
 	}{
+		{},
 		{CommissionRates{zeroDec, halfDec, oneDec}},
 		{CommissionRates{zeroDec, oneThirdDec, twoThirdDec}},
 		{CommissionRates{oneThirdDec, twoThirdDec, oneDec}},
@@ -47,6 +48,12 @@ func assertCommissionRatesDeepCopy(cr1, cr2 CommissionRates) error {
 }
 
 func assertDecCopy(d1, d2 numeric.Dec) error {
+	if d1.IsNil() != d2.IsNil() {
+		return errors.New("IsNil not equal")
+	}
+	if d1.IsNil() {
+		return nil
+	}
 	if !d1.Equal(d2) {
 		return errors.New("value not equal")
 	}

--- a/staking/types/commission_test.go
+++ b/staking/types/commission_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/harmony-one/harmony/numeric"
@@ -35,6 +36,13 @@ func TestCommissionRates_Copy(t *testing.T) {
 }
 
 func assertCommissionRatesDeepCopy(cr1, cr2 CommissionRates) error {
+	if !reflect.DeepEqual(cr1, cr2) {
+		return errors.New("not deep equal")
+	}
+	return assertCommissionRatesCopy(cr1, cr2)
+}
+
+func assertCommissionRatesCopy(cr1, cr2 CommissionRates) error {
 	if err := assertDecCopy(cr1.Rate, cr2.Rate); err != nil {
 		return fmt.Errorf("rate: %v", err)
 	}
@@ -53,9 +61,6 @@ func assertDecCopy(d1, d2 numeric.Dec) error {
 	}
 	if d1.IsNil() {
 		return nil
-	}
-	if !d1.Equal(d2) {
-		return errors.New("value not equal")
 	}
 	if d1 == d2 {
 		return errors.New("same address")

--- a/staking/types/messages.go
+++ b/staking/types/messages.go
@@ -77,11 +77,11 @@ func (v CreateValidator) Copy() StakeMsg {
 		CommissionRates:  v.CommissionRates.Copy(),
 	}
 
-	if len(v.SlotPubKeys) != 0 {
+	if v.SlotPubKeys != nil {
 		cp.SlotPubKeys = make([]shard.BLSPublicKey, len(v.SlotPubKeys))
 		copy(cp.SlotPubKeys, v.SlotPubKeys)
 	}
-	if len(v.SlotKeySigs) != 0 {
+	if v.SlotKeySigs != nil {
 		cp.SlotKeySigs = make([]shard.BLSSignature, len(v.SlotKeySigs))
 		copy(cp.SlotKeySigs, v.SlotKeySigs)
 	}
@@ -161,8 +161,14 @@ func (v Delegate) Type() Directive {
 
 // Copy deep copy of the interface
 func (v Delegate) Copy() StakeMsg {
-	v1 := v
-	return v1
+	cp := Delegate{
+		DelegatorAddress: v.DelegatorAddress,
+		ValidatorAddress: v.ValidatorAddress,
+	}
+	if v.Amount != nil {
+		cp.Amount = new(big.Int).Set(v.Amount)
+	}
+	return cp
 }
 
 // Undelegate - type for removing delegation responsibility

--- a/staking/types/messages.go
+++ b/staking/types/messages.go
@@ -185,8 +185,14 @@ func (v Undelegate) Type() Directive {
 
 // Copy deep copy of the interface
 func (v Undelegate) Copy() StakeMsg {
-	v1 := v
-	return v1
+	cp := Undelegate{
+		DelegatorAddress: v.DelegatorAddress,
+		ValidatorAddress: v.ValidatorAddress,
+	}
+	if v.Amount != nil {
+		cp.Amount = new(big.Int).Set(v.Amount)
+	}
+	return cp
 }
 
 // CollectRewards - type for collecting token rewards
@@ -201,6 +207,7 @@ func (v CollectRewards) Type() Directive {
 
 // Copy deep copy of the interface
 func (v CollectRewards) Copy() StakeMsg {
-	v1 := v
-	return v1
+	return CollectRewards{
+		DelegatorAddress: v.DelegatorAddress,
+	}
 }

--- a/staking/types/messages.go
+++ b/staking/types/messages.go
@@ -69,7 +69,7 @@ func (v CreateValidator) Type() Directive {
 	return DirectiveCreateValidator
 }
 
-// Copy deep copy of the interface
+// Copy returns a deep copy of the CreateValidator as a StakeMsg interface
 func (v CreateValidator) Copy() StakeMsg {
 	cp := CreateValidator{
 		ValidatorAddress: v.ValidatorAddress,
@@ -115,7 +115,7 @@ func (v EditValidator) Type() Directive {
 	return DirectiveEditValidator
 }
 
-// Copy deep copy of the interface
+// Copy returns a deep copy of the EditValidator as a StakeMsg interface
 func (v EditValidator) Copy() StakeMsg {
 	cp := EditValidator{
 		ValidatorAddress: v.ValidatorAddress,
@@ -159,7 +159,7 @@ func (v Delegate) Type() Directive {
 	return DirectiveDelegate
 }
 
-// Copy deep copy of the interface
+// Copy returns a deep copy of the Delegate as a StakeMsg interface
 func (v Delegate) Copy() StakeMsg {
 	cp := Delegate{
 		DelegatorAddress: v.DelegatorAddress,
@@ -183,7 +183,7 @@ func (v Undelegate) Type() Directive {
 	return DirectiveUndelegate
 }
 
-// Copy deep copy of the interface
+// Copy returns a deep copy of the Undelegate as a StakeMsg interface
 func (v Undelegate) Copy() StakeMsg {
 	cp := Undelegate{
 		DelegatorAddress: v.DelegatorAddress,
@@ -205,7 +205,7 @@ func (v CollectRewards) Type() Directive {
 	return DirectiveCollectRewards
 }
 
-// Copy deep copy of the interface
+// Copy returns a deep copy of the CollectRewards as a StakeMsg interface
 func (v CollectRewards) Copy() StakeMsg {
 	return CollectRewards{
 		DelegatorAddress: v.DelegatorAddress,

--- a/staking/types/messages.go
+++ b/staking/types/messages.go
@@ -75,12 +75,16 @@ func (v CreateValidator) Copy() StakeMsg {
 		ValidatorAddress: v.ValidatorAddress,
 		Description:      v.Description,
 		CommissionRates:  v.CommissionRates.Copy(),
-		SlotPubKeys:      make([]shard.BLSPublicKey, len(v.SlotPubKeys)),
-		SlotKeySigs:      make([]shard.BLSSignature, len(v.SlotKeySigs)),
 	}
-	copy(cp.SlotPubKeys, v.SlotPubKeys)
-	copy(cp.SlotKeySigs, v.SlotKeySigs)
 
+	if len(v.SlotPubKeys) != 0 {
+		cp.SlotPubKeys = make([]shard.BLSPublicKey, len(v.SlotPubKeys))
+		copy(cp.SlotPubKeys, v.SlotPubKeys)
+	}
+	if len(v.SlotKeySigs) != 0 {
+		cp.SlotKeySigs = make([]shard.BLSSignature, len(v.SlotKeySigs))
+		copy(cp.SlotKeySigs, v.SlotKeySigs)
+	}
 	if v.MinSelfDelegation != nil {
 		cp.MinSelfDelegation = new(big.Int).Set(v.MinSelfDelegation)
 	}
@@ -113,9 +117,34 @@ func (v EditValidator) Type() Directive {
 
 // Copy deep copy of the interface
 func (v EditValidator) Copy() StakeMsg {
-	v1 := v
-	v1.Description = v.Description
-	return v1
+	cp := EditValidator{
+		ValidatorAddress: v.ValidatorAddress,
+		Description:      v.Description,
+		EPOSStatus:       v.EPOSStatus,
+	}
+	if v.CommissionRate != nil {
+		cr := v.CommissionRate.Copy()
+		cp.CommissionRate = &cr
+	}
+	if v.MinSelfDelegation != nil {
+		cp.MinSelfDelegation = new(big.Int).Set(v.MinSelfDelegation)
+	}
+	if v.MaxTotalDelegation != nil {
+		cp.MaxTotalDelegation = new(big.Int).Set(v.MaxTotalDelegation)
+	}
+	if v.SlotKeyToRemove != nil {
+		keyRem := *v.SlotKeyToRemove
+		cp.SlotKeyToRemove = &keyRem
+	}
+	if v.SlotKeyToAdd != nil {
+		keyAdd := *v.SlotKeyToAdd
+		cp.SlotKeyToAdd = &keyAdd
+	}
+	if v.SlotKeyToAddSig != nil {
+		sigAdd := *v.SlotKeyToAddSig
+		cp.SlotKeyToAddSig = &sigAdd
+	}
+	return cp
 }
 
 // Delegate - type for delegating to a validator

--- a/staking/types/messages_test.go
+++ b/staking/types/messages_test.go
@@ -7,16 +7,17 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/shard"
 	"github.com/harmony-one/harmony/staking/effective"
 )
 
 var (
-	cpTestCreateValidator CreateValidator
-	cpTestEditValidator   EditValidator
-	cpTestDelegate        Delegate
-	cpTestUndelegate      Undelegate
-	cpTestCollectReward   CollectRewards
+	testCreateValidator, zeroCreateValidator CreateValidator
+	testEditValidator, zeroEditValidator     EditValidator
+	testDelegate, zeroDelegate               Delegate
+	testUndelegate, zeroUndelegate           Undelegate
+	testCollectReward, zeroCollectReward     CollectRewards
 )
 
 func init() {
@@ -27,8 +28,9 @@ func TestCreateValidator_Copy(t *testing.T) {
 	tests := []struct {
 		cv CreateValidator
 	}{
-		{cpTestCreateValidator},
-		{CreateValidator{}}, // empty values
+		{testCreateValidator}, // normal values
+		{zeroCreateValidator}, // zero values
+		{CreateValidator{}},   // empty values
 	}
 	for i, test := range tests {
 		cp := test.cv.Copy().(CreateValidator)
@@ -43,8 +45,9 @@ func TestEditValidator_Copy(t *testing.T) {
 	tests := []struct {
 		ev EditValidator
 	}{
-		{cpTestEditValidator},
-		{EditValidator{}}, // empty values
+		{testEditValidator}, // normal values
+		{zeroEditValidator}, // zero values
+		{EditValidator{}},   // empty values
 	}
 	for i, test := range tests {
 		cp := test.ev.Copy().(EditValidator)
@@ -64,12 +67,19 @@ func cpTestDataSetup() {
 		Details:         "wenDetails",
 	}
 	cr := CommissionRates{
-		Rate:          zeroDec,
+		Rate:          oneDec,
 		MaxRate:       oneDec,
+		MaxChangeRate: oneDec,
+	}
+	zeroCr := CommissionRates{
+		Rate:          zeroDec,
+		MaxRate:       zeroDec,
 		MaxChangeRate: zeroDec,
 	}
+	var zeroBLSPub shard.BLSPublicKey
+	var zeroBLSSig shard.BLSSignature
 
-	cpTestCreateValidator = CreateValidator{
+	testCreateValidator = CreateValidator{
 		ValidatorAddress:   validatorAddr,
 		Description:        description,
 		CommissionRates:    cr,
@@ -79,7 +89,16 @@ func cpTestDataSetup() {
 		SlotKeySigs:        slotKeySigs,
 		Amount:             twelveK,
 	}
-	cpTestEditValidator = EditValidator{
+	zeroCreateValidator = CreateValidator{
+		CommissionRates:    zeroCr,
+		MinSelfDelegation:  common.Big0,
+		MaxTotalDelegation: common.Big0,
+		SlotPubKeys:        make([]shard.BLSPublicKey, 0),
+		SlotKeySigs:        make([]shard.BLSSignature, 0),
+		Amount:             common.Big0,
+	}
+
+	testEditValidator = EditValidator{
 		ValidatorAddress:   validatorAddr,
 		Description:        description,
 		CommissionRate:     &oneDec,
@@ -90,7 +109,37 @@ func cpTestDataSetup() {
 		SlotKeyToAddSig:    &slotKeySigs[0],
 		EPOSStatus:         effective.Active,
 	}
+	zeroEditValidator = EditValidator{
+		CommissionRate:     &zeroDec,
+		MinSelfDelegation:  common.Big0,
+		MaxTotalDelegation: common.Big0,
+		SlotKeyToRemove:    &zeroBLSPub,
+		SlotKeyToAdd:       &zeroBLSPub,
+		SlotKeyToAddSig:    &zeroBLSSig,
+	}
 
+	testDelegate = Delegate{
+		DelegatorAddress: common.BigToAddress(common.Big1),
+		ValidatorAddress: validatorAddr,
+		Amount:           twelveK,
+	}
+	zeroDelegate = Delegate{
+		Amount: common.Big0,
+	}
+
+	testUndelegate = Undelegate{
+		DelegatorAddress: common.BigToAddress(common.Big1),
+		ValidatorAddress: validatorAddr,
+		Amount:           twelveK,
+	}
+	zeroUndelegate = Undelegate{
+		Amount: common.Big0,
+	}
+
+	testCollectReward = CollectRewards{
+		DelegatorAddress: common.BigToAddress(common.Big1),
+	}
+	zeroCollectReward = CollectRewards{}
 }
 
 func assertCreateValidatorDeepCopy(cv1, cv2 CreateValidator) error {
@@ -149,6 +198,10 @@ func assertEditValidatorDeepCopy(ev1, ev2 EditValidator) error {
 	if ev1.SlotKeyToAddSig != nil && ev1.SlotKeyToAddSig == ev2.SlotKeyToAddSig {
 		return fmt.Errorf("SlotKeyToAddSig same pointer")
 	}
+	return nil
+}
+
+func assertDelegateDeepEqual(d1, d2 Delegate) error {
 	return nil
 }
 

--- a/staking/types/messages_test.go
+++ b/staking/types/messages_test.go
@@ -24,6 +24,47 @@ func init() {
 	cpTestDataSetup()
 }
 
+func TestDirective_String(t *testing.T) {
+	tests := []struct {
+		dir Directive
+		exp string
+	}{
+		{DirectiveCreateValidator, "CreateValidator"},
+		{DirectiveEditValidator, "EditValidator"},
+		{DirectiveDelegate, "Delegate"},
+		{DirectiveUndelegate, "Undelegate"},
+		{DirectiveCollectRewards, "CollectRewards"},
+		{0xff, "Directive 255"},
+	}
+	for i, test := range tests {
+		s := test.dir.String()
+
+		if s != test.exp {
+			t.Errorf("Test %v: unexpected string: %v / %v", i, s, test.exp)
+		}
+	}
+}
+
+func TestStakeMsg_Type(t *testing.T) {
+	tests := []struct {
+		msg StakeMsg
+		exp Directive
+	}{
+		{testCreateValidator, DirectiveCreateValidator},
+		{testEditValidator, DirectiveEditValidator},
+		{testDelegate, DirectiveDelegate},
+		{testUndelegate, DirectiveUndelegate},
+		{testCollectReward, DirectiveCollectRewards},
+	}
+	for i, test := range tests {
+		dir := test.msg.Type()
+
+		if dir != test.exp {
+			t.Errorf("Test %v: unexpected directive %v / %v", i, dir, test.exp)
+		}
+	}
+}
+
 func TestCreateValidator_Copy(t *testing.T) {
 	tests := []struct {
 		cv CreateValidator

--- a/staking/types/messages_test.go
+++ b/staking/types/messages_test.go
@@ -28,7 +28,7 @@ func TestCreateValidator_Copy(t *testing.T) {
 	tests := []struct {
 		cv CreateValidator
 	}{
-		{testCreateValidator}, // normal values
+		{testCreateValidator}, // non-zero values
 		{zeroCreateValidator}, // zero values
 		{CreateValidator{}},   // empty values
 	}
@@ -45,7 +45,7 @@ func TestEditValidator_Copy(t *testing.T) {
 	tests := []struct {
 		ev EditValidator
 	}{
-		{testEditValidator}, // normal values
+		{testEditValidator}, // non-zero values
 		{zeroEditValidator}, // zero values
 		{EditValidator{}},   // empty values
 	}
@@ -56,6 +56,132 @@ func TestEditValidator_Copy(t *testing.T) {
 			t.Errorf("Test %v: %v", i, err)
 		}
 	}
+}
+
+func TestDelegate_Copy(t *testing.T) {
+	tests := []struct {
+		d Delegate
+	}{
+		{testDelegate}, // non-zero values
+		{zeroDelegate}, // zero values
+		{Delegate{}},   // empty values
+	}
+	for i, test := range tests {
+		cp := test.d.Copy().(Delegate)
+
+		if err := assertDelegateDeepEqual(test.d, cp); err != nil {
+			t.Errorf("Test %v: %v", i, err)
+		}
+	}
+}
+
+func assertCreateValidatorDeepCopy(cv1, cv2 CreateValidator) error {
+	if !reflect.DeepEqual(cv1, cv2) {
+		return fmt.Errorf("not deep equal")
+	}
+	if &cv1.Description == &cv2.Description {
+		return fmt.Errorf("description not copy")
+	}
+	if err := assertCommissionRatesCopy(cv1.CommissionRates, cv2.CommissionRates); err != nil {
+		return fmt.Errorf("commissionRate %v", err)
+	}
+	if err := assertBigIntCopy(cv1.MinSelfDelegation, cv2.MinSelfDelegation); err != nil {
+		return fmt.Errorf("MinSelfDelegation %v", err)
+	}
+	if err := assertBigIntCopy(cv1.MaxTotalDelegation, cv2.MaxTotalDelegation); err != nil {
+		return fmt.Errorf("MaxTotalDelegation %v", err)
+	}
+	if err := assertPubsCopy(cv1.SlotPubKeys, cv2.SlotPubKeys); err != nil {
+		return fmt.Errorf("SlotPubKeys %v", err)
+	}
+	if err := assertSigsCopy(cv1.SlotKeySigs, cv2.SlotKeySigs); err != nil {
+		return fmt.Errorf("SlotKeySigs %v", err)
+	}
+	if err := assertBigIntCopy(cv1.Amount, cv2.Amount); err != nil {
+		return fmt.Errorf("amount %v", err)
+	}
+	return nil
+}
+
+func assertEditValidatorDeepCopy(ev1, ev2 EditValidator) error {
+	if !reflect.DeepEqual(ev1, ev2) {
+		return errors.New("not deep equal")
+	}
+	if &ev1.ValidatorAddress == &ev2.ValidatorAddress {
+		return fmt.Errorf("validator address same pointer")
+	}
+	if &ev1.Description == &ev2.Description {
+		return fmt.Errorf("description same pointer")
+	}
+	if ev1.CommissionRate != nil && ev1.CommissionRate == ev2.CommissionRate {
+		return fmt.Errorf("CommissionRate same pointer")
+	}
+	if err := assertBigIntCopy(ev1.MinSelfDelegation, ev2.MinSelfDelegation); err != nil {
+		return fmt.Errorf("MinSelfDelegation %v", err)
+	}
+	if err := assertBigIntCopy(ev1.MaxTotalDelegation, ev2.MaxTotalDelegation); err != nil {
+		return fmt.Errorf("MaxTotalDelegation %v", err)
+	}
+	if ev1.SlotKeyToRemove != nil && ev1.SlotKeyToRemove == ev2.SlotKeyToRemove {
+		return fmt.Errorf("SlotKeyToRemove same pointer")
+	}
+	if ev1.SlotKeyToAdd != nil && ev1.SlotKeyToAdd == ev2.SlotKeyToAdd {
+		return fmt.Errorf("SlotKeyToAdd same pointer")
+	}
+	if ev1.SlotKeyToAddSig != nil && ev1.SlotKeyToAddSig == ev2.SlotKeyToAddSig {
+		return fmt.Errorf("SlotKeyToAddSig same pointer")
+	}
+	return nil
+}
+
+func assertDelegateDeepEqual(d1, d2 Delegate) error {
+	if !reflect.DeepEqual(d1, d2) {
+		return fmt.Errorf("not deep equal")
+	}
+	if &d1.DelegatorAddress == &d2.DelegatorAddress {
+		return fmt.Errorf("DelegatorAddress same pointer")
+	}
+	if &d1.ValidatorAddress == &d2.ValidatorAddress {
+		return fmt.Errorf("ValidatorAddress same pointer")
+	}
+	if d1.Amount != nil && d1.Amount == d2.Amount {
+		return fmt.Errorf("amount same pointer")
+	}
+	return nil
+}
+
+func assertBigIntCopy(i1, i2 *big.Int) error {
+	if (i1 == nil) != (i2 == nil) {
+		return errors.New("is nil not equal")
+	}
+	if i1 != nil && i1 == i2 {
+		return errors.New("not copy")
+	}
+	return nil
+}
+
+func assertPubsCopy(s1, s2 []shard.BLSPublicKey) error {
+	if len(s1) != len(s2) {
+		return fmt.Errorf("size not equal")
+	}
+	for i := range s1 {
+		if &s1[i] == &s2[i] {
+			return fmt.Errorf("[%v] same address", i)
+		}
+	}
+	return nil
+}
+
+func assertSigsCopy(s1, s2 []shard.BLSSignature) error {
+	if len(s1) != len(s2) {
+		return fmt.Errorf("size not equal")
+	}
+	for i := range s1 {
+		if &s1[i] == &s2[i] {
+			return fmt.Errorf("[%v] same address", i)
+		}
+	}
+	return nil
 }
 
 func cpTestDataSetup() {
@@ -140,103 +266,6 @@ func cpTestDataSetup() {
 		DelegatorAddress: common.BigToAddress(common.Big1),
 	}
 	zeroCollectReward = CollectRewards{}
-}
-
-func assertCreateValidatorDeepCopy(cv1, cv2 CreateValidator) error {
-	if !reflect.DeepEqual(cv1, cv2) {
-		return fmt.Errorf("not deep equal")
-	}
-	if &cv1.Description == &cv2.Description {
-		return fmt.Errorf("description not copy")
-	}
-	if err := assertCommissionRatesCopy(cv1.CommissionRates, cv2.CommissionRates); err != nil {
-		return fmt.Errorf("commissionRate %v", err)
-	}
-	if err := assertBigIntCopy(cv1.MinSelfDelegation, cv2.MinSelfDelegation); err != nil {
-		return fmt.Errorf("MinSelfDelegation %v", err)
-	}
-	if err := assertBigIntCopy(cv1.MaxTotalDelegation, cv2.MaxTotalDelegation); err != nil {
-		return fmt.Errorf("MaxTotalDelegation %v", err)
-	}
-	if err := assertPubsCopy(cv1.SlotPubKeys, cv2.SlotPubKeys); err != nil {
-		return fmt.Errorf("SlotPubKeys %v", err)
-	}
-	if err := assertSigsCopy(cv1.SlotKeySigs, cv2.SlotKeySigs); err != nil {
-		return fmt.Errorf("SlotKeySigs %v", err)
-	}
-	if err := assertBigIntCopy(cv1.Amount, cv2.Amount); err != nil {
-		return fmt.Errorf("amount %v", err)
-	}
-	return nil
-}
-
-func assertEditValidatorDeepCopy(ev1, ev2 EditValidator) error {
-	if !reflect.DeepEqual(ev1, ev2) {
-		return errors.New("not deep equal")
-	}
-	if &ev1.ValidatorAddress == &ev2.ValidatorAddress {
-		return fmt.Errorf("validator address same pointer")
-	}
-	if &ev1.Description == &ev2.Description {
-		return fmt.Errorf("description same pointer")
-	}
-	if ev1.CommissionRate != nil && ev1.CommissionRate == ev2.CommissionRate {
-		return fmt.Errorf("CommissionRate same pointer")
-	}
-	if err := assertBigIntCopy(ev1.MinSelfDelegation, ev2.MinSelfDelegation); err != nil {
-		return fmt.Errorf("MinSelfDelegation %v", err)
-	}
-	if err := assertBigIntCopy(ev1.MaxTotalDelegation, ev2.MaxTotalDelegation); err != nil {
-		return fmt.Errorf("MaxTotalDelegation %v", err)
-	}
-	if ev1.SlotKeyToRemove != nil && ev1.SlotKeyToRemove == ev2.SlotKeyToRemove {
-		return fmt.Errorf("SlotKeyToRemove same pointer")
-	}
-	if ev1.SlotKeyToAdd != nil && ev1.SlotKeyToAdd == ev2.SlotKeyToAdd {
-		return fmt.Errorf("SlotKeyToAdd same pointer")
-	}
-	if ev1.SlotKeyToAddSig != nil && ev1.SlotKeyToAddSig == ev2.SlotKeyToAddSig {
-		return fmt.Errorf("SlotKeyToAddSig same pointer")
-	}
-	return nil
-}
-
-func assertDelegateDeepEqual(d1, d2 Delegate) error {
-	return nil
-}
-
-func assertBigIntCopy(i1, i2 *big.Int) error {
-	if (i1 == nil) != (i2 == nil) {
-		return errors.New("is nil not equal")
-	}
-	if i1 != nil && i1 == i2 {
-		return errors.New("not copy")
-	}
-	return nil
-}
-
-func assertPubsCopy(s1, s2 []shard.BLSPublicKey) error {
-	if len(s1) != len(s2) {
-		return fmt.Errorf("size not equal")
-	}
-	for i := range s1 {
-		if &s1[i] == &s2[i] {
-			return fmt.Errorf("[%v] same address", i)
-		}
-	}
-	return nil
-}
-
-func assertSigsCopy(s1, s2 []shard.BLSSignature) error {
-	if len(s1) != len(s2) {
-		return fmt.Errorf("size not equal")
-	}
-	for i := range s1 {
-		if &s1[i] == &s2[i] {
-			return fmt.Errorf("[%v] same address", i)
-		}
-	}
-	return nil
 }
 
 // var (

--- a/staking/types/messages_test.go
+++ b/staking/types/messages_test.go
@@ -35,7 +35,7 @@ func TestCreateValidator_Copy(t *testing.T) {
 	for i, test := range tests {
 		cp := test.cv.Copy().(CreateValidator)
 
-		if err := assertCreateValidatorDeepCopy(test.cv, cp); err != nil {
+		if err := assertCreateValidatorDeepCopy(cp, test.cv); err != nil {
 			t.Errorf("Test %v: %v", i, err)
 		}
 	}
@@ -52,7 +52,7 @@ func TestEditValidator_Copy(t *testing.T) {
 	for i, test := range tests {
 		cp := test.ev.Copy().(EditValidator)
 
-		if err := assertEditValidatorDeepCopy(test.ev, cp); err != nil {
+		if err := assertEditValidatorDeepCopy(cp, test.ev); err != nil {
 			t.Errorf("Test %v: %v", i, err)
 		}
 	}
@@ -69,7 +69,40 @@ func TestDelegate_Copy(t *testing.T) {
 	for i, test := range tests {
 		cp := test.d.Copy().(Delegate)
 
-		if err := assertDelegateDeepEqual(test.d, cp); err != nil {
+		if err := assertDelegateDeepEqual(cp, test.d); err != nil {
+			t.Errorf("Test %v: %v", i, err)
+		}
+	}
+}
+
+func TestUndelegate_Copy(t *testing.T) {
+	tests := []struct {
+		u Undelegate
+	}{
+		{testUndelegate}, // non-zero values
+		{zeroUndelegate}, // zero values
+		{Undelegate{}},   // empty values
+	}
+	for i, test := range tests {
+		cp := test.u.Copy().(Undelegate)
+
+		if err := assertUndelegateDeepEqual(cp, test.u); err != nil {
+			t.Errorf("Test %v: %v", i, err)
+		}
+	}
+}
+
+func TestCollectRewards_Copy(t *testing.T) {
+	tests := []struct {
+		cr CollectRewards
+	}{
+		{testCollectReward}, // non-zero values
+		{zeroCollectReward}, // zero values
+	}
+	for i, test := range tests {
+		cp := test.cr.Copy().(CollectRewards)
+
+		if err := assertCollectRewardDeepEqual(cp, test.cr); err != nil {
 			t.Errorf("Test %v: %v", i, err)
 		}
 	}
@@ -146,6 +179,32 @@ func assertDelegateDeepEqual(d1, d2 Delegate) error {
 	}
 	if d1.Amount != nil && d1.Amount == d2.Amount {
 		return fmt.Errorf("amount same pointer")
+	}
+	return nil
+}
+
+func assertUndelegateDeepEqual(u1, u2 Undelegate) error {
+	if !reflect.DeepEqual(u1, u2) {
+		return fmt.Errorf("not deep equal")
+	}
+	if &u1.DelegatorAddress == &u2.DelegatorAddress {
+		return fmt.Errorf("DelegatorAddress same pointer")
+	}
+	if &u1.ValidatorAddress == &u2.ValidatorAddress {
+		return fmt.Errorf("ValidatorAddress same pointer")
+	}
+	if u1.Amount != nil && u1.Amount == u2.Amount {
+		return fmt.Errorf("amount same pointer")
+	}
+	return nil
+}
+
+func assertCollectRewardDeepEqual(cr1, cr2 CollectRewards) error {
+	if !reflect.DeepEqual(cr1, cr2) {
+		return fmt.Errorf("not deep equal")
+	}
+	if &cr1.DelegatorAddress == &cr2.DelegatorAddress {
+		return fmt.Errorf("DelegatorAddress same pointer")
 	}
 	return nil
 }


### PR DESCRIPTION
## Issue

Closes [#2920 Fix StakingMsg Deep Copy](https://github.com/harmony-one/harmony/issues/2920).

* Reimplemented the deep copy methods for StakingMsgs in `staking/types`.
* Added the corresponding unit test cases.

## Test

### Unit Test Coverage

Before:

```
$ go test --cover
PASS
coverage: 44.7% of statements
ok      github.com/harmony-one/harmony/staking/types    0.228s
```

After:

```
$ go test --cover
PASS
coverage: 52.2% of statements
ok      github.com/harmony-one/harmony/staking/types    0.494s
```

## Compatibility issues

There shall not be any compatibility issues in this PR since it's just a reimplementation on the current method. 
