### PR TITLE
[network] Limit client sync connection

### DIFF
--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -231,6 +231,10 @@ func (peerConfig *SyncPeerConfig) GetBlocks(hashes [][]byte) ([][]byte, error) {
 
 // CreateSyncConfig creates SyncConfig for StateSync object.
 func (ss *StateSync) CreateSyncConfig(peers []p2p.Peer, isBeacon bool) error {
+	// limit the number of dns peers to connect
+	randSeed := time.Now().UnixNano()
+	peers = limitNumPeers(peers, randSeed)
+
 	utils.Logger().Debug().
 		Int("len", len(peers)).
 		Bool("isBeacon", isBeacon).
@@ -243,10 +247,6 @@ func (ss *StateSync) CreateSyncConfig(peers []p2p.Peer, isBeacon bool) error {
 		ss.syncConfig.CloseConnections()
 	}
 	ss.syncConfig = &SyncConfig{}
-
-	// limit the number of dns peers to connect
-	randSeed := time.Now().UnixNano()
-	peers = limitNumPeers(peers, randSeed)
 
 	var wg sync.WaitGroup
 	for _, peer := range peers {

--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -245,7 +245,9 @@ func (ss *StateSync) CreateSyncConfig(peers []p2p.Peer, isBeacon bool) error {
 	ss.syncConfig = &SyncConfig{}
 
 	// limit the number of dns peers to connect
-	peers = limitNumPeers(peers)
+	randSeed := time.Now().UnixNano()
+	peers = limitNumPeers(peers, randSeed)
+
 	var wg sync.WaitGroup
 	for _, peer := range peers {
 		wg.Add(1)
@@ -275,7 +277,7 @@ func (ss *StateSync) CreateSyncConfig(peers []p2p.Peer, isBeacon bool) error {
 // limitNumPeers limits number of peers to release some server end sources.
 func limitNumPeers(ps []p2p.Peer, randSeed int64) []p2p.Peer {
 	targetSize := calcNumPeersWithBound(len(ps), numPeersLowBound, numPeersHighBound)
-	if targetSize <= len(ps) {
+	if len(ps) <= targetSize {
 		return ps
 	}
 

--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -245,7 +245,7 @@ func (ss *StateSync) CreateSyncConfig(peers []p2p.Peer, isBeacon bool) error {
 	ss.syncConfig = &SyncConfig{}
 
 	// limit the number of dns peers to connect
-	peers = limitPeersWithBound(peers, numPeersLowBound, numPeersHighBound)
+	peers = limitNumPeers(peers)
 	var wg sync.WaitGroup
 	for _, peer := range peers {
 		wg.Add(1)
@@ -272,11 +272,14 @@ func (ss *StateSync) CreateSyncConfig(peers []p2p.Peer, isBeacon bool) error {
 	return nil
 }
 
-// limitPeersWithBound will limit number of peers to release some server end sources.
-func limitPeersWithBound(ps []p2p.Peer, lowBound, highBound int) []p2p.Peer {
-	targetSize := calcNumPeersWithBound(len(ps), lowBound, highBound)
+// limitNumPeers limits number of peers to release some server end sources.
+func limitNumPeers(ps []p2p.Peer, randSeed int64) []p2p.Peer {
+	targetSize := calcNumPeersWithBound(len(ps), numPeersLowBound, numPeersHighBound)
+	if targetSize <= len(ps) {
+		return ps
+	}
 
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	r := rand.New(rand.NewSource(randSeed))
 	r.Shuffle(len(ps), func(i, j int) { ps[i], ps[j] = ps[j], ps[i] })
 
 	return ps[:targetSize]

--- a/api/service/syncing/syncing_test.go
+++ b/api/service/syncing/syncing_test.go
@@ -1,7 +1,11 @@
 package syncing
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
+
+	"github.com/harmony-one/harmony/p2p"
 
 	"github.com/harmony-one/harmony/api/service/syncing/downloader"
 	"github.com/stretchr/testify/assert"
@@ -48,4 +52,70 @@ func TestCreateStateSync(t *testing.T) {
 	if stateSync == nil {
 		t.Error("Unable to create stateSync")
 	}
+}
+
+func TestLimitPeersWithBound(t *testing.T) {
+	tests := []struct {
+		size    int
+		expSize int
+	}{
+		{0, 0},
+		{1, 1},
+		{3, 3},
+		{4, 3},
+		{7, 3},
+		{8, 4},
+		{10, 5},
+		{11, 5},
+		{100, 5},
+	}
+	for i, test := range tests {
+		ps := makePeersForTest(test.size)
+
+		res := limitNumPeers(ps, 1)
+
+		if len(res) != test.expSize {
+			t.Errorf("result size unexpected: %v / %v", len(res), test.expSize)
+		}
+		if err := checkTestPeerDuplicity(res); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func TestLimitPeersWithBound_random(t *testing.T) {
+	ps1 := makePeersForTest(100)
+	ps2 := makePeersForTest(100)
+	s1, s2 := int64(1), int64(2)
+
+	res1 := limitNumPeers(ps1, s1)
+	res2 := limitNumPeers(ps2, s2)
+	if reflect.DeepEqual(res1, res2) {
+		t.Fatal("not randomized limit peer")
+	}
+}
+
+func makePeersForTest(size int) []p2p.Peer {
+	ps := make([]p2p.Peer, 0, size)
+	for i := 0; i != size; i++ {
+		ps = append(ps, p2p.Peer{
+			IP: makeTestPeerIP(i),
+		})
+	}
+	return ps
+}
+
+func checkTestPeerDuplicity(ps []p2p.Peer) error {
+	m := make(map[string]struct{})
+	for _, p := range ps {
+		if _, ok := m[p.IP]; ok {
+			return fmt.Errorf("duplicate ip")
+		}
+		m[p.IP] = struct{}{}
+	}
+	return nil
+}
+
+func makeTestPeerIP(i interface{}) string {
+	return fmt.Sprintf("%v", i)
 }

--- a/api/service/syncing/syncing_test.go
+++ b/api/service/syncing/syncing_test.go
@@ -69,7 +69,7 @@ func TestLimitPeersWithBound(t *testing.T) {
 		{11, 5},
 		{100, 5},
 	}
-	for i, test := range tests {
+	for _, test := range tests {
 		ps := makePeersForTest(test.size)
 
 		res := limitNumPeers(ps, 1)

--- a/api/service/syncing/syncing_test.go
+++ b/api/service/syncing/syncing_test.go
@@ -5,9 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/harmony-one/harmony/p2p"
-
 	"github.com/harmony-one/harmony/api/service/syncing/downloader"
+	"github.com/harmony-one/harmony/p2p"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
## Issue

Intend to solve https://github.com/harmony-one/harmony/issues/3029.

Limit the number of peers connected by GRPC at client end, thus will release more resource of GRPC at server end. Number of connected syncing nodes is first halved and then capped by 3 and 5.

Note this is just a temporary fix. Syncing can be done in a more elegant way.

## Test

### Unit Test Coverage

Before:

```
PASS
coverage: 3.8% of statements
ok      github.com/harmony-one/harmony/api/service/syncing      0.351s
```

After:

```
PASS
coverage: 7.5% of statements
ok      github.com/harmony-one/harmony/api/service/syncing      0.361s
```

### Test/Run Logs

Test quick recap: Added some print log message and run a node connecting to mainnet, and test passed.

1. Connected syncing peers has reduced for each shard from 9 to 4.
2. Node's block number increasing, syncing in progress.

[Test log](https://gist.github.com/JackyWYX/0cb57998812fe1b87749e22877ed0a8d)

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**
