### PR TITLE
set epochs for slot increase

### DIFF
--- a/internal/configs/sharding/mainnet.go
+++ b/internal/configs/sharding/mainnet.go
@@ -29,8 +29,8 @@ const (
 	mainnetV1_4Epoch = 46
 	mainnetV1_5Epoch = 54
 	mainnetV2_0Epoch = 185 // prestaking epoch
-	mainnetV2_1Epoch = 300 // open slots increase from 320 - 480  (TODO): update the epoch
-	mainnetV2_2Epoch = 300 // open slots increase from 480 - 640  (TODO): update the epoch
+	mainnetV2_1Epoch = 208 // open slots increase from 320 - 480
+	mainnetV2_2Epoch = 213 // open slots increase from 480 - 640
 
 	// MainNetHTTPPattern is the http pattern for mainnet.
 	MainNetHTTPPattern = "https://api.s%d.t.hmny.io"


### PR DESCRIPTION
## Issue

Set the epoch number for slot increase from 320->480 at epoch 208 and from 480->640 at epoch 213

## Test

Already tested slot increase in dryrun network.

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

Tested in dryrun network with same slot change at epoch transition.

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**
ETA for epoch 208 is around Wednesday June 24 2020

7. **What should node operators know about this planned change?**

Need to do rolling upgrade before the epoch change. After the epoch change, need to gradually remove the unused internal keys on the nodes..
