### PR TITLE
Merge master to t3 0616

### DIFF
--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -40,7 +40,7 @@ const (
 
 	// after cutting off a number of connected peers, the result number of peers
 	// shall be between numPeersLowBound and numPeersHighBound
-	numPeersLowBound  = 3
+	NumPeersLowBound  = 3
 	numPeersHighBound = 5
 )
 
@@ -276,7 +276,7 @@ func (ss *StateSync) CreateSyncConfig(peers []p2p.Peer, isBeacon bool) error {
 
 // limitNumPeers limits number of peers to release some server end sources.
 func limitNumPeers(ps []p2p.Peer, randSeed int64) []p2p.Peer {
-	targetSize := calcNumPeersWithBound(len(ps), numPeersLowBound, numPeersHighBound)
+	targetSize := calcNumPeersWithBound(len(ps), NumPeersLowBound, numPeersHighBound)
 	if len(ps) <= targetSize {
 		return ps
 	}

--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -131,9 +131,6 @@ func main() {
 		host.GetP2PHost().Network().Notify(NewConnLogger(utils.GetLogInstance()))
 	}
 
-	// set the KValue to 50 for DHT
-	// 50 is the size of every bucket in the DHT
-	kaddht.KValue = 50
 	dataStorePath := fmt.Sprintf(".dht-%s-%s", *ip, *port)
 	dataStore, err := badger.NewDatastore(dataStorePath, nil)
 	if err != nil {

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -69,7 +69,6 @@ var (
 	freshDB     = flag.Bool("fresh_db", false, "true means the existing disk based db will be removed")
 	pprof       = flag.String("pprof", "", "what address and port the pprof profiling server should listen on")
 	versionFlag = flag.Bool("version", false, "Output version info")
-	onlyLogTps  = flag.Bool("only_log_tps", false, "Only log TPS if true")
 	dnsZone     = flag.String("dns_zone", "", "if given and not empty, use peers from the zone (default: use libp2p peer discovery instead)")
 	dnsFlag     = flag.Bool("dns", true, "[deprecated] equivalent to -dns_zone t.hmny.io")
 	dnsPort     = flag.String("dns_port", "9000", "port of dns node")
@@ -139,11 +138,6 @@ func initSetup() {
 	utils.SetLogContext(*port, *ip)
 	utils.SetLogVerbosity(log.Lvl(*verbosity))
 	utils.AddLogFile(fmt.Sprintf("%v/validator-%v-%v.log", *logFolder, *ip, *port), *logMaxSize)
-
-	if *onlyLogTps {
-		matchFilterHandler := log.MatchFilterHandler("msg", "TPS Report", utils.GetLogInstance().GetHandler())
-		utils.GetLogInstance().SetHandler(matchFilterHandler)
-	}
 
 	// Add GOMAXPROCS to achieve max performance.
 	runtime.GOMAXPROCS(runtime.NumCPU() * 4)
@@ -577,7 +571,6 @@ func setupViperConfig() {
 	viperconfig.ResetConfBool(freshDB, envViper, configFileViper, "", "fresh_db")
 	viperconfig.ResetConfString(pprof, envViper, configFileViper, "", "pprof")
 	viperconfig.ResetConfBool(versionFlag, envViper, configFileViper, "", "version")
-	viperconfig.ResetConfBool(onlyLogTps, envViper, configFileViper, "", "only_log_tps")
 	viperconfig.ResetConfString(dnsZone, envViper, configFileViper, "", "dns_zone")
 	viperconfig.ResetConfBool(dnsFlag, envViper, configFileViper, "", "dns")
 	viperconfig.ResetConfInt(minPeers, envViper, configFileViper, "", "min_peers")

--- a/consensus/consensus_msg_sender.go
+++ b/consensus/consensus_msg_sender.go
@@ -2,6 +2,7 @@ package consensus
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	msg_pb "github.com/harmony-one/harmony/api/proto/message"
@@ -18,7 +19,6 @@ const (
 // MessageSender is the wrapper object that controls how a consensus message is sent
 type MessageSender struct {
 	blockNum        uint64 // The current block number at consensus
-	blockNumMutex   sync.Mutex
 	messagesToRetry sync.Map
 	// The p2p host used to send/receive p2p messages
 	host p2p.Host
@@ -28,13 +28,12 @@ type MessageSender struct {
 
 // MessageRetry controls the message that can be retried
 type MessageRetry struct {
-	blockNum      uint64 // The block number this message is for
-	groups        []nodeconfig.GroupID
-	p2pMsg        []byte
-	msgType       msg_pb.MessageType
-	retryCount    int
-	isActive      bool
-	isActiveMutex sync.Mutex
+	blockNum   uint64 // The block number this message is for
+	groups     []nodeconfig.GroupID
+	p2pMsg     []byte
+	msgType    msg_pb.MessageType
+	retryCount int
+	isActive   uint32 // 0 is false, != 0 is true, in order to use atomic.Load/Store functions
 }
 
 // NewMessageSender initializes the consensus message sender.
@@ -44,9 +43,7 @@ func NewMessageSender(host p2p.Host) *MessageSender {
 
 // Reset resets the sender's state for new block
 func (sender *MessageSender) Reset(blockNum uint64) {
-	sender.blockNumMutex.Lock()
-	sender.blockNum = blockNum
-	sender.blockNumMutex.Unlock()
+	atomic.StoreUint64(&sender.blockNum, blockNum)
 	sender.StopAllRetriesExceptCommitted()
 	sender.messagesToRetry.Range(func(key interface{}, value interface{}) bool {
 		if msgRetry, ok := value.(*MessageRetry); ok {
@@ -60,9 +57,9 @@ func (sender *MessageSender) Reset(blockNum uint64) {
 
 // SendWithRetry sends message with retry logic.
 func (sender *MessageSender) SendWithRetry(blockNum uint64, msgType msg_pb.MessageType, groups []nodeconfig.GroupID, p2pMsg []byte) error {
-	willRetry := sender.retryTimes != 0
-	msgRetry := MessageRetry{blockNum: blockNum, groups: groups, p2pMsg: p2pMsg, msgType: msgType, retryCount: 0, isActive: willRetry}
-	if willRetry {
+	if sender.retryTimes != 0 {
+		msgRetry := MessageRetry{blockNum: blockNum, groups: groups, p2pMsg: p2pMsg, msgType: msgType, retryCount: 0}
+		atomic.StoreUint32(&msgRetry.isActive, 1)
 		sender.messagesToRetry.Store(msgType, &msgRetry)
 		go func() {
 			sender.Retry(&msgRetry)
@@ -86,22 +83,18 @@ func (sender *MessageSender) Retry(msgRetry *MessageRetry) {
 			return
 		}
 
-		msgRetry.isActiveMutex.Lock()
-		if !msgRetry.isActive {
-			msgRetry.isActiveMutex.Unlock()
+		isActive := atomic.LoadUint32(&msgRetry.isActive)
+		if isActive == 0 {
 			// Retry is stopped
 			return
 		}
-		msgRetry.isActiveMutex.Unlock()
 
 		if msgRetry.msgType != msg_pb.MessageType_COMMITTED {
-			sender.blockNumMutex.Lock()
-			if msgRetry.blockNum < sender.blockNum {
-				sender.blockNumMutex.Unlock()
+			senderBlockNum := atomic.LoadUint64(&sender.blockNum)
+			if msgRetry.blockNum < senderBlockNum {
 				// Block already moved ahead, no need to retry old block's messages
 				return
 			}
-			sender.blockNumMutex.Unlock()
 		}
 
 		msgRetry.retryCount++
@@ -118,9 +111,7 @@ func (sender *MessageSender) StopRetry(msgType msg_pb.MessageType) {
 	data, ok := sender.messagesToRetry.Load(msgType)
 	if ok {
 		msgRetry := data.(*MessageRetry)
-		msgRetry.isActiveMutex.Lock()
-		msgRetry.isActive = false
-		msgRetry.isActiveMutex.Unlock()
+		atomic.StoreUint32(&msgRetry.isActive, 0)
 	}
 }
 
@@ -129,9 +120,7 @@ func (sender *MessageSender) StopAllRetriesExceptCommitted() {
 	sender.messagesToRetry.Range(func(k, v interface{}) bool {
 		if msgRetry, ok := v.(*MessageRetry); ok {
 			if msgRetry.msgType != msg_pb.MessageType_COMMITTED {
-				msgRetry.isActiveMutex.Lock()
-				msgRetry.isActive = false
-				msgRetry.isActiveMutex.Unlock()
+				atomic.StoreUint32(&msgRetry.isActive, 0)
 			}
 		}
 		return true

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -2,6 +2,7 @@ package consensus
 
 import (
 	"math/big"
+	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/common"
 	protobuf "github.com/golang/protobuf/proto"
@@ -273,9 +274,7 @@ func (consensus *Consensus) checkViewID(msg *FBFTMessage) error {
 
 // SetBlockNum sets the blockNum in consensus object, called at node bootstrap
 func (consensus *Consensus) SetBlockNum(blockNum uint64) {
-	consensus.infoMutex.Lock()
-	defer consensus.infoMutex.Unlock()
-	consensus.blockNum = blockNum
+	atomic.StoreUint64(&consensus.blockNum, blockNum)
 }
 
 // ReadSignatureBitmapPayload read the payload for signature and bitmap; offset is the beginning position of reading

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"sync/atomic"
 	"time"
 
 	"github.com/harmony-one/bls/ffi/go/bls"
@@ -13,6 +14,7 @@ import (
 	"github.com/harmony-one/harmony/core/types"
 	vrf_bls "github.com/harmony-one/harmony/crypto/vrf/bls"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
+	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/shard"
 	"github.com/harmony-one/vdf/src/vdf_go"
@@ -25,6 +27,8 @@ var (
 
 // HandleMessageUpdate will update the consensus state according to received message
 func (consensus *Consensus) HandleMessageUpdate(ctx context.Context, msg *msg_pb.Message, senderKey *bls.PublicKey) error {
+	entryTime := time.Now()
+	defer utils.SampledLogger().Info().Str("cost", time.Now().Sub(entryTime).String()).Msg("[cost:handle_consensus_message]")
 	// when node is in ViewChanging mode, it still accepts normal messages into FBFTLog
 	// in order to avoid possible trap forever but drop PREPARE and COMMIT
 	// which are message types specifically for a node acting as leader
@@ -260,7 +264,7 @@ func (consensus *Consensus) tryCatchup() {
 
 		// TODO(Chao): Explain the reasoning for these code
 		consensus.blockHash = [32]byte{}
-		consensus.blockNum = consensus.blockNum + 1
+		atomic.AddUint64(&consensus.blockNum, 1)
 		consensus.viewID = committedMsg.ViewID + 1
 		consensus.LeaderPubKey = committedMsg.SenderPubkey
 
@@ -320,7 +324,7 @@ func (consensus *Consensus) Start(
 		}
 		consensus.getLogger().Info().Time("time", time.Now()).Msg("[ConsensusMainLoop] Consensus started")
 		defer close(stoppedChan)
-		ticker := time.NewTicker(time.Second)
+		ticker := time.NewTicker(3 * time.Second)
 		defer ticker.Stop()
 		consensus.consensusTimeout[timeoutBootstrap].Start()
 		consensus.getLogger().Debug().

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1731,6 +1732,10 @@ func (bc *BlockChain) ReadShardState(epoch *big.Int) (*shard.State, error) {
 	}
 	shardState, err := rawdb.ReadShardState(bc.db, epoch)
 	if err != nil {
+		if strings.Contains(err.Error(), rawdb.MsgNoShardStateFromDB) &&
+			shard.Schedule.IsSkippedEpoch(bc.ShardID(), epoch) {
+			return nil, fmt.Errorf("epoch skipped on chain: %w", err)
+		}
 		return nil, err
 	}
 	bc.shardStateCache.Add(cacheKey, shardState)

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/libp2p/go-libp2p-crypto v0.1.0
 	github.com/libp2p/go-libp2p-discovery v0.4.0
 	github.com/libp2p/go-libp2p-host v0.1.0
-	github.com/libp2p/go-libp2p-kad-dht v0.5.0
+	github.com/libp2p/go-libp2p-kad-dht v0.8.0
 	github.com/libp2p/go-libp2p-net v0.1.0
 	github.com/libp2p/go-libp2p-peer v0.2.0
 	github.com/libp2p/go-libp2p-peerstore v0.2.4

--- a/internal/configs/sharding/fixedschedule.go
+++ b/internal/configs/sharding/fixedschedule.go
@@ -61,6 +61,11 @@ func (s fixedSchedule) GetShardingStructure(numShard, shardID int) []map[string]
 	return genShardingStructure(numShard, shardID, TestNetHTTPPattern, TestNetHTTPPattern)
 }
 
+// IsSkippedEpoch returns if an epoch was skipped on shard due to staking epoch
+func (s fixedSchedule) IsSkippedEpoch(shardID uint32, epoch *big.Int) bool {
+	return false
+}
+
 // NewFixedSchedule returns a sharding configuration schedule that uses the
 // given config instance for all epochs.  Useful for testing.
 func NewFixedSchedule(instance Instance) Schedule {

--- a/internal/configs/sharding/localnet.go
+++ b/internal/configs/sharding/localnet.go
@@ -28,7 +28,7 @@ const (
 	localnetRandomnessStartingEpoch = 0
 )
 
-func (localnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
+func (ls localnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	switch {
 	case epoch.Cmp(params.LocalnetChainConfig.StakingEpoch) >= 0:
 		return localnetV2
@@ -106,6 +106,11 @@ func (ls localnetSchedule) GetShardingStructure(numShard, shardID int) []map[str
 		})
 	}
 	return res
+}
+
+// IsSkippedEpoch returns if an epoch was skipped on shard due to staking epoch
+func (ls localnetSchedule) IsSkippedEpoch(shardID uint32, epoch *big.Int) bool {
+	return false
 }
 
 var (

--- a/internal/configs/sharding/pangaea.go
+++ b/internal/configs/sharding/pangaea.go
@@ -26,7 +26,7 @@ const (
 	PangaeaWSPattern = "wss://ws.s%d.os.hmny.io"
 )
 
-func (pangaeaSchedule) InstanceForEpoch(epoch *big.Int) Instance {
+func (ps pangaeaSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	switch {
 	case epoch.Cmp(params.PangaeaChainConfig.StakingEpoch) >= 0:
 		return pangaeaV1
@@ -66,13 +66,18 @@ func (ps pangaeaSchedule) RandomnessStartingEpoch() uint64 {
 	return mainnetRandomnessStartingEpoch
 }
 
-func (pangaeaSchedule) GetNetworkID() NetworkID {
+func (ps pangaeaSchedule) GetNetworkID() NetworkID {
 	return Pangaea
 }
 
 // GetShardingStructure is the sharding structure for mainnet.
-func (pangaeaSchedule) GetShardingStructure(numShard, shardID int) []map[string]interface{} {
+func (ps pangaeaSchedule) GetShardingStructure(numShard, shardID int) []map[string]interface{} {
 	return genShardingStructure(numShard, shardID, PangaeaHTTPPattern, PangaeaWSPattern)
+}
+
+// IsSkippedEpoch returns if an epoch was skipped on shard due to staking epoch
+func (ps pangaeaSchedule) IsSkippedEpoch(shardID uint32, epoch *big.Int) bool {
+	return false
 }
 
 var pangaeaReshardingEpoch = []*big.Int{

--- a/internal/configs/sharding/partner.go
+++ b/internal/configs/sharding/partner.go
@@ -27,7 +27,7 @@ const (
 	PartnerWSPattern = "wss://ws.s%d.ps.hmny.io"
 )
 
-func (partnerSchedule) InstanceForEpoch(epoch *big.Int) Instance {
+func (ps partnerSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	switch {
 	case epoch.Cmp(params.PartnerChainConfig.StakingEpoch) >= 0:
 		return partnerV1
@@ -36,7 +36,7 @@ func (partnerSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	}
 }
 
-func (partnerSchedule) BlocksPerEpoch() uint64 {
+func (ps partnerSchedule) BlocksPerEpoch() uint64 {
 	return partnerBlocksPerEpoch
 }
 
@@ -75,6 +75,11 @@ func (ps partnerSchedule) GetNetworkID() NetworkID {
 // GetShardingStructure is the sharding structure for partner.
 func (ps partnerSchedule) GetShardingStructure(numShard, shardID int) []map[string]interface{} {
 	return genShardingStructure(numShard, shardID, PartnerHTTPPattern, PartnerWSPattern)
+}
+
+// IsSkippedEpoch returns if an epoch was skipped on shard due to staking epoch
+func (ps partnerSchedule) IsSkippedEpoch(shardID uint32, epoch *big.Int) bool {
+	return false
 }
 
 var partnerReshardingEpoch = []*big.Int{

--- a/internal/configs/sharding/shardingconfig.go
+++ b/internal/configs/sharding/shardingconfig.go
@@ -43,6 +43,9 @@ type Schedule interface {
 
 	// GetShardingStructure returns sharding structure.
 	GetShardingStructure(int, int) []map[string]interface{}
+
+	// IsSkippedEpoch returns if epoch was skipped on shard chain
+	IsSkippedEpoch(uint32, *big.Int) bool
 }
 
 // Instance is one sharding configuration instance.

--- a/internal/configs/sharding/stress.go
+++ b/internal/configs/sharding/stress.go
@@ -27,7 +27,7 @@ const (
 	StressNetWSPattern = "wss://ws.s%d.stn.hmny.io"
 )
 
-func (stressnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
+func (ss stressnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	switch {
 	case epoch.Cmp(params.StressnetChainConfig.StakingEpoch) >= 0:
 		return stressnetV1
@@ -36,7 +36,7 @@ func (stressnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	}
 }
 
-func (stressnetSchedule) BlocksPerEpoch() uint64 {
+func (ss stressnetSchedule) BlocksPerEpoch() uint64 {
 	return stressnetBlocksPerEpoch
 }
 
@@ -75,6 +75,11 @@ func (ss stressnetSchedule) GetNetworkID() NetworkID {
 // GetShardingStructure is the sharding structure for stressnet.
 func (ss stressnetSchedule) GetShardingStructure(numShard, shardID int) []map[string]interface{} {
 	return genShardingStructure(numShard, shardID, StressNetHTTPPattern, StressNetWSPattern)
+}
+
+// IsSkippedEpoch returns if an epoch was skipped on shard due to staking epoch
+func (ss stressnetSchedule) IsSkippedEpoch(shardID uint32, epoch *big.Int) bool {
+	return false
 }
 
 var stressnetReshardingEpoch = []*big.Int{

--- a/internal/configs/sharding/testnet.go
+++ b/internal/configs/sharding/testnet.go
@@ -26,7 +26,7 @@ const (
 	TestNetWSPattern = "wss://ws.s%d.b.hmny.io"
 )
 
-func (testnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
+func (ts testnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	switch {
 	case epoch.Cmp(params.TestnetChainConfig.StakingEpoch) >= 0:
 		return testnetV1
@@ -35,7 +35,7 @@ func (testnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	}
 }
 
-func (testnetSchedule) BlocksPerEpoch() uint64 {
+func (ts testnetSchedule) BlocksPerEpoch() uint64 {
 	return testnetBlocksPerEpoch
 }
 
@@ -74,6 +74,11 @@ func (ts testnetSchedule) GetNetworkID() NetworkID {
 // GetShardingStructure is the sharding structure for testnet.
 func (ts testnetSchedule) GetShardingStructure(numShard, shardID int) []map[string]interface{} {
 	return genShardingStructure(numShard, shardID, TestNetHTTPPattern, TestNetWSPattern)
+}
+
+// IsSkippedEpoch returns if an epoch was skipped on shard due to staking epoch
+func (ts testnetSchedule) IsSkippedEpoch(shardID uint32, epoch *big.Int) bool {
+	return false
 }
 
 var testnetReshardingEpoch = []*big.Int{

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -569,6 +569,18 @@ func (s *PublicBlockChainAPI) LatestHeader(ctx context.Context) *HeaderInformati
 	return newHeaderInformation(header)
 }
 
+// GetHeaderByNumber returns block header at given number
+func (s *PublicBlockChainAPI) GetHeaderByNumber(ctx context.Context, blockNum rpc.BlockNumber) (*HeaderInformation, error) {
+	if err := s.isBlockGreaterThanLatest(blockNum); err != nil {
+		return nil, err
+	}
+	header, err := s.b.HeaderByNumber(context.Background(), blockNum)
+	if err != nil {
+		return nil, err
+	}
+	return newHeaderInformation(header), nil
+}
+
 // GetTotalStaking returns total staking by validators, only meant to be called on beaconchain
 // explorer node
 func (s *PublicBlockChainAPI) GetTotalStaking() (*big.Int, error) {

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -520,6 +520,18 @@ func (s *PublicBlockChainAPI) LatestHeader(ctx context.Context) *HeaderInformati
 	return newHeaderInformation(header)
 }
 
+// GetHeaderByNumber returns block header at given number
+func (s *PublicBlockChainAPI) GetHeaderByNumber(ctx context.Context, blockNum uint64) (*HeaderInformation, error) {
+	if err := s.isBlockGreaterThanLatest(blockNum); err != nil {
+		return nil, err
+	}
+	header, err := s.b.HeaderByNumber(context.Background(), rpc.BlockNumber(blockNum))
+	if err != nil {
+		return nil, err
+	}
+	return newHeaderInformation(header), nil
+}
+
 // GetTotalStaking returns total staking by validators, only meant to be called on beaconchain
 // explorer node
 func (s *PublicBlockChainAPI) GetTotalStaking() (*big.Int, error) {

--- a/internal/utils/singleton.go
+++ b/internal/utils/singleton.go
@@ -31,6 +31,9 @@ var (
 	// ZeroLog
 	zeroLogger      *zerolog.Logger
 	zeroLoggerLevel = zerolog.Disabled
+
+	onceForSampleLogger sync.Once
+	sampledLogger       *zerolog.Logger
 )
 
 // SetLogContext used to print out loggings of node with port and ip.
@@ -53,12 +56,6 @@ func SetLogVerbosity(verbosity log.Lvl) {
 // AddLogFile creates a StreamHandler that outputs JSON logs
 // into rotating files with specified max file size
 func AddLogFile(filepath string, maxSize int) {
-	AddLogHandler(log.StreamHandler(&lumberjack.Logger{
-		Filename: filepath,
-		MaxSize:  maxSize,
-		Compress: true,
-	}, log.JSONFormat()))
-
 	setZeroLoggerFileOutput(filepath, maxSize)
 }
 
@@ -178,6 +175,24 @@ func Logger() *zerolog.Logger {
 		zeroLogger = &logger
 	}
 	return zeroLogger
+}
+
+// SampledLogger returns a sampled zerolog singleton to be used in criticial path like p2p message handling
+func SampledLogger() *zerolog.Logger {
+	// Will let 3 log messages per period of 1 second.
+	// Over 3 log messages, 1 every 100 messages are logged.
+	onceForSampleLogger.Do(func() {
+		sLog := zeroLogger.Sample(
+			&zerolog.BurstSampler{
+				Burst:       3,
+				Period:      1 * time.Second,
+				NextSampler: &zerolog.BasicSampler{N: 100},
+			},
+		)
+		sampledLogger = &sLog
+	})
+
+	return sampledLogger
 }
 
 func updateZeroLogLevel(level int) {

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -26,7 +26,6 @@ const (
 	lastMileThreshold = 4
 	inSyncThreshold   = 1 // unit in number of block
 	SyncFrequency     = 60
-	MinConnectedPeers = 10 // minimum number of peers connected to in node syncing
 )
 
 // getNeighborPeers is a helper function to return list of peers
@@ -223,7 +222,7 @@ func (node *Node) doSync(bc *core.BlockChain, worker *worker.Worker, willJoinCon
 		node.stateSync = syncing.CreateStateSync(node.SelfPeer.IP, node.SelfPeer.Port, node.GetSyncID())
 		utils.Logger().Debug().Msg("[SYNC] initialized state sync")
 	}
-	if node.stateSync.GetActivePeerNumber() < MinConnectedPeers {
+	if node.stateSync.GetActivePeerNumber() < syncing.NumPeersLowBound {
 		shardID := bc.ShardID()
 		peers, err := node.SyncingPeerProvider.SyncingPeers(shardID)
 		if err != nil {

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -56,6 +56,8 @@ const (
 	SetAsideOtherwise = 1 << 12
 	// MaxMessageHandlers ..
 	MaxMessageHandlers = SetAsideForConsensus + SetAsideOtherwise
+	// MaxMessageSize is 2Mb
+	MaxMessageSize = 1 << 21
 )
 
 // NewHost ..
@@ -85,6 +87,8 @@ func NewHost(self *Peer, key libp2p_crypto.PrivKey) (Host, error) {
 		libp2p_pubsub.WithValidateWorkers(runtime.NumCPU() * 2),
 		// WithValidateThrottle sets the upper bound on the number of active validation goroutines across all topics. The default is 8192.
 		libp2p_pubsub.WithValidateThrottle(MaxMessageHandlers),
+		// WithMaxMessageSize sets the global maximum message size for pubsub wire messages. The default value is 1MiB (DefaultMaxMessageSize).
+		libp2p_pubsub.WithMaxMessageSize(MaxMessageSize),
 	}
 
 	traceFile := os.Getenv("P2P_TRACEFILE")


### PR DESCRIPTION
```
3b72b4e4 (HEAD -> t3, leo/merge_master_to_t3_0616) Merge remote-tracking branch 'origin/master' into t3
8da55713 (origin/master, origin/HEAD) address review comments on #3164
3eb2b508 [log] add more debug info in errChan with p2p validation
8c01dbca [p2p] add some more comments and error messages
2b9f9c8e [context] change log level to warn if deadline exceeded
303c6eff [p2p] output validation context exceed error
fcc4a0c6 [p2p] set max pubsub message size to 256Kb
b32e2c2c [log] add more log context in err message
02967df2 [context] shorten the timeout of message handler
9f7d8bc3 [p2p] use validation function context
33d4bfb5 [log] add sample log of message handle time
e05724c6 [log] sample the cost log of p2p validation
6f7e8823 [p2p] sample log p2p validation error messages
e4026738 [log] add a sampledLogger to utils
48adf50e Merge pull request #3165 from janet-harmony/header_by_number_rpc
6542ae54 [rpc] Add rpc to get block headers from any block
23de42f3 (master) [networkinfo] gradually increase the peer finding interval
ba812508 [p2p] upgrade kad-dht module
6189a613 [p2p] increase timeout of validator
03508c5a [cleanup] remove unused flag and log file
8f20883a [p2p] add counters of valid/invalid messages
b41f56cb [consensus] use atomic operation when set blocknum
0891d67e [consensus] replace isActiveMutex with atomic.Value in messageSender
f6b8bc5c [consensus] replace blockNumMutex with atomic.Value in messageSender
49e995a6 [syncing] fix mis-matched min syncing peers
87d63431 [internal] Add IsSkippedEpoch to each network config & interface (#3155)
7b185c0a [rpc] Expose crosslinks in RPCs that return block headers (#3158)
b5056522 [internal] Add IsSkippedEpoch to each network config & interface [blockchain] Add check to ReadShardState error to check if the epoch was skipped due to staking
```