### PR TITLE
Make leader commit m1payload itself

### DIFF
--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -189,6 +189,9 @@ func (consensus *Consensus) onPrepare(msg *msg_pb.Message) {
 }
 
 func (consensus *Consensus) onCommit(msg *msg_pb.Message) {
+	if consensus.viewID == 10 {
+		return
+	}
 	recvMsg, err := ParseFBFTMessage(msg)
 	if err != nil {
 		consensus.getLogger().Debug().Err(err).Msg("[OnCommit] Parse pbft message failed")

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -189,9 +189,6 @@ func (consensus *Consensus) onPrepare(msg *msg_pb.Message) {
 }
 
 func (consensus *Consensus) onCommit(msg *msg_pb.Message) {
-	if consensus.viewID == 10 {
-		return
-	}
 	recvMsg, err := ParseFBFTMessage(msg)
 	if err != nil {
 		consensus.getLogger().Debug().Err(err).Msg("[OnCommit] Parse pbft message failed")

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -195,16 +195,29 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 			msg_pb.MessageType_PREPARED, recvMsg.BlockNum,
 		)
 		preparedMsg := consensus.FBFTLog.FindMessageByMaxViewID(preparedMsgs)
-
-		if preparedMsg != nil && consensus.FBFTLog.GetBlockByHash(
-			preparedMsg.BlockHash,
-		) != nil {
+		hasBlock := false
+		if preparedMsg != nil {
+			if preparedBlock := consensus.FBFTLog.GetBlockByHash(
+				preparedMsg.BlockHash,
+			); preparedBlock != nil {
+				if consensus.BlockVerifier(preparedBlock); err != nil {
+					consensus.getLogger().Error().Err(err).Msg("[onViewChange] My own prepared block verification failed")
+				} else {
+					hasBlock = true
+				}
+			}
+		}
+		if hasBlock {
 			consensus.getLogger().Debug().Msg("[onViewChange] add my M1 type messaage")
 			msgToSign := append(preparedMsg.BlockHash[:], preparedMsg.Payload...)
 			for i, key := range consensus.PubKey.PublicKey {
 				priKey := consensus.priKey.PrivateKey[i]
 				consensus.bhpSigs[recvMsg.ViewID][key.SerializeToHexStr()] = priKey.SignHash(msgToSign)
 				consensus.bhpBitmap[recvMsg.ViewID].SetKey(key, true)
+			}
+			// if m1Payload is empty, we just add one
+			if len(consensus.m1Payload) == 0 {
+				consensus.m1Payload = append(preparedMsg.BlockHash[:], preparedMsg.Payload...)
 			}
 		} else {
 			consensus.getLogger().Debug().Msg("[onViewChange] add my M2(NIL) type messaage")
@@ -357,7 +370,7 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 	consensus.viewIDBitmap[recvMsg.ViewID].SetKey(recvMsg.SenderPubkey, true)
 	consensus.getLogger().Debug().
 		Int("have", len(consensus.viewIDSigs[recvMsg.ViewID])).
-		Int64("needed", consensus.Decider.TwoThirdsSignersCount()).
+		Int64("total", consensus.Decider.ParticipantsCount()).
 		Msg("[onViewChange]")
 
 	// received enough view change messages, change state to normal consensus


### PR DESCRIPTION
Hit a view change stuck issue in https://github.com/harmony-one/harmony/issues/2976 . The issue is that leader added M1 msg itself, while no one else votes on M1 (prepared)
![image](https://user-images.githubusercontent.com/1042540/81781505-0f969000-94ad-11ea-9bfc-e058895f9f7b.png)

But Leader didn't put m1payload itself, which caused the newView msg validation failure on validators. `[onNewView] M1 (prepared) Type Payload Not Have Enough Length"`

Solution is to let the leader itself add m1payload when itself added M1 signatures.

Tested locally.