### PR TITLE
Enable NatPortMap in p2p host

### DIFF
--- a/p2p/host/hostv2/hostv2.go
+++ b/p2p/host/hostv2/hostv2.go
@@ -234,6 +234,7 @@ func New(self *p2p.Peer, priKey libp2p_crypto.PrivKey) (*HostV2, error) {
 	ctx := context.Background()
 	p2pHost, err := libp2p.New(ctx,
 		libp2p.ListenAddrs(listenAddr), libp2p.Identity(priKey),
+		libp2p.NATPortMap(),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Issue

This is commit addressing issue 2959 "[Feature] enable NAT traversal for simple 1-level NAT situation with UPNP support: connecting local host validator behind a NAT to public leaders " 

## Test

Have tried this changes behind a NAT set up in an AWS VPC. And it seems the node is running properly and blockchain keeps synced to the network. 

Note: at this point we can't test every possible NATs in the world and there could be some NATs which do not support UPNP tools, but based on my impression, UPNP should be pretty common. And whenever libp2p add support to any more NATs, we get that additional support for free. 

### Unit Test Coverage

Jians-MacBook-Pro:p2p jz$ go test --cover
PASS
coverage: 19.6% of statements
ok  	github.com/harmony-one/harmony/p2p	0.013s
Jians-MacBook-Pro:p2p jz$


./test/test_before_submit.sh

=== RUN   TestGetHashFromNodeList
--- PASS: TestGetHashFromNodeList (0.00s)
=== RUN   TestHash
--- PASS: TestHash (0.00s)
PASS
ok  	github.com/harmony-one/harmony/shard	0.023s
testing: warning: no tests to run
PASS
ok  	github.com/harmony-one/harmony/staking/types	0.068s [no tests to run]
?   	github.com/harmony-one/harmony/test/chain	[no test files]
?   	github.com/harmony-one/harmony/test/crypto/bls	[no test files]
?   	github.com/harmony-one/harmony/test/p2pchat	[no test files]
?   	github.com/harmony-one/harmony/test/txgen	[no test files]
go test succeeded.
Some checks failed; see output above.


### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

   NO

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    NO

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

NO, don't have any significant changes in terms of CPU/memory/disk...
