### PR TITLE
Fix error sink msg duplication & false positives

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/harmony-one/harmony/consensus"
 	"github.com/harmony-one/harmony/consensus/quorum"
 	"github.com/harmony-one/harmony/core"
+	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/internal/blsgen"
 	"github.com/harmony-one/harmony/internal/common"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
@@ -451,15 +452,20 @@ func setupConsensusAndNode(nodeConfig *nodeconfig.ConfigType) *node.Node {
 	currentConsensus.SetCommitDelay(commitDelay)
 	currentConsensus.MinPeers = *minPeers
 
+	// Current node.
+	chainDBFactory := &shardchain.LDBFactory{RootDir: nodeConfig.DBDir}
 	blacklist, err := setupBlacklist()
 	if err != nil {
 		utils.Logger().Warn().Msgf("Blacklist setup error: %s", err.Error())
 	}
-
-	// Current node.
-	chainDBFactory := &shardchain.LDBFactory{RootDir: nodeConfig.DBDir}
-
-	currentNode := node.New(myHost, currentConsensus, chainDBFactory, blacklist, *isArchival)
+	transactionErrorSink, err := types.NewTransactionErrorSink()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Error when setting up TransactionErrorSink: %v \n", err)
+		os.Exit(1)
+	}
+	currentNode := node.New(
+		myHost, currentConsensus, chainDBFactory, blacklist, transactionErrorSink, *isArchival,
+	)
 
 	switch {
 	case *networkType == nodeconfig.Localnet:

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -25,7 +25,6 @@ import (
 	"github.com/harmony-one/harmony/consensus"
 	"github.com/harmony-one/harmony/consensus/quorum"
 	"github.com/harmony-one/harmony/core"
-	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/internal/blsgen"
 	"github.com/harmony-one/harmony/internal/common"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
@@ -452,20 +451,15 @@ func setupConsensusAndNode(nodeConfig *nodeconfig.ConfigType) *node.Node {
 	currentConsensus.SetCommitDelay(commitDelay)
 	currentConsensus.MinPeers = *minPeers
 
-	// Current node.
-	chainDBFactory := &shardchain.LDBFactory{RootDir: nodeConfig.DBDir}
 	blacklist, err := setupBlacklist()
 	if err != nil {
 		utils.Logger().Warn().Msgf("Blacklist setup error: %s", err.Error())
 	}
-	transactionErrorSink, err := types.NewTransactionErrorSink()
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Error when setting up TransactionErrorSink: %v \n", err)
-		os.Exit(1)
-	}
-	currentNode := node.New(
-		myHost, currentConsensus, chainDBFactory, blacklist, transactionErrorSink, *isArchival,
-	)
+
+	// Current node.
+	chainDBFactory := &shardchain.LDBFactory{RootDir: nodeConfig.DBDir}
+
+	currentNode := node.New(myHost, currentConsensus, chainDBFactory, blacklist, *isArchival)
 
 	switch {
 	case *networkType == nodeconfig.Localnet:

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -863,6 +863,10 @@ func (pool *TxPool) validateStakingTx(tx *staking.StakingTransaction) error {
 // the pool due to pricing constraints.
 func (pool *TxPool) add(tx types.PoolTransaction, local bool) (bool, error) {
 	logger := utils.Logger().With().Stack().Logger()
+	// If the transaction is in the error sink, remove it as it may succeed
+	if pool.txErrorSink.Contains(tx.Hash().String()) {
+		pool.txErrorSink.Remove(tx)
+	}
 	// If the transaction is already known, discard it
 	hash := tx.Hash()
 	if pool.all.Get(hash) != nil {

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -250,33 +250,32 @@ type TxPool struct {
 
 	wg sync.WaitGroup // for shutdown sync
 
-	errorReporter *txPoolErrorReporter // The reporter for the tx error sinks
+	txErrorSink *types.TransactionErrorSink // All failed txs gets reported here
 
 	homestead bool
 }
 
 // NewTxPool creates a new transaction pool to gather, sort and filter inbound
 // transactions from the network.
-func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain blockChain,
-	txnErrorSink func([]types.RPCTransactionError),
-	stakingTxnErrorSink func([]staking.RPCTransactionError),
+func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig,
+	chain blockChain, txErrorSink *types.TransactionErrorSink,
 ) *TxPool {
 	// Sanitize the input to ensure no vulnerable gas prices are set
 	config = (&config).sanitize()
 
 	// Create the transaction pool with its initial settings
 	pool := &TxPool{
-		config:        config,
-		chainconfig:   chainconfig,
-		chain:         chain,
-		signer:        types.NewEIP155Signer(chainconfig.ChainID),
-		pending:       make(map[common.Address]*txList),
-		queue:         make(map[common.Address]*txList),
-		beats:         make(map[common.Address]time.Time),
-		all:           newTxLookup(),
-		chainHeadCh:   make(chan ChainHeadEvent, chainHeadChanSize),
-		gasPrice:      new(big.Int).SetUint64(config.PriceLimit),
-		errorReporter: newTxPoolErrorReporter(txnErrorSink, stakingTxnErrorSink),
+		config:      config,
+		chainconfig: chainconfig,
+		chain:       chain,
+		signer:      types.NewEIP155Signer(chainconfig.ChainID),
+		pending:     make(map[common.Address]*txList),
+		queue:       make(map[common.Address]*txList),
+		beats:       make(map[common.Address]time.Time),
+		all:         newTxLookup(),
+		chainHeadCh: make(chan ChainHeadEvent, chainHeadChanSize),
+		gasPrice:    new(big.Int).SetUint64(config.PriceLimit),
+		txErrorSink: txErrorSink,
 	}
 	pool.locals = newAccountSet(pool.signer)
 	for _, addr := range config.Locals {
@@ -1069,7 +1068,7 @@ func (pool *TxPool) addTx(tx types.PoolTransaction, local bool) error {
 	if err != nil {
 		errCause := errors.Cause(err)
 		if errCause != ErrKnownTransaction {
-			pool.errorReporter.add(tx, err)
+			pool.txErrorSink.Add(tx, err)
 		}
 		return errCause
 	}
@@ -1077,10 +1076,6 @@ func (pool *TxPool) addTx(tx types.PoolTransaction, local bool) error {
 	if !replace {
 		from, _ := types.PoolTransactionSender(pool.signer, tx) // already validated
 		pool.promoteExecutables([]common.Address{from})
-	}
-	if err := pool.errorReporter.report(); err != nil {
-		utils.Logger().Error().Err(err).
-			Msg("could not report failed transactions in tx pool when adding 1 tx")
 	}
 	return nil
 }
@@ -1108,7 +1103,7 @@ func (pool *TxPool) addTxsLocked(txs types.PoolTransactions, local bool) []error
 		}
 		errCause := errors.Cause(err)
 		if err != nil && errCause != ErrKnownTransaction {
-			pool.errorReporter.add(tx, err)
+			pool.txErrorSink.Add(tx, err)
 		}
 		errs[i] = errCause
 	}
@@ -1121,11 +1116,6 @@ func (pool *TxPool) addTxsLocked(txs types.PoolTransactions, local bool) []error
 			i++
 		}
 		pool.promoteExecutables(addrs)
-	}
-
-	if err := pool.errorReporter.report(); err != nil {
-		utils.Logger().Error().Err(err).
-			Msg("could not report failed transactions in tx pool when adding txs")
 	}
 	return errs
 }
@@ -1182,7 +1172,7 @@ func (pool *TxPool) removeTx(hash common.Hash, outofbound bool) {
 			// Postpone any invalidated transactions
 			for _, tx := range invalids {
 				if _, err := pool.enqueueTx(tx.Hash(), tx); err != nil {
-					pool.errorReporter.add(tx, err)
+					pool.txErrorSink.Add(tx, err)
 				}
 			}
 			// Update the account nonce if needed
@@ -1198,11 +1188,6 @@ func (pool *TxPool) removeTx(hash common.Hash, outofbound bool) {
 		if future.Empty() {
 			delete(pool.queue, addr)
 		}
-	}
-
-	if err := pool.errorReporter.report(); err != nil {
-		utils.Logger().Error().Err(err).
-			Msg("could not report failed transactions in tx pool when removing tx from queue")
 	}
 }
 
@@ -1259,7 +1244,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 			for _, tx := range list.Cap(int(pool.config.AccountQueue)) {
 				hash := tx.Hash()
 				logger.Warn().Str("hash", hash.Hex()).Msg("Removed cap-exceeding queued transaction")
-				pool.errorReporter.add(tx, fmt.Errorf("exceeds cap for queued transactions for account %s", addr.String()))
+				pool.txErrorSink.Add(tx, fmt.Errorf("exceeds cap for queued transactions for account %s", addr.String()))
 				pool.all.Remove(hash)
 				pool.priced.Removed()
 				queuedRateLimitCounter.Inc(1)
@@ -1308,7 +1293,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 						for _, tx := range list.Cap(list.Len() - 1) {
 							// Drop the transaction from the global pools too
 							hash := tx.Hash()
-							pool.errorReporter.add(tx, fmt.Errorf("fairness-exceeding pending transaction"))
+							pool.txErrorSink.Add(tx, fmt.Errorf("fairness-exceeding pending transaction"))
 							pool.all.Remove(hash)
 							pool.priced.Removed()
 
@@ -1331,7 +1316,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 					for _, tx := range list.Cap(list.Len() - 1) {
 						// Drop the transaction from the global pools too
 						hash := tx.Hash()
-						pool.errorReporter.add(tx, fmt.Errorf("fairness-exceeding pending transaction"))
+						pool.txErrorSink.Add(tx, fmt.Errorf("fairness-exceeding pending transaction"))
 						pool.all.Remove(hash)
 						pool.priced.Removed()
 
@@ -1372,7 +1357,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 			// Drop all transactions if they are less than the overflow
 			if size := uint64(list.Len()); size <= drop {
 				for _, tx := range list.Flatten() {
-					pool.errorReporter.add(tx, fmt.Errorf("exceeds global cap for queued transactions"))
+					pool.txErrorSink.Add(tx, fmt.Errorf("exceeds global cap for queued transactions"))
 					pool.removeTx(tx.Hash(), true)
 				}
 				drop -= size
@@ -1382,17 +1367,12 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 			// Otherwise drop only last few transactions
 			txs := list.Flatten()
 			for i := len(txs) - 1; i >= 0 && drop > 0; i-- {
-				pool.errorReporter.add(txs[i], fmt.Errorf("exceeds global cap for queued transactions"))
+				pool.txErrorSink.Add(txs[i], fmt.Errorf("exceeds global cap for queued transactions"))
 				pool.removeTx(txs[i].Hash(), true)
 				drop--
 				queuedRateLimitCounter.Inc(1)
 			}
 		}
-	}
-
-	if err := pool.errorReporter.report(); err != nil {
-		logger.Error().Err(err).
-			Msg("could not report failed transactions in tx pool when promoting executables")
 	}
 }
 
@@ -1426,7 +1406,7 @@ func (pool *TxPool) demoteUnexecutables() {
 			hash := tx.Hash()
 			logger.Warn().Str("hash", hash.Hex()).Msg("Demoting pending transaction")
 			if _, err := pool.enqueueTx(hash, tx); err != nil {
-				pool.errorReporter.add(tx, err)
+				pool.txErrorSink.Add(tx, err)
 			}
 		}
 		// If there's a gap in front, alert (should never happen) and postpone all transactions
@@ -1435,7 +1415,7 @@ func (pool *TxPool) demoteUnexecutables() {
 				hash := tx.Hash()
 				logger.Error().Str("hash", hash.Hex()).Msg("Demoting invalidated transaction")
 				if _, err := pool.enqueueTx(hash, tx); err != nil {
-					pool.errorReporter.add(tx, err)
+					pool.txErrorSink.Add(tx, err)
 				}
 			}
 		}
@@ -1444,62 +1424,7 @@ func (pool *TxPool) demoteUnexecutables() {
 			delete(pool.pending, addr)
 			delete(pool.beats, addr)
 		}
-
-		if err := pool.errorReporter.report(); err != nil {
-			logger.Error().Err(err).
-				Msg("could not report failed transactions in tx pool when demoting unexecutables")
-		}
 	}
-}
-
-// txPoolErrorReporter holds and reports transaction errors in the tx-pool.
-// Format assumes that error i in errors corresponds to transaction i in transactions.
-type txPoolErrorReporter struct {
-	transactions          types.PoolTransactions
-	errors                []error
-	txnErrorReportSink    func([]types.RPCTransactionError)
-	stkTxnErrorReportSink func([]staking.RPCTransactionError)
-}
-
-func newTxPoolErrorReporter(txnErrorSink func([]types.RPCTransactionError),
-	stakingTxnErrorSink func([]staking.RPCTransactionError),
-) *txPoolErrorReporter {
-	return &txPoolErrorReporter{
-		transactions:          types.PoolTransactions{},
-		errors:                []error{},
-		txnErrorReportSink:    txnErrorSink,
-		stkTxnErrorReportSink: stakingTxnErrorSink,
-	}
-}
-
-func (txErrs *txPoolErrorReporter) add(tx types.PoolTransaction, err error) {
-	txErrs.transactions = append(txErrs.transactions, tx)
-	txErrs.errors = append(txErrs.errors, err)
-}
-
-func (txErrs *txPoolErrorReporter) reset() {
-	txErrs.transactions = types.PoolTransactions{}
-	txErrs.errors = []error{}
-}
-
-// report errors thrown in the tx pool to the appropriate error sink.
-// It resets the held errors after the errors are reported to the sink.
-func (txErrs *txPoolErrorReporter) report() error {
-	plainTxErrors := []types.RPCTransactionError{}
-	stakingTxErrors := []staking.RPCTransactionError{}
-	for i, tx := range txErrs.transactions {
-		if plainTx, ok := tx.(*types.Transaction); ok {
-			plainTxErrors = append(plainTxErrors, types.NewRPCTransactionError(plainTx.Hash(), txErrs.errors[i]))
-		} else if stakingTx, ok := tx.(*staking.StakingTransaction); ok {
-			stakingTxErrors = append(stakingTxErrors, staking.NewRPCTransactionError(stakingTx.Hash(), stakingTx.StakingType(), txErrs.errors[i]))
-		} else {
-			return types.ErrUnknownPoolTxType
-		}
-	}
-	txErrs.txnErrorReportSink(plainTxErrors)
-	txErrs.stkTxnErrorReportSink(stakingTxErrors)
-	txErrs.reset()
-	return nil
 }
 
 // addressByHeartbeat is an account address tagged with its last activity timestamp.

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -50,10 +50,10 @@ var (
 	testBLSPubKey    = "30b2c38b1316da91e068ac3bd8751c0901ef6c02a1d58bc712104918302c6ed03d5894671d0c816dad2b4d303320f202"
 	testBLSPrvKey    = "c6d7603520311f7a4e6aac0b26701fc433b75b38df504cd416ef2b900cd66205"
 
-	gasPrice          = big.NewInt(1e9)
-	gasLimit          = big.NewInt(int64(params.TxGasValidatorCreation))
-	cost              = big.NewInt(1).Mul(gasPrice, gasLimit)
-	dummyErrorSink, _ = types.NewTransactionErrorSink()
+	gasPrice       = big.NewInt(1e9)
+	gasLimit       = big.NewInt(int64(params.TxGasValidatorCreation))
+	cost           = big.NewInt(1).Mul(gasPrice, gasLimit)
+	dummyErrorSink = types.NewTransactionErrorSink()
 )
 
 func init() {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"math/big"
 	"sync/atomic"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -69,22 +68,6 @@ type Transaction struct {
 	hash atomic.Value
 	size atomic.Value
 	from atomic.Value
-}
-
-// RPCTransactionError ..
-type RPCTransactionError struct {
-	TxHashID             string `json:"tx-hash-id"`
-	TimestampOfRejection int64  `json:"time-at-rejection"`
-	ErrMessage           string `json:"error-message"`
-}
-
-// NewRPCTransactionError ...
-func NewRPCTransactionError(hash common.Hash, err error) RPCTransactionError {
-	return RPCTransactionError{
-		TxHashID:             hash.Hex(),
-		TimestampOfRejection: time.Now().Unix(),
-		ErrMessage:           err.Error(),
-	}
 }
 
 //String print mode string

--- a/core/types/tx_errorsink.go
+++ b/core/types/tx_errorsink.go
@@ -1,0 +1,166 @@
+package types
+
+import (
+	"time"
+
+	lru "github.com/hashicorp/golang-lru"
+
+	"github.com/harmony-one/harmony/internal/utils"
+	staking "github.com/harmony-one/harmony/staking/types"
+)
+
+const (
+	maxPlainSinkCapacity   = 1024
+	maxStakingSinkCapacity = 1024
+	logTag                 = "[TransactionErrorSink]"
+)
+
+// TransactionError ..
+type TransactionError struct {
+	TxHashID             string `json:"tx-hash-id"`
+	StakingDirective     string `json:"directive-kind,omitempty"`
+	TimestampOfRejection int64  `json:"time-at-rejection"`
+	ErrMessage           string `json:"error-message"`
+}
+
+// TransactionErrors
+type TransactionErrors []*TransactionError
+
+// TransactionErrorSink is where all failed transactions get reported.
+// Note that the keys of the lru caches are tx-hash strings.
+type TransactionErrorSink struct {
+	failedPlainTxs   *lru.Cache
+	failedStakingTxs *lru.Cache
+}
+
+// NewTransactionErrorSink ..
+func NewTransactionErrorSink() (*TransactionErrorSink, error) {
+	failedPlainTx, err := lru.New(maxPlainSinkCapacity)
+	if err != nil {
+		return nil, err
+	}
+	failedStakingTx, err := lru.New(maxStakingSinkCapacity)
+	if err != nil {
+		return nil, err
+	}
+	return &TransactionErrorSink{
+		failedPlainTxs:   failedPlainTx,
+		failedStakingTxs: failedStakingTx,
+	}, nil
+}
+
+// Add a transaction to the error sink with the given error
+func (sink *TransactionErrorSink) Add(tx PoolTransaction, err error) {
+	// no-op if no error is provided
+	if err == nil {
+		return
+	}
+	if plainTx, ok := tx.(*Transaction); ok {
+		hash := plainTx.Hash().String()
+		sink.failedPlainTxs.Add(hash, &TransactionError{
+			TxHashID:             hash,
+			TimestampOfRejection: time.Now().Unix(),
+			ErrMessage:           err.Error(),
+		})
+		utils.Logger().Debug().
+			Str("tag", logTag).
+			Interface("tx-hash-id", hash).
+			Msgf("Added plain transaction error message")
+	} else if stakingTx, ok := tx.(*staking.StakingTransaction); ok {
+		hash := stakingTx.Hash().String()
+		sink.failedStakingTxs.Add(hash, &TransactionError{
+			TxHashID:             hash,
+			StakingDirective:     stakingTx.StakingType().String(),
+			TimestampOfRejection: time.Now().Unix(),
+			ErrMessage:           err.Error(),
+		})
+		utils.Logger().Debug().
+			Str("tag", logTag).
+			Interface("tx-hash-id", hash).
+			Msgf("Added staking transaction error message")
+	} else {
+		utils.Logger().Error().
+			Str("tag", logTag).
+			Interface("tx", tx).
+			Msg("Attempted to add an unknown transaction type")
+	}
+}
+
+// Contains checks if there is an error associated with the given hash
+// Note that the keys of the lru caches are tx-hash strings.
+func (sink *TransactionErrorSink) Contains(hash string) bool {
+	return sink.failedPlainTxs.Contains(hash) || sink.failedStakingTxs.Contains(hash)
+}
+
+// Remove a transaction's error from the error sink
+func (sink *TransactionErrorSink) Remove(tx PoolTransaction) {
+	if plainTx, ok := tx.(*Transaction); ok {
+		hash := plainTx.Hash().String()
+		present := sink.failedPlainTxs.Remove(hash)
+		utils.Logger().Debug().
+			Str("tag", logTag).
+			Interface("tx-hash-id", hash).
+			Bool("was-in-error-sink", present).
+			Msgf("Removed plain transaction error message")
+	} else if stakingTx, ok := tx.(*staking.StakingTransaction); ok {
+		hash := stakingTx.Hash().String()
+		present := sink.failedStakingTxs.Remove(hash)
+		utils.Logger().Debug().
+			Str("tag", logTag).
+			Interface("tx-hash-id", hash).
+			Bool("was-in-error-sink", present).
+			Msgf("Removed staking transaction error message")
+	} else {
+		utils.Logger().Error().
+			Str("tag", logTag).
+			Interface("tx", tx).
+			Msg("Attempted to remove an unknown transaction type")
+	}
+}
+
+// PlainReport ..
+func (sink *TransactionErrorSink) PlainReport() TransactionErrors {
+	return reportErrorsFromLruCache(sink.failedPlainTxs)
+}
+
+// StakingReport ..
+func (sink *TransactionErrorSink) StakingReport() TransactionErrors {
+	return reportErrorsFromLruCache(sink.failedStakingTxs)
+}
+
+// PlainCount ..
+func (sink *TransactionErrorSink) PlainCount() int {
+	return sink.failedPlainTxs.Len()
+}
+
+// StakingCount ..
+func (sink *TransactionErrorSink) StakingCount() int {
+	return sink.failedStakingTxs.Len()
+}
+
+// reportErrorsFromLruCache is a helper for reporting errors
+// from the TransactionErrorSink's lru cache. Do not use this function directly,
+// use the respective public methods of TransactionErrorSink.
+func reportErrorsFromLruCache(lruCache *lru.Cache) TransactionErrors {
+	rpcErrors := TransactionErrors{}
+	for _, txHash := range lruCache.Keys() {
+		rpcErrorFetch, ok := lruCache.Get(txHash)
+		if !ok {
+			utils.Logger().Warn().
+				Str("tag", logTag).
+				Interface("tx-hash-id", txHash).
+				Msgf("Error not found in staking sink")
+			continue
+		}
+		rpcError, ok := rpcErrorFetch.(*TransactionError)
+		if !ok {
+			utils.Logger().Error().
+				Str("tag", logTag).
+				Interface("tx-hash-id", txHash).
+				Msgf("Invalid type in staking sink")
+			continue
+		}
+		rpcErrors = append(rpcErrors, rpcError)
+	}
+	return rpcErrors
+}

--- a/core/types/tx_errorsink.go
+++ b/core/types/tx_errorsink.go
@@ -10,9 +10,9 @@ import (
 )
 
 const (
-	maxPlainSinkCapacity   = 1024
-	maxStakingSinkCapacity = 1024
-	logTag                 = "[TransactionErrorSink]"
+	plainTxSinkLimit   = 1024
+	stakingTxSinkLimit = 1024
+	logTag             = "[TransactionErrorSink]"
 )
 
 // TransactionErrorReport ..
@@ -23,7 +23,7 @@ type TransactionErrorReport struct {
 	ErrMessage           string `json:"error-message"`
 }
 
-// TransactionErrorReports
+// TransactionErrorReports ..
 type TransactionErrorReports []*TransactionErrorReport
 
 // TransactionErrorSink is where all failed transactions get reported.
@@ -34,19 +34,13 @@ type TransactionErrorSink struct {
 }
 
 // NewTransactionErrorSink ..
-func NewTransactionErrorSink() (*TransactionErrorSink, error) {
-	failedPlainTx, err := lru.New(maxPlainSinkCapacity)
-	if err != nil {
-		return nil, err
-	}
-	failedStakingTx, err := lru.New(maxStakingSinkCapacity)
-	if err != nil {
-		return nil, err
-	}
+func NewTransactionErrorSink() *TransactionErrorSink {
+	failedPlainTx, _ := lru.New(plainTxSinkLimit)
+	failedStakingTx, _ := lru.New(stakingTxSinkLimit)
 	return &TransactionErrorSink{
 		failedPlainTxs:   failedPlainTx,
 		failedStakingTxs: failedStakingTx,
-	}, nil
+	}
 }
 
 // Add a transaction to the error sink with the given error

--- a/core/types/tx_errorsink.go
+++ b/core/types/tx_errorsink.go
@@ -149,7 +149,7 @@ func reportErrorsFromLruCache(lruCache *lru.Cache) TransactionErrors {
 			utils.Logger().Warn().
 				Str("tag", logTag).
 				Interface("tx-hash-id", txHash).
-				Msgf("Error not found in staking sink")
+				Msgf("Error not found in sink")
 			continue
 		}
 		rpcError, ok := rpcErrorFetch.(*TransactionError)
@@ -157,7 +157,7 @@ func reportErrorsFromLruCache(lruCache *lru.Cache) TransactionErrors {
 			utils.Logger().Error().
 				Str("tag", logTag).
 				Interface("tx-hash-id", txHash).
-				Msgf("Invalid type in staking sink")
+				Msgf("Invalid type of value in sink")
 			continue
 		}
 		rpcErrors = append(rpcErrors, rpcError)

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -229,7 +229,6 @@ func (b *APIBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscripti
 }
 
 // GetPoolTransactions returns pool transactions.
-// TODO: this is not implemented or verified yet for harmony.
 func (b *APIBackend) GetPoolTransactions() (types.PoolTransactions, error) {
 	pending, err := b.hmy.txPool.Pending()
 	if err != nil {
@@ -240,6 +239,11 @@ func (b *APIBackend) GetPoolTransactions() (types.PoolTransactions, error) {
 		txs = append(txs, batch...)
 	}
 	return txs, nil
+}
+
+// GetPoolStats returns the number of pending and queued transactions
+func (b *APIBackend) GetPoolStats() (pendingCount, queuedCount int) {
+	return b.hmy.txPool.Stats()
 }
 
 // GetAccountNonce returns the nonce value of the given address for the given block number

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -617,13 +617,13 @@ func (b *APIBackend) GetShardState() (*shard.State, error) {
 }
 
 // GetCurrentStakingErrorSink ..
-func (b *APIBackend) GetCurrentStakingErrorSink() []staking.RPCTransactionError {
-	return b.hmy.nodeAPI.ErroredStakingTransactionSink()
+func (b *APIBackend) GetCurrentStakingErrorSink() types.TransactionErrorReports {
+	return b.hmy.nodeAPI.ReportStakingErrorSink()
 }
 
 // GetCurrentTransactionErrorSink ..
-func (b *APIBackend) GetCurrentTransactionErrorSink() []types.RPCTransactionError {
-	return b.hmy.nodeAPI.ErroredTransactionSink()
+func (b *APIBackend) GetCurrentTransactionErrorSink() types.TransactionErrorReports {
+	return b.hmy.nodeAPI.ReportPlainErrorSink()
 }
 
 // GetPendingCXReceipts ..

--- a/hmy/backend.go
+++ b/hmy/backend.go
@@ -48,8 +48,8 @@ type NodeAPI interface {
 	GetTransactionsCount(address, txType string) (uint64, error)
 	GetStakingTransactionsCount(address, txType string) (uint64, error)
 	IsCurrentlyLeader() bool
-	ErroredStakingTransactionSink() []staking.RPCTransactionError
-	ErroredTransactionSink() []types.RPCTransactionError
+	ReportStakingErrorSink() types.TransactionErrorReports
+	ReportPlainErrorSink() types.TransactionErrorReports
 	PendingCXReceipts() []*types.CXReceiptsProof
 	GetNodeBootTime() int64
 }

--- a/internal/configs/sharding/testnet.go
+++ b/internal/configs/sharding/testnet.go
@@ -82,5 +82,5 @@ var testnetReshardingEpoch = []*big.Int{
 	params.TestnetChainConfig.StakingEpoch,
 }
 
-var testnetV0 = MustNewInstance(4, 25, 25, numeric.OneDec(), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())
+var testnetV0 = MustNewInstance(4, 30, 25, numeric.OneDec(), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())
 var testnetV1 = MustNewInstance(4, 50, 25, numeric.MustNewDecFromStr("0.68"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())

--- a/internal/hmyapi/apiv1/backend.go
+++ b/internal/hmyapi/apiv1/backend.go
@@ -51,10 +51,10 @@ type Backend interface {
 	// GetTransaction(ctx context.Context, txHash common.Hash) (*types.Transaction, common.Hash, uint64, uint64, error)
 	GetPoolTransactions() (types.PoolTransactions, error)
 	GetPoolTransaction(txHash common.Hash) types.PoolTransaction
+	GetPoolStats() (pendingCount, queuedCount int)
 	GetPoolNonce(ctx context.Context, addr common.Address) (uint64, error)
 	// Get account nonce
 	GetAccountNonce(ctx context.Context, address common.Address, blockNr rpc.BlockNumber) (uint64, error)
-	// Stats() (pending int, queued int)
 	// TxPoolContent() (map[common.Address]types.Transactions, map[common.Address]types.Transactions)
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
 	ChainConfig() *params.ChainConfig

--- a/internal/hmyapi/apiv1/backend.go
+++ b/internal/hmyapi/apiv1/backend.go
@@ -79,8 +79,8 @@ type Backend interface {
 	GetDelegationsByDelegator(delegator common.Address) ([]common.Address, []*staking.Delegation)
 	GetValidatorSelfDelegation(addr common.Address) *big.Int
 	GetShardState() (*shard.State, error)
-	GetCurrentStakingErrorSink() []staking.RPCTransactionError
-	GetCurrentTransactionErrorSink() []types.RPCTransactionError
+	GetCurrentStakingErrorSink() types.TransactionErrorReports
+	GetCurrentTransactionErrorSink() types.TransactionErrorReports
 	GetMedianRawStakeSnapshot() (*committee.CompletedEPoSRound, error)
 	GetPendingCXReceipts() []*types.CXReceiptsProof
 	GetCurrentUtilityMetrics() (*network.UtilityMetric, error)

--- a/internal/hmyapi/apiv1/transactionpool.go
+++ b/internal/hmyapi/apiv1/transactionpool.go
@@ -376,12 +376,12 @@ func (s *PublicTransactionPoolAPI) PendingStakingTransactions() ([]*RPCStakingTr
 }
 
 // GetCurrentTransactionErrorSink ..
-func (s *PublicTransactionPoolAPI) GetCurrentTransactionErrorSink() []types.RPCTransactionError {
+func (s *PublicTransactionPoolAPI) GetCurrentTransactionErrorSink() types.TransactionErrorReports {
 	return s.b.GetCurrentTransactionErrorSink()
 }
 
 // GetCurrentStakingErrorSink ..
-func (s *PublicTransactionPoolAPI) GetCurrentStakingErrorSink() []staking.RPCTransactionError {
+func (s *PublicTransactionPoolAPI) GetCurrentStakingErrorSink() types.TransactionErrorReports {
 	return s.b.GetCurrentStakingErrorSink()
 }
 

--- a/internal/hmyapi/apiv1/transactionpool.go
+++ b/internal/hmyapi/apiv1/transactionpool.go
@@ -337,6 +337,15 @@ func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, ha
 	return fields, nil
 }
 
+// GetPoolStats returns stats for the tx-pool
+func (s *PublicTransactionPoolAPI) GetPoolStats() map[string]interface{} {
+	pendingCount, queuedCount := s.b.GetPoolStats()
+	return map[string]interface{}{
+		"executable-count":     pendingCount,
+		"non-executable-count": queuedCount,
+	}
+}
+
 // PendingTransactions returns the plain transactions that are in the transaction pool
 func (s *PublicTransactionPoolAPI) PendingTransactions() ([]*RPCTransaction, error) {
 	pending, err := s.b.GetPoolTransactions()

--- a/internal/hmyapi/apiv2/backend.go
+++ b/internal/hmyapi/apiv2/backend.go
@@ -51,6 +51,7 @@ type Backend interface {
 	SendTx(ctx context.Context, signedTx *types.Transaction) error
 	GetPoolTransactions() (types.PoolTransactions, error)
 	GetPoolTransaction(txHash common.Hash) types.PoolTransaction
+	GetPoolStats() (pendingCount, queuedCount int)
 	GetPoolNonce(ctx context.Context, addr common.Address) (uint64, error)
 	GetAccountNonce(ctx context.Context, addr common.Address, blockNr rpc.BlockNumber) (uint64, error)
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription

--- a/internal/hmyapi/apiv2/backend.go
+++ b/internal/hmyapi/apiv2/backend.go
@@ -74,8 +74,8 @@ type Backend interface {
 	GetDelegationsByDelegator(delegator common.Address) ([]common.Address, []*staking.Delegation)
 	GetValidatorSelfDelegation(addr common.Address) *big.Int
 	GetShardState() (*shard.State, error)
-	GetCurrentStakingErrorSink() []staking.RPCTransactionError
-	GetCurrentTransactionErrorSink() []types.RPCTransactionError
+	GetCurrentStakingErrorSink() types.TransactionErrorReports
+	GetCurrentTransactionErrorSink() types.TransactionErrorReports
 	GetMedianRawStakeSnapshot() (*committee.CompletedEPoSRound, error)
 	GetPendingCXReceipts() []*types.CXReceiptsProof
 	GetCurrentUtilityMetrics() (*network.UtilityMetric, error)

--- a/internal/hmyapi/apiv2/transactionpool.go
+++ b/internal/hmyapi/apiv2/transactionpool.go
@@ -418,12 +418,12 @@ func (s *PublicTransactionPoolAPI) PendingStakingTransactions() ([]*RPCStakingTr
 }
 
 // GetCurrentTransactionErrorSink ..
-func (s *PublicTransactionPoolAPI) GetCurrentTransactionErrorSink() []types.RPCTransactionError {
+func (s *PublicTransactionPoolAPI) GetCurrentTransactionErrorSink() types.TransactionErrorReports {
 	return s.b.GetCurrentTransactionErrorSink()
 }
 
 // GetCurrentStakingErrorSink ..
-func (s *PublicTransactionPoolAPI) GetCurrentStakingErrorSink() []staking.RPCTransactionError {
+func (s *PublicTransactionPoolAPI) GetCurrentStakingErrorSink() types.TransactionErrorReports {
 	return s.b.GetCurrentStakingErrorSink()
 }
 

--- a/internal/hmyapi/apiv2/transactionpool.go
+++ b/internal/hmyapi/apiv2/transactionpool.go
@@ -361,6 +361,11 @@ func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, ha
 	return fields, nil
 }
 
+// GetPoolStats returns stats for the tx-pool
+func (s *PublicTransactionPoolAPI) GetPoolStats() (pendingCount, queuedCount int) {
+	return s.b.GetPoolStats()
+}
+
 // PendingTransactions returns the plain transactions that are in the transaction pool
 // and have a from address that is one of the accounts this node manages.
 func (s *PublicTransactionPoolAPI) PendingTransactions() ([]*RPCTransaction, error) {

--- a/internal/hmyapi/backend.go
+++ b/internal/hmyapi/backend.go
@@ -46,6 +46,7 @@ type Backend interface {
 	SendTx(ctx context.Context, signedTx *types.Transaction) error
 	GetPoolTransactions() (types.PoolTransactions, error)
 	GetPoolTransaction(txHash common.Hash) types.PoolTransaction
+	GetPoolStats() (pendingCount, queuedCount int)
 	GetPoolNonce(ctx context.Context, addr common.Address) (uint64, error)
 	GetAccountNonce(ctx context.Context, address common.Address, blockNr rpc.BlockNumber) (uint64, error)
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription

--- a/internal/hmyapi/backend.go
+++ b/internal/hmyapi/backend.go
@@ -68,8 +68,8 @@ type Backend interface {
 	GetDelegationsByDelegator(delegator common.Address) ([]common.Address, []*staking.Delegation)
 	GetValidatorSelfDelegation(addr common.Address) *big.Int
 	GetShardState() (*shard.State, error)
-	GetCurrentStakingErrorSink() []staking.RPCTransactionError
-	GetCurrentTransactionErrorSink() []types.RPCTransactionError
+	GetCurrentStakingErrorSink() types.TransactionErrorReports
+	GetCurrentTransactionErrorSink() types.TransactionErrorReports
 	GetMedianRawStakeSnapshot() (*committee.CompletedEPoSRound, error)
 	GetPendingCXReceipts() []*types.CXReceiptsProof
 	GetCurrentUtilityMetrics() (*network.UtilityMetric, error)

--- a/node/node.go
+++ b/node/node.go
@@ -1,7 +1,6 @@
 package node
 
 import (
-	"container/ring"
 	"context"
 	"crypto/ecdsa"
 	"fmt"
@@ -148,19 +147,15 @@ type Node struct {
 	// Chain configuration.
 	chainConfig params.ChainConfig
 	// map of service type to its message channel.
-	serviceMessageChan map[service.Type]chan *msg_pb.Message
-	isFirstTime        bool // the node was started with a fresh database
-	// Last 1024 staking transaction error, only in memory
-	errorSink struct {
-		sync.Mutex
-		failedStakingTxns *ring.Ring
-		failedTxns        *ring.Ring
-	}
+	serviceMessageChan  map[service.Type]chan *msg_pb.Message
+	isFirstTime         bool // the node was started with a fresh database
 	unixTimeAtNodeStart int64
 	// KeysToAddrs holds the addresses of bls keys run by the node
 	KeysToAddrs      map[string]common.Address
 	keysToAddrsEpoch *big.Int
 	keysToAddrsMutex sync.Mutex
+	// TransactionErrorSink contains error messages for any failed transaction, in memory only
+	TransactionErrorSink *types.TransactionErrorSink
 }
 
 // Blockchain returns the blockchain for the node's current shard.
@@ -428,16 +423,12 @@ func New(
 	consensusObj *consensus.Consensus,
 	chainDBFactory shardchain.DBFactory,
 	blacklist map[common.Address]struct{},
+	transactionErrorSink *types.TransactionErrorSink,
 	isArchival bool,
 ) *Node {
 	node := Node{}
 	node.unixTimeAtNodeStart = time.Now().Unix()
-	const sinkSize = 4096
-	node.errorSink = struct {
-		sync.Mutex
-		failedStakingTxns *ring.Ring
-		failedTxns        *ring.Ring
-	}{sync.Mutex{}, ring.New(sinkSize), ring.New(sinkSize)}
+	node.TransactionErrorSink = transactionErrorSink
 	// Get the node config that's created in the harmony.go program.
 	if consensusObj != nil {
 		node.NodeConfig = nodeconfig.GetShardConfig(consensusObj.ShardID)
@@ -489,26 +480,7 @@ func New(
 		node.BeaconBlockChannel = make(chan *types.Block)
 		txPoolConfig := core.DefaultTxPoolConfig
 		txPoolConfig.Blacklist = blacklist
-		node.TxPool = core.NewTxPool(txPoolConfig, node.Blockchain().Config(), blockchain,
-			func(payload []types.RPCTransactionError) {
-				if len(payload) > 0 {
-					node.errorSink.Lock()
-					for i := range payload {
-						node.errorSink.failedTxns.Value = payload[i]
-						node.errorSink.failedTxns = node.errorSink.failedTxns.Next()
-					}
-					node.errorSink.Unlock()
-				}
-			},
-			func(payload []staking.RPCTransactionError) {
-				node.errorSink.Lock()
-				for i := range payload {
-					node.errorSink.failedStakingTxns.Value = payload[i]
-					node.errorSink.failedStakingTxns = node.errorSink.failedStakingTxns.Next()
-				}
-				node.errorSink.Unlock()
-			},
-		)
+		node.TxPool = core.NewTxPool(txPoolConfig, node.Blockchain().Config(), blockchain, transactionErrorSink)
 		node.CxPool = core.NewCxPool(core.CxPoolSize)
 		node.Worker = worker.New(node.Blockchain().Config(), blockchain, chain.Engine)
 

--- a/node/node.go
+++ b/node/node.go
@@ -423,12 +423,11 @@ func New(
 	consensusObj *consensus.Consensus,
 	chainDBFactory shardchain.DBFactory,
 	blacklist map[common.Address]struct{},
-	transactionErrorSink *types.TransactionErrorSink,
 	isArchival bool,
 ) *Node {
 	node := Node{}
 	node.unixTimeAtNodeStart = time.Now().Unix()
-	node.TransactionErrorSink = transactionErrorSink
+	node.TransactionErrorSink = types.NewTransactionErrorSink()
 	// Get the node config that's created in the harmony.go program.
 	if consensusObj != nil {
 		node.NodeConfig = nodeconfig.GetShardConfig(consensusObj.ShardID)
@@ -480,7 +479,7 @@ func New(
 		node.BeaconBlockChannel = make(chan *types.Block)
 		txPoolConfig := core.DefaultTxPoolConfig
 		txPoolConfig.Blacklist = blacklist
-		node.TxPool = core.NewTxPool(txPoolConfig, node.Blockchain().Config(), blockchain, transactionErrorSink)
+		node.TxPool = core.NewTxPool(txPoolConfig, node.Blockchain().Config(), blockchain, node.TransactionErrorSink)
 		node.CxPool = core.NewCxPool(core.CxPoolSize)
 		node.Worker = worker.New(node.Blockchain().Config(), blockchain, chain.Engine)
 

--- a/node/rpc.go
+++ b/node/rpc.go
@@ -16,7 +16,6 @@ import (
 	"github.com/harmony-one/harmony/internal/hmyapi/apiv2"
 	"github.com/harmony-one/harmony/internal/hmyapi/filters"
 	"github.com/harmony-one/harmony/internal/utils"
-	staking "github.com/harmony-one/harmony/staking/types"
 )
 
 const (
@@ -55,17 +54,9 @@ func (node *Node) PendingCXReceipts() []*types.CXReceiptsProof {
 	return cxReceipts
 }
 
-// ErroredStakingTransactionSink is the inmemory failed staking transactions this node has
-func (node *Node) ErroredStakingTransactionSink() []staking.RPCTransactionError {
-	node.errorSink.Lock()
-	defer node.errorSink.Unlock()
-	result := []staking.RPCTransactionError{}
-	node.errorSink.failedStakingTxns.Do(func(d interface{}) {
-		if d != nil {
-			result = append(result, d.(staking.RPCTransactionError))
-		}
-	})
-	return result
+// ReportStakingErrorSink is the report of failed staking transactions this node has (held inmemory only)
+func (node *Node) ReportStakingErrorSink() types.TransactionErrorReports {
+	return node.TransactionErrorSink.StakingReport()
 }
 
 // GetNodeBootTime ..
@@ -73,17 +64,9 @@ func (node *Node) GetNodeBootTime() int64 {
 	return node.unixTimeAtNodeStart
 }
 
-// ErroredTransactionSink is the inmemory failed transactions this node has
-func (node *Node) ErroredTransactionSink() []types.RPCTransactionError {
-	node.errorSink.Lock()
-	defer node.errorSink.Unlock()
-	result := []types.RPCTransactionError{}
-	node.errorSink.failedTxns.Do(func(d interface{}) {
-		if d != nil {
-			result = append(result, d.(types.RPCTransactionError))
-		}
-	})
-	return result
+// ReportPlainErrorSink is the report of failed transactions this node has (held inmemory only)
+func (node *Node) ReportPlainErrorSink() types.TransactionErrorReports {
+	return node.TransactionErrorSink.PlainReport()
 }
 
 // StartRPC start RPC service

--- a/staking/types/transaction.go
+++ b/staking/types/transaction.go
@@ -5,10 +5,10 @@ import (
 	"io"
 	"math/big"
 	"sync/atomic"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
+
 	"github.com/harmony-one/harmony/crypto/hash"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/shard"
@@ -72,24 +72,6 @@ type StakingTransaction struct {
 	hash atomic.Value
 	size atomic.Value
 	from atomic.Value
-}
-
-// RPCTransactionError ..
-type RPCTransactionError struct {
-	TxHashID             string `json:"tx-hash-id"`
-	StakingDirective     string `json:"directive-kind"`
-	TimestampOfRejection int64  `json:"time-at-rejection"`
-	ErrMessage           string `json:"error-message"`
-}
-
-// NewRPCTransactionError ...
-func NewRPCTransactionError(hash common.Hash, directive Directive, err error) RPCTransactionError {
-	return RPCTransactionError{
-		TxHashID:             hash.Hex(),
-		StakingDirective:     directive.String(),
-		TimestampOfRejection: time.Now().Unix(),
-		ErrMessage:           err.Error(),
-	}
 }
 
 // StakeMsgFulfiller is signature of callback intended to produce the StakeMsg

--- a/test/chain/main.go
+++ b/test/chain/main.go
@@ -196,9 +196,7 @@ func playFaucetContract(chain *core.BlockChain) {
 func main() {
 	genesis := gspec.MustCommit(database)
 	chain, _ := core.NewBlockChain(database, nil, gspec.Config, chain.Engine(), vm.Config{}, nil)
-
-	txErrorSink, _ := types.NewTransactionErrorSink()
-	txpool := core.NewTxPool(core.DefaultTxPoolConfig, chainConfig, chain, txErrorSink)
+	txpool := core.NewTxPool(core.DefaultTxPoolConfig, chainConfig, chain, types.NewTransactionErrorSink())
 
 	backend := &testWorkerBackend{
 		db:     database,

--- a/test/chain/main.go
+++ b/test/chain/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/harmony-one/harmony/crypto/hash"
 	"github.com/harmony-one/harmony/internal/params"
 	pkgworker "github.com/harmony-one/harmony/node/worker"
-	staking "github.com/harmony-one/harmony/staking/types"
 )
 
 const (
@@ -198,8 +197,8 @@ func main() {
 	genesis := gspec.MustCommit(database)
 	chain, _ := core.NewBlockChain(database, nil, gspec.Config, chain.Engine(), vm.Config{}, nil)
 
-	txpool := core.NewTxPool(core.DefaultTxPoolConfig, chainConfig, chain,
-		func([]types.RPCTransactionError) {}, func([]staking.RPCTransactionError) {})
+	txErrorSink, _ := types.NewTransactionErrorSink()
+	txpool := core.NewTxPool(core.DefaultTxPoolConfig, chainConfig, chain, txErrorSink)
 
 	backend := &testWorkerBackend{
 		db:     database,


### PR DESCRIPTION
## Issue

Currently, the error sink just dumps any error to a ring buffer and does not remove any error report from the buffer if the tx ended up being successful. Some downstream tools (like CLI and block explorer) use the sink to check if a recent transaction failed and short circuits a failure msg if it does not. Therefore, it is important that the error sink does not duplicate error msgs and removes error messages for txs that made it through.

Moreover, I exposed the TxPool stats RPC.

SS of RPC:

![Screen Shot 2020-05-05 at 3 19 46 AM](https://user-images.githubusercontent.com/31291913/81057422-36d3d880-8e81-11ea-9285-98507468ceb7.png)

## Test

It is sufficient to test this on localnet as you can cause errors as needed. This was done & a unit test was added.

### Unit Test Coverage

Before:

```
PASS
coverage: 26.5% of statements
ok  	github.com/harmony-one/harmony/core	7.030s
```

After:

```
PASS
coverage: 26.2% of statements
ok  	github.com/harmony-one/harmony/core	6.991s
```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**
