### PR TITLE
Hard code 106 as the cap of bls keys per validator

### DIFF
--- a/core/staking_verifier.go
+++ b/core/staking_verifier.go
@@ -114,8 +114,7 @@ func VerifyAndCreateValidatorFromMsg(
 	wrapper.Counters.NumBlocksSigned = big.NewInt(0)
 	wrapper.Counters.NumBlocksToSign = big.NewInt(0)
 	wrapper.BlockReward = big.NewInt(0)
-	maxBLSKeyAllowed := shard.ExternalSlotsAvailableForEpoch(epoch) / 3
-	if err := wrapper.SanityCheck(maxBLSKeyAllowed); err != nil {
+	if err := wrapper.SanityCheck(); err != nil {
 		return nil, err
 	}
 	return wrapper, nil
@@ -180,8 +179,7 @@ func VerifyAndEditValidatorFromMsg(
 	) {
 		return nil, errCommissionRateChangeTooFast
 	}
-	maxBLSKeyAllowed := shard.ExternalSlotsAvailableForEpoch(epoch) / 3
-	if err := wrapper.SanityCheck(maxBLSKeyAllowed); err != nil {
+	if err := wrapper.SanityCheck(); err != nil {
 		return nil, err
 	}
 	return wrapper, nil
@@ -232,9 +230,7 @@ func VerifyAndDelegateFromMsg(
 		delegation := &wrapper.Delegations[i]
 		if bytes.Equal(delegation.DelegatorAddress.Bytes(), msg.DelegatorAddress.Bytes()) {
 			delegation.Amount.Add(delegation.Amount, msg.Amount)
-			if err := wrapper.SanityCheck(
-				staking.DoNotEnforceMaxBLS,
-			); err != nil {
+			if err := wrapper.SanityCheck(); err != nil {
 				return nil, nil, err
 			}
 			return wrapper, msg.Amount, nil
@@ -247,7 +243,7 @@ func VerifyAndDelegateFromMsg(
 			msg.DelegatorAddress, msg.Amount,
 		),
 	)
-	if err := wrapper.SanityCheck(staking.DoNotEnforceMaxBLS); err != nil {
+	if err := wrapper.SanityCheck(); err != nil {
 		return nil, nil, err
 	}
 	return wrapper, msg.Amount, nil
@@ -287,9 +283,7 @@ func VerifyAndUndelegateFromMsg(
 			if err := delegation.Undelegate(epoch, msg.Amount); err != nil {
 				return nil, err
 			}
-			if err := wrapper.SanityCheck(
-				staking.DoNotEnforceMaxBLS,
-			); err != nil {
+			if err := wrapper.SanityCheck(); err != nil {
 				// allow self delegation to go below min self delegation
 				// but set the status to inactive
 				if errors.Cause(err) == staking.ErrInvalidSelfDelegation {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -745,14 +745,12 @@ func (db *DB) ValidatorWrapperCopy(
 	return &val, nil
 }
 
-const doNotEnforceMaxBLS = -1
-
 // UpdateValidatorWrapper updates staking information of
 // a given validator (including delegation info)
 func (db *DB) UpdateValidatorWrapper(
 	addr common.Address, val *stk.ValidatorWrapper,
 ) error {
-	if err := val.SanityCheck(doNotEnforceMaxBLS); err != nil {
+	if err := val.SanityCheck(); err != nil {
 		return err
 	}
 

--- a/staking/slash/double-sign.go
+++ b/staking/slash/double-sign.go
@@ -485,7 +485,7 @@ func Apply(
 			RawJSON("slash", []byte(slash.String())).
 			Msg("about to update staking info for a validator after a slash")
 
-		if err := current.SanityCheck(staking.DoNotEnforceMaxBLS); err != nil {
+		if err := current.SanityCheck(); err != nil {
 			return nil, err
 		}
 	}

--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -231,8 +231,8 @@ type Validator struct {
 	CreationHeight *big.Int `json:"creation-height"`
 }
 
-// DoNotEnforceMaxBLS ..
-const DoNotEnforceMaxBLS = -1
+// MaxBLSPerValidator ..
+const MaxBLSPerValidator = 106
 
 var (
 	oneAsBigInt  = big.NewInt(denominations.One)
@@ -240,7 +240,7 @@ var (
 )
 
 // SanityCheck checks basic requirements of a validator
-func (v *Validator) SanityCheck(oneThirdExtrn int) error {
+func (v *Validator) SanityCheck() error {
 	if _, err := v.EnsureLength(); err != nil {
 		return err
 	}
@@ -249,11 +249,10 @@ func (v *Validator) SanityCheck(oneThirdExtrn int) error {
 		return errNeedAtLeastOneSlotKey
 	}
 
-	if c := len(v.SlotPubKeys); oneThirdExtrn != DoNotEnforceMaxBLS &&
-		c > oneThirdExtrn {
+	if c := len(v.SlotPubKeys); c > MaxBLSPerValidator {
 		return errors.Wrapf(
 			ErrExcessiveBLSKeys, "have: %d allowed: %d",
-			c, oneThirdExtrn,
+			c, MaxBLSPerValidator,
 		)
 	}
 
@@ -341,12 +340,8 @@ var (
 )
 
 // SanityCheck checks the basic requirements
-func (w *ValidatorWrapper) SanityCheck(
-	oneThirdExternalValidator int,
-) error {
-	if err := w.Validator.SanityCheck(
-		oneThirdExternalValidator,
-	); err != nil {
+func (w *ValidatorWrapper) SanityCheck() error {
+	if err := w.Validator.SanityCheck(); err != nil {
 		return err
 	}
 	// Self delegation must be >= MinSelfDelegation

--- a/staking/types/validator_test.go
+++ b/staking/types/validator_test.go
@@ -179,7 +179,7 @@ func TestValidator_SanityCheck(t *testing.T) {
 	for i, test := range tests {
 		v := makeValidValidator()
 		test.editValidator(&v)
-		err := v.SanityCheck(DoNotEnforceMaxBLS)
+		err := v.SanityCheck()
 		if assErr := assertError(err, test.expErr); assErr != nil {
 			t.Errorf("Test %v: %v", i, assErr)
 		}
@@ -242,7 +242,7 @@ func TestValidatorWrapper_SanityCheck(t *testing.T) {
 	for i, test := range tests {
 		vw := makeValidValidatorWrapper()
 		test.editValidatorWrapper(&vw)
-		err := vw.SanityCheck(DoNotEnforceMaxBLS)
+		err := vw.SanityCheck()
 		if assErr := assertError(err, test.expErr); assErr != nil {
 			t.Errorf("Test %v: %v", i, assErr)
 		}


### PR DESCRIPTION
## Issue

The previous cap of bls key is a dynamic number based on total open slots. It was 1/3 of open slots, so 320/3 = 106 in mainnet. This change hard code that limit and not let it float. This way, we will keep a relatively low cap after we keep adding new open slots.

## Test

Tested locally

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

9. **Does the existing `node.sh` continue to work with this change?**

Yes

10. **What should node operators know about this change?**

We will have announcement on this.

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

No

