### PR TITLE
[network] Added caching to node server

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -158,8 +158,8 @@ type Node struct {
 	// TransactionErrorSink contains error messages for any failed transaction, in memory only
 	TransactionErrorSink *types.TransactionErrorSink
 	// caching fields for node requests
-	blockHeaderSF singleflight.Group
-	blockSF       singleflight.Group
+	headerGroup singleflight.Group
+	blockGroup  singleflight.Group
 }
 
 // Blockchain returns the blockchain for the node's current shard.

--- a/node/node.go
+++ b/node/node.go
@@ -40,7 +40,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/semaphore"
-	"golang.org/x/sync/singleflight"
 )
 
 // State is a state of a node.
@@ -157,9 +156,6 @@ type Node struct {
 	keysToAddrsMutex sync.Mutex
 	// TransactionErrorSink contains error messages for any failed transaction, in memory only
 	TransactionErrorSink *types.TransactionErrorSink
-	// caching fields for node requests
-	headerGroup singleflight.Group
-	blockGroup  singleflight.Group
 }
 
 // Blockchain returns the blockchain for the node's current shard.

--- a/node/node.go
+++ b/node/node.go
@@ -40,6 +40,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/semaphore"
+	"golang.org/x/sync/singleflight"
 )
 
 // State is a state of a node.
@@ -156,6 +157,9 @@ type Node struct {
 	keysToAddrsMutex sync.Mutex
 	// TransactionErrorSink contains error messages for any failed transaction, in memory only
 	TransactionErrorSink *types.TransactionErrorSink
+	// caching fields for node requests
+	blockHeaderSF singleflight.Group
+	blockSF       singleflight.Group
 }
 
 // Blockchain returns the blockchain for the node's current shard.

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -473,7 +473,7 @@ var (
 
 func (node *Node) getEncodedBlockHeaderByHash(hash common.Hash) ([]byte, error) {
 	key := fmt.Sprintf("%x", hash)
-	b, err, _ := node.blockHeaderSF.Do(key, func() (interface{}, error) {
+	b, err, _ := node.headerGroup.Do(key, func() (interface{}, error) {
 		h := node.Blockchain().GetHeaderByHash(hash)
 		if h == nil {
 			return nil, errHeaderNotExist
@@ -485,7 +485,7 @@ func (node *Node) getEncodedBlockHeaderByHash(hash common.Hash) ([]byte, error) 
 
 func (node *Node) getEncodedBlockByHash(hash common.Hash) ([]byte, error) {
 	key := fmt.Sprintf("%x", hash)
-	b, err, _ := node.blockSF.Do(key, func() (interface{}, error) {
+	b, err, _ := node.blockGroup.Do(key, func() (interface{}, error) {
 		blk := node.Blockchain().GetBlockByHash(hash)
 		if blk == nil {
 			return nil, errBlockNotExist

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -484,6 +484,9 @@ func (node *Node) getEncodedBlockHeaderByHash(hash common.Hash) ([]byte, error) 
 		}
 		return rlp.EncodeToBytes(h)
 	})
+	if err != nil {
+		node.headerGroup.Forget(key)
+	}
 	return b.([]byte), err
 }
 
@@ -496,5 +499,8 @@ func (node *Node) getEncodedBlockByHash(hash common.Hash) ([]byte, error) {
 		}
 		return rlp.EncodeToBytes(blk)
 	})
+	if err != nil {
+		node.blockGroup.Forget(key)
+	}
 	return b.([]byte), err
 }

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -472,8 +472,8 @@ func (node *Node) CalculateResponse(request *downloader_pb.DownloaderRequest, in
 }
 
 const (
-	headerCacheSize = 100000
-	blockCacheSize  = 100000
+	headerCacheSize = 10000
+	blockCacheSize  = 10000
 )
 
 var (

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -472,8 +472,8 @@ func (node *Node) CalculateResponse(request *downloader_pb.DownloaderRequest, in
 }
 
 const (
-	headerCacheSize = 50000000
-	blockCacheSize  = 100000000
+	headerCacheSize = 100000
+	blockCacheSize  = 100000
 )
 
 var (

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -379,18 +379,22 @@ func (node *Node) CalculateResponse(request *downloader_pb.DownloaderRequest, in
 		var hash common.Hash
 		for _, bytes := range request.Hashes {
 			hash.SetBytes(bytes)
-			encodedBlockHeader, _ := node.getEncodedBlockHeaderByHash(hash)
+			encodedBlockHeader, err := node.getEncodedBlockHeaderByHash(hash)
 
-			response.Payload = append(response.Payload, encodedBlockHeader)
+			if err == nil {
+				response.Payload = append(response.Payload, encodedBlockHeader)
+			}
 		}
 
 	case downloader_pb.DownloaderRequest_BLOCK:
 		var hash common.Hash
 		for _, bytes := range request.Hashes {
 			hash.SetBytes(bytes)
-			encodedBlock, _ := node.getEncodedBlockByHash(hash)
+			encodedBlock, err := node.getEncodedBlockByHash(hash)
 
-			response.Payload = append(response.Payload, encodedBlock)
+			if err == nil {
+				response.Payload = append(response.Payload, encodedBlock)
+			}
 		}
 
 	case downloader_pb.DownloaderRequest_BLOCKHEIGHT:


### PR DESCRIPTION
## Issue

Added caching mechanism to node handling sync traffic for two requests:

1. `DownloaderRequest_BLOCKHEADER`
2. `DownloaderRequest_BLOCK`

The two requested are heavily handled in explorer node. Caching these two requests will save one rlp CPU time each request.


## Test

Code passed local test. 

[test log](https://gist.github.com/JackyWYX/c1e21f37ec4c0cdb8565f03d9b16f8c7)

After changed the solution from `singleflight` to `lru.Cache`, tested again and passed.

[test log](https://gist.github.com/JackyWYX/fa6a57acc78893ee7c8c3e9e9caf2629)

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**
