### PR TITLE
Reduce number of calls to consensus messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d
 	github.com/cespare/cp v1.1.1
 	github.com/davecgh/go-spew v1.1.1
-	github.com/davidlazar/go-crypto v0.0.0-20190912175916-7055855a373f // indirect
 	github.com/deckarep/golang-set v1.7.1
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/ethereum/go-ethereum v1.8.27
@@ -31,10 +30,8 @@ require (
 	github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365
 	github.com/ipfs/go-ds-badger v0.2.4
 	github.com/jackpal/gateway v1.0.6 // indirect
-	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/karalabe/hid v1.0.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
-	github.com/libp2p/go-addr-util v0.0.2 // indirect
 	github.com/libp2p/go-libp2p v0.9.2
 	github.com/libp2p/go-libp2p-core v0.5.6
 	github.com/libp2p/go-libp2p-crypto v0.1.0

--- a/node/node.go
+++ b/node/node.go
@@ -163,6 +163,7 @@ type Node struct {
 	BroadcastInvalidTx bool
 
 	// metrics of p2p messages
+	NumTotalMessages   uint32
 	NumValidMessages   uint32
 	NumInvalidMessages uint32
 }
@@ -394,6 +395,7 @@ func (node *Node) validateShardBoundMessage(
 		m         msg_pb.Message
 		senderKey *bls.PublicKey
 	)
+	atomic.AddUint32(&node.NumTotalMessages, 1)
 	entryTime := time.Now()
 	defer utils.SampledLogger().Debug().Str("cost", time.Now().Sub(entryTime).String()).Msg("[cost:validate_shard_bound_message]")
 
@@ -867,9 +869,14 @@ func New(
 		for {
 			select {
 			case <-ticker.C:
-				utils.Logger().Info().Uint32("ValidMessage", node.NumValidMessages).Uint32("InvalidMessage", node.NumInvalidMessages).Msg("MsgValidator")
+				utils.Logger().Info().
+					Uint32("TotalMessage", node.NumTotalMessages).
+					Uint32("ValidMessage", node.NumValidMessages).
+					Uint32("InvalidMessage", node.NumInvalidMessages).
+					Msg("MsgValidator")
 				atomic.StoreUint32(&node.NumInvalidMessages, 0)
 				atomic.StoreUint32(&node.NumValidMessages, 0)
+				atomic.StoreUint32(&node.NumTotalMessages, 0)
 			}
 		}
 	}()

--- a/node/node.go
+++ b/node/node.go
@@ -536,11 +536,6 @@ func (node *Node) Start() error {
 		senderPubKey   *bls.PublicKey
 	}
 
-	type p2pSenderInfo struct {
-		source    libp2p_peer.ID
-		forwarder libp2p_peer.ID
-	}
-
 	isThisNodeAnExplorerNode := node.NodeConfig.Role() == nodeconfig.ExplorerNode
 
 	for i := range allTopics {
@@ -571,7 +566,7 @@ func (node *Node) Start() error {
 					errChan <- withError{
 						errors.WithStack(errors.Wrapf(
 							errMsgHadNoHMYPayLoadAssumption, "on topic %s", topicNamed,
-						)), p2pSenderInfo{msg.GetFrom(), msg.ReceivedFrom},
+						)), msg.GetFrom(),
 					}
 					return false
 				}
