### PR TITLE
Add quick unlock feature at epoch 190

### DIFF
--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -332,10 +332,14 @@ func payoutUndelegations(
 				"[Finalize] failed to get validator from state to finalize",
 			)
 		}
+		lockPeriod := staking.LockPeriodInEpoch
+		if chain.Config().IsQuickUnlock(header.Epoch()) {
+			lockPeriod = staking.LockPeriodInEpochV2
+		}
 		for i := range wrapper.Delegations {
 			delegation := &wrapper.Delegations[i]
 			totalWithdraw := delegation.RemoveUnlockedUndelegations(
-				header.Epoch(), wrapper.LastEpochInCommittee,
+				header.Epoch(), wrapper.LastEpochInCommittee, lockPeriod,
 			)
 			state.AddBalance(delegation.DelegatorAddress, totalWithdraw)
 		}

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -25,77 +25,83 @@ var EpochTBD = big.NewInt(10000000)
 var (
 	// MainnetChainConfig is the chain parameters to run a node on the main network.
 	MainnetChainConfig = &ChainConfig{
-		ChainID:         MainnetChainID,
-		CrossTxEpoch:    big.NewInt(28),
-		CrossLinkEpoch:  big.NewInt(186),
-		StakingEpoch:    big.NewInt(186),
-		PreStakingEpoch: big.NewInt(185),
-		EIP155Epoch:     big.NewInt(28),
-		S3Epoch:         big.NewInt(28),
-		ReceiptLogEpoch: big.NewInt(101),
+		ChainID:          MainnetChainID,
+		CrossTxEpoch:     big.NewInt(28),
+		CrossLinkEpoch:   big.NewInt(186),
+		StakingEpoch:     big.NewInt(186),
+		PreStakingEpoch:  big.NewInt(185),
+		QuickUnlockEpoch: big.NewInt(190), // Around May 25 11:44 PM PST 2020
+		EIP155Epoch:      big.NewInt(28),
+		S3Epoch:          big.NewInt(28),
+		ReceiptLogEpoch:  big.NewInt(101),
 	}
 
 	// TestnetChainConfig contains the chain parameters to run a node on the harmony test network.
 	TestnetChainConfig = &ChainConfig{
-		ChainID:         TestnetChainID,
-		CrossTxEpoch:    big.NewInt(0),
-		CrossLinkEpoch:  big.NewInt(4),
-		StakingEpoch:    big.NewInt(4),
-		PreStakingEpoch: big.NewInt(2),
-		EIP155Epoch:     big.NewInt(0),
-		S3Epoch:         big.NewInt(0),
-		ReceiptLogEpoch: big.NewInt(0),
+		ChainID:          TestnetChainID,
+		CrossTxEpoch:     big.NewInt(0),
+		CrossLinkEpoch:   big.NewInt(4),
+		StakingEpoch:     big.NewInt(4),
+		PreStakingEpoch:  big.NewInt(2),
+		QuickUnlockEpoch: big.NewInt(0),
+		EIP155Epoch:      big.NewInt(0),
+		S3Epoch:          big.NewInt(0),
+		ReceiptLogEpoch:  big.NewInt(0),
 	}
 
 	// PangaeaChainConfig contains the chain parameters for the Pangaea network.
 	// All features except for CrossLink are enabled at launch.
 	PangaeaChainConfig = &ChainConfig{
-		ChainID:         PangaeaChainID,
-		CrossTxEpoch:    big.NewInt(0),
-		CrossLinkEpoch:  big.NewInt(2),
-		StakingEpoch:    big.NewInt(2),
-		PreStakingEpoch: big.NewInt(1),
-		EIP155Epoch:     big.NewInt(0),
-		S3Epoch:         big.NewInt(0),
-		ReceiptLogEpoch: big.NewInt(0),
+		ChainID:          PangaeaChainID,
+		CrossTxEpoch:     big.NewInt(0),
+		CrossLinkEpoch:   big.NewInt(2),
+		StakingEpoch:     big.NewInt(2),
+		PreStakingEpoch:  big.NewInt(1),
+		QuickUnlockEpoch: big.NewInt(0),
+		EIP155Epoch:      big.NewInt(0),
+		S3Epoch:          big.NewInt(0),
+		ReceiptLogEpoch:  big.NewInt(0),
 	}
 
 	// PartnerChainConfig contains the chain parameters for the Partner network.
 	// All features except for CrossLink are enabled at launch.
 	PartnerChainConfig = &ChainConfig{
-		ChainID:         PartnerChainID,
-		CrossTxEpoch:    big.NewInt(0),
-		CrossLinkEpoch:  big.NewInt(2),
-		StakingEpoch:    big.NewInt(2),
-		PreStakingEpoch: big.NewInt(1),
-		EIP155Epoch:     big.NewInt(0),
-		S3Epoch:         big.NewInt(0),
-		ReceiptLogEpoch: big.NewInt(0),
+		ChainID:          PartnerChainID,
+		CrossTxEpoch:     big.NewInt(0),
+		CrossLinkEpoch:   big.NewInt(2),
+		StakingEpoch:     big.NewInt(2),
+		PreStakingEpoch:  big.NewInt(1),
+		QuickUnlockEpoch: big.NewInt(0),
+		EIP155Epoch:      big.NewInt(0),
+		S3Epoch:          big.NewInt(0),
+		ReceiptLogEpoch:  big.NewInt(0),
 	}
 
 	// StressnetChainConfig contains the chain parameters for the Stress test network.
 	// All features except for CrossLink are enabled at launch.
 	StressnetChainConfig = &ChainConfig{
-		ChainID:         StressnetChainID,
-		CrossTxEpoch:    big.NewInt(0),
-		CrossLinkEpoch:  big.NewInt(2),
-		StakingEpoch:    big.NewInt(2),
-		PreStakingEpoch: big.NewInt(1),
-		EIP155Epoch:     big.NewInt(0),
-		S3Epoch:         big.NewInt(0),
-		ReceiptLogEpoch: big.NewInt(0),
+		ChainID:          StressnetChainID,
+		CrossTxEpoch:     big.NewInt(0),
+		CrossLinkEpoch:   big.NewInt(2),
+		StakingEpoch:     big.NewInt(2),
+		PreStakingEpoch:  big.NewInt(1),
+		QuickUnlockEpoch: big.NewInt(0),
+		EIP155Epoch:      big.NewInt(0),
+		S3Epoch:          big.NewInt(0),
+		ReceiptLogEpoch:  big.NewInt(0),
 	}
 
 	// LocalnetChainConfig contains the chain parameters to run for local development.
 	LocalnetChainConfig = &ChainConfig{
-		ChainID:         TestnetChainID,
-		CrossTxEpoch:    big.NewInt(0),
-		CrossLinkEpoch:  big.NewInt(2),
-		StakingEpoch:    big.NewInt(2),
-		PreStakingEpoch: big.NewInt(0),
-		EIP155Epoch:     big.NewInt(0),
-		S3Epoch:         big.NewInt(0),
-		ReceiptLogEpoch: big.NewInt(0),
+		ChainID:          TestnetChainID,
+		CrossTxEpoch:     big.NewInt(0),
+		CrossLinkEpoch:   big.NewInt(2),
+		StakingEpoch:     big.NewInt(2),
+		PreStakingEpoch:  big.NewInt(0),
+		QuickUnlockEpoch: big.NewInt(0),
+		EIP155Epoch:      big.NewInt(0),
+		S3Epoch:          big.NewInt(0),
+		ReceiptLogEpoch:  big.NewInt(0),
 	}
 
 	// AllProtocolChanges ...
@@ -107,6 +113,7 @@ var (
 		big.NewInt(0),             // CrossLinkEpoch
 		big.NewInt(0),             // StakingEpoch
 		big.NewInt(0),             // PreStakingEpoch
+		big.NewInt(0),             // QuickUnlockEpoch
 		big.NewInt(0),             // EIP155Epoch
 		big.NewInt(0),             // S3Epoch
 		big.NewInt(0),             // ReceiptLogEpoch
@@ -121,6 +128,7 @@ var (
 		big.NewInt(0), // CrossLinkEpoch
 		big.NewInt(0), // StakingEpoch
 		big.NewInt(0), // PreStakingEpoch
+		big.NewInt(0), // QuickUnlockEpoch
 		big.NewInt(0), // EIP155Epoch
 		big.NewInt(0), // S3Epoch
 		big.NewInt(0), // ReceiptLogEpoch
@@ -164,6 +172,9 @@ type ChainConfig struct {
 
 	// PreStakingEpoch is the epoch we allow staking transactions
 	PreStakingEpoch *big.Int `json:"prestaking-epoch,omitempty"`
+
+	// QuickUnlockEpoch is the epoch when undelegation will be unlocked at the current epoch
+	QuickUnlockEpoch *big.Int `json:"quick-unlock-epoch,omitempty"`
 
 	// EIP155 hard fork epoch (include EIP158 too)
 	EIP155Epoch *big.Int `json:"eip155-epoch,omitempty"`
@@ -220,6 +231,11 @@ func (c *ChainConfig) IsStaking(epoch *big.Int) bool {
 // IsPreStaking determines whether staking transactions are allowed
 func (c *ChainConfig) IsPreStaking(epoch *big.Int) bool {
 	return isForked(c.PreStakingEpoch, epoch)
+}
+
+// IsQuickUnlock determines whether it's the epoch when the undelegation should be unlocked at end of current epoch
+func (c *ChainConfig) IsQuickUnlock(epoch *big.Int) bool {
+	return isForked(c.QuickUnlockEpoch, epoch)
 }
 
 // IsCrossLink returns whether epoch is either equal to the CrossLink fork epoch or greater.

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -282,10 +282,8 @@ func (node *Node) BroadcastCrossLink() {
 		batchSize := crossLinkBatchSize
 		diff := curBlock.Number().Uint64() - latestBlockNum
 
-		if diff > 100 {
-			// Increase batch size by 1 for every 100 blocks beyond
-			batchSize += int(diff-100) / 100
-		}
+		// Increase batch size by 1 for every 100 blocks beyond
+		batchSize += int(diff) / 100
 
 		// Cap at a sane size to avoid overload network
 		if batchSize > crossLinkBatchSize*2 {

--- a/staking/types/delegation.go
+++ b/staking/types/delegation.go
@@ -19,6 +19,8 @@ var (
 const (
 	// LockPeriodInEpoch is the number of epochs a undelegated token needs to be before it's released to the delegator's balance
 	LockPeriodInEpoch = 7
+	// LockPeriodInEpochV2 there is no extended locking time besides the current epoch time.
+	LockPeriodInEpochV2 = 0
 )
 
 // Delegation represents the bond with tokens held by an account. It is
@@ -176,13 +178,13 @@ func (d *Delegation) DeleteEntry(epoch *big.Int) {
 // RemoveUnlockedUndelegations removes all fully unlocked
 // undelegations and returns the total sum
 func (d *Delegation) RemoveUnlockedUndelegations(
-	curEpoch, lastEpochInCommittee *big.Int,
+	curEpoch, lastEpochInCommittee *big.Int, lockPeriod int,
 ) *big.Int {
 	totalWithdraw := big.NewInt(0)
 	count := 0
 	for j := range d.Undelegations {
-		if big.NewInt(0).Sub(curEpoch, d.Undelegations[j].Epoch).Int64() >= LockPeriodInEpoch ||
-			big.NewInt(0).Sub(curEpoch, lastEpochInCommittee).Int64() >= LockPeriodInEpoch {
+		if big.NewInt(0).Sub(curEpoch, d.Undelegations[j].Epoch).Int64() >= int64(lockPeriod) ||
+			big.NewInt(0).Sub(curEpoch, lastEpochInCommittee).Int64() >= int64(lockPeriod) {
 			// need to wait at least 7 epochs to withdraw; or the validator has been out of committee for 7 epochs
 			totalWithdraw.Add(totalWithdraw, d.Undelegations[j].Amount)
 			count++

--- a/staking/types/delegation_test.go
+++ b/staking/types/delegation_test.go
@@ -75,7 +75,7 @@ func TestUnlockedLastEpochInCommittee(t *testing.T) {
 	amount4 := big.NewInt(4000)
 	delegation.Undelegate(epoch4, amount4)
 
-	result := delegation.RemoveUnlockedUndelegations(curEpoch, lastEpochInCommittee)
+	result := delegation.RemoveUnlockedUndelegations(curEpoch, lastEpochInCommittee, 7)
 	if result.Cmp(big.NewInt(8000)) != 0 {
 		t.Errorf("removing an unlocked undelegation fails")
 	}
@@ -90,7 +90,7 @@ func TestUnlockedLastEpochInCommitteeFail(t *testing.T) {
 	amount4 := big.NewInt(4000)
 	delegation.Undelegate(epoch4, amount4)
 
-	result := delegation.RemoveUnlockedUndelegations(curEpoch, lastEpochInCommittee)
+	result := delegation.RemoveUnlockedUndelegations(curEpoch, lastEpochInCommittee, 7)
 	if result.Cmp(big.NewInt(0)) != 0 {
 		t.Errorf("premature delegation shouldn't be unlocked")
 	}
@@ -104,7 +104,7 @@ func TestUnlockedFullPeriod(t *testing.T) {
 	amount5 := big.NewInt(4000)
 	delegation.Undelegate(epoch5, amount5)
 
-	result := delegation.RemoveUnlockedUndelegations(curEpoch, lastEpochInCommittee)
+	result := delegation.RemoveUnlockedUndelegations(curEpoch, lastEpochInCommittee, 7)
 	if result.Cmp(big.NewInt(4000)) != 0 {
 		t.Errorf("removing an unlocked undelegation fails")
 	}
@@ -119,7 +119,7 @@ func TestUnlockedFullPeriodFail(t *testing.T) {
 	amount5 := big.NewInt(4000)
 	delegation.Undelegate(epoch5, amount5)
 
-	result := delegation.RemoveUnlockedUndelegations(curEpoch, lastEpochInCommittee)
+	result := delegation.RemoveUnlockedUndelegations(curEpoch, lastEpochInCommittee, 7)
 	if result.Cmp(big.NewInt(0)) != 0 {
 		t.Errorf("premature delegation shouldn't be unlocked")
 	}
@@ -133,8 +133,22 @@ func TestUnlockedPremature(t *testing.T) {
 	amount6 := big.NewInt(4000)
 	delegation.Undelegate(epoch6, amount6)
 
-	result := delegation.RemoveUnlockedUndelegations(curEpoch, lastEpochInCommittee)
+	result := delegation.RemoveUnlockedUndelegations(curEpoch, lastEpochInCommittee, 7)
 	if result.Cmp(big.NewInt(0)) != 0 {
 		t.Errorf("premature delegation shouldn't be unlocked")
+	}
+}
+
+func TestQuickUnlock(t *testing.T) {
+	lastEpochInCommittee := big.NewInt(54)
+	curEpoch := big.NewInt(54)
+
+	epoch7 := big.NewInt(54)
+	amount7 := big.NewInt(4000)
+	delegation.Undelegate(epoch7, amount7)
+
+	result := delegation.RemoveUnlockedUndelegations(curEpoch, lastEpochInCommittee, 0)
+	if result.Cmp(big.NewInt(4000)) != 0 {
+		t.Errorf("removing an unlocked undelegation fails")
 	}
 }

--- a/staking/types/delegation_test.go
+++ b/staking/types/delegation_test.go
@@ -110,6 +110,20 @@ func TestUnlockedFullPeriod(t *testing.T) {
 	}
 }
 
+func TestQuickUnlock(t *testing.T) {
+	lastEpochInCommittee := big.NewInt(44)
+	curEpoch := big.NewInt(44)
+
+	epoch7 := big.NewInt(44)
+	amount7 := big.NewInt(4000)
+	delegation.Undelegate(epoch7, amount7)
+
+	result := delegation.RemoveUnlockedUndelegations(curEpoch, lastEpochInCommittee, 0)
+	if result.Cmp(big.NewInt(4000)) != 0 {
+		t.Errorf("removing an unlocked undelegation fails")
+	}
+}
+
 func TestUnlockedFullPeriodFail(t *testing.T) {
 	delegation := NewDelegation(delegatorAddr, delegationAmt)
 	lastEpochInCommittee := big.NewInt(34)
@@ -136,19 +150,5 @@ func TestUnlockedPremature(t *testing.T) {
 	result := delegation.RemoveUnlockedUndelegations(curEpoch, lastEpochInCommittee, 7)
 	if result.Cmp(big.NewInt(0)) != 0 {
 		t.Errorf("premature delegation shouldn't be unlocked")
-	}
-}
-
-func TestQuickUnlock(t *testing.T) {
-	lastEpochInCommittee := big.NewInt(54)
-	curEpoch := big.NewInt(54)
-
-	epoch7 := big.NewInt(54)
-	amount7 := big.NewInt(4000)
-	delegation.Undelegate(epoch7, amount7)
-
-	result := delegation.RemoveUnlockedUndelegations(curEpoch, lastEpochInCommittee, 0)
-	if result.Cmp(big.NewInt(4000)) != 0 {
-		t.Errorf("removing an unlocked undelegation fails")
 	}
 }


### PR DESCRIPTION
Make unlocking of undelegated token to happen right at the end of current epoch.

Based on proposal in https://talk.harmony.one/t/proposal-shortening-of-undelegation-locking-period/634

Tested locally.

Will need a rolling upgrade before the QuickUnlockEpoch.