### PR TITLE
[RPC] add input on newRPCTransaction

### DIFF
--- a/internal/hmyapi/apiv1/types.go
+++ b/internal/hmyapi/apiv1/types.go
@@ -172,6 +172,7 @@ func newRPCTransaction(
 		Gas:       hexutil.Uint64(tx.Gas()),
 		GasPrice:  (*hexutil.Big)(tx.GasPrice()),
 		Hash:      tx.Hash(),
+		Input:     hexutil.Bytes(tx.Data()),
 		Nonce:     hexutil.Uint64(tx.Nonce()),
 		Value:     (*hexutil.Big)(tx.Value()),
 		ShardID:   tx.ShardID(),


### PR DESCRIPTION
In apiv1, the NewRPCTransaction missed the input information, which exists in apiv2, then all the HRC transaction returned by apiv1 RPC showed '0x'