### PR TITLE
don't sign the block that is not verified

### DIFF
--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -452,7 +452,9 @@ func (consensus *Consensus) UpdateConsensusInformation() Mode {
 	}
 
 	consensus.getLogger().Info().Msg("[UpdateConsensusInformation] Updating.....")
-	if len(curHeader.ShardState()) > 0 {
+	// genesis block is a special case that will have shard state and needs to skip processing
+	isNotGenesisBlock := curHeader.Number().Cmp(big.NewInt(0)) > 0
+	if len(curHeader.ShardState()) > 0 && isNotGenesisBlock {
 		// increase curEpoch by one if it's the last block
 		consensus.SetEpochNum(curEpoch.Uint64() + 1)
 		consensus.getLogger().Info().

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -163,8 +163,9 @@ func (consensus *Consensus) onPrepared(msg *msg_pb.Message) {
 		Msg("[OnPrepared] Prepared message and block added")
 
 	consensus.tryCatchup()
-	if consensus.current.Mode() == ViewChanging {
-		consensus.getLogger().Debug().Msg("[OnPrepared] Still in ViewChanging mode, Exiting!!")
+	if consensus.current.Mode() != Normal {
+		// don't sign the block that is not verified
+		consensus.getLogger().Info().Msg("[OnPrepared] Not in normal mode, Exiting!!")
 		return
 	}
 


### PR DESCRIPTION
if the validator is in any other mode than normal, don't sign the block because the block can only be fully verified in normal mode. we still want to add the received block to the FBFTLog for later tryCatchup. in case of malicious leader forcing validators to syncing mode, validators that fail to verify the block won't sign, hence breaking the malicious leader attempt to flood validators with malformed blocks.

tested the fix by running a node on ostn, fully syncing and getting into consensus. also tried multiple times stopping the node to get it out-of-sync (syncing mode) and the node comes back online and successfully starts signing blocks. 

this should not have any regression.