### PR TITLE
[rpc] Add rpc to get block headers from any block

### DIFF
--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -569,6 +569,18 @@ func (s *PublicBlockChainAPI) LatestHeader(ctx context.Context) *HeaderInformati
 	return newHeaderInformation(header)
 }
 
+// GetHeaderByNumber returns block header at given number
+func (s *PublicBlockChainAPI) GetHeaderByNumber(ctx context.Context, blockNum rpc.BlockNumber) (*HeaderInformation, error) {
+	if err := s.isBlockGreaterThanLatest(blockNum); err != nil {
+		return nil, err
+	}
+	header, err := s.b.HeaderByNumber(context.Background(), blockNum)
+	if err != nil {
+		return nil, err
+	}
+	return newHeaderInformation(header), nil
+}
+
 // GetTotalStaking returns total staking by validators, only meant to be called on beaconchain
 // explorer node
 func (s *PublicBlockChainAPI) GetTotalStaking() (*big.Int, error) {

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -520,6 +520,18 @@ func (s *PublicBlockChainAPI) LatestHeader(ctx context.Context) *HeaderInformati
 	return newHeaderInformation(header)
 }
 
+// GetHeaderByNumber returns block header at given number
+func (s *PublicBlockChainAPI) GetHeaderByNumber(ctx context.Context, blockNum uint64) (*HeaderInformation, error) {
+	if err := s.isBlockGreaterThanLatest(blockNum); err != nil {
+		return nil, err
+	}
+	header, err := s.b.HeaderByNumber(context.Background(), rpc.BlockNumber(blockNum))
+	if err != nil {
+		return nil, err
+	}
+	return newHeaderInformation(header), nil
+}
+
 // GetTotalStaking returns total staking by validators, only meant to be called on beaconchain
 // explorer node
 func (s *PublicBlockChainAPI) GetTotalStaking() (*big.Int, error) {


### PR DESCRIPTION
```
$ curl --location --request POST 'http://localhost:9500' \
> --header 'Content-Type: application/json' \
> --data-raw '{
>     "jsonrpc": "2.0",
>     "method": "hmy_getHeaderByNumber",
>     "params": ["0x3"],
>     "id": 1
> }' | jq
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "blockHash": "0xa818b2e33d7ff384bf53d3a1dac5bc14d40c2f97b79f77e5c69b0ab751310ef8",
    "blockNumber": 3,
    "shardID": 0,
    "leader": "one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy",
    "viewID": 3,
    "epoch": 0,
    "timestamp": "2020-06-16 00:57:39 +0000 UTC",
    "unixtime": 1592269059,
    "lastCommitSig": "98bc5101971640357d8a110b873777d1c34ec5248524d4d66ead157b5beb369d326bf0e11ab4e1474ea70811f0fc0b11d8d911578707dab763b8c263659bec0023cef06f090d554a369da261ea253aff77e543c833b22ac6e75e217d49725510",
    "lastCommitBitmap": "7f",
    "crossLinks": []
  }
}
```