### PR TITLE
Fix both total stake counting and delegation index for validator itself

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2624,11 +2624,15 @@ func (bc *BlockChain) prepareStakingMetaData(
 				blockNum,
 			}
 			delegations, ok := newDelegations[createValidator.ValidatorAddress]
-			if ok {
-				delegations = append(delegations, selfIndex)
-			} else {
-				delegations = staking.DelegationIndexes{selfIndex}
+			if !ok {
+				// If the cache doesn't have it, load it from DB for the first time.
+				delegations, err = bc.ReadDelegationsByDelegator(createValidator.ValidatorAddress)
+				if err != nil {
+					return nil, nil, err
+				}
 			}
+
+			delegations = append(delegations, selfIndex)
 			newDelegations[createValidator.ValidatorAddress] = delegations
 		case staking.DirectiveEditValidator:
 		case staking.DirectiveDelegate:

--- a/core/rawdb/accessors_offchain.go
+++ b/core/rawdb/accessors_offchain.go
@@ -242,6 +242,7 @@ func WriteValidatorList(
 }
 
 // ReadDelegationsByDelegator retrieves the list of validators delegated by a delegator
+// Returns empty results instead of error if there is not data found.
 func ReadDelegationsByDelegator(db DatabaseReader, delegator common.Address) (staking.DelegationIndexes, error) {
 	data, err := db.Get(delegatorValidatorListKey(delegator))
 	if err != nil || len(data) == 0 {

--- a/shard/committee/assignment.go
+++ b/shard/committee/assignment.go
@@ -146,15 +146,6 @@ func prepareOrders(
 			continue
 		}
 
-		validatorStake := big.NewInt(0)
-		for i := range validator.Delegations {
-			validatorStake.Add(
-				validatorStake, validator.Delegations[i].Amount,
-			)
-		}
-
-		totalStaked.Add(totalStaked, validatorStake)
-
 		found := false
 		for _, key := range validator.SlotPubKeys {
 			if _, ok := blsKeys[key]; ok {
@@ -167,6 +158,15 @@ func prepareOrders(
 		if found {
 			continue
 		}
+
+		validatorStake := big.NewInt(0)
+		for i := range validator.Delegations {
+			validatorStake.Add(
+				validatorStake, validator.Delegations[i].Amount,
+			)
+		}
+
+		totalStaked.Add(totalStaked, validatorStake)
 
 		essentials[validator.Address] = &effective.SlotOrder{
 			validatorStake,
@@ -240,6 +240,7 @@ var (
 	ErrComputeForEpochInPast = errors.New("cannot compute for epoch in past")
 )
 
+// This is the shard state computation logic before staking epoch.
 func preStakingEnabledCommittee(s shardingconfig.Instance) *shard.State {
 	shardNum := int(s.NumShards())
 	shardHarmonyNodes := s.NumHarmonyOperatedNodesPerShard()


### PR DESCRIPTION
Fixes following corner case:

Issue.1
    Total stake counted the validators with duplicate keys. It shouldn't count those stake.

Issue.2 (https://github.com/harmony-one/harmony/issues/2882)
    Delegators who delegated first and then create validator on themselves will have their delegation index cleared out. It shouldn't.