### PR TITLE
[rpc][p2p] Expose peer connectivity

### DIFF
--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -791,6 +791,8 @@ func (b *APIBackend) GetNodeMetadata() commonRPC.NodeMetadata {
 			blsKeys = append(blsKeys, key.SerializeToHexStr())
 		}
 	}
+	c := commonRPC.C{}
+	c.TotalKnownPeers, c.Connected, c.NotConnected = b.hmy.nodeAPI.PeerConnectivity()
 
 	return commonRPC.NodeMetadata{
 		blsKeys,
@@ -805,5 +807,6 @@ func (b *APIBackend) GetNodeMetadata() commonRPC.NodeMetadata {
 		cfg.DNSZone,
 		cfg.GetArchival(),
 		b.hmy.nodeAPI.GetNodeBootTime(),
+		c,
 	}
 }

--- a/hmy/backend.go
+++ b/hmy/backend.go
@@ -52,6 +52,7 @@ type NodeAPI interface {
 	ReportPlainErrorSink() types.TransactionErrorReports
 	PendingCXReceipts() []*types.CXReceiptsProof
 	GetNodeBootTime() int64
+	PeerConnectivity() (int, int, int)
 }
 
 // New creates a new Harmony object (including the

--- a/internal/hmyapi/common/types.go
+++ b/internal/hmyapi/common/types.go
@@ -2,6 +2,13 @@ package common
 
 import "github.com/harmony-one/harmony/internal/params"
 
+// C ..
+type C struct {
+	TotalKnownPeers int `json:"total-known-peers"`
+	Connected       int `json:"connected"`
+	NotConnected    int `json:"not-connected"`
+}
+
 // NodeMetadata captures select metadata of the RPC answering node
 type NodeMetadata struct {
 	BLSPublicKey   []string           `json:"blskey"`
@@ -16,4 +23,5 @@ type NodeMetadata struct {
 	DNSZone        string             `json:"dns-zone"`
 	Archival       bool               `json:"is-archival"`
 	NodeBootTime   int64              `json:"node-unix-start-time"`
+	C              C                  `json:"p2p-connectivity"`
 }

--- a/node/rpc.go
+++ b/node/rpc.go
@@ -43,6 +43,11 @@ func (node *Node) IsCurrentlyLeader() bool {
 	return node.Consensus.IsLeader()
 }
 
+// PeerConnectivity ..
+func (node *Node) PeerConnectivity() (int, int, int) {
+	return node.host.C()
+}
+
 // PendingCXReceipts returns node.pendingCXReceiptsProof
 func (node *Node) PendingCXReceipts() []*types.CXReceiptsProof {
 	cxReceipts := make([]*types.CXReceiptsProof, len(node.pendingCXReceipts))


### PR DESCRIPTION
 hmy utility metadata 
```json
{
  "id": "1",
  "jsonrpc": "2.0",
  "result": {
    "blocks-per-epoch": 5,
    "blskey": [
      "65f55eb3052f9e9f632b2923be594ba77c55543f5c58ee1454b9cfd658d25e06373b0f7d42a19c84768139ea294f6204"
    ],
    "chain-config": {
      "chain-id": 2,
      "cross-link-epoch": 2,
      "cross-tx-epoch": 0,
      "eip155-epoch": 0,
      "prestaking-epoch": 0,
      "receipt-log-epoch": 0,
      "s3-epoch": 0,
      "staking-epoch": 2
    },
    "current-epoch": 0,
    "dns-zone": "",
    "is-archival": false,
    "is-leader": true,
    "network": "localnet",
    "node-unix-start-time": 1588955016,
    "p2p-connectivity": {
      "connected": 23,
      "not-connected": 1,
      "total-known-peers": 24
    },
    "role": "Validator",
    "shard-id": 0,
    "version": "Harmony (C) 2020. harmony, version v5920-v1.3.8-43-g2d0d9561-dirty (edgar@ 2020-05-08T09:23:27-0700)"
  }
}
```