### PR TITLE
[rpc] add viewID and epoch to RPCMarshalBlock

### DIFF
--- a/internal/hmyapi/apiv1/types.go
+++ b/internal/hmyapi/apiv1/types.go
@@ -176,6 +176,8 @@ func newRPCPendingTransaction(tx *types.Transaction) *RPCTransaction {
 // RPCBlock represents a block that will serialize to the RPC representation of a block
 type RPCBlock struct {
 	Number           *hexutil.Big     `json:"number"`
+	ViewID           *hexutil.Big     `json:"viewID"`
+	Epoch            *hexutil.Big     `json:"epoch"`
 	Hash             common.Hash      `json:"hash"`
 	ParentHash       common.Hash      `json:"parentHash"`
 	Nonce            types.BlockNonce `json:"nonce"`
@@ -203,6 +205,8 @@ func RPCMarshalBlock(b *types.Block, inclTx bool, fullTx bool) (map[string]inter
 	head := b.Header() // copies the header once
 	fields := map[string]interface{}{
 		"number":           (*hexutil.Big)(head.Number()),
+		"viewID":           (*hexutil.Big)(head.ViewID()),
+		"epoch":            (*hexutil.Big)(head.Epoch()),
 		"hash":             b.Hash(),
 		"parentHash":       head.ParentHash(),
 		"nonce":            0, // Remove this because we don't have it in our header

--- a/internal/hmyapi/apiv2/types.go
+++ b/internal/hmyapi/apiv2/types.go
@@ -176,6 +176,8 @@ func newRPCPendingTransaction(tx *types.Transaction) *RPCTransaction {
 // RPCBlock represents a block that will serialize to the RPC representation of a block
 type RPCBlock struct {
 	Number           *big.Int         `json:"number"`
+	ViewID           *big.Int         `json:"viewID"`
+	Epoch            *big.Int         `json:"epoch"`
 	Hash             common.Hash      `json:"hash"`
 	ParentHash       common.Hash      `json:"parentHash"`
 	Nonce            types.BlockNonce `json:"nonce"`
@@ -203,6 +205,8 @@ func RPCMarshalBlock(b *types.Block, blockArgs BlockArgs) (map[string]interface{
 	head := b.Header() // copies the header once
 	fields := map[string]interface{}{
 		"number":           (*big.Int)(head.Number()),
+		"viewID":           (*big.Int)(head.ViewID()),
+		"epoch":            (*big.Int)(head.Epoch()),
 		"hash":             b.Hash(),
 		"parentHash":       head.ParentHash(),
 		"nonce":            0, // Remove this because we don't have it in our header


### PR DESCRIPTION
add viewID and epoch for RPCMarshalBlock function in order to check the consecutiveness of viewID in mainnet.