### PR TITLE
[p2p] increase timeout of validator

### DIFF
--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -321,7 +321,7 @@ func (consensus *Consensus) Start(
 		}
 		consensus.getLogger().Info().Time("time", time.Now()).Msg("[ConsensusMainLoop] Consensus started")
 		defer close(stoppedChan)
-		ticker := time.NewTicker(time.Second)
+		ticker := time.NewTicker(3 * time.Second)
 		defer ticker.Stop()
 		consensus.consensusTimeout[timeoutBootstrap].Start()
 		consensus.getLogger().Debug().

--- a/node/node.go
+++ b/node/node.go
@@ -604,7 +604,8 @@ func (node *Node) Start() error {
 
 			},
 			// WithValidatorTimeout is an option that sets a timeout for an (asynchronous) topic validator. By default there is no timeout in asynchronous validators.
-			libp2p_pubsub.WithValidatorTimeout(50*time.Microsecond),
+			libp2p_pubsub.WithValidatorTimeout(50*time.Millisecond),
+			// WithValidatorConcurrency set the concurernt validator, default is 1024
 			libp2p_pubsub.WithValidatorConcurrency(p2p.SetAsideForConsensus),
 		); err != nil {
 			return err


### PR DESCRIPTION
* restore the ticker to the original 3 seconds
* try to address https://github.com/harmony-one/harmony/issues/3150

Signed-off-by: Leo Chen <leo@harmony.one>
