### PR TITLE
fix a nil pointer crash due to previous revert

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -125,7 +125,10 @@ func (v *BlockValidator) ValidateState(block *types.Block, statedb *state.DB, re
 // given engine. Verifying the seal may be done optionally here, or explicitly
 // via the VerifySeal method.
 func (v *BlockValidator) ValidateHeader(block *types.Block, seal bool) error {
-	return v.engine.VerifyHeader(v.bc, block.Header(), true)
+	if h := block.Header(); h != nil {
+		return v.engine.VerifyHeader(v.bc, h, true)
+	}
+	return errors.New("header field was nil")
 }
 
 // ValidateHeaders verifies a batch of blocks' headers concurrently. The method returns a quit channel

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -172,6 +172,9 @@ func (e *engineImpl) VerifySeal(chain engine.ChainReader, header *block.Header) 
 	if chain.CurrentHeader().Number().Uint64() <= uint64(1) {
 		return nil
 	}
+	if header == nil {
+		return errors.New("[VerifySeal] nil block header")
+	}
 	publicKeys, err := ReadPublicKeysFromLastBlock(chain, header)
 
 	if err != nil {


### PR DESCRIPTION
Found the crash during release test.
https://github.com/harmony-one/harmony/issues/3088

Signed-off-by: Leo Chen <leo@harmony.one>
