### PR TITLE
Avoid duplicate bls as harmony nodes; Fix epoch gap issue

### DIFF
--- a/consensus/votepower/roster.go
+++ b/consensus/votepower/roster.go
@@ -207,7 +207,6 @@ func Compute(subComm *shard.Committee, epoch *big.Int) (*Roster, error) {
 			ourPercentage = ourPercentage.Add(member.OverallPercent)
 		}
 
-		// TODO: make sure external user's BLS key can be same as harmony's bls keys
 		if _, ok := roster.Voters[staked[i].BLSPublicKey]; !ok {
 			roster.Voters[staked[i].BLSPublicKey] = &member
 		} else {

--- a/staking/effective/calculate.go
+++ b/staking/effective/calculate.go
@@ -110,6 +110,9 @@ func Compute(
 	// Expand
 	for _, staker := range shorter {
 		slotsCount := len(staker.slot.SpreadAmong)
+		if slotsCount == 0 {
+			continue
+		}
 		spread := numeric.NewDecFromBigInt(staker.slot.Stake).
 			QuoInt64(int64(slotsCount))
 		for i := 0; i < slotsCount; i++ {


### PR DESCRIPTION
1. Avoid duplicate bls keys as harmony nodes from validators.
2. Fix a corner case issue when there is a epoch gap for shard chains, which will cause the Decider to be set incorrectly when it's already in staking epoch.
3. Add a check for div by 0