### PR TITLE
Sampledlog for more p2p errors

### DIFF
--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -14,6 +14,7 @@ import (
 	"github.com/harmony-one/harmony/core/types"
 	vrf_bls "github.com/harmony-one/harmony/crypto/vrf/bls"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
+	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/shard"
 	"github.com/harmony-one/vdf/src/vdf_go"
@@ -26,6 +27,8 @@ var (
 
 // HandleMessageUpdate will update the consensus state according to received message
 func (consensus *Consensus) HandleMessageUpdate(ctx context.Context, msg *msg_pb.Message, senderKey *bls.PublicKey) error {
+	entryTime := time.Now()
+	defer utils.SampledLogger().Info().Str("cost", time.Now().Sub(entryTime).String()).Msg("[cost:handle_consensus_message]")
 	// when node is in ViewChanging mode, it still accepts normal messages into FBFTLog
 	// in order to avoid possible trap forever but drop PREPARE and COMMIT
 	// which are message types specifically for a node acting as leader

--- a/node/node.go
+++ b/node/node.go
@@ -543,7 +543,7 @@ func (node *Node) Start() error {
 			// this is the validation function called to quickly validate every p2p message
 			func(ctx context.Context, peer libp2p_peer.ID, msg *libp2p_pubsub.Message) bool {
 				entryTime := time.Now()
-				defer utils.SampledLogger().Info().Str("cost", time.Now().Sub(entryTime).String()).Msg("[cost:topic_validator]")
+				defer utils.SampledLogger().Debug().Str("cost", time.Now().Sub(entryTime).String()).Msg("[cost:topic_validator]")
 
 				hmyMsg := msg.GetData()
 
@@ -552,7 +552,7 @@ func (node *Node) Start() error {
 					errChan <- withError{
 						errors.WithStack(errors.Wrapf(
 							errMsgHadNoHMYPayLoadAssumption, "on topic %s", topicNamed,
-						)), nil,
+						)), msg.GetFrom(),
 					}
 					return false
 				}
@@ -577,7 +577,7 @@ func (node *Node) Start() error {
 					)
 
 					if err != nil {
-						errChan <- withError{err, validMsg}
+						errChan <- withError{err, msg.GetFrom()}
 						return false
 					}
 
@@ -600,8 +600,18 @@ func (node *Node) Start() error {
 					return false
 				}
 
-				return true
+				select {
+				case <-ctx.Done():
+					if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+						utils.Logger().Info().
+							Str("topic", topicNamed).Msg("exceeded validation deadline")
+					}
+					errChan <- withError{errors.WithStack(ctx.Err()), nil}
+				default:
+					return true
+				}
 
+				return true
 			},
 			// WithValidatorTimeout is an option that sets a timeout for an (asynchronous) topic validator. By default there is no timeout in asynchronous validators.
 			libp2p_pubsub.WithValidatorTimeout(50*time.Millisecond),
@@ -649,7 +659,7 @@ func (node *Node) Start() error {
 						case <-ctx.Done():
 							if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 								utils.Logger().Info().
-									Str("topic", topicNamed).Msg("exceeded deadline")
+									Str("topic", topicNamed).Msg("exceeded handler deadline")
 							}
 							errChan <- withError{errors.WithStack(ctx.Err()), nil}
 						default:

--- a/node/node.go
+++ b/node/node.go
@@ -551,7 +551,7 @@ func (node *Node) Start() error {
 				if len(hmyMsg) < p2pMsgPrefixSize {
 					errChan <- withError{
 						errors.WithStack(errors.Wrapf(
-							errMsgHadNoHMYPayLoadAssumption, "on topic %s", topicNamed,
+							errMsgHadNoHMYPayLoadAssumption, "on topic %s (len:%d)", topicNamed, len(hmyMsg),
 						)), nil,
 					}
 					return false
@@ -617,7 +617,8 @@ func (node *Node) Start() error {
 		go func() {
 
 			for msg := range msgChan {
-				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				// should not take more than 3 seconds to process one message
+				ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 				msg := msg
 
 				go func() {

--- a/node/node.go
+++ b/node/node.go
@@ -395,7 +395,7 @@ func (node *Node) validateShardBoundMessage(
 		senderKey *bls.PublicKey
 	)
 	entryTime := time.Now()
-	defer utils.Logger().Debug().Str("cost", time.Now().Sub(entryTime).String()).Msg("[cost:validate_shard_bound_message]")
+	defer utils.SampledLogger().Info().Str("cost", time.Now().Sub(entryTime).String()).Msg("[cost:validate_shard_bound_message]")
 
 	if err := protobuf.Unmarshal(payload, &m); err != nil {
 		atomic.AddUint32(&node.NumInvalidMessages, 1)

--- a/node/node.go
+++ b/node/node.go
@@ -573,7 +573,7 @@ func (node *Node) Start() error {
 
 					// validate consensus message
 					validMsg, senderPubKey, err := node.validateShardBoundMessage(
-						context.TODO(), openBox[proto.MessageCategoryBytes:],
+						ctx, openBox[proto.MessageCategoryBytes:],
 					)
 
 					if err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -603,8 +603,8 @@ func (node *Node) Start() error {
 				select {
 				case <-ctx.Done():
 					if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-						utils.Logger().Info().
-							Str("topic", topicNamed).Msg("exceeded validation deadline")
+						utils.Logger().Warn().
+							Str("topic", topicNamed).Msg("[context] exceeded validation deadline")
 					}
 					errChan <- withError{errors.WithStack(ctx.Err()), nil}
 				default:
@@ -658,8 +658,8 @@ func (node *Node) Start() error {
 						select {
 						case <-ctx.Done():
 							if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-								utils.Logger().Info().
-									Str("topic", topicNamed).Msg("exceeded handler deadline")
+								utils.Logger().Warn().
+									Str("topic", topicNamed).Msg("[context] exceeded handler deadline")
 							}
 							errChan <- withError{errors.WithStack(ctx.Err()), nil}
 						default:

--- a/node/node.go
+++ b/node/node.go
@@ -681,9 +681,9 @@ func (node *Node) Start() error {
 	}
 
 	for e := range errChan {
-		utils.Logger().Debug().
+		utils.SampledLogger().Info().
 			Interface("item", e.payload).
-			Msgf("issue while handling incoming p2p message: %v", e.err)
+			Msgf("[p2p]: issue while handling incoming p2p message: %v", e.err)
 	}
 	// NOTE never gets here
 	return nil

--- a/node/node.go
+++ b/node/node.go
@@ -499,7 +499,7 @@ func (node *Node) Start() error {
 
 	pubsub := node.host.PubSub()
 	ownID := node.host.GetID()
-	errChan := make(chan withError)
+	errChan := make(chan withError, 100)
 
 	// p2p consensus message handler function
 	type p2pHandlerConsensus func(
@@ -624,7 +624,7 @@ func (node *Node) Start() error {
 					return true
 				}
 
-				return true
+				return false
 			},
 			// WithValidatorTimeout is an option that sets a timeout for an (asynchronous) topic validator. By default there is no timeout in asynchronous validators.
 			libp2p_pubsub.WithValidatorTimeout(50*time.Millisecond),

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -56,6 +56,8 @@ const (
 	SetAsideOtherwise = 1 << 12
 	// MaxMessageHandlers ..
 	MaxMessageHandlers = SetAsideForConsensus + SetAsideOtherwise
+	// MaxMessageSize is the 256Kb
+	MaxMessageSize = 1 << 18
 )
 
 // NewHost ..
@@ -85,6 +87,8 @@ func NewHost(self *Peer, key libp2p_crypto.PrivKey) (Host, error) {
 		libp2p_pubsub.WithValidateWorkers(runtime.NumCPU() * 2),
 		// WithValidateThrottle sets the upper bound on the number of active validation goroutines across all topics. The default is 8192.
 		libp2p_pubsub.WithValidateThrottle(MaxMessageHandlers),
+		// WithMaxMessageSize sets the global maximum message size for pubsub wire messages. The default value is 1MiB (DefaultMaxMessageSize).
+		libp2p_pubsub.WithMaxMessageSize(MaxMessageSize),
 	}
 
 	traceFile := os.Getenv("P2P_TRACEFILE")

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -56,8 +56,8 @@ const (
 	SetAsideOtherwise = 1 << 12
 	// MaxMessageHandlers ..
 	MaxMessageHandlers = SetAsideForConsensus + SetAsideOtherwise
-	// MaxMessageSize is the 256Kb
-	MaxMessageSize = 1 << 18
+	// MaxMessageSize is 2Mb
+	MaxMessageSize = 1 << 21
 )
 
 // NewHost ..


### PR DESCRIPTION
The sampledlogger helped me identify more p2p errors on mainnet so that I can tune the parameters and prepare for the blacklist feature, and adjust the timeout value for context.