@@ -586,7 +581,7 @@ func (node *Node) Start() error {
 					if !isConsensusBound {
 						errChan <- withError{
 							errors.WithStack(errConsensusMessageOnUnexpectedTopic),
-							p2pSenderInfo{msg.GetFrom(), msg.ReceivedFrom},
+							msg.GetFrom(),
 						}
 						return false
 					}
@@ -598,7 +593,8 @@ func (node *Node) Start() error {
 
 					if err != nil {
 						errChan <- withError{err,
-							p2pSenderInfo{msg.GetFrom(), msg.ReceivedFrom}}
+							msg.GetFrom(),
+						}
 						return false
 					}
 

--- a/node/node.go
+++ b/node/node.go
@@ -563,12 +563,7 @@ func (node *Node) Start() error {
 
 				// first to validate the size of the p2p message
 				if len(hmyMsg) < p2pMsgPrefixSize {
-					errChan <- withError{
-						errors.WithStack(errors.Wrapf(
-							errMsgHadNoHMYPayLoadAssumption, "on topic %s", topicNamed,
-						)), msg.GetFrom(),
-					}
-					return false
+					return true
 				}
 
 				openBox := hmyMsg[p2pMsgPrefixSize:]

--- a/node/node.go
+++ b/node/node.go
@@ -389,41 +389,53 @@ var (
 // verify message signature
 func (node *Node) validateShardBoundMessage(
 	ctx context.Context, payload []byte,
-) (*msg_pb.Message, *bls.PublicKey, error) {
+) (*msg_pb.Message, *bls.PublicKey, bool, error) {
 	var (
 		m         msg_pb.Message
 		senderKey *bls.PublicKey
 	)
 	entryTime := time.Now()
-	defer utils.SampledLogger().Info().Str("cost", time.Now().Sub(entryTime).String()).Msg("[cost:validate_shard_bound_message]")
+	defer utils.SampledLogger().Debug().Str("cost", time.Now().Sub(entryTime).String()).Msg("[cost:validate_shard_bound_message]")
 
 	if err := protobuf.Unmarshal(payload, &m); err != nil {
 		atomic.AddUint32(&node.NumInvalidMessages, 1)
-		return nil, nil, errors.WithStack(err)
+		return nil, nil, true, errors.WithStack(err)
 	}
+	if node.Consensus.IsLeader() {
+		switch m.Type {
+		case msg_pb.MessageType_ANNOUNCE, msg_pb.MessageType_PREPARED, msg_pb.MessageType_COMMITTED:
+			return nil, nil, true, nil
+		}
+	} else {
+		switch m.Type {
+		case msg_pb.MessageType_PREPARE, msg_pb.MessageType_COMMIT:
+			return nil, nil, true, nil
+		}
+	}
+
 	var senderPubKeyViaWire []byte
 	maybeCon, maybeVC := m.GetConsensus(), m.GetViewchange()
 
 	if maybeCon != nil {
 		if maybeCon.ShardId != node.Consensus.ShardID {
 			atomic.AddUint32(&node.NumInvalidMessages, 1)
-			return nil, nil, errors.WithStack(errWrongShardID)
+			return nil, nil, true, errors.WithStack(errWrongShardID)
 		}
 		senderPubKeyViaWire = maybeCon.GetSenderPubkey()
 	} else if maybeVC != nil {
 		if maybeVC.ShardId != node.Consensus.ShardID {
 			atomic.AddUint32(&node.NumInvalidMessages, 1)
-			return nil, nil, errors.WithStack(errWrongShardID)
+			return nil, nil, true, errors.WithStack(errWrongShardID)
 		}
 		senderPubKeyViaWire = maybeVC.GetSenderPubkey()
 	} else {
 		atomic.AddUint32(&node.NumInvalidMessages, 1)
-		return nil, nil, errors.WithStack(errNoSenderPubKey)
+		return nil, nil, true, errors.WithStack(errNoSenderPubKey)
 	}
 
 	if len(senderPubKeyViaWire) != shard.PublicKeySizeInBytes {
 		atomic.AddUint32(&node.NumInvalidMessages, 1)
-		return nil, nil, errors.WithStack(errNotRightKeySize)
+		return nil, nil, true, errors.WithStack(errNotRightKeySize)
 	}
 
 	key, err := bls_cosi.BytesToBLSPublicKey(
@@ -431,17 +443,17 @@ func (node *Node) validateShardBoundMessage(
 	)
 	if err != nil {
 		atomic.AddUint32(&node.NumInvalidMessages, 1)
-		return nil, nil, errors.WithStack(err)
+		return nil, nil, true, errors.WithStack(err)
 	}
 	senderKey = key
 
 	if !node.Consensus.IsValidatorInCommittee(senderKey) {
 		atomic.AddUint32(&node.NumInvalidMessages, 1)
-		return &m, nil, errors.WithStack(shard.ErrValidNotInCommittee)
+		return &m, nil, true, errors.WithStack(shard.ErrValidNotInCommittee)
 	}
 
 	atomic.AddUint32(&node.NumValidMessages, 1)
-	return &m, senderKey, nil
+	return &m, senderKey, false, nil
 }
 
 var (
@@ -580,7 +592,7 @@ func (node *Node) Start() error {
 					}
 
 					// validate consensus message
-					validMsg, senderPubKey, err := node.validateShardBoundMessage(
+					validMsg, senderPubKey, ignore, err := node.validateShardBoundMessage(
 						ctx, openBox[proto.MessageCategoryBytes:],
 					)
 
@@ -588,6 +600,10 @@ func (node *Node) Start() error {
 						errChan <- withError{err,
 							p2pSenderInfo{msg.GetFrom(), msg.ReceivedFrom}}
 						return false
+					}
+
+					if ignore {
+						return true
 					}
 
 					msg.ValidatorData = validated{

--- a/node/node.go
+++ b/node/node.go
@@ -602,6 +602,7 @@ func (node *Node) Start() error {
 						return false
 					}
 
+					// ignore the further processing of the p2p messages as it is not intended for this node
 					if ignore {
 						return true
 					}
@@ -718,6 +719,10 @@ func (node *Node) Start() error {
 				if validatedMessage, ok := nextMsg.ValidatorData.(validated); ok {
 					msgChan <- validatedMessage
 				} else {
+					// continue if ValidatorData is nil
+					if nextMsg.ValidatorData == nil {
+						continue
+					}
 					errChan <- withError{errors.WithStack(errConvertToValidMessage), nextMsg}
 				}
 			}


### PR DESCRIPTION
Previous release v2.1.5 hit an issue that leaders weren't able to process all the commit messages sent by validators, even the consensus was reached.

The issue was the added validation layer as it's gone after we revert leader to v2.1.3 release.

When the pubsub validation function is added to p2p layer, every p2p message will spawn a goroutine (https://github.com/harmony-one/harmony/blob/23d1890619ba11a8f159c95dcbdb99724e7336b4/node/node.go#L390) to do validation. After the validation, every valid p2p message will spawn a new goroutine (https://github.com/harmony-one/harmony/blob/23d1890619ba11a8f159c95dcbdb99724e7336b4/consensus/consensus_v2.go#L29) to process each message.
However, due to the redundancy of p2p messages, not all messages are intended for leaders/validators, but the massive number of p2p messages will spawn massive number of goroutines that may exceed the number of goroutine limited by the system/configuration.  Thus, we've seen the drop of message processing on leaders when leaders won't be able to collect 100% of the commit messages from all validators.

Before the addition of the validation layer, as we only spawn one goroutine per p2p message, the number of goroutine didn't explode. With the validation layer, the number almost doubled. I added some logs in the code and collected the stats in mainnet to verify it. So, with this fix, we ignore most of the redundant messages that are not intended for consensus message handlers, to avoid the explosion of the goroutine.

I've tested it on the devnet and canary nodes on mainnet. We can see a clear drop of the CPU load after the update. Network traffic also dropped, but that maybe because of the restart of the node program.

We still need to the fix on the leaders though.

![image](https://user-images.githubusercontent.com/4513927/85081787-d45d4000-b181-11ea-91a6-f9106c4ea3c4.png)

![image](https://user-images.githubusercontent.com/4513927/85081797-de7f3e80-b181-11ea-8269-4fd56af66ae1.png)

![image](https://user-images.githubusercontent.com/4513927/85081826-f0f97800-b181-11ea-812d-eebaa21c7141.png)

![image](https://user-images.githubusercontent.com/4513927/85081853-0b335600-b182-11ea-9e45-34225aeb88b5.png)

