### PR TITLE
[STN] Updated network settings for Edgar's P2P tests

### DIFF
--- a/internal/configs/sharding/stress.go
+++ b/internal/configs/sharding/stress.go
@@ -82,5 +82,5 @@ var stressnetReshardingEpoch = []*big.Int{
 	params.StressnetChainConfig.StakingEpoch,
 }
 
-var stressnetV0 = MustNewInstance(2, 30, 30, numeric.OneDec(), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, stressnetReshardingEpoch, StressNetSchedule.BlocksPerEpoch())
-var stressnetV1 = MustNewInstance(2, 50, 30, numeric.MustNewDecFromStr("0.9"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, stressnetReshardingEpoch, StressNetSchedule.BlocksPerEpoch())
+var stressnetV0 = MustNewInstance(4, 75, 75, numeric.OneDec(), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, stressnetReshardingEpoch, StressNetSchedule.BlocksPerEpoch())
+var stressnetV1 = MustNewInstance(4, 100, 75, numeric.MustNewDecFromStr("0.9"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, stressnetReshardingEpoch, StressNetSchedule.BlocksPerEpoch())


### PR DESCRIPTION
## Issue

@fxfactorial needs a larger STN network configuration to fully test his new p2p layer.

This PR increases the number of shards to 4 and the number of nodes per shard to 75 (75 operated by Harmony) for pre-staking epochs and 100 nodes (75 operated by Harmony) for staking epochs.