### PR TITLE
Fix the unsafe big int usage

### DIFF
--- a/core/offchain.go
+++ b/core/offchain.go
@@ -243,7 +243,7 @@ func (bc *BlockChain) CommitOffChainData(
 					}
 					for j := range stats.MetricsPerShard {
 						if stats.MetricsPerShard[j].Vote.Identity == paid[i].EarningKey {
-							stats.MetricsPerShard[j].Earned.Add(
+							stats.MetricsPerShard[j].Earned = new(big.Int).Add(
 								stats.MetricsPerShard[j].Earned,
 								paid[i].NewlyEarned,
 							)

--- a/core/staking_verifier.go
+++ b/core/staking_verifier.go
@@ -111,9 +111,8 @@ func VerifyAndCreateValidatorFromMsg(
 	wrapper.Delegations = []staking.Delegation{
 		staking.NewDelegation(v.Address, msg.Amount),
 	}
-	zero := big.NewInt(0)
-	wrapper.Counters.NumBlocksSigned = zero
-	wrapper.Counters.NumBlocksToSign = zero
+	wrapper.Counters.NumBlocksSigned = big.NewInt(0)
+	wrapper.Counters.NumBlocksToSign = big.NewInt(0)
 	wrapper.BlockReward = big.NewInt(0)
 	maxBLSKeyAllowed := shard.ExternalSlotsAvailableForEpoch(epoch) / 3
 	if err := wrapper.SanityCheck(maxBLSKeyAllowed); err != nil {
@@ -232,7 +231,7 @@ func VerifyAndDelegateFromMsg(
 	for i := range wrapper.Delegations {
 		delegation := &wrapper.Delegations[i]
 		if bytes.Equal(delegation.DelegatorAddress.Bytes(), msg.DelegatorAddress.Bytes()) {
-			delegation.Amount.Add(delegation.Amount, msg.Amount)
+			delegation.Amount = new(big.Int).Add(delegation.Amount, msg.Amount)
 			if err := wrapper.SanityCheck(
 				staking.DoNotEnforceMaxBLS,
 			); err != nil {
@@ -327,7 +326,7 @@ func VerifyAndCollectRewardsFromDelegation(
 		if uint64(len(wrapper.Delegations)) > delegation.Index {
 			delegation := &wrapper.Delegations[delegation.Index]
 			if delegation.Reward.Cmp(common.Big0) > 0 {
-				totalRewards.Add(totalRewards, delegation.Reward)
+				totalRewards = new(big.Int).Add(totalRewards, delegation.Reward)
 				delegation.Reward.SetUint64(0)
 			}
 		} else {

--- a/staking/availability/measure.go
+++ b/staking/availability/measure.go
@@ -97,12 +97,12 @@ func bumpCount(
 				return err
 			}
 
-			wrapper.Counters.NumBlocksToSign.Add(
+			wrapper.Counters.NumBlocksToSign = new(big.Int).Add(
 				wrapper.Counters.NumBlocksToSign, common.Big1,
 			)
 
 			if subset.didSign {
-				wrapper.Counters.NumBlocksSigned.Add(
+				wrapper.Counters.NumBlocksSigned = new(big.Int).Add(
 					wrapper.Counters.NumBlocksSigned, common.Big1,
 				)
 			}

--- a/staking/slash/double-sign.go
+++ b/staking/slash/double-sign.go
@@ -34,8 +34,8 @@ func payDebt(
 		Uint64("payment", payment.Uint64()).
 		RawJSON("slash-track", []byte(slashDiff.String())).
 		Msg("slash debt payment before application")
-	slashDiff.TotalSlashed.Add(slashDiff.TotalSlashed, payment)
-	slashDebt.Sub(slashDebt, payment)
+	slashDiff.TotalSlashed = new(big.Int).Add(slashDiff.TotalSlashed, payment)
+	slashDebt = new(big.Int).Sub(slashDebt, payment)
 	if slashDebt.Cmp(common.Big0) == -1 {
 		x1, _ := rlp.EncodeToBytes(snapshot)
 		x2, _ := rlp.EncodeToBytes(current)
@@ -307,7 +307,7 @@ func payDownAsMuchAsCan(
 	if nowAmt.Cmp(common.Big0) == 1 && slashDebt.Cmp(common.Big0) == 1 {
 		// 0.50_amount > 0.06_debt => slash == 0.0, nowAmt == 0.44
 		if nowAmt.Cmp(slashDebt) >= 0 {
-			nowAmt.Sub(nowAmt, slashDebt)
+			nowAmt = new(big.Int).Sub(nowAmt, slashDebt)
 			if err := payDebt(
 				snapshot, current, slashDebt, slashDebt, slashDiff,
 			); err != nil {
@@ -320,7 +320,7 @@ func payDownAsMuchAsCan(
 			); err != nil {
 				return err
 			}
-			nowAmt.Sub(nowAmt, nowAmt)
+			nowAmt = new(big.Int).Sub(nowAmt, nowAmt)
 		}
 	}
 
@@ -408,7 +408,7 @@ func delegatorSlashApply(
 				// NOTE only need to pay snitch here,
 				// they only get half of what was actually dispersed
 				halfOfSlashDebt := new(big.Int).Div(slashDiff.TotalSlashed, common.Big2)
-				slashDiff.TotalSnitchReward.Add(slashDiff.TotalSnitchReward, halfOfSlashDebt)
+				slashDiff.TotalSnitchReward = new(big.Int).Add(slashDiff.TotalSnitchReward, halfOfSlashDebt)
 				utils.Logger().Info().
 					RawJSON("delegation-snapshot", []byte(delegationSnapshot.String())).
 					RawJSON("delegation-current", []byte(delegationNow.String())).
@@ -416,10 +416,10 @@ func delegatorSlashApply(
 					RawJSON("application", []byte(slashDiff.String())).
 					Msg("completed an application of slashing")
 				state.AddBalance(reporter, halfOfSlashDebt)
-				slashTrack.TotalSnitchReward.Add(
+				slashTrack.TotalSnitchReward = new(big.Int).Add(
 					slashTrack.TotalSnitchReward, slashDiff.TotalSnitchReward,
 				)
-				slashTrack.TotalSlashed.Add(
+				slashTrack.TotalSlashed = new(big.Int).Add(
 					slashTrack.TotalSlashed, slashDiff.TotalSlashed,
 				)
 			}

--- a/staking/slash/double-sign.go
+++ b/staking/slash/double-sign.go
@@ -35,7 +35,7 @@ func payDebt(
 		RawJSON("slash-track", []byte(slashDiff.String())).
 		Msg("slash debt payment before application")
 	slashDiff.TotalSlashed = new(big.Int).Add(slashDiff.TotalSlashed, payment)
-	slashDebt = new(big.Int).Sub(slashDebt, payment)
+	slashDebt.Sub(slashDebt, payment)
 	if slashDebt.Cmp(common.Big0) == -1 {
 		x1, _ := rlp.EncodeToBytes(snapshot)
 		x2, _ := rlp.EncodeToBytes(current)
@@ -307,7 +307,7 @@ func payDownAsMuchAsCan(
 	if nowAmt.Cmp(common.Big0) == 1 && slashDebt.Cmp(common.Big0) == 1 {
 		// 0.50_amount > 0.06_debt => slash == 0.0, nowAmt == 0.44
 		if nowAmt.Cmp(slashDebt) >= 0 {
-			nowAmt = new(big.Int).Sub(nowAmt, slashDebt)
+			nowAmt.Sub(nowAmt, slashDebt)
 			if err := payDebt(
 				snapshot, current, slashDebt, slashDebt, slashDiff,
 			); err != nil {
@@ -320,7 +320,7 @@ func payDownAsMuchAsCan(
 			); err != nil {
 				return err
 			}
-			nowAmt = new(big.Int).Sub(nowAmt, nowAmt)
+			nowAmt.Sub(nowAmt, nowAmt)
 		}
 	}
 

--- a/staking/types/delegation.go
+++ b/staking/types/delegation.go
@@ -125,13 +125,13 @@ func (d *Delegation) Undelegate(epoch *big.Int, amt *big.Int) error {
 	if d.Amount.Cmp(amt) < 0 {
 		return errInsufficientBalance
 	}
-	d.Amount.Sub(d.Amount, amt)
+	d.Amount = new(big.Int).Sub(d.Amount, amt)
 
 	exist := false
 	for _, entry := range d.Undelegations {
 		if entry.Epoch.Cmp(epoch) == 0 {
 			exist = true
-			entry.Amount.Add(entry.Amount, amt)
+			entry.Amount = new(big.Int).Add(entry.Amount, amt)
 			return nil
 		}
 	}
@@ -154,7 +154,7 @@ func (d *Delegation) Undelegate(epoch *big.Int, amt *big.Int) error {
 func (d *Delegation) TotalInUndelegation() *big.Int {
 	total := big.NewInt(0)
 	for i := range d.Undelegations {
-		total.Add(total, d.Undelegations[i].Amount)
+		total = new(big.Int).Add(total, d.Undelegations[i].Amount)
 	}
 	return total
 }
@@ -184,7 +184,7 @@ func (d *Delegation) RemoveUnlockedUndelegations(
 		if big.NewInt(0).Sub(curEpoch, d.Undelegations[j].Epoch).Int64() >= LockPeriodInEpoch ||
 			big.NewInt(0).Sub(curEpoch, lastEpochInCommittee).Int64() >= LockPeriodInEpoch {
 			// need to wait at least 7 epochs to withdraw; or the validator has been out of committee for 7 epochs
-			totalWithdraw.Add(totalWithdraw, d.Undelegations[j].Amount)
+			totalWithdraw = new(big.Int).Add(totalWithdraw, d.Undelegations[j].Amount)
 			count++
 		} else {
 			break

--- a/staking/types/transaction.go
+++ b/staking/types/transaction.go
@@ -166,7 +166,7 @@ func (tx *StakingTransaction) Cost() (*big.Int, error) {
 		if !ok {
 			return nil, errStakingTransactionTypeCastErr
 		}
-		total.Add(total, stkMsg.Amount)
+		total = new(big.Int).Add(total, stkMsg.Amount)
 	case DirectiveDelegate:
 		msg, err := RLPDecodeStakeMsg(tx.Data(), DirectiveDelegate)
 		if err != nil {
@@ -176,7 +176,7 @@ func (tx *StakingTransaction) Cost() (*big.Int, error) {
 		if !ok {
 			return nil, errStakingTransactionTypeCastErr
 		}
-		total.Add(total, stkMsg.Amount)
+		total = new(big.Int).Add(total, stkMsg.Amount)
 	}
 	return total, nil
 }

--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -322,7 +322,7 @@ func (v *Validator) SanityCheck(oneThirdExtrn int) error {
 func (w *ValidatorWrapper) TotalDelegation() *big.Int {
 	total := big.NewInt(0)
 	for _, entry := range w.Delegations {
-		total.Add(total, entry.Amount)
+		total = new(big.Int).Add(total, entry.Amount)
 	}
 	return total
 }


### PR DESCRIPTION
## Description

Fix some unsafe usage of big.Int. Changed usage from 

```
x.Add(x, y)
```

To 

```
x = new(big.Int).Add(x, y)
```

Note that the usage is not changed in function `staking/slash/payDebt` since the integer is used as a return value.

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    NO.

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    NO

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    NO

## TODO

Rewrite `payDebt (staking/slash/double-sign.go:25)` function to avoid usage of big.Int.