### PR TITLE
Make EPoS compute work with correct epoch shard config

### DIFF
--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -552,7 +552,9 @@ func (b *APIBackend) GetMedianRawStakeSnapshot() (
 	res, err := b.SingleFlightRequest(
 		key,
 		func() (interface{}, error) {
-			return committee.NewEPoSRound(b.hmy.BlockChain())
+			// Compute for next epoch
+			epoch := big.NewInt(0).Add(b.CurrentBlock().Epoch(), big.NewInt(1))
+			return committee.NewEPoSRound(epoch, b.hmy.BlockChain())
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
## Issue

Previously, the EPoS computation uses the current epoch for fetching shard configs, which should be using the new epoch.

This PR correct that for both epoch transition and RPC logic with regard to the EPoS computation.

