### PR TITLE
[P2PNetwork] Add network configuration 

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -83,7 +83,7 @@ var (
 	// nodeType indicates the type of the node: validator, explorer
 	nodeType = flag.String("node_type", "validator", "node type: validator, explorer")
 	// networkType indicates the type of the network
-	networkType = flag.String("network_type", "mainnet", "type of the network: mainnet, testnet, pangaea, partner, stressnet, devnet, localnet")
+	networkType = flag.String("network_type", "mainnet", "type of the network: mainnet, testnet, pangaea, partner, stressnet, p2pnet, devnet, localnet")
 	// blockPeriod indicates the how long the leader waits to propose a new block.
 	blockPeriod = flag.Int("block_period", 8, "how long in second the leader waits to propose a new block.")
 	// staking indicates whether the node is operating in staking mode.
@@ -642,6 +642,8 @@ func main() {
 		shard.Schedule = shardingconfig.PartnerSchedule
 	case nodeconfig.Stressnet:
 		shard.Schedule = shardingconfig.StressNetSchedule
+	case nodeconfig.P2PNet:
+		shard.Schedule = shardingconfig.P2PNetSchedule
 	case nodeconfig.Devnet:
 		if *devnetHarmonySize < 0 {
 			*devnetHarmonySize = *devnetShardSize

--- a/internal/configs/node/config.go
+++ b/internal/configs/node/config.go
@@ -52,7 +52,7 @@ const (
 	Stressnet = "stressnet"
 	Devnet    = "devnet"
 	Localnet  = "localnet"
-	P2PNet    = "p2p"
+	P2PNet    = "p2pnet"
 )
 
 // Global is the index of the global node configuration

--- a/internal/configs/node/config.go
+++ b/internal/configs/node/config.go
@@ -52,6 +52,7 @@ const (
 	Stressnet = "stressnet"
 	Devnet    = "devnet"
 	Localnet  = "localnet"
+	P2PNet    = "p2p"
 )
 
 // Global is the index of the global node configuration
@@ -307,6 +308,8 @@ func (t NetworkType) ChainConfig() params.ChainConfig {
 		return *params.StressnetChainConfig
 	case Localnet:
 		return *params.LocalnetChainConfig
+	case P2PNet:
+		return *params.P2PNetChainConfig
 	default:
 		return *params.TestnetChainConfig
 	}

--- a/internal/configs/sharding/instance.go
+++ b/internal/configs/sharding/instance.go
@@ -20,6 +20,7 @@ const (
 	Partner
 	StressNet
 	DevNet
+	P2PNet
 )
 
 type instance struct {

--- a/internal/configs/sharding/p2pnet.go
+++ b/internal/configs/sharding/p2pnet.go
@@ -1,0 +1,86 @@
+package shardingconfig
+
+import (
+	"math/big"
+
+	"github.com/harmony-one/harmony/numeric"
+
+	"github.com/harmony-one/harmony/internal/genesis"
+	"github.com/harmony-one/harmony/internal/params"
+)
+
+// P2PNetSchedule is a temporary testing network for p2p changes
+// configuration schedule.
+var P2PNetSchedule p2pNetSchedule
+
+type p2pNetSchedule struct{}
+
+const (
+	// ~304 sec epochs for P2 of open staking
+	p2pNetBlocksPerEpoch = 38
+
+	p2pNetVdfDifficulty = 10000 // This takes about 20s to finish the vdf
+
+	// P2PNetHTTPPattern is the http pattern for p2pNet.
+	P2PNetHTTPPattern = "https://api.s%d.p2p.hmny.io"
+	// P2PNetWSPattern is the websocket pattern for p2pNet.
+	P2PNetWSPattern = "wss://ws.s%d.p2p.hmny.io"
+)
+
+func (p2pNetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
+	switch {
+	case epoch.Cmp(params.P2PNetChainConfig.StakingEpoch) >= 0:
+		return p2pNetV1
+	default: // genesis
+		return p2pNetV0
+	}
+}
+
+func (p2pNetSchedule) BlocksPerEpoch() uint64 {
+	return p2pNetBlocksPerEpoch
+}
+
+func (ss p2pNetSchedule) CalcEpochNumber(blockNum uint64) *big.Int {
+	epoch := blockNum / ss.BlocksPerEpoch()
+	return big.NewInt(int64(epoch))
+}
+
+func (ss p2pNetSchedule) IsLastBlock(blockNum uint64) bool {
+	return (blockNum+1)%ss.BlocksPerEpoch() == 0
+}
+
+func (ss p2pNetSchedule) EpochLastBlock(epochNum uint64) uint64 {
+	return ss.BlocksPerEpoch()*(epochNum+1) - 1
+}
+
+func (ss p2pNetSchedule) VdfDifficulty() int {
+	return p2pNetVdfDifficulty
+}
+
+// ConsensusRatio ratio of new nodes vs consensus total nodes
+func (ss p2pNetSchedule) ConsensusRatio() float64 {
+	return mainnetConsensusRatio
+}
+
+// TODO: remove it after randomness feature turned on mainnet
+//RandonnessStartingEpoch returns starting epoch of randonness generation
+func (ss p2pNetSchedule) RandomnessStartingEpoch() uint64 {
+	return mainnetRandomnessStartingEpoch
+}
+
+func (ss p2pNetSchedule) GetNetworkID() NetworkID {
+	return P2PNet
+}
+
+// GetShardingStructure is the sharding structure for p2pNet.
+func (ss p2pNetSchedule) GetShardingStructure(numShard, shardID int) []map[string]interface{} {
+	return genShardingStructure(numShard, shardID, P2PNetHTTPPattern, P2PNetWSPattern)
+}
+
+var p2pNetReshardingEpoch = []*big.Int{
+	big.NewInt(0),
+	params.P2PNetChainConfig.StakingEpoch,
+}
+
+var p2pNetV0 = MustNewInstance(4, 75, 75, numeric.OneDec(), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, p2pNetReshardingEpoch, P2PNetSchedule.BlocksPerEpoch())
+var p2pNetV1 = MustNewInstance(4, 100, 75, numeric.MustNewDecFromStr("0.9"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, p2pNetReshardingEpoch, P2PNetSchedule.BlocksPerEpoch())

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -14,6 +14,7 @@ var (
 	PangaeaChainID            = big.NewInt(3)
 	PartnerChainID            = big.NewInt(4)
 	StressnetChainID          = big.NewInt(5)
+	P2PNetChainID             = big.NewInt(7)   // 6 is already reserved for devnet
 	TestChainID               = big.NewInt(99)  // not a real network
 	AllProtocolChangesChainID = big.NewInt(100) // not a real network
 )
@@ -77,6 +78,19 @@ var (
 	// All features except for CrossLink are enabled at launch.
 	StressnetChainConfig = &ChainConfig{
 		ChainID:         StressnetChainID,
+		CrossTxEpoch:    big.NewInt(0),
+		CrossLinkEpoch:  big.NewInt(2),
+		StakingEpoch:    big.NewInt(2),
+		PreStakingEpoch: big.NewInt(1),
+		EIP155Epoch:     big.NewInt(0),
+		S3Epoch:         big.NewInt(0),
+		ReceiptLogEpoch: big.NewInt(0),
+	}
+
+	// P2PNetChainConfig contains the chain parameters for the P2P test network.
+	// All features except for CrossLink are enabled at launch.
+	P2PNetChainConfig = &ChainConfig{
+		ChainID:         P2PNetChainID,
 		CrossTxEpoch:    big.NewInt(0),
 		CrossLinkEpoch:  big.NewInt(2),
 		StakingEpoch:    big.NewInt(2),

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -378,6 +378,15 @@ stn|stress|stressnet)
   dns_zone=stn.hmny.io
   syncdir=stn
   ;;
+p2p|p2pnet)
+  bootnodes=(
+    /ip4/52.40.84.2/tcp/9842/p2p/QmbPVwrqWsTYXq1RxGWcxx9SWaTUCfoo1wA6wmdbduWe29
+  )
+  REL=p2p
+  network_type=p2pnet
+  dns_zone=p2p.hmny.io
+  syncdir=p2p
+  ;;
 devnet)
   bootnodes=(
     /ip4/54.86.126.90/tcp/9870/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv


### PR DESCRIPTION
## Issue

@fxfactorial needs a dedicated testing network for his P2P PR.

This PR adds support for such a new network, called p2p/p2pnet.

## Test

### Unit Test Coverage

```
$ cd internal/configs/
$ go test -cover ./...
ok  	github.com/harmony-one/harmony/internal/configs/node	(cached)	coverage: 55.2% of statements
ok  	github.com/harmony-one/harmony/internal/configs/sharding	(cached)	coverage: 19.7% of statements
?   	github.com/harmony-one/harmony/internal/configs/viper	[no test files]
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

9. **Does the existing `node.sh` continue to work with this change?**

    **YES**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
