### PR TITLE
Fix multi-key related issues when keys are not in committee

### DIFF
--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -57,6 +57,13 @@ func (consensus *Consensus) announce(block *types.Block) {
 
 	// Leader sign the block hash itself
 	for i, key := range consensus.PubKey.PublicKey {
+		if err := consensus.prepareBitmap.SetKey(key, true); err != nil {
+			consensus.getLogger().Warn().Err(err).Msg(
+				"[Announce] Leader prepareBitmap SetKey failed",
+			)
+			continue
+		}
+
 		if _, err := consensus.Decider.SubmitVote(
 			quorum.Prepare,
 			key,
@@ -66,11 +73,6 @@ func (consensus *Consensus) announce(block *types.Block) {
 			block.Header().ViewID().Uint64(),
 		); err != nil {
 			return
-		}
-		if err := consensus.prepareBitmap.SetKey(key, true); err != nil {
-			consensus.getLogger().Warn().Err(err).Msg(
-				"[Announce] Leader prepareBitmap SetKey failed",
-			)
 		}
 	}
 	// Construct broadcast p2p message

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -58,8 +58,8 @@ func (consensus *Consensus) announce(block *types.Block) {
 	// Leader sign the block hash itself
 	for i, key := range consensus.PubKey.PublicKey {
 		if err := consensus.prepareBitmap.SetKey(key, true); err != nil {
-			consensus.getLogger().Warn().Err(err).Msg(
-				"[Announce] Leader prepareBitmap SetKey failed",
+			consensus.getLogger().Warn().Err(err).Msgf(
+				"[Announce] Leader prepareBitmap SetKey failed for key at index %d", i,
 			)
 			continue
 		}

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -71,7 +71,6 @@ func (consensus *Consensus) announce(block *types.Block) {
 			consensus.getLogger().Warn().Err(err).Msg(
 				"[Announce] Leader prepareBitmap SetKey failed",
 			)
-			return
 		}
 	}
 	// Construct broadcast p2p message

--- a/consensus/threshold.go
+++ b/consensus/threshold.go
@@ -51,6 +51,11 @@ func (consensus *Consensus) didReachPrepareQuorum() error {
 	// so by this point, everyone has committed to the blockhash of this block
 	// in prepare and so this is the actual block.
 	for i, key := range consensus.PubKey.PublicKey {
+		if err := consensus.commitBitmap.SetKey(key, true); err != nil {
+			consensus.getLogger().Debug().Msg("[OnPrepare] Leader commit bitmap set failed")
+			continue
+		}
+
 		if _, err := consensus.Decider.SubmitVote(
 			quorum.Commit,
 			key,
@@ -60,10 +65,6 @@ func (consensus *Consensus) didReachPrepareQuorum() error {
 			blockObj.Header().ViewID().Uint64(),
 		); err != nil {
 			return err
-		}
-
-		if err := consensus.commitBitmap.SetKey(key, true); err != nil {
-			consensus.getLogger().Debug().Msg("[OnPrepare] Leader commit bitmap set failed")
 		}
 	}
 	if err := consensus.msgSender.SendWithRetry(
@@ -75,7 +76,7 @@ func (consensus *Consensus) didReachPrepareQuorum() error {
 	); err != nil {
 		consensus.getLogger().Warn().Msg("[OnPrepare] Cannot send prepared message")
 	} else {
-		consensus.getLogger().Debug().
+		consensus.getLogger().Info().
 			Hex("blockHash", consensus.blockHash[:]).
 			Uint64("blockNum", consensus.blockNum).
 			Msg("[OnPrepare] Sent Prepared Message!!")

--- a/consensus/threshold.go
+++ b/consensus/threshold.go
@@ -64,7 +64,6 @@ func (consensus *Consensus) didReachPrepareQuorum() error {
 
 		if err := consensus.commitBitmap.SetKey(key, true); err != nil {
 			consensus.getLogger().Debug().Msg("[OnPrepare] Leader commit bitmap set failed")
-			return err
 		}
 	}
 	if err := consensus.msgSender.SendWithRetry(

--- a/consensus/threshold.go
+++ b/consensus/threshold.go
@@ -52,7 +52,7 @@ func (consensus *Consensus) didReachPrepareQuorum() error {
 	// in prepare and so this is the actual block.
 	for i, key := range consensus.PubKey.PublicKey {
 		if err := consensus.commitBitmap.SetKey(key, true); err != nil {
-			consensus.getLogger().Debug().Msg("[OnPrepare] Leader commit bitmap set failed")
+			consensus.getLogger().Warn().Msgf("[OnPrepare] Leader commit bitmap set failed for key at index %d", i)
 			continue
 		}
 

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -211,9 +211,12 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 			consensus.getLogger().Debug().Msg("[onViewChange] add my M1 type messaage")
 			msgToSign := append(preparedMsg.BlockHash[:], preparedMsg.Payload...)
 			for i, key := range consensus.PubKey.PublicKey {
+				if err := consensus.bhpBitmap[recvMsg.ViewID].SetKey(key, true); err != nil {
+					consensus.getLogger().Warn().Msgf("[onViewChange] bhpBitmap setkey failed for key at index %d", i)
+					continue
+				}
 				priKey := consensus.priKey.PrivateKey[i]
 				consensus.bhpSigs[recvMsg.ViewID][key.SerializeToHexStr()] = priKey.SignHash(msgToSign)
-				consensus.bhpBitmap[recvMsg.ViewID].SetKey(key, true)
 			}
 			// if m1Payload is empty, we just add one
 			if len(consensus.m1Payload) == 0 {
@@ -222,9 +225,12 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 		} else {
 			consensus.getLogger().Debug().Msg("[onViewChange] add my M2(NIL) type messaage")
 			for i, key := range consensus.PubKey.PublicKey {
+				if err := consensus.nilBitmap[recvMsg.ViewID].SetKey(key, true); err != nil {
+					consensus.getLogger().Warn().Msgf("[onViewChange] nilBitmap setkey failed for key at index %d", i)
+					continue
+				}
 				priKey := consensus.priKey.PrivateKey[i]
 				consensus.nilSigs[recvMsg.ViewID][key.SerializeToHexStr()] = priKey.SignHash(NIL)
-				consensus.nilBitmap[recvMsg.ViewID].SetKey(key, true)
 			}
 		}
 	}
@@ -411,6 +417,12 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 			commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
 				block.Epoch(), block.Hash(), block.NumberU64(), block.Header().ViewID().Uint64())
 			for i, key := range consensus.PubKey.PublicKey {
+				if err := consensus.commitBitmap.SetKey(key, true); err != nil {
+					consensus.getLogger().Debug().
+						Msg("[OnViewChange] New Leader commit bitmap set failed")
+					continue
+				}
+
 				priKey := consensus.priKey.PrivateKey[i]
 				if _, err := consensus.Decider.SubmitVote(
 					quorum.Commit,
@@ -424,11 +436,6 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 					return
 				}
 
-				if err := consensus.commitBitmap.SetKey(key, true); err != nil {
-					consensus.getLogger().Debug().
-						Msg("[OnViewChange] New Leader commit bitmap set failed")
-					return
-				}
 			}
 		}
 

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -240,9 +240,12 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 		viewIDBytes := make([]byte, 8)
 		binary.LittleEndian.PutUint64(viewIDBytes, recvMsg.ViewID)
 		for i, key := range consensus.PubKey.PublicKey {
+			if err := consensus.viewIDBitmap[recvMsg.ViewID].SetKey(key, true); err != nil {
+				consensus.getLogger().Warn().Msgf("[onViewChange] viewIDBitmap setkey failed for key at index %d", i)
+				continue
+			}
 			priKey := consensus.priKey.PrivateKey[i]
 			consensus.viewIDSigs[recvMsg.ViewID][key.SerializeToHexStr()] = priKey.SignHash(viewIDBytes)
-			consensus.viewIDBitmap[recvMsg.ViewID].SetKey(key, true)
 		}
 	}
 

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -421,8 +421,8 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 				block.Epoch(), block.Hash(), block.NumberU64(), block.Header().ViewID().Uint64())
 			for i, key := range consensus.PubKey.PublicKey {
 				if err := consensus.commitBitmap.SetKey(key, true); err != nil {
-					consensus.getLogger().Debug().
-						Msg("[OnViewChange] New Leader commit bitmap set failed")
+					consensus.getLogger().Warn().
+						Msgf("[OnViewChange] New Leader commit bitmap set failed for key at index %d", i)
 					continue
 				}
 


### PR DESCRIPTION
## Issue
Previously, the multi-key feature assumes all the keys are in committee for the leader. But if it's not true, the leader node will fail to propose new blocks or fail to count votes correctly.

## Test

tested in dryrun network with slot changes.

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**
