### PR TITLE
Remove unnecessary block verification

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -90,6 +90,7 @@ type Consensus struct {
 	// whether to ignore viewID check
 	ignoreViewIDCheck bool
 	// global consensus mutex
+	// TODO(optimization): Avoid mutex and use more efficient locking primitives
 	mutex sync.Mutex
 	// consensus information update mutex
 	infoMutex sync.Mutex

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -257,12 +257,6 @@ func (consensus *Consensus) tryCatchup() {
 				continue
 			}
 
-			if consensus.BlockVerifier == nil {
-				// do nothing
-			} else if err := consensus.BlockVerifier(tmpBlock); err != nil {
-				consensus.getLogger().Info().Msg("[TryCatchup] block verification failed")
-				continue
-			}
 			committedMsg = msgs[i]
 			block = tmpBlock
 			break

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -543,6 +543,10 @@ func (consensus *Consensus) onNewView(msg *msg_pb.Message) {
 			return
 		}
 		hasBlock = true
+		if consensus.BlockVerifier(preparedBlock); err != nil {
+			consensus.getLogger().Error().Err(err).Msg("[onNewView] Prepared block verification failed")
+			return
+		}
 	}
 
 	if m2Mask == nil || m2Mask.Bitmap == nil ||
@@ -605,10 +609,6 @@ func (consensus *Consensus) onNewView(msg *msg_pb.Message) {
 	// NewView message is verified, change state to normal consensus
 	if hasBlock {
 		// Construct and send the commit message
-		if consensus.BlockVerifier(preparedBlock); err != nil {
-			consensus.getLogger().Error().Err(err).Msg("[onNewView] Prepared block verification failed")
-			return
-		}
 		commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
 			preparedBlock.Epoch(), preparedBlock.Hash(), preparedBlock.NumberU64(), preparedBlock.Header().ViewID().Uint64())
 		groupID := []nodeconfig.GroupID{


### PR DESCRIPTION
The block is fetched from fbftLog and it was already verified before it's added to the log. So we don't need to verify it again.

This actually slows down the leader by 1-2s in beacon chain because the block verification of crosslinks is very expensive.

tested locally.