### PR TITLE
Do not rollback current block on failed block sync

### DIFF
--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -558,7 +558,7 @@ func (ss *StateSync) UpdateBlockAndStatus(block *types.Block, bc *core.BlockChai
 			utils.Logger().Error().Err(err).Msgf("[SYNC] UpdateBlockAndStatus: failed verifying signatures for new block %d", block.NumberU64())
 
 			if !verifyAllSig {
-				utils.Logger().Debug().Interface("block", bc.CurrentBlock()).Msg("[SYNC] UpdateBlockAndStatus: Rolling back last 99 blocks!")
+				utils.Logger().Info().Interface("block", bc.CurrentBlock()).Msg("[SYNC] UpdateBlockAndStatus: Rolling back last 99 blocks!")
 				for i := uint64(0); i < verifyHeaderBatchSize-1; i++ {
 					bc.Rollback([]common.Hash{bc.CurrentBlock().Hash()})
 				}
@@ -576,11 +576,6 @@ func (ss *StateSync) UpdateBlockAndStatus(block *types.Block, bc *core.BlockChai
 				block.NumberU64(),
 				block.ShardID(),
 			)
-
-		utils.Logger().Debug().
-			Interface("block", bc.CurrentBlock()).
-			Msg("[SYNC] UpdateBlockAndStatus: Rolling back current block!")
-		bc.Rollback([]common.Hash{bc.CurrentBlock().Hash()})
 		return err
 	}
 	utils.Logger().Info().

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -126,7 +126,6 @@ func (node *Node) HandleMessage(content []byte, sender libp2p_peer.ID) {
 						for _, block := range blocks {
 							if block.ShardID() == 0 {
 								utils.Logger().Info().
-									Uint64("block", blocks[0].NumberU64()).
 									Msgf("Beacon block being handled by block channel: %d", block.NumberU64())
 								go func(blk *types.Block) {
 									node.BeaconBlockChannel <- blk


### PR DESCRIPTION
Potentially fixing https://github.com/harmony-one/harmony/issues/3098

The previous logic rollback current valid block and it caused following state issues.

We shouldn't rollback current block when receiving a new bad block.