### PR TITLE
Use lru to cache blspubkey

### DIFF
--- a/consensus/quorum/quorum.go
+++ b/consensus/quorum/quorum.go
@@ -179,6 +179,7 @@ func (s *cIdentities) IndexOf(pubKey *bls.PublicKey) int {
 	for k, v := range s.publicKeys {
 		if v.IsEqual(pubKey) {
 			idx = k
+			break
 		}
 	}
 	return idx


### PR DESCRIPTION
Inline validator is used to solve the missing signature issue of leader.