### PR TITLE
[apr] compute APR for current committee not next committee, fix previous APRs in the snapshot

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2317,6 +2317,13 @@ func (bc *BlockChain) UpdateValidatorVotingPower(
 				} else {
 					stats.BootedStatus = effective.LostEPoSAuction
 				}
+
+				// compute APR for the exiting validators
+				if err := bc.ComputeAndUpdateAPR(
+					block, currentEpochSuperCommittee.Epoch, wrapper, stats,
+				); err != nil {
+					return nil, err
+				}
 			}
 			validatorStats[currentValidator] = stats
 		}
@@ -2375,46 +2382,56 @@ func (bc *BlockChain) UpdateValidatorVotingPower(
 			}
 		}
 
-		// This means it's already in staking epoch
+		// This means it's already in staking epoch, and
+		// compute APR for validators in current committee only
 		if currentEpochSuperCommittee.Epoch != nil {
-			wrapper, err := state.ValidatorWrapper(key)
-			if err != nil {
-				return nil, err
-			}
-
-			if wrapper.Delegations[0].Amount.Cmp(common.Big0) > 0 {
-				if aprComputed, err := apr.ComputeForValidator(
-					bc, block, wrapper,
-				); err != nil {
-					if errors.Cause(err) == apr.ErrInsufficientEpoch {
-						utils.Logger().Info().Err(err).Msg("apr could not be computed")
-					} else {
-						return nil, err
-					}
-				} else {
-					now := currentEpochSuperCommittee.Epoch
-					// only insert if APR for current epoch does not exists
-					aprEntry := staking.APREntry{now, *aprComputed}
-					l := len(stats.APRs)
-					// first time inserting apr for validator or
-					// apr for current epoch does not exists
-					// check the last entry's epoch, if not same, insert
-					if l == 0 || stats.APRs[l-1].Epoch.Cmp(now) != 0 {
-						stats.APRs = append(stats.APRs, aprEntry)
-					}
-					// if history is more than staking.APRHistoryLength, pop front
-					if l > staking.APRHistoryLength {
-						stats.APRs = stats.APRs[1:]
-					}
+			if _, ok := existing.LookupSet[key]; ok {
+				wrapper, err := state.ValidatorWrapper(key)
+				if err != nil {
+					return nil, err
 				}
-			} else {
-				utils.Logger().Info().Msg("zero total delegation, skipping apr computation")
+
+				if err := bc.ComputeAndUpdateAPR(
+					block, currentEpochSuperCommittee.Epoch, wrapper, stats,
+				); err != nil {
+					return nil, err
+				}
 			}
 		}
 		validatorStats[key] = stats
 	}
 
 	return validatorStats, nil
+}
+
+func (bc *BlockChain) ComputeAndUpdateAPR(
+	block *types.Block, now *big.Int,
+	wrapper *staking.ValidatorWrapper, stats *staking.ValidatorStats,
+) error {
+	if aprComputed, err := apr.ComputeForValidator(
+		bc, block, wrapper,
+	); err != nil {
+		if errors.Cause(err) == apr.ErrInsufficientEpoch {
+			utils.Logger().Info().Err(err).Msg("apr could not be computed")
+		} else {
+			return err
+		}
+	} else {
+		// only insert if APR for current epoch does not exists
+		aprEntry := staking.APREntry{now, *aprComputed}
+		l := len(stats.APRs)
+		// first time inserting apr for validator or
+		// apr for current epoch does not exists
+		// check the last entry's epoch, if not same, insert
+		if l == 0 || stats.APRs[l-1].Epoch.Cmp(now) != 0 {
+			stats.APRs = append(stats.APRs, aprEntry)
+		}
+		// if history is more than staking.APRHistoryLength, pop front
+		if l > staking.APRHistoryLength {
+			stats.APRs = stats.APRs[1:]
+		}
+	}
+	return nil
 }
 
 // UpdateValidatorSnapshots updates the content snapshot of all validators

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2404,6 +2404,7 @@ func (bc *BlockChain) UpdateValidatorVotingPower(
 	return validatorStats, nil
 }
 
