### PR TITLE
Transaction api improvements

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -110,8 +110,9 @@ var (
 	revertTo       = flag.Int("revert_to", 0, "The revert will rollback all blocks until and including block number revert_to")
 	revertBeacon   = flag.Bool("revert_beacon", false, "Whether to revert beacon chain or the chain this node is assigned to")
 	// Blacklist of addresses
-	blacklistPath   = flag.String("blacklist", "./.hmy/blacklist.txt", "Path to newline delimited file of blacklisted wallet addresses")
-	webHookYamlPath = flag.String(
+	blacklistPath      = flag.String("blacklist", "./.hmy/blacklist.txt", "Path to newline delimited file of blacklisted wallet addresses")
+	broadcastInvalidTx = flag.Bool("broadcast_invalid_tx", true, "Broadcast invalid transactions to sync pool state (default: true)")
+	webHookYamlPath    = flag.String(
 		"webhook_yaml", "", "path for yaml config reporting double signing",
 	)
 	// aws credentials
@@ -460,6 +461,7 @@ func setupConsensusAndNode(nodeConfig *nodeconfig.ConfigType) *node.Node {
 	chainDBFactory := &shardchain.LDBFactory{RootDir: nodeConfig.DBDir}
 
 	currentNode := node.New(myHost, currentConsensus, chainDBFactory, blacklist, *isArchival)
+	currentNode.BroadcastInvalidTx = *broadcastInvalidTx
 
 	switch {
 	case *networkType == nodeconfig.Localnet:

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -111,7 +111,7 @@ var (
 	revertBeacon   = flag.Bool("revert_beacon", false, "Whether to revert beacon chain or the chain this node is assigned to")
 	// Blacklist of addresses
 	blacklistPath      = flag.String("blacklist", "./.hmy/blacklist.txt", "Path to newline delimited file of blacklisted wallet addresses")
-	broadcastInvalidTx = flag.Bool("broadcast_invalid_tx", true, "Broadcast invalid transactions to sync pool state (default: true)")
+	broadcastInvalidTx = flag.Bool("broadcast_invalid_tx", false, "Broadcast invalid transactions to sync pool state (default: false)")
 	webHookYamlPath    = flag.String(
 		"webhook_yaml", "", "path for yaml config reporting double signing",
 	)

--- a/internal/hmyapi/apiv1/util.go
+++ b/internal/hmyapi/apiv1/util.go
@@ -36,7 +36,9 @@ func SubmitTransaction(
 	ctx context.Context, b Backend, tx *types.Transaction,
 ) (common.Hash, error) {
 	if err := b.SendTx(ctx, tx); err != nil {
-		return common.Hash{}, err
+		// legacy behavior is to never return error and always return tx hash
+		utils.Logger().Warn().Err(err).Msg("Could not submit transaction")
+		return tx.Hash(), nil
 	}
 	if tx.To() == nil {
 		signer := types.MakeSigner(b.ChainConfig(), b.CurrentBlock().Epoch())
@@ -63,7 +65,9 @@ func SubmitStakingTransaction(
 	ctx context.Context, b Backend, tx *staking.StakingTransaction,
 ) (common.Hash, error) {
 	if err := b.SendStakingTx(ctx, tx); err != nil {
-		return common.Hash{}, err
+		// legacy behavior is to never return error and always return tx hash
+		utils.Logger().Warn().Err(err).Msg("Could not submit staking transaction")
+		return tx.Hash(), nil
 	}
 	utils.Logger().Info().Str("fullhash", tx.Hash().Hex()).Msg("Submitted Staking transaction")
 	return tx.Hash(), nil

--- a/internal/hmyapi/apiv2/util.go
+++ b/internal/hmyapi/apiv2/util.go
@@ -36,7 +36,9 @@ func SubmitTransaction(
 	ctx context.Context, b Backend, tx *types.Transaction,
 ) (common.Hash, error) {
 	if err := b.SendTx(ctx, tx); err != nil {
-		return common.Hash{}, err
+		// legacy behavior is to never return error and always return tx hash
+		utils.Logger().Warn().Err(err).Msg("Could not submit transaction")
+		return tx.Hash(), nil
 	}
 	if tx.To() == nil {
 		signer := types.MakeSigner(b.ChainConfig(), b.CurrentBlock().Epoch())
@@ -63,7 +65,9 @@ func SubmitStakingTransaction(
 	ctx context.Context, b Backend, tx *staking.StakingTransaction,
 ) (common.Hash, error) {
 	if err := b.SendStakingTx(ctx, tx); err != nil {
-		return common.Hash{}, err
+		// legacy behavior is to never return error and always return tx hash
+		utils.Logger().Warn().Err(err).Msg("Could not submit staking transaction")
+		return tx.Hash(), nil
 	}
 	utils.Logger().Info().Str("fullhash", tx.Hash().Hex()).Msg("Submitted Staking transaction")
 	return tx.Hash(), nil

--- a/node/node.go
+++ b/node/node.go
@@ -156,6 +156,8 @@ type Node struct {
 	keysToAddrsMutex sync.Mutex
 	// TransactionErrorSink contains error messages for any failed transaction, in memory only
 	TransactionErrorSink *types.TransactionErrorSink
+	// BroadcastInvalidTx flag is considered when adding pending tx to tx-pool
+	BroadcastInvalidTx bool
 }
 
 // Blockchain returns the blockchain for the node's current shard.
@@ -258,13 +260,18 @@ func (node *Node) AddPendingStakingTransaction(
 ) error {
 	if node.NodeConfig.ShardID == shard.BeaconChainShardID {
 		errs := node.addPendingStakingTransactions(staking.StakingTransactions{newStakingTx})
+		var err error
 		for i := range errs {
 			if errs[i] != nil {
-				return errs[i]
+				err = errs[i]
+				break
 			}
 		}
-		utils.Logger().Info().Str("Hash", newStakingTx.Hash().Hex()).Msg("Broadcasting Staking Tx")
-		node.tryBroadcastStaking(newStakingTx)
+		if err == nil || node.BroadcastInvalidTx {
+			utils.Logger().Info().Str("Hash", newStakingTx.Hash().Hex()).Msg("Broadcasting Staking Tx")
+			node.tryBroadcastStaking(newStakingTx)
+		}
+		return err
 	}
 	return nil
 }
@@ -274,13 +281,18 @@ func (node *Node) AddPendingStakingTransaction(
 func (node *Node) AddPendingTransaction(newTx *types.Transaction) error {
 	if newTx.ShardID() == node.NodeConfig.ShardID {
 		errs := node.addPendingTransactions(types.Transactions{newTx})
+		var err error
 		for i := range errs {
 			if errs[i] != nil {
-				return errs[i]
+				err = errs[i]
+				break
 			}
 		}
-		utils.Logger().Info().Str("Hash", newTx.Hash().Hex()).Msg("Broadcasting Tx")
-		node.tryBroadcast(newTx)
+		if err == nil || node.BroadcastInvalidTx {
+			utils.Logger().Info().Str("Hash", newTx.Hash().Hex()).Msg("Broadcasting Tx")
+			node.tryBroadcast(newTx)
+		}
+		return err
 	}
 	return nil
 }

--- a/node/node.go
+++ b/node/node.go
@@ -264,7 +264,7 @@ func (node *Node) AddPendingStakingTransaction(
 		var err error
 		for i := range errs {
 			if errs[i] != nil {
-        utils.Logger().Info().Err(errs[i]).Msg("[AddPendingStakingTransaction] Failed adding new staking transaction")
+				utils.Logger().Info().Err(errs[i]).Msg("[AddPendingStakingTransaction] Failed adding new staking transaction")
 				err = errs[i]
 				break
 			}
@@ -286,10 +286,10 @@ func (node *Node) AddPendingTransaction(newTx *types.Transaction) error {
 		var err error
 		for i := range errs {
 			if errs[i] != nil {
-        utils.Logger().Info().Err(errs[i]).Msg("[AddPendingTransaction] Failed adding new transaction")
+				utils.Logger().Info().Err(errs[i]).Msg("[AddPendingTransaction] Failed adding new transaction")
 				err = errs[i]
-				break			
-      }
+				break
+			}
 		}
 		if err == nil || node.BroadcastInvalidTx {
 			utils.Logger().Info().Str("Hash", newTx.Hash().Hex()).Msg("Broadcasting Tx")

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -188,6 +188,7 @@ options:
    -r address     start a pprof profiling server listening on the specified address
    -I             use statically linked Harmony binary (default: true)
    -R tracefile   enable p2p trace using tracefile (default: off)
+   -L             limit broadcasting of invalid transactions (default: off)
 
 examples:
 
@@ -239,7 +240,7 @@ BUCKET=pub.harmony.one
 OS=$(uname -s)
 
 unset start_clean loop run_as_root blspass do_not_download download_only network node_type shard_id download_harmony_db db_file_to_dl
-unset upgrade_rel public_rpc staking_mode pub_port multi_key blsfolder blacklist verify TRACEFILE minpeers max_bls_keys_per_node
+unset upgrade_rel public_rpc staking_mode pub_port multi_key blsfolder blacklist verify TRACEFILE minpeers max_bls_keys_per_node broadcast_invalid_tx
 start_clean=false
 loop=true
 run_as_root=true
@@ -260,12 +261,13 @@ static=true
 verify=false
 minpeers=6
 max_bls_keys_per_node=10
+broadcast_invalid_tx=true
 ${BLSKEYFILE=}
 ${TRACEFILE=}
 
 unset OPTIND OPTARG opt
 OPTIND=1
-while getopts :1chk:sSp:dDN:T:i:ba:U:PvVyzn:MAIB:r:Y:f:R:m: opt
+while getopts :1chk:sSp:dDN:T:i:ba:U:PvVyzn:MAIB:r:Y:f:R:m:L opt
 do
    case "${opt}" in
    '?') usage "unrecognized option -${OPTARG}";;
@@ -302,6 +304,7 @@ do
    y) staking_mode=false;;
    A) archival=true;;
    R) TRACEFILE="${OPTARG}";;
+   L) broadcast_invalid_tx=false;;
    *) err 70 "unhandled option -${OPTARG}";;  # EX_SOFTWARE
    esac
 done
@@ -891,6 +894,7 @@ do
       -blacklist="${blacklist}"
       -min_peers="${minpeers}"
       -max_bls_keys_per_node="${max_bls_keys_per_node}"
+      -broadcast_invalid_tx="${broadcast_invalid_tx}"
    )
    args+=(
       -is_archival="${archival}"


### PR DESCRIPTION
## Issue

Currently, we don't check if transactions have been finalized before adding it to tx pool.
Moreover, we don't broadcast failed tx which makes the error sink inconsistent across all nodes. However, to protect the network from needless tx spam in the case of an attack, one can enable the option to not broadcast failed txs. 

## Test

Tested locally by sending a bunch of invalid txs to all nodes on localnet, error sink stayed synced. 
Also tested replay of same tx, error sink didn't report and saw the warning in logs that tx was not added to pool. 

### Unit Test Coverage

Before:

```
PASS
coverage: 11.3% of statements
ok      github.com/harmony-one/harmony/node     1.515s

```

After:

```
PASS
coverage: 11.2% of statements
ok      github.com/harmony-one/harmony/node     1.565s

```


## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**