### PR TITLE
fix latest param handling in api v1

### DIFF
--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -66,7 +66,9 @@ func (s *PublicBlockChainAPI) isBeaconShard() error {
 }
 
 func (s *PublicBlockChainAPI) isBlockGreaterThanLatest(blockNum rpc.BlockNumber) error {
-	if uint64(blockNum) > s.b.CurrentBlock().NumberU64() {
+	if blockNum != rpc.PendingBlockNumber &&
+		blockNum != rpc.LatestBlockNumber &&
+		uint64(blockNum) > s.b.CurrentBlock().NumberU64() {
 		return ErrRequestedBlockTooHigh
 	}
 	return nil

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -66,6 +66,9 @@ func (s *PublicBlockChainAPI) isBeaconShard() error {
 }
 
 func (s *PublicBlockChainAPI) isBlockGreaterThanLatest(blockNum rpc.BlockNumber) error {
+	// rpc.BlockNumber is int64 (latest = -1. pending = -2) and currentBlockNum is uint64.
+	// Most straightfoward to make sure to return nil error for latest and pending block num
+	// since they are never greater than latest
 	if blockNum != rpc.PendingBlockNumber &&
 		blockNum != rpc.LatestBlockNumber &&
 		uint64(blockNum) > s.b.CurrentBlock().NumberU64() {


### PR DESCRIPTION
## Issue

"latest" block number param regression bug fix.
This caused truffle contract deployment to fail because current truffle version performs validates the deployment of contract by calling rpc apis of api v1, including for example getBlockByNumber(). 

## Test

Before:
```
dennis.won@Jongs-MacBook-Pro:~ $ curl -s --request POST 'http://localhost:9500' --header 'Content-Type: application/json' --data-raw '{ "jsonrpc": "2.0", "method": "hmy_getBlockByNumber", "params": ["latest", true], "id": 1}'

{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"requested block number greater than current block number"}}
```
After:
```
dennis.won@Jongs-MacBook-Pro:~ $ curl -s --request POST 'http://localhost:9500' --header 'Content-Type: application/json' --data-raw '{ "jsonrpc": "2.0", "method": "hmy_getBlockByNumber", "params": ["latest", true], "id": 1}'

{"jsonrpc":"2.0","id":1,"result":{"difficulty":0,"extraData":"0x","gasLimit":"0x4c4b400","gasUsed":"0x0","hash":"0x52a2eb34feb19745f9ac149f6b389d4418cf531c0b5b9e8e42edfdb092deb810","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","miner":"0x6911b75b2560be9a8f71164a33086be4511fc99a","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":0,"number":"0xf","parentHash":"0x031180afafdd9ab21d254c3fb4da9179e997e85802fecd8aa2d12ea2439037db","receiptsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","size":"0x31f","stakingTransactions":[],"stateRoot":"0x182604f69dd908411c4e7e716b4df12721cf27ef9d7ef404b59be2c98bf05d5a","timestamp":"0x5ec7aeac","transactions":[],"transactionsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","uncles":[]}}
```