+// ComputeAndUpdateAPR ...
 func (bc *BlockChain) ComputeAndUpdateAPR(
 	block *types.Block, now *big.Int,
 	wrapper *staking.ValidatorWrapper, stats *staking.ValidatorStats,

--- a/core/offchain.go
+++ b/core/offchain.go
@@ -17,6 +17,7 @@ import (
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/shard"
+	"github.com/harmony-one/harmony/staking/apr"
 	"github.com/harmony-one/harmony/staking/slash"
 	staking "github.com/harmony-one/harmony/staking/types"
 	"github.com/pkg/errors"
@@ -212,6 +213,60 @@ func (bc *BlockChain) CommitOffChainData(
 			utils.Logger().
 				Err(err).
 				Msg("[UpdateValidatorVotingPower] Failed to decode shard state")
+		}
+		// let's fix previous aprs at the epoch transition from 191 to 192
+		// this code will be removed after the rolling upgrade
+		stakingEpoch := bc.Config().StakingEpoch
+		secondStakingEpoch := big.NewInt(0).Add(stakingEpoch, common.Big1)
+		fixEpoch := big.NewInt(0).Add(stakingEpoch, big.NewInt(5)) // epoch 191
+		isFixEpoch := block.Epoch().Cmp(fixEpoch) == 0
+		fixEpochPlus := big.NewInt(0).Add(fixEpoch, common.Big1) // epoch 192
+		if isFixEpoch {
+			validators, _ := bc.ReadValidatorList()
+			for _, addr := range validators {
+				// loop for epochs 187->191
+				reset := false
+				for i := secondStakingEpoch.Int64(); i <= fixEpochPlus.Int64(); i++ {
+					epoch := big.NewInt(i)
+					// read snapshot to be used as wrapper
+					if snapshot, err := bc.ReadValidatorSnapshotAtEpoch(
+						epoch, addr,
+					); err == nil {
+						oneEpochAgo := big.NewInt(i - 1)
+						shardState, _ := bc.ReadShardState(oneEpochAgo)
+						committee := shardState.StakedValidators()
+						if _, elected := committee.LookupSet[addr]; !elected {
+							continue
+						}
+						epochLastBlock := bc.GetBlockByNumber(
+							shard.Schedule.EpochLastBlock(oneEpochAgo.Uint64()),
+						)
+						if epochLastBlock == nil || block.Epoch().Cmp(oneEpochAgo) == 0 {
+							epochLastBlock = block
+						}
+						if epochLastBlock != nil {
+							if aprComputed, err := apr.ComputeForValidator(
+								bc, epochLastBlock, snapshot.Validator,
+							); err == nil {
+								stats, ok := tempValidatorStats[addr]
+								if !ok {
+									stats, err = bc.ReadValidatorStats(addr)
+									if err != nil {
+										continue
+									}
+								}
+								if !reset {
+									// ignore the previous aprs and reinitialize it
+									reset = true
+									stats.APRs = []staking.APREntry{}
+								}
+								stats.APRs = append(stats.APRs, staking.APREntry{oneEpochAgo, *aprComputed})
+								tempValidatorStats[addr] = stats
+							}
+						}
+					}
+				}
+			}
 		}
 	}
 

--- a/core/offchain.go
+++ b/core/offchain.go
@@ -17,7 +17,6 @@ import (
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/shard"
-	"github.com/harmony-one/harmony/staking/apr"
 	"github.com/harmony-one/harmony/staking/slash"
 	staking "github.com/harmony-one/harmony/staking/types"
 	"github.com/pkg/errors"
@@ -213,44 +212,6 @@ func (bc *BlockChain) CommitOffChainData(
 			utils.Logger().
 				Err(err).
 				Msg("[UpdateValidatorVotingPower] Failed to decode shard state")
-		}
-		// fix the possible wrong apr in the staking epoch
-		stakingEpoch := bc.Config().StakingEpoch
-		secondStakingEpoch := big.NewInt(0).Add(stakingEpoch, common.Big1)
-		thirdStakingEpoch := big.NewInt(0).Add(secondStakingEpoch, common.Big1)
-		isThirdStakingEpoch := block.Epoch().Cmp(thirdStakingEpoch) == 0
-		if isThirdStakingEpoch {
-			// we have to do it for all validators, not only currently elected
-			if validators, err := bc.ReadValidatorList(); err == nil {
-				for _, addr := range validators {
-					// get wrapper from the second staking epoch
-					if snapshot, err := bc.ReadValidatorSnapshotAtEpoch(
-						secondStakingEpoch, addr,
-					); err == nil {
-						if block := bc.GetBlockByNumber(
-							shard.Schedule.EpochLastBlock(stakingEpoch.Uint64()),
-						); block != nil {
-							if aprComputed, err := apr.ComputeForValidator(
-								bc, block, snapshot.Validator,
-							); err == nil {
-								stats, ok := tempValidatorStats[addr]
-								if !ok {
-									stats, err = bc.ReadValidatorStats(addr)
-									if err != nil {
-										continue
-									}
-								}
-								for i := range stats.APRs {
-									if stats.APRs[i].Epoch.Cmp(stakingEpoch) == 0 {
-										stats.APRs[i] = staking.APREntry{stakingEpoch, *aprComputed}
-									}
-								}
-								tempValidatorStats[addr] = stats
-							}
-						}
-					}
-				}
-			}
 		}
 	}
 


### PR DESCRIPTION
This PR fixes the APR computation logic bug, which was iterating over next epoch validators for computing the APR, instead it should iterate over the current epoch validators. The PR also adds a APR correction logic to be applied at the epoch 191 to 192 transition to correct the previous APR values in the db.