### PR TITLE
Add LastEpochInCommittee at prestaking epoch too

### DIFF
--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -248,11 +248,12 @@ func (e *engineImpl) Finalize(
 
 	isBeaconChain := header.ShardID() == shard.BeaconChainShardID
 	isNewEpoch := len(header.ShardState()) > 0
+	inPreStakingEra := chain.Config().IsPreStaking(header.Epoch())
 	inStakingEra := chain.Config().IsStaking(header.Epoch())
 
 	// Process Undelegations, set LastEpochInCommittee and set EPoS status
 	// Needs to be before AccumulateRewardsAndCountSigs
-	if isBeaconChain && isNewEpoch && inStakingEra {
+	if isBeaconChain && isNewEpoch && inPreStakingEra {
 		if err := payoutUndelegations(chain, header, state); err != nil {
 			return nil, nil, err
 		}

--- a/staking/availability/measure.go
+++ b/staking/availability/measure.go
@@ -205,6 +205,7 @@ func ComputeAndMutateEPOSStatus(
 		wrapper.Status = effective.Inactive
 		utils.Logger().Info().
 			Str("threshold", measure.String()).
+			Interface("computed", computed).
 			Msg("validator failed availability threshold, set to inactive")
 	default:
 		// Default is no-op so validator who wants


### PR DESCRIPTION
LastEpochInCommittee wasn't set at prestaking epoch for the first staking epoch.

Which caused the unavailability rule to malfunctioning in the first staking epoch.

This PR changes the logic to also set LastEpochInCommittee in pre-staking epoch.