### PR TITLE
Fix commit payload

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -33,8 +33,6 @@ type Consensus struct {
 	phase FBFTPhase
 	// current indicates what state a node is in
 	current State
-	// epoch: current epoch number
-	epoch uint64
 	// blockNum: the next blockNumber that FBFT is going to agree on,
 	// should be equal to the blockNumber of next block
 	blockNum uint64

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -199,7 +199,7 @@ func (consensus *Consensus) String() string {
 	}
 
 	return fmt.Sprintf(
-		"[Duty:%s Pub:%s Header:%s Num:%d View:%d Shard:%d Epoch:%d]",
+		"[Duty:%s Pub:%s Header:%s Num:%d View:%d Shard:%d]",
 		duty,
 		consensus.PubKey.SerializeToHexStr(),
 		hex.EncodeToString(consensus.blockHeader),

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -1,8 +1,6 @@
 package consensus
 
 import (
-	"encoding/hex"
-	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -187,26 +185,6 @@ func (consensus *Consensus) ResetState() {
 	consensus.commitBitmap = commitBitmap
 	consensus.aggregatedPrepareSig = nil
 	consensus.aggregatedCommitSig = nil
-}
-
-// Returns a string representation of this consensus
-func (consensus *Consensus) String() string {
-	duty := ""
-	if consensus.IsLeader() {
-		duty = "leader"
-	} else {
-		duty = "validator"
-	}
-
-	return fmt.Sprintf(
-		"[Duty:%s Pub:%s Header:%s Num:%d View:%d Shard:%d]",
-		duty,
-		consensus.PubKey.SerializeToHexStr(),
-		hex.EncodeToString(consensus.blockHeader),
-		consensus.blockNum,
-		consensus.viewID,
-		consensus.ShardID,
-	)
 }
 
 // ToggleConsensusCheck flip the flag of whether ignore viewID check during consensus process

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -197,7 +197,7 @@ func (consensus *Consensus) BlockCommitSig(blockNum uint64) ([]byte, []byte, err
 	if err != nil ||
 		len(lastCommits) < shard.BLSSignatureSizeInBytes {
 		msgs := consensus.FBFTLog.GetMessagesByTypeSeq(
-			msg_pb.MessageType_COMMITTED, consensus.blockNum-1,
+			msg_pb.MessageType_COMMITTED, blockNum,
 		)
 		if len(msgs) != 1 {
 			consensus.getLogger().Error().

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -16,7 +16,6 @@ import (
 func (consensus *Consensus) announce(block *types.Block) {
 	blockHash := block.Hash()
 	copy(consensus.blockHash[:], blockHash[:])
-	consensus.epoch = block.Epoch().Uint64()
 
 	// prepare message and broadcast to validators
 	encodedBlock, err := rlp.EncodeToBytes(block)

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -1,10 +1,8 @@
 package consensus
 
 import (
-	"math/big"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/harmony-one/bls/ffi/go/bls"
 	msg_pb "github.com/harmony-one/harmony/api/proto/message"
@@ -18,6 +16,8 @@ import (
 func (consensus *Consensus) announce(block *types.Block) {
 	blockHash := block.Hash()
 	copy(consensus.blockHash[:], blockHash[:])
+	consensus.epoch = block.Epoch().Uint64()
+
 	// prepare message and broadcast to validators
 	encodedBlock, err := rlp.EncodeToBytes(block)
 	if err != nil {
@@ -62,9 +62,9 @@ func (consensus *Consensus) announce(block *types.Block) {
 			quorum.Prepare,
 			key,
 			consensus.priKey.PrivateKey[i].SignHash(consensus.blockHash[:]),
-			common.BytesToHash(consensus.blockHash[:]),
-			consensus.blockNum,
-			consensus.viewID,
+			block.Hash(),
+			block.NumberU64(),
+			block.Header().ViewID().Uint64(),
 		); err != nil {
 			return
 		}
@@ -222,9 +222,18 @@ func (consensus *Consensus) onCommit(msg *msg_pb.Message) {
 		logger.Debug().Msg("[OnCommit] Failed to deserialize bls signature")
 		return
 	}
-
+	// Must have the corresponding block to verify committed message.
+	blockObj := consensus.FBFTLog.GetBlockByHash(recvMsg.BlockHash)
+	if blockObj == nil {
+		consensus.getLogger().Debug().
+			Uint64("blockNum", recvMsg.BlockNum).
+			Uint64("viewID", recvMsg.ViewID).
+			Str("blockHash", recvMsg.BlockHash.Hex()).
+			Msg("[OnCommit] Failed finding a matching block for committed message")
+		return
+	}
 	commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
-		new(big.Int).SetUint64(consensus.epoch), recvMsg.BlockHash, recvMsg.BlockNum, consensus.viewID)
+		blockObj.Epoch(), blockObj.Hash(), blockObj.NumberU64(), blockObj.Header().ViewID().Uint64())
 	logger = logger.With().
 		Uint64("MsgViewID", recvMsg.ViewID).
 		Uint64("MsgBlockNum", recvMsg.BlockNum).

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -3,7 +3,6 @@ package consensus
 import (
 	"bytes"
 	"encoding/hex"
-	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -202,9 +201,9 @@ func (consensus *Consensus) onPrepared(msg *msg_pb.Message) {
 		copy(consensus.blockHash[:], blockHash[:])
 	}
 
-	// local viewID may not be constant with other, so use received msg viewID.
+	// Sign commit signature on the received block
 	commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
-		new(big.Int).SetUint64(consensus.epoch), consensus.blockHash, consensus.blockNum, recvMsg.ViewID)
+		blockObj.Epoch(), blockObj.Hash(), blockObj.NumberU64(), blockObj.Header().ViewID().Uint64())
 	groupID := []nodeconfig.GroupID{
 		nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(consensus.ShardID)),
 	}
@@ -259,9 +258,18 @@ func (consensus *Consensus) onCommitted(msg *msg_pb.Message) {
 		return
 	}
 
-	// Received msg must be about same epoch, otherwise it's invalid anyways.
+	// Must have the corresponding block to verify committed message.
+	blockObj := consensus.FBFTLog.GetBlockByHash(recvMsg.BlockHash)
+	if blockObj == nil {
+		consensus.getLogger().Debug().
+			Uint64("blockNum", recvMsg.BlockNum).
+			Uint64("viewID", recvMsg.ViewID).
+			Str("blockHash", recvMsg.BlockHash.Hex()).
+			Msg("[OnCommitted] Failed finding a matching block for committed message")
+		return
+	}
 	commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
-		new(big.Int).SetUint64(consensus.epoch), recvMsg.BlockHash, recvMsg.BlockNum, recvMsg.ViewID)
+		blockObj.Epoch(), blockObj.Hash(), blockObj.NumberU64(), blockObj.Header().ViewID().Uint64())
 	if !aggSig.VerifyHash(mask.AggregatePublic, commitPayload) {
 		consensus.getLogger().Error().
 			Uint64("MsgBlockNum", recvMsg.BlockNum).

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
-	"math/big"
 	"sync"
 	"time"
 
@@ -393,7 +392,7 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 				return
 			}
 			commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
-				new(big.Int).SetUint64(consensus.epoch), consensus.blockHash, consensus.blockNum, block.Header().ViewID().Uint64())
+				block.Epoch(), block.Hash(), block.NumberU64(), block.Header().ViewID().Uint64())
 			for i, key := range consensus.PubKey.PublicKey {
 				priKey := consensus.priKey.PrivateKey[i]
 				if _, err := consensus.Decider.SubmitVote(
@@ -401,8 +400,8 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 					key,
 					priKey.SignHash(commitPayload),
 					common.BytesToHash(consensus.blockHash[:]),
-					consensus.blockNum,
-					recvMsg.ViewID,
+					block.NumberU64(),
+					block.Header().ViewID().Uint64(),
 				); err != nil {
 					consensus.getLogger().Debug().Msg("submit vote on viewchange commit failed")
 					return
@@ -590,7 +589,7 @@ func (consensus *Consensus) onNewView(msg *msg_pb.Message) {
 			return
 		}
 		commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
-			new(big.Int).SetUint64(consensus.epoch), preparedBlock.Hash(), preparedBlock.NumberU64(), preparedBlock.Header().ViewID().Uint64())
+			preparedBlock.Epoch(), preparedBlock.Hash(), preparedBlock.NumberU64(), preparedBlock.Header().ViewID().Uint64())
 		groupID := []nodeconfig.GroupID{
 			nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(consensus.ShardID))}
 		for i, key := range consensus.PubKey.PublicKey {

--- a/core/offchain.go
+++ b/core/offchain.go
@@ -235,6 +235,7 @@ func (bc *BlockChain) CommitOffChainData(
 						stats, err = bc.ReadValidatorStats(paid[i].Addr)
 						if err != nil {
 							utils.Logger().Info().Err(err).
+								Str("addr", paid[i].Addr.Hex()).
 								Str("bls-earning-key", paid[i].EarningKey.Hex()).
 								Msg("could not read validator stats to update for earning per key")
 							continue

--- a/staking/slash/double-sign_test.go
+++ b/staking/slash/double-sign_test.go
@@ -39,7 +39,7 @@ var (
 const (
 	// validator creation parameters
 	doubleSignShardID     = 0
-	doubleSignEpoch       = 3
+	doubleSignEpoch       = 1
 	doubleSignBlockNumber = 37
 	doubleSignViewID      = 38
 

--- a/staking/slash/double-sign_test.go
+++ b/staking/slash/double-sign_test.go
@@ -39,7 +39,7 @@ var (
 const (
 	// validator creation parameters
 	doubleSignShardID     = 0
-	doubleSignEpoch       = 1
+	doubleSignEpoch       = 4
 	doubleSignBlockNumber = 37
 	doubleSignViewID      = 38
 
@@ -162,7 +162,7 @@ func TestVerify(t *testing.T) {
 			// error from blockchain.ReadShardState (fakeChainErrEpoch)
 			r: func() Record {
 				r := defaultSlashRecord()
-				r.Evidence.Epoch = big.NewInt(fakeChainErrEpoch)
+				r.Evidence.Epoch = big.NewInt(currentEpoch)
 				return r
 			}(),
 			sdb:   defaultTestStateDB(),

--- a/staking/slash/interface_test.go
+++ b/staking/slash/interface_test.go
@@ -35,7 +35,7 @@ func (bc *fakeBlockChain) CurrentBlock() *types.Block {
 }
 
 func (bc *fakeBlockChain) ReadShardState(epoch *big.Int) (*shard.State, error) {
-	if epoch.Cmp(big.NewInt(fakeChainErrEpoch)) == 0 {
+	if epoch.Cmp(big.NewInt(currentEpoch)) == 0 {
 		return nil, errFakeChainUnexpectEpoch
 	}
 	return &bc.superCommittee, nil


### PR DESCRIPTION
The commit signature payload was changed with a forking logic based on epoch.

The original code used data from somewhere not directly from the block data, which can cause issues if those data are inconsistent.

Should always directly use the block's data for commit payload.

Also:
1. Add commit signature into block explorer commit
2. Remove consensus.epoch

Tested locally, consensus reached.

Fixing: https://github.com/harmony-one/harmony/issues/2976