### PR TITLE
fix crash on parsed block

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -384,6 +384,9 @@ func NewBlockWithHeader(header *block.Header) *Block {
 // CopyHeader creates a deep copy of a block header to prevent side effects from
 // modifying a header variable.
 func CopyHeader(h *block.Header) *block.Header {
+	if h == nil {
+		return nil
+	}
 	cpy := *h
 	cpy.Header = cpy.Header.Copy()
 	return &cpy


### PR DESCRIPTION
fix crash:

panic: runtime error: invalid memory address or nil pointer dereference
May 12 20:29:25 ip-172-31-3-164.us-west-1.compute.internal harmony[17497]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x10faaf5]
May 12 20:29:25 ip-172-31-3-164.us-west-1.compute.internal harmony[17497]: goroutine 799 [running]:
May 12 20:29:25 ip-172-31-3-164.us-west-1.compute.internal harmony[17497]: github.com/harmony-one/harmony/core/types.CopyHeader(...)
May 12 20:29:25 ip-172-31-3-164.us-west-1.compute.internal harmony[17497]: /home/ec2-user/go/src/github.com/harmony-one/harmony/core/types/block.go:387
May 12 20:29:25 ip-172-31-3-164.us-west-1.compute.internal harmony[17497]: github.com/harmony-one/harmony/core/types.(*Block).Header(...)
May 12 20:29:25 ip-172-31-3-164.us-west-1.compute.internal harmony[17497]: /home/ec2-user/go/src/github.com/harmony-one/harmony/core/types/block.go:520
May 12 20:29:25 ip-172-31-3-164.us-west-1.compute.internal harmony[17497]: github.com/harmony-one/harmony/node.(*Node).VerifyNewBlock(0xc00052a480, 0xc017e00410, 0xc000774f01, 0xc017e00410)
May 12 20:29:25 ip-172-31-3-164.us-west-1.compute.internal harmony[17497]: /home/ec2-user/go/src/github.com/harmony-one/harmony/node/node_handler.go:291 +0xd95
May 12 20:29:25 ip-172-31-3-164.us-west-1.compute.internal harmony[17497]: github.com/harmony-one/harmony/consensus.(*Consensus).onViewChange(0xc0000bed80, 0xc01c502640)
May 12 20:29:25 ip-172-31-3-164.us-west-1.compute.internal harmony[17497]: /home/ec2-user/go/src/github.com/harmony-one/harmony/consensus/view_change.go:262 +0xb0d
May 12 20:29:25 ip-172-31-3-164.us-west-1.compute.internal harmony[17497]: github.com/harmony-one/harmony/consensus.(*Consensus).handleMessageUpdate(0xc0000bed80, 0xc01c8e4006, 0x197, 0x19a)
May 12 20:29:25 ip-172-31-3-164.us-west-1.compute.internal harmony[17497]: /home/ec2-user/go/src/github.com/harmony-one/harmony/consensus/consensus_v2.go:94 +0x254
May 12 20:29:25 ip-172-31-3-164.us-west-1.compute.internal harmony[17497]: github.com/harmony-one/harmony/consensus.(*Consensus).Start.func1(0xc0000bed80, 0xc0005444e0, 0xc0003d7620, 0xc000481e60, 0xc0003d75c0)
May 12 20:29:25 ip-172-31-3-164.us-west-1.compute.internal harmony[17497]: /home/ec2-user/go/src/github.com/harmony-one/harmony/consensus/consensus_v2.go:500 +0x652
May 12 20:29:25 ip-172-31-3-164.us-west-1.compute.internal harmony[17497]: created by github.com/harmony-one/harmony/consensus.(*Consensus).Start
May 12 20:29:25 ip-172-31-3-164.us-west-1.compute.internal harmony[17497]: /home/ec2-user/go/src/github.com/harmony-one/harmony/consensus/consensus_v2.go:339 +0x67
May 12 20:29:25 ip-172-31-3-164.us-west-1.compute.internal harmony[17497]: node.sh: node process finished with status 2

![image](https://user-images.githubusercontent.com/1042540/81754119-367fa280-946a-11ea-8eaa-c6727f529ce9.png)
