### PR TITLE
[rpc] add viewID and epoch to RPCMarshalBlock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ENV LD_LIBRARY_PATH=${BLS_DIR}/lib:${MCL_DIR}/lib
 ENV GIMME_GO_VERSION="1.14.1"
 ENV PATH="/root/bin:${PATH}"
 
+RUN apt-get update -y
 RUN apt install libgmp-dev libssl-dev curl git \
 psmisc dnsutils jq make gcc g++ bash tig tree sudo vim \
 silversearcher-ag unzip emacs-nox nano bash-completion -y

--- a/internal/hmyapi/apiv1/types.go
+++ b/internal/hmyapi/apiv1/types.go
@@ -353,6 +353,8 @@ func newRPCStakingTransaction(tx *types2.StakingTransaction, blockHash common.Ha
 // RPCBlock represents a block that will serialize to the RPC representation of a block
 type RPCBlock struct {
 	Number           *hexutil.Big     `json:"number"`
+	ViewID           *hexutil.Big     `json:"viewID"`
+	Epoch            *hexutil.Big     `json:"epoch"`
 	Hash             common.Hash      `json:"hash"`
 	ParentHash       common.Hash      `json:"parentHash"`
 	Nonce            types.BlockNonce `json:"nonce"`
@@ -382,6 +384,8 @@ func RPCMarshalBlock(b *types.Block, blockArgs BlockArgs) (map[string]interface{
 	head := b.Header() // copies the header once
 	fields := map[string]interface{}{
 		"number":           (*hexutil.Big)(head.Number()),
+		"viewID":           (*hexutil.Big)(head.ViewID()),
+		"epoch":            (*hexutil.Big)(head.Epoch()),
 		"hash":             b.Hash(),
 		"parentHash":       head.ParentHash(),
 		"nonce":            0, // Remove this because we don't have it in our header

--- a/internal/hmyapi/apiv2/types.go
+++ b/internal/hmyapi/apiv2/types.go
@@ -355,6 +355,8 @@ func newRPCStakingTransaction(
 // RPCBlock represents a block that will serialize to the RPC representation of a block
 type RPCBlock struct {
 	Number           *big.Int         `json:"number"`
+	ViewID           *big.Int         `json:"viewID"`
+	Epoch            *big.Int         `json:"epoch"`
 	Hash             common.Hash      `json:"hash"`
 	ParentHash       common.Hash      `json:"parentHash"`
 	Nonce            types.BlockNonce `json:"nonce"`
@@ -384,6 +386,8 @@ func RPCMarshalBlock(b *types.Block, blockArgs BlockArgs) (map[string]interface{
 	head := b.Header() // copies the header once
 	fields := map[string]interface{}{
 		"number":           (*big.Int)(head.Number()),
+		"viewID":           (*big.Int)(head.ViewID()),
+		"epoch":            (*big.Int)(head.Epoch()),
 		"hash":             b.Hash(),
 		"parentHash":       head.ParentHash(),
 		"nonce":            0, // Remove this because we don't have it in our header


### PR DESCRIPTION
want to get the number of block numbers in each epoch for non-beacon shards, so add epoch number to `hmy_getBlockByNumber`. 