### PR TITLE
[core] fail repair on missing block

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -540,7 +540,7 @@ func (bc *BlockChain) repair(head **types.Block) error {
 				Str("number", (*head).Number().String()).
 				Str("hash", (*head).Hash().Hex()).
 				Msg("Rewound blockchain to past state")
-			return nil
+			return bc.removeInValidatorList(valsToRemove)
 		}
 		// Repair last commit sigs
 		lastSig := (*head).Header().LastCommitSignature()
@@ -557,9 +557,12 @@ func (bc *BlockChain) repair(head **types.Block) error {
 				}
 			}
 		}
-		(*head) = bc.GetBlock((*head).ParentHash(), (*head).NumberU64()-1)
+		block := bc.GetBlock((*head).ParentHash(), (*head).NumberU64()-1)
+		if block == nil {
+			return fmt.Errorf("missing block %d [%x]", (*head).NumberU64()-1, (*head).ParentHash())
+		}
+		*head = block
 	}
-	return bc.removeInValidatorList(valsToRemove)
 }
 
 // This func is used to remove the validator addresses from the validator list.


### PR DESCRIPTION
Fixes: https://github.com/harmony-one/harmony/issues/3139
* Applying patch from go-ethereum: https://github.com/ethereum/go-ethereum/blob/4b2ff1457ac28fb2894485194e0e344e84c2bcd7/core/blockchain.go#L626 for taking care of nil pointer when rewinding in repair. 
* Move validator remove call to rewind success branch, it was dead code before.