### PR TITLE
Add SenderAddress to plain Tx Type

### DIFF
--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -199,7 +199,7 @@ func validateTxPoolInternals(pool *TxPool) error {
 }
 
 func deriveSender(tx types.PoolTransaction) (common.Address, error) {
-	return types.PoolTransactionSender(types.HomesteadSigner{}, tx)
+	return tx.SenderAddress()
 }
 
 type testChain struct {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -415,6 +415,22 @@ func (tx *Transaction) Copy() *Transaction {
 	return &tx2
 }
 
+// SenderAddress returns the address of transaction sender
+// Note that mainnet has unprotected transactions prior to Epoch 28
+func (tx *Transaction) SenderAddress() (common.Address, error) {
+	var signer Signer
+	if !tx.Protected() {
+		signer = HomesteadSigner{}
+	} else {
+		signer = NewEIP155Signer(tx.ChainID())
+	}
+	addr, err := Sender(signer, tx)
+	if err != nil {
+		return common.Address{}, err
+	}
+	return addr, nil
+}
+
 // Transactions is a Transaction slice type for basic sorting.
 type Transactions []*Transaction
 

--- a/core/types/tx_pool.go
+++ b/core/types/tx_pool.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
-	staking "github.com/harmony-one/harmony/staking/types"
 )
 
 const (
@@ -30,6 +29,7 @@ type PoolTransaction interface {
 	ChainID() *big.Int
 	ShardID() uint32
 	To() *common.Address
+	SenderAddress() (common.Address, error)
 	Size() common.StorageSize
 	Data() []byte
 	GasPrice() *big.Int
@@ -39,26 +39,6 @@ type PoolTransaction interface {
 	EncodeRLP(w io.Writer) error
 	DecodeRLP(s *rlp.Stream) error
 	Protected() bool
-}
-
-// PoolTransactionSender returns the address derived from the signature (V, R, S) u
-// sing secp256k1 elliptic curve and an error if it failed deriving or upon an
-// incorrect signature.
-//
-// Sender may cache the address, allowing it to be used regardless of
-// signing method. The cache is invalidated if the cached signer does
-// not match the signer used in the current call.
-//
-// Note that the signer is an interface since different txs have different signers.
-func PoolTransactionSender(signer interface{}, tx PoolTransaction) (common.Address, error) {
-	if plainTx, ok := tx.(*Transaction); ok {
-		if sig, ok := signer.(Signer); ok {
-			return Sender(sig, plainTx)
-		}
-	} else if stakingTx, ok := tx.(*staking.StakingTransaction); ok {
-		return stakingTx.SenderAddress()
-	}
-	return common.Address{}, errors.WithMessage(ErrUnknownPoolTxType, "when fetching transaction sender")
 }
 
 // PoolTransactions is a PoolTransactions slice type for basic sorting.

--- a/internal/hmyapi/apiv1/types.go
+++ b/internal/hmyapi/apiv1/types.go
@@ -162,7 +162,7 @@ func newRPCTransaction(
 	tx *types.Transaction, blockHash common.Hash,
 	blockNumber uint64, timestamp uint64, index uint64,
 ) *RPCTransaction {
-	from, err := types.PoolTransactionSender(types.NewEIP155Signer(tx.ChainID()), tx)
+	from, err := tx.SenderAddress()
 	if err != nil {
 		return nil
 	}
@@ -211,7 +211,7 @@ func newRPCTransaction(
 func newRPCStakingTransaction(tx *types2.StakingTransaction, blockHash common.Hash,
 	blockNumber uint64, timestamp uint64, index uint64,
 ) *RPCStakingTransaction {
-	from, err := types.PoolTransactionSender(nil, tx)
+	from, err := tx.SenderAddress()
 	if err != nil {
 		return nil
 	}

--- a/internal/hmyapi/apiv2/types.go
+++ b/internal/hmyapi/apiv2/types.go
@@ -162,7 +162,7 @@ func newRPCTransaction(
 	tx *types.Transaction, blockHash common.Hash,
 	blockNumber uint64, timestamp uint64, index uint64,
 ) *RPCTransaction {
-	from, err := types.PoolTransactionSender(types.NewEIP155Signer(tx.ChainID()), tx)
+	from, err := tx.SenderAddress()
 	if err != nil {
 		return nil
 	}
@@ -213,7 +213,7 @@ func newRPCStakingTransaction(
 	tx *types2.StakingTransaction, blockHash common.Hash,
 	blockNumber uint64, timestamp uint64, index uint64,
 ) *RPCStakingTransaction {
-	from, err := types.PoolTransactionSender(nil, tx)
+	from, err := tx.SenderAddress()
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
## Issue

Plain tx had a cumbersome way to fetch sender address, so added `SenderAddress` to plain tx, to make the same as staking tx. Doing this meant I could remove uses of `PoolTransactionSender`, so did that as well and refactored all associated functions. 

## Test

Tested locally, sending staking and plain tx all worked and passed through the pool.

### Unit Test Coverage

Before:

```
PASS
coverage: 26.0% of statements
ok      github.com/harmony-one/harmony/core     6.913s

```

After:

```
PASS
coverage: 26.0% of statements
ok      github.com/harmony-one/harmony/core     6.927s
```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**