### PR TITLE
[rpc] Add active status back to Validator information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ libs:
 	make -C $(TOP)/bls BLS_SWAP_G=1 -j8
 
 exe:
-	./scripts/go_executable_build.sh
+	./scripts/go_executable_build.sh -S
 
 race:
 	./scripts/go_executable_build.sh -r

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -387,7 +387,7 @@ var (
 // GetValidatorInformation returns the information of validator
 func (b *APIBackend) GetValidatorInformation(
 	addr common.Address, block *types.Block,
-) (*staking.ValidatorRPCEnchanced, error) {
+) (*staking.ValidatorRPCEnhanced, error) {
 	bc := b.hmy.BlockChain()
 	wrapper, err := bc.ReadValidatorInformationAt(addr, block.Root())
 	if err != nil {
@@ -399,7 +399,7 @@ func (b *APIBackend) GetValidatorInformation(
 	// At the last block of epoch, block epoch is e while val.LastEpochInCommittee
 	// is already updated to e+1. So need the >= check rather than ==
 	inCommittee := wrapper.LastEpochInCommittee.Cmp(now) >= 0
-	defaultReply := &staking.ValidatorRPCEnchanced{
+	defaultReply := &staking.ValidatorRPCEnhanced{
 		CurrentlyInCommittee: inCommittee,
 		Wrapper:              *wrapper,
 		Performance:          nil,
@@ -410,6 +410,7 @@ func (b *APIBackend) GetValidatorInformation(
 		).String(),
 		EPoSWinningStake: nil,
 		BootedStatus:     nil,
+		ActiveStatus:     wrapper.Validator.Status.String(),
 		Lifetime: &staking.AccumulatedOverLifetime{
 			wrapper.BlockReward,
 			wrapper.Counters,

--- a/internal/hmyapi/apiv1/backend.go
+++ b/internal/hmyapi/apiv1/backend.go
@@ -74,7 +74,7 @@ type Backend interface {
 	SendStakingTx(ctx context.Context, newStakingTx *staking.StakingTransaction) error
 	GetElectedValidatorAddresses() []common.Address
 	GetAllValidatorAddresses() []common.Address
-	GetValidatorInformation(addr common.Address, block *types.Block) (*staking.ValidatorRPCEnchanced, error)
+	GetValidatorInformation(addr common.Address, block *types.Block) (*staking.ValidatorRPCEnhanced, error)
 	GetDelegationsByValidator(validator common.Address) []*staking.Delegation
 	GetDelegationsByDelegator(delegator common.Address) ([]common.Address, []*staking.Delegation)
 	GetDelegationsByDelegatorByBlock(delegator common.Address, block *types.Block) ([]common.Address, []*staking.Delegation)

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -627,7 +627,7 @@ func (s *PublicBlockChainAPI) GetElectedValidatorAddresses() ([]string, error) {
 // GetValidatorInformation returns information about a validator.
 func (s *PublicBlockChainAPI) GetValidatorInformation(
 	ctx context.Context, address string,
-) (*staking.ValidatorRPCEnchanced, error) {
+) (*staking.ValidatorRPCEnhanced, error) {
 	if err := s.isBeaconShard(); err != nil {
 		return nil, err
 	}
@@ -643,7 +643,7 @@ func (s *PublicBlockChainAPI) GetValidatorInformation(
 // GetValidatorInformationByBlockNumber returns information about a validator.
 func (s *PublicBlockChainAPI) GetValidatorInformationByBlockNumber(
 	ctx context.Context, address string, blockNr rpc.BlockNumber,
-) (*staking.ValidatorRPCEnchanced, error) {
+) (*staking.ValidatorRPCEnhanced, error) {
 	if err := s.isBeaconShard(); err != nil {
 		return nil, err
 	}
@@ -661,13 +661,13 @@ func (s *PublicBlockChainAPI) GetValidatorInformationByBlockNumber(
 
 func (s *PublicBlockChainAPI) getAllValidatorInformation(
 	ctx context.Context, page int, blockNr rpc.BlockNumber,
-) ([]*staking.ValidatorRPCEnchanced, error) {
+) ([]*staking.ValidatorRPCEnhanced, error) {
 	if page < -1 {
 		return nil, errors.Errorf("page given %d cannot be less than -1", page)
 	}
 	addresses := s.b.GetAllValidatorAddresses()
 	if page != -1 && len(addresses) <= page*validatorsPageSize {
-		return make([]*staking.ValidatorRPCEnchanced, 0), nil
+		return make([]*staking.ValidatorRPCEnhanced, 0), nil
 	}
 	validatorsNum := len(addresses)
 	start := 0
@@ -678,7 +678,7 @@ func (s *PublicBlockChainAPI) getAllValidatorInformation(
 			validatorsNum = len(addresses) - start
 		}
 	}
-	validators := make([]*staking.ValidatorRPCEnchanced, validatorsNum)
+	validators := make([]*staking.ValidatorRPCEnhanced, validatorsNum)
 	block, err := s.b.BlockByNumber(ctx, rpc.BlockNumber(blockNr))
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not retrieve the block information for block number: %d", blockNr)
@@ -697,7 +697,7 @@ func (s *PublicBlockChainAPI) getAllValidatorInformation(
 // If page is -1, return all instead of `validatorsPageSize` elements.
 func (s *PublicBlockChainAPI) GetAllValidatorInformation(
 	ctx context.Context, page int,
-) ([]*staking.ValidatorRPCEnchanced, error) {
+) ([]*staking.ValidatorRPCEnhanced, error) {
 	if err := s.isBeaconShard(); err != nil {
 		return nil, err
 	}
@@ -717,14 +717,14 @@ func (s *PublicBlockChainAPI) GetAllValidatorInformation(
 	if err != nil {
 		return nil, err
 	}
-	return res.([]*staking.ValidatorRPCEnchanced), nil
+	return res.([]*staking.ValidatorRPCEnhanced), nil
 }
 
 // GetAllValidatorInformationByBlockNumber returns information about all validators.
 // If page is -1, return all instead of `validatorsPageSize` elements.
 func (s *PublicBlockChainAPI) GetAllValidatorInformationByBlockNumber(
 	ctx context.Context, page int, blockNr rpc.BlockNumber,
-) ([]*staking.ValidatorRPCEnchanced, error) {
+) ([]*staking.ValidatorRPCEnhanced, error) {
 	if err := s.isBeaconShard(); err != nil {
 		return nil, err
 	}

--- a/internal/hmyapi/apiv2/backend.go
+++ b/internal/hmyapi/apiv2/backend.go
@@ -70,7 +70,7 @@ type Backend interface {
 	SendStakingTx(ctx context.Context, newStakingTx *staking.StakingTransaction) error
 	GetElectedValidatorAddresses() []common.Address
 	GetAllValidatorAddresses() []common.Address
-	GetValidatorInformation(addr common.Address, block *types.Block) (*staking.ValidatorRPCEnchanced, error)
+	GetValidatorInformation(addr common.Address, block *types.Block) (*staking.ValidatorRPCEnhanced, error)
 	GetDelegationsByValidator(validator common.Address) []*staking.Delegation
 	GetDelegationsByDelegator(delegator common.Address) ([]common.Address, []*staking.Delegation)
 	GetDelegationsByDelegatorByBlock(delegator common.Address, block *types.Block) ([]common.Address, []*staking.Delegation)

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -578,7 +578,7 @@ func (s *PublicBlockChainAPI) GetElectedValidatorAddresses() ([]string, error) {
 // GetValidatorInformation ..
 func (s *PublicBlockChainAPI) GetValidatorInformation(
 	ctx context.Context, address string,
-) (*staking.ValidatorRPCEnchanced, error) {
+) (*staking.ValidatorRPCEnhanced, error) {
 	if err := s.isBeaconShard(); err != nil {
 		return nil, err
 	}
@@ -594,7 +594,7 @@ func (s *PublicBlockChainAPI) GetValidatorInformation(
 // GetValidatorInformationByBlockNumber ..
 func (s *PublicBlockChainAPI) GetValidatorInformationByBlockNumber(
 	ctx context.Context, address string, blockNr uint64,
-) (*staking.ValidatorRPCEnchanced, error) {
+) (*staking.ValidatorRPCEnhanced, error) {
 	if err := s.isBeaconShard(); err != nil {
 		return nil, err
 	}
@@ -612,13 +612,13 @@ func (s *PublicBlockChainAPI) GetValidatorInformationByBlockNumber(
 
 func (s *PublicBlockChainAPI) getAllValidatorInformation(
 	ctx context.Context, page int, blockNr rpc.BlockNumber,
-) ([]*staking.ValidatorRPCEnchanced, error) {
+) ([]*staking.ValidatorRPCEnhanced, error) {
 	if page < -1 {
 		return nil, errors.Errorf("page given %d cannot be less than -1", page)
 	}
 	addresses := s.b.GetAllValidatorAddresses()
 	if page != -1 && len(addresses) <= page*validatorsPageSize {
-		return make([]*staking.ValidatorRPCEnchanced, 0), nil
+		return make([]*staking.ValidatorRPCEnhanced, 0), nil
 	}
 	validatorsNum := len(addresses)
 	start := 0
@@ -629,7 +629,7 @@ func (s *PublicBlockChainAPI) getAllValidatorInformation(
 			validatorsNum = len(addresses) - start
 		}
 	}
-	validators := make([]*staking.ValidatorRPCEnchanced, validatorsNum)
+	validators := make([]*staking.ValidatorRPCEnhanced, validatorsNum)
 	block, err := s.b.BlockByNumber(ctx, rpc.BlockNumber(blockNr))
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not retrieve the block information for block number: %d", blockNr)
@@ -648,7 +648,7 @@ func (s *PublicBlockChainAPI) getAllValidatorInformation(
 // If page is -1, return all else return the pagination.
 func (s *PublicBlockChainAPI) GetAllValidatorInformation(
 	ctx context.Context, page int,
-) ([]*staking.ValidatorRPCEnchanced, error) {
+) ([]*staking.ValidatorRPCEnhanced, error) {
 	if err := s.isBeaconShard(); err != nil {
 		return nil, err
 	}
@@ -669,7 +669,7 @@ func (s *PublicBlockChainAPI) GetAllValidatorInformation(
 	if err != nil {
 		return nil, err
 	}
-	return res.([]*staking.ValidatorRPCEnchanced), nil
+	return res.([]*staking.ValidatorRPCEnhanced), nil
 
 }
 
@@ -677,7 +677,7 @@ func (s *PublicBlockChainAPI) GetAllValidatorInformation(
 // If page is -1, return all else return the pagination.
 func (s *PublicBlockChainAPI) GetAllValidatorInformationByBlockNumber(
 	ctx context.Context, page int, blockNr uint64,
-) ([]*staking.ValidatorRPCEnchanced, error) {
+) ([]*staking.ValidatorRPCEnhanced, error) {
 	if err := s.isBeaconShard(); err != nil {
 		return nil, err
 	}

--- a/internal/hmyapi/backend.go
+++ b/internal/hmyapi/backend.go
@@ -64,7 +64,7 @@ type Backend interface {
 	SendStakingTx(ctx context.Context, newStakingTx *staking.StakingTransaction) error
 	GetElectedValidatorAddresses() []common.Address
 	GetAllValidatorAddresses() []common.Address
-	GetValidatorInformation(addr common.Address, block *types.Block) (*staking.ValidatorRPCEnchanced, error)
+	GetValidatorInformation(addr common.Address, block *types.Block) (*staking.ValidatorRPCEnhanced, error)
 	GetDelegationsByValidator(validator common.Address) []*staking.Delegation
 	GetDelegationsByDelegator(delegator common.Address) ([]common.Address, []*staking.Delegation)
 	GetDelegationsByDelegatorByBlock(delegator common.Address, block *types.Block) ([]common.Address, []*staking.Delegation)

--- a/staking/effective/eligible.go
+++ b/staking/effective/eligible.go
@@ -21,6 +21,19 @@ const (
 	Banned
 )
 
+func (e Eligibility) String() string {
+	switch e {
+	case Active:
+		return "active"
+	case Inactive:
+		return "inactive"
+	case Banned:
+		return doubleSigningBanned
+	default:
+		return "unknown"
+	}
+}
+
 // Candidacy is a more semantically meaningful
 // value that is derived from core protocol logic but
 // meant more for the presentation of user, like at RPC

--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -138,8 +138,8 @@ type CurrentEpochPerformance struct {
 	CurrentSigningPercentage Computed `json:"current-epoch-signing-percent"`
 }
 
-// ValidatorRPCEnchanced contains extra information for RPC consumer
-type ValidatorRPCEnchanced struct {
+// ValidatorRPCEnhanced contains extra information for RPC consumer
+type ValidatorRPCEnhanced struct {
 	Wrapper              ValidatorWrapper         `json:"validator"`
 	Performance          *CurrentEpochPerformance `json:"current-epoch-performance"`
 	ComputedMetrics      *ValidatorStats          `json:"metrics"`
@@ -148,6 +148,7 @@ type ValidatorRPCEnchanced struct {
 	EPoSStatus           string                   `json:"epos-status"`
 	EPoSWinningStake     *numeric.Dec             `json:"epos-winning-stake"`
 	BootedStatus         *string                  `json:"booted-status"`
+	ActiveStatus         string                   `json:"active-status"`
 	Lifetime             *AccumulatedOverLifetime `json:"lifetime"`
 }
 


### PR DESCRIPTION
Requested by validators to clearly see effect of `edit-validator --active true` does
Also needed for AutoNode

Example in RPC:
```
"active-status": "active",
```
```
"active-status": "inactive",
```
```
"active-status": "banned",
```
```
"active-status": "unknown",
```