### PR TITLE
[TxPool] Fix stuck staking transactions

### DIFF
--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -283,7 +283,7 @@ func (l *txList) Forward(threshold uint64) types.PoolTransactions {
 	return l.txs.Forward(threshold)
 }
 
-// Filter removes all transactions from the list with a cost or gas limit higher
+// FilterCost removes all transactions from the list with a cost or gas limit higher
 // than the provided thresholds. Every removed transaction is returned for any
 // post-removal maintenance. Strict-mode invalidated transactions are also
 // returned.
@@ -292,7 +292,7 @@ func (l *txList) Forward(threshold uint64) types.PoolTransactions {
 // a point in calculating all the costs or if the balance covers all. If the threshold
 // is lower than the costgas cap, the caps will be reset to a new high after removing
 // the newly invalidated transactions.
-func (l *txList) Filter(costLimit *big.Int, gasLimit uint64) (types.PoolTransactions, types.PoolTransactions) {
+func (l *txList) FilterCost(costLimit *big.Int, gasLimit uint64) (types.PoolTransactions, types.PoolTransactions) {
 	// If all transactions are below the threshold, short circuit
 	if l.costcap.Cmp(costLimit) <= 0 && l.gascap <= gasLimit {
 		return nil, nil
@@ -300,18 +300,26 @@ func (l *txList) Filter(costLimit *big.Int, gasLimit uint64) (types.PoolTransact
 	l.costcap = new(big.Int).Set(costLimit) // Lower the caps to the thresholds
 	l.gascap = gasLimit
 
-	// Filter out all the transactions above the account's funds
-	removed := l.txs.Filter(func(tx types.PoolTransaction) bool {
+	return l.Filter(func(tx types.PoolTransaction) bool {
 		cost, err := tx.Cost()
 		if err != nil {
 			return true // failure should lead to removal of the tx
 		}
 		return cost.Cmp(costLimit) > 0 || tx.Gas() > gasLimit
 	})
+}
 
+// Filter iterates over the list of transactions and removes all of them for which
+// the specified function evaluates to true. Moreover, it returns all transactions
+// that were invalidated from the filter
+func (l *txList) Filter(
+	filter func(types.PoolTransaction) bool,
+) (types.PoolTransactions, types.PoolTransactions) {
 	// If the list was strict, filter anything above the lowest nonce
 	var invalids types.PoolTransactions
 
+	// Filter out all the transactions above the account's funds
+	removed := l.txs.Filter(filter)
 	if l.strict && len(removed) > 0 {
 		lowest := uint64(math.MaxUint64)
 		for _, tx := range removed {

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -616,7 +616,7 @@ func (pool *TxPool) Content() (map[common.Address]types.PoolTransactions, map[co
 	return pending, queued
 }
 
-// Pending retrieves all currently processable transactions, grouped by origin
+// Pending retrieves all currently executable transactions, grouped by origin
 // account and sorted by nonce. The returned transaction set is a copy and can be
 // freely modified by calling code.
 func (pool *TxPool) Pending() (map[common.Address]types.PoolTransactions, error) {
@@ -628,6 +628,20 @@ func (pool *TxPool) Pending() (map[common.Address]types.PoolTransactions, error)
 		pending[addr] = list.Flatten()
 	}
 	return pending, nil
+}
+
+// Queued retrieves all currently non-executable transactions, grouped by origin
+// account and sorted by nonce. The returned transaction set is a copy and can be
+// freely modified by calling code.
+func (pool *TxPool) Queued() (map[common.Address]types.PoolTransactions, error) {
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
+
+	queued := make(map[common.Address]types.PoolTransactions)
+	for addr, list := range pool.queue {
+		queued[addr] = list.Flatten()
+	}
+	return queued, nil
 }
 
 // Locals retrieves the accounts currently considered local by the pool.

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -245,8 +245,15 @@ func (b *APIBackend) GetPoolTransactions() (types.PoolTransactions, error) {
 	if err != nil {
 		return nil, err
 	}
+	queued, err := b.hmy.txPool.Queued()
+	if err != nil {
+		return nil, err
+	}
 	var txs types.PoolTransactions
 	for _, batch := range pending {
+		txs = append(txs, batch...)
+	}
+	for _, batch := range queued {
 		txs = append(txs, batch...)
 	}
 	return txs, nil

--- a/internal/hmyapi/apiv1/types.go
+++ b/internal/hmyapi/apiv1/types.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	types2 "github.com/harmony-one/harmony/staking/types"
+	staking "github.com/harmony-one/harmony/staking/types"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -208,7 +208,7 @@ func newRPCTransaction(
 
 // newRPCStakingTransaction returns a staking transaction that will serialize to the RPC
 // representation, with the given location metadata set (if available).
-func newRPCStakingTransaction(tx *types2.StakingTransaction, blockHash common.Hash,
+func newRPCStakingTransaction(tx *staking.StakingTransaction, blockHash common.Hash,
 	blockNumber uint64, timestamp uint64, index uint64,
 ) *RPCStakingTransaction {
 	from, err := tx.SenderAddress()
@@ -217,13 +217,15 @@ func newRPCStakingTransaction(tx *types2.StakingTransaction, blockHash common.Ha
 	}
 	v, r, s := tx.RawSignatureValues()
 
-	stakingTxType := tx.StakingType()
-	message := tx.StakingMessage()
 	fields := map[string]interface{}{}
 
-	switch stakingTxType {
-	case types2.DirectiveCreateValidator:
-		msg, ok := message.(types2.CreateValidator)
+	switch tx.StakingType() {
+	case staking.DirectiveCreateValidator:
+		rawMsg, err := staking.RLPDecodeStakeMsg(tx.Data(), staking.DirectiveCreateValidator)
+		if err != nil {
+			return nil
+		}
+		msg, ok := rawMsg.(*staking.CreateValidator)
 		if !ok {
 			return nil
 		}
@@ -246,8 +248,12 @@ func newRPCStakingTransaction(tx *types2.StakingTransaction, blockHash common.Ha
 			"details":            msg.Description.Details,
 			"slotPubKeys":        msg.SlotPubKeys,
 		}
-	case types2.DirectiveEditValidator:
-		msg, ok := message.(types2.EditValidator)
+	case staking.DirectiveEditValidator:
+		rawMsg, err := staking.RLPDecodeStakeMsg(tx.Data(), staking.DirectiveEditValidator)
+		if err != nil {
+			return nil
+		}
+		msg, ok := rawMsg.(*staking.EditValidator)
 		if !ok {
 			return nil
 		}
@@ -273,8 +279,12 @@ func newRPCStakingTransaction(tx *types2.StakingTransaction, blockHash common.Ha
 			"slotPubKeyToAdd":    msg.SlotKeyToAdd,
 			"slotPubKeyToRemove": msg.SlotKeyToRemove,
 		}
-	case types2.DirectiveCollectRewards:
-		msg, ok := message.(types2.CollectRewards)
+	case staking.DirectiveCollectRewards:
+		rawMsg, err := staking.RLPDecodeStakeMsg(tx.Data(), staking.DirectiveCollectRewards)
+		if err != nil {
+			return nil
+		}
+		msg, ok := rawMsg.(*staking.CollectRewards)
 		if !ok {
 			return nil
 		}
@@ -285,8 +295,12 @@ func newRPCStakingTransaction(tx *types2.StakingTransaction, blockHash common.Ha
 		fields = map[string]interface{}{
 			"delegatorAddress": delegatorAddress,
 		}
-	case types2.DirectiveDelegate:
-		msg, ok := message.(types2.Delegate)
+	case staking.DirectiveDelegate:
+		rawMsg, err := staking.RLPDecodeStakeMsg(tx.Data(), staking.DirectiveDelegate)
+		if err != nil {
+			return nil
+		}
+		msg, ok := rawMsg.(*staking.Delegate)
 		if !ok {
 			return nil
 		}
@@ -303,8 +317,12 @@ func newRPCStakingTransaction(tx *types2.StakingTransaction, blockHash common.Ha
 			"validatorAddress": validatorAddress,
 			"amount":           (*hexutil.Big)(msg.Amount),
 		}
-	case types2.DirectiveUndelegate:
-		msg, ok := message.(types2.Undelegate)
+	case staking.DirectiveUndelegate:
+		rawMsg, err := staking.RLPDecodeStakeMsg(tx.Data(), staking.DirectiveUndelegate)
+		if err != nil {
+			return nil
+		}
+		msg, ok := rawMsg.(*staking.Undelegate)
 		if !ok {
 			return nil
 		}
@@ -332,7 +350,7 @@ func newRPCStakingTransaction(tx *types2.StakingTransaction, blockHash common.Ha
 		V:         (*hexutil.Big)(v),
 		R:         (*hexutil.Big)(r),
 		S:         (*hexutil.Big)(s),
-		Type:      stakingTxType.String(),
+		Type:      tx.StakingType().String(),
 		Msg:       fields,
 	}
 	if blockHash != (common.Hash{}) {
@@ -423,11 +441,11 @@ func RPCMarshalBlock(b *types.Block, blockArgs BlockArgs) (map[string]interface{
 		fields["transactions"] = transactions
 
 		if blockArgs.InclStaking {
-			formatStakingTx := func(tx *types2.StakingTransaction) (interface{}, error) {
+			formatStakingTx := func(tx *staking.StakingTransaction) (interface{}, error) {
 				return tx.Hash(), nil
 			}
 			if blockArgs.FullTx {
-				formatStakingTx = func(tx *types2.StakingTransaction) (interface{}, error) {
+				formatStakingTx = func(tx *staking.StakingTransaction) (interface{}, error) {
 					return newRPCStakingTransactionFromBlockHash(b, tx.Hash()), nil
 				}
 			}

--- a/test/debug.sh
+++ b/test/debug.sh
@@ -1,3 +1,4 @@
 ./test/kill_node.sh
 rm -rf tmp_log*
+rm *.rlp
 ./test/deploy.sh -D 60000 ./test/configs/local-resharding.txt


### PR DESCRIPTION
## Issue

This closes #3107.

The primary issue was that the tx-pool was not demoting invalid or 'unexecutable' staking transactions from the pending list, thus the transactions could never be removed from the pool. Note that timeout only applies to queued (aka unexecutable/demoted) transactions, so even the timeout does not currently work. 

Moreover, the pending transactions & pending staking transactions RPC only returned pending transaction, when they should also return queued transactions.

Lastly, the RPC staking tx could not handle all staking transaction types (failed to RLP decode correctly on some staking txs). This caused pending staking txs RPC to falsely report no txs (b/c of error). This has been changed to follow the staking RLP decode flow used in the tx pool.

## Test
The stuck pending staking tx was tested on localnet as follows:
1) Create a validator and add a BLS key to it.
```bash
$ hmy staking create-validator --validator-addr one18tvf56zqjkjnak686lwutcp5mqfnvee35xjnhc --name test --identity test --website test --security-contact test --details test --rate 0.1 --max-rate 0.9 --max-change-rate 0.05 --min-self-delegation 10100 --max-total-delegation 10000000 --amount 10200 --bls-pubkeys 282554f2478661b4844a05a9deb1837aac83931029cb282872f0dcd7239297c499c02ea8da8746d2f08ca2b037e89891 
$ hmy staking edit-validator --validator-addr one18tvf56zqjkjnak686lwutcp5mqfnvee35xjnhc --add-bls-key 84a4f54543262aed00b696a5dcde4fa80e2bc78459ffef9c89efbb8fe24d70af54dde82a8cbccf9c9e8de0f6ff91ef94
```

2) Send 2 remove BLS key edit-validator transactions at the same time
```bash
$ hmy staking edit-validator --validator-addr one18tvf56zqjkjnak686lwutcp5mqfnvee35xjnhc --remove-bls-key 84a4f54543262aed00b696a5dcde4fa80e2bc78459ffef9c89efbb8fe24d70af54dde82a8cbccf9c9e8de0f6ff91ef94 --nonce 2 --timeout 0 & hmy staking edit-validator --validator-addr one18tvf56zqjkjnak686lwutcp5mqfnvee35xjnhc --remove-bls-key 84a4f54543262aed00b696a5dcde4fa80e2bc78459ffef9c89efbb8fe24d70af54dde82a8cbccf9c9e8de0f6ff91ef94 --nonce 3 --timeout 0 
```
This gave the following tx hashes
```
{"transaction-receipt":"0xc6a6a58b5b99ae9984736b32c9f6b9ec605348dc20f0a1e21a0cf1d45929fe7a"}
{"transaction-receipt":"0x5eca74bdb0a91199f519f0b7cd3b2c88e49dcc3d1db3afc95afadadd7294c8f4"}
```

3) Check the logs to ensure both staking txs were broadcasted (so both added to pool)
```
1048:{"level":"info","port":"9000","ip":"127.0.0.1","Hash":"0xc6a6a58b5b99ae9984736b32c9f6b9ec605348dc20f0a1e21a0cf1d45929fe7a","caller":"/Users/danielvdm/go/src/github.com/harmony-one/harmony/node/node.go:271","time":"2020-05-29T10:09:36.052813-07:00","message":"Broadcasting Staking Tx"}
1054:{"level":"info","port":"9000","ip":"127.0.0.1","Hash":"0x5eca74bdb0a91199f519f0b7cd3b2c88e49dcc3d1db3afc95afadadd7294c8f4","caller":"/Users/danielvdm/go/src/github.com/harmony-one/harmony/node/node.go:271","time":"2020-05-29T10:09:36.128875-07:00","message":"Broadcasting Staking Tx"}
```

4) Check staking error sink to make sure one edit validator tx got dropped, got:
```
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": [
        {
            "tx-hash-id": "0x5eca74bdb0a91199f519f0b7cd3b2c88e49dcc3d1db3afc95afadadd7294c8f4",
            "directive-kind": "EditValidator",
            "time-at-rejection": 1590772177,
            "error-message": "removed unexecutable pending transaction"
        }
    ]
}
```

5) Make sure we can send another staking transaction (so stx not stuck)
```bash
$ hmy staking edit-validator --validator-addr one18tvf56zqjkjnak686lwutcp5mqfnvee35xjnhc --active true
{
  "id": "16",
  "jsonrpc": "2.0",
  "result": {
    "blockHash": "0xd2af718801cc15670c4b3d094e181f6c34bb8ef8f01cb6991ccee731c217f950",
    "blockNumber": "0x25",
    "contractAddress": null,
    "cumulativeGasUsed": "0x5b54",
    "gasUsed": "0x5b54",
    "logs": [],
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "sender": "one18tvf56zqjkjnak686lwutcp5mqfnvee35xjnhc",
    "status": "0x1",
    "transactionHash": "0xcc17cfc982d9d5f048b1fc6be6c15500161a594f3b538a18a05d1d4e38db336c",
    "transactionIndex": "0x0",
    "type": 1
  }
}
```

Pending Staking transaction working here:
![image](https://user-images.githubusercontent.com/31291913/83288026-8f07ad00-a197-11ea-8f03-a6676fdbf7bc.png)

### Unit Test Coverage

Before:

```
PASS
coverage: 29.1% of statements
ok  	github.com/harmony-one/harmony/core	6.923s
```

After:

```
PASS
coverage: 29.2% of statements
ok  	github.com/harmony-one/harmony/core	6.813s
```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**
