### PR TITLE
Add timeouts for the explorer HTTP service

### DIFF
--- a/api/service/explorer/service.go
+++ b/api/service/explorer/service.go
@@ -102,7 +102,13 @@ func (s *Service) Run() *http.Server {
 
 	// Do serving now.
 	utils.Logger().Info().Str("port", GetExplorerPort(s.Port)).Msg("Listening")
-	server := &http.Server{Addr: addr, Handler: s.router}
+	server := &http.Server{
+		Addr:         addr,
+		Handler:      s.router,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
 	go func() {
 		if err := server.ListenAndServe(); err != nil {
 			utils.Logger().Warn().Err(err).Msg("server.ListenAndServe()")


### PR DESCRIPTION
## Issue

The current explorer RPC/HTTP endpoint won't automatically close lingering connections, resulting in `"Too many open files"` errors.

This PR sets the following settings for the RPC/HTTP server:
```
ReadTimeout:  5 * time.Second,
WriteTimeout: 10 * time.Second,
IdleTimeout:  120 * time.Second,
```

Related: https://blog.cloudflare.com/exposing-go-on-the-internet/

## Test

### Unit Test Coverage

Before:

```
$ go test -cover
PASS
coverage: 12.3% of statements
ok  	github.com/harmony-one/harmony/api/service/explorer	0.531s
```

After:

```
$ go test -cover
PASS
coverage: 12.3% of statements
ok  	github.com/harmony-one/harmony/api/service/explorer	0.310s
```
## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

9. **Does the existing `node.sh` continue to work with this change?**

    **YES**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**