### PR TITLE
U3

### DIFF
--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -40,7 +40,7 @@ const (
 
 	// after cutting off a number of connected peers, the result number of peers
 	// shall be between numPeersLowBound and numPeersHighBound
-	numPeersLowBound  = 3
+	NumPeersLowBound  = 3
 	numPeersHighBound = 5
 )
 
@@ -276,7 +276,7 @@ func (ss *StateSync) CreateSyncConfig(peers []p2p.Peer, isBeacon bool) error {
 
 // limitNumPeers limits number of peers to release some server end sources.
 func limitNumPeers(ps []p2p.Peer, randSeed int64) []p2p.Peer {
-	targetSize := calcNumPeersWithBound(len(ps), numPeersLowBound, numPeersHighBound)
+	targetSize := calcNumPeersWithBound(len(ps), NumPeersLowBound, numPeersHighBound)
 	if len(ps) <= targetSize {
 		return ps
 	}

--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -131,9 +131,6 @@ func main() {
 		host.GetP2PHost().Network().Notify(NewConnLogger(utils.GetLogInstance()))
 	}
 
-	// set the KValue to 50 for DHT
-	// 50 is the size of every bucket in the DHT
-	kaddht.KValue = 50
 	dataStorePath := fmt.Sprintf(".dht-%s-%s", *ip, *port)
 	dataStore, err := badger.NewDatastore(dataStorePath, nil)
 	if err != nil {

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -69,7 +69,6 @@ var (
 	freshDB     = flag.Bool("fresh_db", false, "true means the existing disk based db will be removed")
 	pprof       = flag.String("pprof", "", "what address and port the pprof profiling server should listen on")
 	versionFlag = flag.Bool("version", false, "Output version info")
-	onlyLogTps  = flag.Bool("only_log_tps", false, "Only log TPS if true")
 	dnsZone     = flag.String("dns_zone", "", "if given and not empty, use peers from the zone (default: use libp2p peer discovery instead)")
 	dnsFlag     = flag.Bool("dns", true, "[deprecated] equivalent to -dns_zone t.hmny.io")
 	dnsPort     = flag.String("dns_port", "9000", "port of dns node")
@@ -139,11 +138,6 @@ func initSetup() {
 	utils.SetLogContext(*port, *ip)
 	utils.SetLogVerbosity(log.Lvl(*verbosity))
 	utils.AddLogFile(fmt.Sprintf("%v/validator-%v-%v.log", *logFolder, *ip, *port), *logMaxSize)
-
-	if *onlyLogTps {
-		matchFilterHandler := log.MatchFilterHandler("msg", "TPS Report", utils.GetLogInstance().GetHandler())
-		utils.GetLogInstance().SetHandler(matchFilterHandler)
-	}
 
 	// Add GOMAXPROCS to achieve max performance.
 	runtime.GOMAXPROCS(runtime.NumCPU() * 4)
@@ -577,7 +571,6 @@ func setupViperConfig() {
 	viperconfig.ResetConfBool(freshDB, envViper, configFileViper, "", "fresh_db")
 	viperconfig.ResetConfString(pprof, envViper, configFileViper, "", "pprof")
 	viperconfig.ResetConfBool(versionFlag, envViper, configFileViper, "", "version")
-	viperconfig.ResetConfBool(onlyLogTps, envViper, configFileViper, "", "only_log_tps")
 	viperconfig.ResetConfString(dnsZone, envViper, configFileViper, "", "dns_zone")
 	viperconfig.ResetConfBool(dnsFlag, envViper, configFileViper, "", "dns")
 	viperconfig.ResetConfInt(minPeers, envViper, configFileViper, "", "min_peers")

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -2,6 +2,7 @@ package consensus
 
 import (
 	"math/big"
+	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/common"
 	protobuf "github.com/golang/protobuf/proto"
@@ -275,9 +276,7 @@ func (consensus *Consensus) checkViewID(msg *FBFTMessage) error {
 
 // SetBlockNum sets the blockNum in consensus object, called at node bootstrap
 func (consensus *Consensus) SetBlockNum(blockNum uint64) {
-	consensus.infoMutex.Lock()
-	defer consensus.infoMutex.Unlock()
-	consensus.blockNum = blockNum
+	atomic.StoreUint64(&consensus.blockNum, blockNum)
 }
 
 // ReadSignatureBitmapPayload read the payload for signature and bitmap; offset is the beginning position of reading

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -3,6 +3,7 @@ package consensus
 import (
 	"bytes"
 	"encoding/hex"
+	"sync/atomic"
 	"time"
 
 	protobuf "github.com/golang/protobuf/proto"
@@ -283,7 +284,7 @@ func (consensus *Consensus) tryCatchup() {
 
 		// TODO(Chao): Explain the reasoning for these code
 		consensus.blockHash = [32]byte{}
-		consensus.blockNum = consensus.blockNum + 1
+		atomic.AddUint64(&consensus.blockNum, 1)
 		consensus.viewID = committedMsg.ViewID + 1
 		consensus.LeaderPubKey = committedMsg.SenderPubkey
 

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -13,6 +13,7 @@ import (
 	"github.com/harmony-one/harmony/core/types"
 	vrf_bls "github.com/harmony-one/harmony/crypto/vrf/bls"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
+	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/shard"
 	"github.com/harmony-one/vdf/src/vdf_go"
@@ -21,6 +22,9 @@ import (
 
 // handlemessageupdate will update the consensus state according to received message
 func (consensus *Consensus) handleMessageUpdate(payload []byte) {
+	entryTime := time.Now()
+	defer utils.SampledLogger().Info().Str("cost", time.Now().Sub(entryTime).String()).Msg("[cost:handle_consensus_message]")
+
 	if len(payload) == 0 {
 		return
 	}

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -57,6 +57,13 @@ func (consensus *Consensus) announce(block *types.Block) {
 
 	// Leader sign the block hash itself
 	for i, key := range consensus.PubKey.PublicKey {
+		if err := consensus.prepareBitmap.SetKey(key, true); err != nil {
+			consensus.getLogger().Warn().Err(err).Msgf(
+				"[Announce] Leader prepareBitmap SetKey failed for key at index %d", i,
+			)
+			continue
+		}
+
 		if _, err := consensus.Decider.SubmitVote(
 			quorum.Prepare,
 			key,
@@ -65,12 +72,6 @@ func (consensus *Consensus) announce(block *types.Block) {
 			block.NumberU64(),
 			block.Header().ViewID().Uint64(),
 		); err != nil {
-			return
-		}
-		if err := consensus.prepareBitmap.SetKey(key, true); err != nil {
-			consensus.getLogger().Warn().Err(err).Msg(
-				"[Announce] Leader prepareBitmap SetKey failed",
-			)
 			return
 		}
 	}

--- a/consensus/quorum/quorum.go
+++ b/consensus/quorum/quorum.go
@@ -179,6 +179,7 @@ func (s *cIdentities) IndexOf(pubKey *bls.PublicKey) int {
 	for k, v := range s.publicKeys {
 		if v.IsEqual(pubKey) {
 			idx = k
+			break
 		}
 	}
 	return idx

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1731,6 +1732,10 @@ func (bc *BlockChain) ReadShardState(epoch *big.Int) (*shard.State, error) {
 	}
 	shardState, err := rawdb.ReadShardState(bc.db, epoch)
 	if err != nil {
+		if strings.Contains(err.Error(), rawdb.MsgNoShardStateFromDB) &&
+			shard.Schedule.IsSkippedEpoch(bc.ShardID(), epoch) {
+			return nil, fmt.Errorf("epoch skipped on chain: %w", err)
+		}
 		return nil, err
 	}
 	bc.shardStateCache.Add(cacheKey, shardState)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1996,10 +1996,11 @@ func (bc *BlockChain) ReadPendingCrossLinks() ([]types.CrossLink, error) {
 	if cached, ok := bc.pendingCrossLinksCache.Get(pendingCLCacheKey); ok {
 		bytes = cached.([]byte)
 	} else {
-		bytes, err := rawdb.ReadPendingCrossLinks(bc.db)
-		if err != nil || len(bytes) == 0 {
+		by, err := rawdb.ReadPendingCrossLinks(bc.db)
+		if err != nil || len(by) == 0 {
 			return nil, err
 		}
+		bytes = by
 	}
 	cls := []types.CrossLink{}
 	if err := rlp.DecodeBytes(bytes, &cls); err != nil {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -540,7 +540,7 @@ func (bc *BlockChain) repair(head **types.Block) error {
 				Str("number", (*head).Number().String()).
 				Str("hash", (*head).Hash().Hex()).
 				Msg("Rewound blockchain to past state")
-			return nil
+			return bc.removeInValidatorList(valsToRemove)
 		}
 		// Repair last commit sigs
 		lastSig := (*head).Header().LastCommitSignature()
@@ -557,9 +557,12 @@ func (bc *BlockChain) repair(head **types.Block) error {
 				}
 			}
 		}
-		(*head) = bc.GetBlock((*head).ParentHash(), (*head).NumberU64()-1)
+		block := bc.GetBlock((*head).ParentHash(), (*head).NumberU64()-1)
+		if block == nil {
+			return fmt.Errorf("missing block %d [%x]", (*head).NumberU64()-1, (*head).ParentHash())
+		}
+		*head = block
 	}
-	return bc.removeInValidatorList(valsToRemove)
 }
 
 // This func is used to remove the validator addresses from the validator list.

--- a/core/staking_verifier.go
+++ b/core/staking_verifier.go
@@ -114,8 +114,7 @@ func VerifyAndCreateValidatorFromMsg(
 	wrapper.Counters.NumBlocksSigned = big.NewInt(0)
 	wrapper.Counters.NumBlocksToSign = big.NewInt(0)
 	wrapper.BlockReward = big.NewInt(0)
-	maxBLSKeyAllowed := shard.ExternalSlotsAvailableForEpoch(epoch) / 3
-	if err := wrapper.SanityCheck(maxBLSKeyAllowed); err != nil {
+	if err := wrapper.SanityCheck(); err != nil {
 		return nil, err
 	}
 	return wrapper, nil
@@ -180,8 +179,7 @@ func VerifyAndEditValidatorFromMsg(
 	) {
 		return nil, errCommissionRateChangeTooFast
 	}
-	maxBLSKeyAllowed := shard.ExternalSlotsAvailableForEpoch(epoch) / 3
-	if err := wrapper.SanityCheck(maxBLSKeyAllowed); err != nil {
+	if err := wrapper.SanityCheck(); err != nil {
 		return nil, err
 	}
 	return wrapper, nil
@@ -232,9 +230,7 @@ func VerifyAndDelegateFromMsg(
 		delegation := &wrapper.Delegations[i]
 		if bytes.Equal(delegation.DelegatorAddress.Bytes(), msg.DelegatorAddress.Bytes()) {
 			delegation.Amount.Add(delegation.Amount, msg.Amount)
-			if err := wrapper.SanityCheck(
-				staking.DoNotEnforceMaxBLS,
-			); err != nil {
+			if err := wrapper.SanityCheck(); err != nil {
 				return nil, nil, err
 			}
 			return wrapper, msg.Amount, nil
@@ -247,7 +243,7 @@ func VerifyAndDelegateFromMsg(
 			msg.DelegatorAddress, msg.Amount,
 		),
 	)
-	if err := wrapper.SanityCheck(staking.DoNotEnforceMaxBLS); err != nil {
+	if err := wrapper.SanityCheck(); err != nil {
 		return nil, nil, err
 	}
 	return wrapper, msg.Amount, nil
@@ -287,9 +283,7 @@ func VerifyAndUndelegateFromMsg(
 			if err := delegation.Undelegate(epoch, msg.Amount); err != nil {
 				return nil, err
 			}
-			if err := wrapper.SanityCheck(
-				staking.DoNotEnforceMaxBLS,
-			); err != nil {
+			if err := wrapper.SanityCheck(); err != nil {
 				// allow self delegation to go below min self delegation
 				// but set the status to inactive
 				if errors.Cause(err) == staking.ErrInvalidSelfDelegation {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -745,14 +745,12 @@ func (db *DB) ValidatorWrapperCopy(
 	return &val, nil
 }
 
-const doNotEnforceMaxBLS = -1
-
 // UpdateValidatorWrapper updates staking information of
 // a given validator (including delegation info)
 func (db *DB) UpdateValidatorWrapper(
 	addr common.Address, val *stk.ValidatorWrapper,
 ) error {
-	if err := val.SanityCheck(doNotEnforceMaxBLS); err != nil {
+	if err := val.SanityCheck(); err != nil {
 		return err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/libp2p/go-libp2p-crypto v0.1.0
 	github.com/libp2p/go-libp2p-discovery v0.4.0
 	github.com/libp2p/go-libp2p-host v0.1.0
-	github.com/libp2p/go-libp2p-kad-dht v0.5.0
+	github.com/libp2p/go-libp2p-kad-dht v0.8.0
 	github.com/libp2p/go-libp2p-net v0.1.0
 	github.com/libp2p/go-libp2p-peer v0.2.0
 	github.com/libp2p/go-libp2p-peerstore v0.2.4

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/libp2p/go-libp2p-net v0.1.0
 	github.com/libp2p/go-libp2p-peer v0.2.0
 	github.com/libp2p/go-libp2p-peerstore v0.2.4
-	github.com/libp2p/go-libp2p-pubsub v0.3.0
+	github.com/libp2p/go-libp2p-pubsub v0.3.1
 	github.com/multiformats/go-multiaddr v0.2.2
 	github.com/multiformats/go-multiaddr-net v0.1.5
 	github.com/natefinch/lumberjack v2.0.0+incompatible

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -552,7 +552,9 @@ func (b *APIBackend) GetMedianRawStakeSnapshot() (
 	res, err := b.SingleFlightRequest(
 		key,
 		func() (interface{}, error) {
-			return committee.NewEPoSRound(b.hmy.BlockChain())
+			// Compute for next epoch
+			epoch := big.NewInt(0).Add(b.CurrentBlock().Epoch(), big.NewInt(1))
+			return committee.NewEPoSRound(epoch, b.hmy.BlockChain())
 		},
 	)
 	if err != nil {

--- a/internal/configs/sharding/fixedschedule.go
+++ b/internal/configs/sharding/fixedschedule.go
@@ -61,6 +61,11 @@ func (s fixedSchedule) GetShardingStructure(numShard, shardID int) []map[string]
 	return genShardingStructure(numShard, shardID, TestNetHTTPPattern, TestNetHTTPPattern)
 }
 
+// IsSkippedEpoch returns if an epoch was skipped on shard due to staking epoch
+func (s fixedSchedule) IsSkippedEpoch(shardID uint32, epoch *big.Int) bool {
+	return false
+}
+
 // NewFixedSchedule returns a sharding configuration schedule that uses the
 // given config instance for all epochs.  Useful for testing.
 func NewFixedSchedule(instance Instance) Schedule {

--- a/internal/configs/sharding/localnet.go
+++ b/internal/configs/sharding/localnet.go
@@ -28,7 +28,7 @@ const (
 	localnetRandomnessStartingEpoch = 0
 )
 
-func (localnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
+func (ls localnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	switch {
 	case epoch.Cmp(params.LocalnetChainConfig.StakingEpoch) >= 0:
 		return localnetV2
@@ -106,6 +106,11 @@ func (ls localnetSchedule) GetShardingStructure(numShard, shardID int) []map[str
 		})
 	}
 	return res
+}
+
+// IsSkippedEpoch returns if an epoch was skipped on shard due to staking epoch
+func (ls localnetSchedule) IsSkippedEpoch(shardID uint32, epoch *big.Int) bool {
+	return false
 }
 
 var (

--- a/internal/configs/sharding/mainnet.go
+++ b/internal/configs/sharding/mainnet.go
@@ -29,8 +29,8 @@ const (
 	mainnetV1_4Epoch = 46
 	mainnetV1_5Epoch = 54
 	mainnetV2_0Epoch = 185 // prestaking epoch
-	mainnetV2_1Epoch = 300 // open slots increase from 320 - 480  (TODO): update the epoch
-	mainnetV2_2Epoch = 300 // open slots increase from 480 - 640  (TODO): update the epoch
+	mainnetV2_1Epoch = 208 // open slots increase from 320 - 480
+	mainnetV2_2Epoch = 213 // open slots increase from 480 - 640
 
 	// MainNetHTTPPattern is the http pattern for mainnet.
 	MainNetHTTPPattern = "https://api.s%d.t.hmny.io"

--- a/internal/configs/sharding/mainnet.go
+++ b/internal/configs/sharding/mainnet.go
@@ -29,6 +29,8 @@ const (
 	mainnetV1_4Epoch = 46
 	mainnetV1_5Epoch = 54
 	mainnetV2_0Epoch = 185 // prestaking epoch
+	mainnetV2_1Epoch = 300 // open slots increase from 320 - 480  (TODO): update the epoch
+	mainnetV2_2Epoch = 300 // open slots increase from 480 - 640  (TODO): update the epoch
 
 	// MainNetHTTPPattern is the http pattern for mainnet.
 	MainNetHTTPPattern = "https://api.s%d.t.hmny.io"
@@ -43,6 +45,10 @@ type mainnetSchedule struct{}
 
 func (mainnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	switch {
+	case epoch.Cmp(big.NewInt(mainnetV2_2Epoch)) >= 0:
+		return mainnetV2_2
+	case epoch.Cmp(big.NewInt(mainnetV2_1Epoch)) >= 0:
+		return mainnetV2_1
 	case epoch.Cmp(big.NewInt(mainnetV2_0Epoch)) >= 0:
 		// 185 resharding epoch (for shard 0) around 14/05/2020 ~15:00 PDT
 		return mainnetV2_0
@@ -141,7 +147,7 @@ func (ms mainnetSchedule) GetShardingStructure(numShard, shardID int) []map[stri
 	return genShardingStructure(numShard, shardID, MainNetHTTPPattern, MainNetWSPattern)
 }
 
-var mainnetReshardingEpoch = []*big.Int{big.NewInt(0), big.NewInt(mainnetV0_1Epoch), big.NewInt(mainnetV0_2Epoch), big.NewInt(mainnetV0_3Epoch), big.NewInt(mainnetV0_4Epoch), big.NewInt(mainnetV1Epoch), big.NewInt(mainnetV1_1Epoch), big.NewInt(mainnetV1_2Epoch), big.NewInt(mainnetV1_3Epoch), big.NewInt(mainnetV1_4Epoch), big.NewInt(mainnetV1_5Epoch), big.NewInt(mainnetV2_0Epoch)}
+var mainnetReshardingEpoch = []*big.Int{big.NewInt(0), big.NewInt(mainnetV0_1Epoch), big.NewInt(mainnetV0_2Epoch), big.NewInt(mainnetV0_3Epoch), big.NewInt(mainnetV0_4Epoch), big.NewInt(mainnetV1Epoch), big.NewInt(mainnetV1_1Epoch), big.NewInt(mainnetV1_2Epoch), big.NewInt(mainnetV1_3Epoch), big.NewInt(mainnetV1_4Epoch), big.NewInt(mainnetV1_5Epoch), big.NewInt(mainnetV2_0Epoch), big.NewInt(mainnetV2_1Epoch), big.NewInt(mainnetV2_2Epoch)}
 
 var (
 	mainnetV0   = MustNewInstance(4, 150, 112, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccounts, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
@@ -156,4 +162,6 @@ var (
 	mainnetV1_4 = MustNewInstance(4, 250, 170, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_4, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
 	mainnetV1_5 = MustNewInstance(4, 250, 170, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
 	mainnetV2_0 = MustNewInstance(4, 250, 170, numeric.MustNewDecFromStr("0.68"), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV2_1 = MustNewInstance(4, 250, 130, numeric.MustNewDecFromStr("0.68"), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV2_2 = MustNewInstance(4, 250, 90, numeric.MustNewDecFromStr("0.68"), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
 )

--- a/internal/configs/sharding/pangaea.go
+++ b/internal/configs/sharding/pangaea.go
@@ -26,7 +26,7 @@ const (
 	PangaeaWSPattern = "wss://ws.s%d.os.hmny.io"
 )
 
-func (pangaeaSchedule) InstanceForEpoch(epoch *big.Int) Instance {
+func (ps pangaeaSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	switch {
 	case epoch.Cmp(params.PangaeaChainConfig.StakingEpoch) >= 0:
 		return pangaeaV1
@@ -66,13 +66,18 @@ func (ps pangaeaSchedule) RandomnessStartingEpoch() uint64 {
 	return mainnetRandomnessStartingEpoch
 }
 
-func (pangaeaSchedule) GetNetworkID() NetworkID {
+func (ps pangaeaSchedule) GetNetworkID() NetworkID {
 	return Pangaea
 }
 
 // GetShardingStructure is the sharding structure for mainnet.
-func (pangaeaSchedule) GetShardingStructure(numShard, shardID int) []map[string]interface{} {
+func (ps pangaeaSchedule) GetShardingStructure(numShard, shardID int) []map[string]interface{} {
 	return genShardingStructure(numShard, shardID, PangaeaHTTPPattern, PangaeaWSPattern)
+}
+
+// IsSkippedEpoch returns if an epoch was skipped on shard due to staking epoch
+func (ps pangaeaSchedule) IsSkippedEpoch(shardID uint32, epoch *big.Int) bool {
+	return false
 }
 
 var pangaeaReshardingEpoch = []*big.Int{

--- a/internal/configs/sharding/partner.go
+++ b/internal/configs/sharding/partner.go
@@ -27,7 +27,7 @@ const (
 	PartnerWSPattern = "wss://ws.s%d.ps.hmny.io"
 )
 
-func (partnerSchedule) InstanceForEpoch(epoch *big.Int) Instance {
+func (ps partnerSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	switch {
 	case epoch.Cmp(params.PartnerChainConfig.StakingEpoch) >= 0:
 		return partnerV1
@@ -36,7 +36,7 @@ func (partnerSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	}
 }
 
-func (partnerSchedule) BlocksPerEpoch() uint64 {
+func (ps partnerSchedule) BlocksPerEpoch() uint64 {
 	return partnerBlocksPerEpoch
 }
 
@@ -75,6 +75,11 @@ func (ps partnerSchedule) GetNetworkID() NetworkID {
 // GetShardingStructure is the sharding structure for partner.
 func (ps partnerSchedule) GetShardingStructure(numShard, shardID int) []map[string]interface{} {
 	return genShardingStructure(numShard, shardID, PartnerHTTPPattern, PartnerWSPattern)
+}
+
+// IsSkippedEpoch returns if an epoch was skipped on shard due to staking epoch
+func (ps partnerSchedule) IsSkippedEpoch(shardID uint32, epoch *big.Int) bool {
+	return false
 }
 
 var partnerReshardingEpoch = []*big.Int{

--- a/internal/configs/sharding/shardingconfig.go
+++ b/internal/configs/sharding/shardingconfig.go
@@ -43,6 +43,9 @@ type Schedule interface {
 
 	// GetShardingStructure returns sharding structure.
 	GetShardingStructure(int, int) []map[string]interface{}
+
+	// IsSkippedEpoch returns if epoch was skipped on shard chain
+	IsSkippedEpoch(uint32, *big.Int) bool
 }
 
 // Instance is one sharding configuration instance.

--- a/internal/configs/sharding/stress.go
+++ b/internal/configs/sharding/stress.go
@@ -27,7 +27,7 @@ const (
 	StressNetWSPattern = "wss://ws.s%d.stn.hmny.io"
 )
 
-func (stressnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
+func (ss stressnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	switch {
 	case epoch.Cmp(params.StressnetChainConfig.StakingEpoch) >= 0:
 		return stressnetV1
@@ -36,7 +36,7 @@ func (stressnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	}
 }
 
-func (stressnetSchedule) BlocksPerEpoch() uint64 {
+func (ss stressnetSchedule) BlocksPerEpoch() uint64 {
 	return stressnetBlocksPerEpoch
 }
 
@@ -75,6 +75,11 @@ func (ss stressnetSchedule) GetNetworkID() NetworkID {
 // GetShardingStructure is the sharding structure for stressnet.
 func (ss stressnetSchedule) GetShardingStructure(numShard, shardID int) []map[string]interface{} {
 	return genShardingStructure(numShard, shardID, StressNetHTTPPattern, StressNetWSPattern)
+}
+
+// IsSkippedEpoch returns if an epoch was skipped on shard due to staking epoch
+func (ss stressnetSchedule) IsSkippedEpoch(shardID uint32, epoch *big.Int) bool {
+	return false
 }
 
 var stressnetReshardingEpoch = []*big.Int{

--- a/internal/configs/sharding/testnet.go
+++ b/internal/configs/sharding/testnet.go
@@ -26,7 +26,7 @@ const (
 	TestNetWSPattern = "wss://ws.s%d.b.hmny.io"
 )
 
-func (testnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
+func (ts testnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	switch {
 	case epoch.Cmp(params.TestnetChainConfig.StakingEpoch) >= 0:
 		return testnetV1
@@ -35,7 +35,7 @@ func (testnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	}
 }
 
-func (testnetSchedule) BlocksPerEpoch() uint64 {
+func (ts testnetSchedule) BlocksPerEpoch() uint64 {
 	return testnetBlocksPerEpoch
 }
 
@@ -74,6 +74,11 @@ func (ts testnetSchedule) GetNetworkID() NetworkID {
 // GetShardingStructure is the sharding structure for testnet.
 func (ts testnetSchedule) GetShardingStructure(numShard, shardID int) []map[string]interface{} {
 	return genShardingStructure(numShard, shardID, TestNetHTTPPattern, TestNetWSPattern)
+}
+
+// IsSkippedEpoch returns if an epoch was skipped on shard due to staking epoch
+func (ts testnetSchedule) IsSkippedEpoch(shardID uint32, epoch *big.Int) bool {
+	return false
 }
 
 var testnetReshardingEpoch = []*big.Int{

--- a/internal/configs/sharding/testnet.go
+++ b/internal/configs/sharding/testnet.go
@@ -24,10 +24,14 @@ const (
 	TestNetHTTPPattern = "https://api.s%d.b.hmny.io"
 	// TestNetWSPattern is the websocket pattern for testnet.
 	TestNetWSPattern = "wss://ws.s%d.b.hmny.io"
+
+	testnetV2Epoch = 6050 // per shard, reduce internal node from 15 to 8, and external nodes from 5 to 22
 )
 
 func (ts testnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	switch {
+	case epoch.Cmp(big.NewInt(testnetV2Epoch)) >= 0:
+		return testnetV2
 	case epoch.Cmp(params.TestnetChainConfig.StakingEpoch) >= 0:
 		return testnetV1
 	default: // genesis
@@ -88,3 +92,4 @@ var testnetReshardingEpoch = []*big.Int{
 
 var testnetV0 = MustNewInstance(4, 16, 15, numeric.OneDec(), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())
 var testnetV1 = MustNewInstance(4, 20, 15, numeric.MustNewDecFromStr("0.90"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())
+var testnetV2 = MustNewInstance(4, 30, 8, numeric.MustNewDecFromStr("0.90"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -569,6 +569,18 @@ func (s *PublicBlockChainAPI) LatestHeader(ctx context.Context) *HeaderInformati
 	return newHeaderInformation(header)
 }
 
+// GetHeaderByNumber returns block header at given number
+func (s *PublicBlockChainAPI) GetHeaderByNumber(ctx context.Context, blockNum rpc.BlockNumber) (*HeaderInformation, error) {
+	if err := s.isBlockGreaterThanLatest(blockNum); err != nil {
+		return nil, err
+	}
+	header, err := s.b.HeaderByNumber(context.Background(), blockNum)
+	if err != nil {
+		return nil, err
+	}
+	return newHeaderInformation(header), nil
+}
+
 // GetTotalStaking returns total staking by validators, only meant to be called on beaconchain
 // explorer node
 func (s *PublicBlockChainAPI) GetTotalStaking() (*big.Int, error) {

--- a/internal/hmyapi/apiv1/types.go
+++ b/internal/hmyapi/apiv1/types.go
@@ -172,6 +172,7 @@ func newRPCTransaction(
 		Gas:       hexutil.Uint64(tx.Gas()),
 		GasPrice:  (*hexutil.Big)(tx.GasPrice()),
 		Hash:      tx.Hash(),
+		Input:     hexutil.Bytes(tx.Data()),
 		Nonce:     hexutil.Uint64(tx.Nonce()),
 		Value:     (*hexutil.Big)(tx.Value()),
 		ShardID:   tx.ShardID(),

--- a/internal/hmyapi/apiv1/util.go
+++ b/internal/hmyapi/apiv1/util.go
@@ -36,7 +36,6 @@ func SubmitTransaction(
 	ctx context.Context, b Backend, tx *types.Transaction,
 ) (common.Hash, error) {
 	if err := b.SendTx(ctx, tx); err != nil {
-		// legacy behavior is to never return error and always return tx hash
 		utils.Logger().Warn().Err(err).Msg("Could not submit transaction")
 		return tx.Hash(), err
 	}

--- a/internal/hmyapi/apiv1/util.go
+++ b/internal/hmyapi/apiv1/util.go
@@ -38,7 +38,7 @@ func SubmitTransaction(
 	if err := b.SendTx(ctx, tx); err != nil {
 		// legacy behavior is to never return error and always return tx hash
 		utils.Logger().Warn().Err(err).Msg("Could not submit transaction")
-		return tx.Hash(), nil
+		return tx.Hash(), err
 	}
 	if tx.To() == nil {
 		signer := types.MakeSigner(b.ChainConfig(), b.CurrentBlock().Epoch())

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -520,6 +520,18 @@ func (s *PublicBlockChainAPI) LatestHeader(ctx context.Context) *HeaderInformati
 	return newHeaderInformation(header)
 }
 
+// GetHeaderByNumber returns block header at given number
+func (s *PublicBlockChainAPI) GetHeaderByNumber(ctx context.Context, blockNum uint64) (*HeaderInformation, error) {
+	if err := s.isBlockGreaterThanLatest(blockNum); err != nil {
+		return nil, err
+	}
+	header, err := s.b.HeaderByNumber(context.Background(), rpc.BlockNumber(blockNum))
+	if err != nil {
+		return nil, err
+	}
+	return newHeaderInformation(header), nil
+}
+
 // GetTotalStaking returns total staking by validators, only meant to be called on beaconchain
 // explorer node
 func (s *PublicBlockChainAPI) GetTotalStaking() (*big.Int, error) {

--- a/internal/hmyapi/apiv2/util.go
+++ b/internal/hmyapi/apiv2/util.go
@@ -36,9 +36,8 @@ func SubmitTransaction(
 	ctx context.Context, b Backend, tx *types.Transaction,
 ) (common.Hash, error) {
 	if err := b.SendTx(ctx, tx); err != nil {
-		// legacy behavior is to never return error and always return tx hash
 		utils.Logger().Warn().Err(err).Msg("Could not submit transaction")
-		return tx.Hash(), nil
+		return tx.Hash(), err
 	}
 	if tx.To() == nil {
 		signer := types.MakeSigner(b.ChainConfig(), b.CurrentBlock().Epoch())

--- a/internal/utils/singleton.go
+++ b/internal/utils/singleton.go
@@ -53,12 +53,6 @@ func SetLogVerbosity(verbosity log.Lvl) {
 // AddLogFile creates a StreamHandler that outputs JSON logs
 // into rotating files with specified max file size
 func AddLogFile(filepath string, maxSize int) {
-	AddLogHandler(log.StreamHandler(&lumberjack.Logger{
-		Filename: filepath,
-		MaxSize:  maxSize,
-		Compress: true,
-	}, log.JSONFormat()))
-
 	setZeroLoggerFileOutput(filepath, maxSize)
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -294,7 +294,7 @@ func (node *Node) AddPendingTransaction(newTx *types.Transaction) error {
 			node.tryBroadcast(newTx)
 		}
 		return err
-	}else{	
+	} else {
 		return errors.New("shard do not match")
 	}
 }

--- a/node/node.go
+++ b/node/node.go
@@ -524,7 +524,7 @@ func New(
 	// Setup initial state of syncing.
 	node.peerRegistrationRecord = map[string]*syncConfig{}
 	node.startConsensus = make(chan struct{})
-	go node.bootstrapConsensus()
+	go node.BootstrapConsensus()
 	// Broadcast double-signers reported by consensus
 	if node.Consensus != nil {
 		go func() {

--- a/node/node.go
+++ b/node/node.go
@@ -294,8 +294,9 @@ func (node *Node) AddPendingTransaction(newTx *types.Transaction) error {
 			node.tryBroadcast(newTx)
 		}
 		return err
+	}else{	
+		return errors.New("shard do not match")
 	}
-	return nil
 }
 
 // AddPendingReceipts adds one receipt message to pending list.

--- a/node/node.go
+++ b/node/node.go
@@ -294,9 +294,8 @@ func (node *Node) AddPendingTransaction(newTx *types.Transaction) error {
 			node.tryBroadcast(newTx)
 		}
 		return err
-	} else {
-		return errors.New("shard do not match")
 	}
+	return errors.New("shard do not match")
 }
 
 // AddPendingReceipts adds one receipt message to pending list.

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -26,7 +26,6 @@ const (
 	lastMileThreshold = 4
 	inSyncThreshold   = 1 // unit in number of block
 	SyncFrequency     = 60
-	MinConnectedPeers = 10 // minimum number of peers connected to in node syncing
 )
 
 // getNeighborPeers is a helper function to return list of peers
@@ -223,7 +222,7 @@ func (node *Node) doSync(bc *core.BlockChain, worker *worker.Worker, willJoinCon
 		node.stateSync = syncing.CreateStateSync(node.SelfPeer.IP, node.SelfPeer.Port, node.GetSyncID())
 		utils.Logger().Debug().Msg("[SYNC] initialized state sync")
 	}
-	if node.stateSync.GetActivePeerNumber() < MinConnectedPeers {
+	if node.stateSync.GetActivePeerNumber() < syncing.NumPeersLowBound {
 		shardID := bc.ShardID()
 		peers, err := node.SyncingPeerProvider.SyncingPeers(shardID)
 		if err != nil {

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -63,6 +63,11 @@ func (p Peer) String() string {
 	)
 }
 
+const (
+	// MaxMessageSize is the 2048Kb
+	MaxMessageSize = 1 << 21
+)
+
 // NewHost ..
 func NewHost(self *Peer, key libp2p_crypto.PrivKey) (Host, error) {
 	listenAddr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/0.0.0.0/tcp/%s", self.Port))
@@ -78,10 +83,9 @@ func NewHost(self *Peer, key libp2p_crypto.PrivKey) (Host, error) {
 		return nil, errors.Wrapf(err, "cannot initialize libp2p host")
 	}
 
-	const MaxSize = 2145728
 	options := []libp2p_pubsub.Option{
 		libp2p_pubsub.WithPeerOutboundQueueSize(64),
-		libp2p_pubsub.WithMaxMessageSize(MaxSize),
+		libp2p_pubsub.WithMaxMessageSize(MaxMessageSize),
 	}
 
 	traceFile := os.Getenv("P2P_TRACEFILE")

--- a/staking/slash/double-sign.go
+++ b/staking/slash/double-sign.go
@@ -485,7 +485,7 @@ func Apply(
 			RawJSON("slash", []byte(slash.String())).
 			Msg("about to update staking info for a validator after a slash")
 
-		if err := current.SanityCheck(staking.DoNotEnforceMaxBLS); err != nil {
+		if err := current.SanityCheck(); err != nil {
 			return nil, err
 		}
 	}

--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -231,8 +231,8 @@ type Validator struct {
 	CreationHeight *big.Int `json:"creation-height"`
 }
 
-// DoNotEnforceMaxBLS ..
-const DoNotEnforceMaxBLS = -1
+// MaxBLSPerValidator ..
+const MaxBLSPerValidator = 106
 
 var (
 	oneAsBigInt  = big.NewInt(denominations.One)
@@ -240,7 +240,7 @@ var (
 )
 
 // SanityCheck checks basic requirements of a validator
-func (v *Validator) SanityCheck(oneThirdExtrn int) error {
+func (v *Validator) SanityCheck() error {
 	if _, err := v.EnsureLength(); err != nil {
 		return err
 	}
@@ -249,11 +249,10 @@ func (v *Validator) SanityCheck(oneThirdExtrn int) error {
 		return errNeedAtLeastOneSlotKey
 	}
 
-	if c := len(v.SlotPubKeys); oneThirdExtrn != DoNotEnforceMaxBLS &&
-		c > oneThirdExtrn {
+	if c := len(v.SlotPubKeys); c > MaxBLSPerValidator {
 		return errors.Wrapf(
 			ErrExcessiveBLSKeys, "have: %d allowed: %d",
-			c, oneThirdExtrn,
+			c, MaxBLSPerValidator,
 		)
 	}
 
@@ -341,12 +340,8 @@ var (
 )
 
 // SanityCheck checks the basic requirements
-func (w *ValidatorWrapper) SanityCheck(
-	oneThirdExternalValidator int,
-) error {
-	if err := w.Validator.SanityCheck(
-		oneThirdExternalValidator,
-	); err != nil {
+func (w *ValidatorWrapper) SanityCheck() error {
+	if err := w.Validator.SanityCheck(); err != nil {
 		return err
 	}
 	// Self delegation must be >= MinSelfDelegation

--- a/staking/types/validator_test.go
+++ b/staking/types/validator_test.go
@@ -179,7 +179,7 @@ func TestValidator_SanityCheck(t *testing.T) {
 	for i, test := range tests {
 		v := makeValidValidator()
 		test.editValidator(&v)
-		err := v.SanityCheck(DoNotEnforceMaxBLS)
+		err := v.SanityCheck()
 		if assErr := assertError(err, test.expErr); assErr != nil {
 			t.Errorf("Test %v: %v", i, assErr)
 		}
@@ -242,7 +242,7 @@ func TestValidatorWrapper_SanityCheck(t *testing.T) {
 	for i, test := range tests {
 		vw := makeValidValidatorWrapper()
 		test.editValidatorWrapper(&vw)
-		err := vw.SanityCheck(DoNotEnforceMaxBLS)
+		err := vw.SanityCheck()
 		if assErr := assertError(err, test.expErr); assErr != nil {
 			t.Errorf("Test %v: %v", i, assErr)
 		}


### PR DESCRIPTION
```
commit 2da96566c08c389306844f5311a0be5498a93c0f
Author: Leo Chen <leo@harmony.one>
Date:   Sat Jun 20 02:09:40 2020 +0000

    [quorum] return earlier idx if found in IndexOf
    
    Signed-off-by: Leo Chen <leo@harmony.one>

commit 511a42ead764a4fad7e649e54803b4ca019e34a0
Author: Leo Chen <leo@harmony.one>
Date:   Fri Jun 19 22:34:54 2020 +0000

    [bls] cache BLSPubKey deserialization with LRU
    
    Signed-off-by: Leo Chen <leo@harmony.one>

commit 39dc6943d44349d2da3ea9db647ea9ddbfd271fd
Author: songgeng87 <songgeng87@gmail.com>
Date:   Sat Jun 20 14:13:32 2020 +0800

    clean-up a old comment "// legacy behavior is to never return error and always return tx hash"
    the same changes in apiv2

commit c2099413fbe9809b2c5f5dcb624b66b31204a41f
Author: songgeng87 <songgeng87@gmail.com>
Date:   Thu Jun 18 12:31:50 2020 +0800

    if block ends with a return statement, so drop this else and outdent its block

commit 884ead15e6c5c64b5edafffb049ce74c79d42443
Author: songgeng87 <songgeng87@gmail.com>
Date:   Thu Jun 18 12:11:47 2020 +0800

    fmt error

commit 310ce608208fb15a358c9020fec674b82232ad50
Author: 宋赓 <songgeng87@gmail.com>
Date:   Wed Jun 17 16:57:37 2020 +0800

    Update util.go
    
    return err info

commit 84cebd7422dfc0fd2faf93e985713718cd3711ce
Author: 宋赓 <songgeng87@gmail.com>
Date:   Wed Jun 17 16:56:03 2020 +0800

    Update node.go
    
    add error info

commit 2e3c48c1ecbb37739d0c6d056c3f842fb99c5567
Author: Rongjian Lan <rongjian.lan@gmail.com>
Date:   Thu Jun 18 14:13:20 2020 -0700

    Add slot increase for testnet

commit 3531af497954b41d9b0e0a5b36b2f6d21eab1665
Author: Rongjian Lan <rongjian.lan@gmail.com>
Date:   Wed Jun 17 23:36:32 2020 -0700

    Make EPoS compute work with correct epoch shard config

commit b20d209faf62971f7a554f756c569f054ca08ef3
Author: Rongjian Lan <rongjian.lan@gmail.com>
Date:   Wed Jun 17 14:27:54 2020 -0700

    set epochs for slot increase

commit fd4c1596e40069286147567797c62f4dd7b23bc6
Author: Rongjian Lan <rongjian.lan@gmail.com>
Date:   Tue Jun 16 14:20:02 2020 -0700

    Hard code 106 as the cap of bls keys per validator

commit f9bb38d9f20ac2e57d4450641ab43e502bab9b91
Author: Leo Chen <leo@harmony.one>
Date:   Mon Jun 15 10:26:24 2020 +0000

    [p2p] set max pubsub message size to 256Kb
    
    Signed-off-by: Leo Chen <leo@harmony.one>

commit 64647ca243c65e9292fe5988966eb2f7717d7105
Author: Leo Chen <leo@harmony.one>
Date:   Mon Jun 15 06:59:21 2020 +0000

    [log] add sample log of message handle time
    
    Signed-off-by: Leo Chen <leo@harmony.one>

commit 3fbdfa651d87778a53171f75cb500c0224a66cbf
Author: Leo Chen <leo@harmony.one>
Date:   Mon Jun 15 06:57:11 2020 +0000

    [log] add a sampledLogger to utils
    
    Signed-off-by: Leo Chen <leo@harmony.one>

commit 557258e9181d04c17bafbfb3f7e820f87f732e98
Author: Janet Liang <janet@harmony.one>
Date:   Mon Jun 15 17:41:21 2020 -0700

    [rpc] Add rpc to get block headers from any block

commit 215e934cfcef1ecdfc7915c04b2cdb704d4fa472
Author: Leo Chen <leo@harmony.one>
Date:   Sun Jun 14 08:51:25 2020 +0000

    [networkinfo] gradually increase the peer finding interval
    
    Signed-off-by: Leo Chen <leo@harmony.one>

commit 5abf70229c48f892b4512c7a210a0d499b1a56a0
Author: Leo Chen <leo@harmony.one>
Date:   Sun Jun 14 07:50:56 2020 +0000

    [p2p] upgrade kad-dht module
    
    Signed-off-by: Leo Chen <leo@harmony.one>

commit 0b7dbb54a33c81be73c97c0619d5c847bd9cc899
Author: Leo Chen <leo@harmony.one>
Date:   Sun Jun 14 10:08:34 2020 +0000

    [cleanup] remove unused flag and log file
    
    Signed-off-by: Leo Chen <leo@harmony.one>

commit 521b0051c2589baa6d3ea19c4a05f5b7f937b0b8
Author: Leo Chen <leo@harmony.one>
Date:   Thu Jun 11 23:24:54 2020 -0700

    [consensus] use atomic operation when set blocknum
    
    Signed-off-by: Leo Chen <leo@harmony.one>

commit 2720b1997b1f84f66f294d9d680d86371c22e5d4
Author: Leo Chen <leo@harmony.one>
Date:   Thu Jun 11 17:40:34 2020 -0700

    [consensus] replace isActiveMutex with atomic.Value in messageSender
    
    Signed-off-by: Leo Chen <leo@harmony.one>

commit adaba9c4cf3a29075e6fd5ad6cf6f197eb4a2ed8
Author: Leo Chen <leo@harmony.one>
Date:   Thu Jun 11 17:34:51 2020 -0700

    [consensus] replace blockNumMutex with atomic.Value in messageSender
    
    Signed-off-by: Leo Chen <leo@harmony.one>

commit d8ff316497f6343dd417544d77710bcc7aa8918c
Author: Leo Chen <leo@harmony.one>
Date:   Fri Jun 12 00:19:48 2020 -0700

    [syncing] fix mis-matched min syncing peers
    
    Signed-off-by: Leo Chen <leo@harmony.one>

commit 23038db3bc4e36ca6c3caed707a64a2122c4bb6f
Author: Janet Liang <janet@harmony.one>
Date:   Thu Jun 11 23:30:48 2020 -0700

    [internal] Add IsSkippedEpoch to each network config & interface
    [blockchain] Add check to ReadShardState error to check if the epoch was skipped due to staking

commit 35b812aecbb5759ccfd98c4b67d9fad3f5f78cda
Author: Janet Liang <56005637+janet-harmony@users.noreply.github.com>
Date:   Sat Jun 13 11:05:09 2020 -0700

    [rpc] Expose crosslinks in RPCs that return block headers (#3158)

commit c56578bdd6bc67d5ba4d7c8442ba0bfebce8ad29
Author: Ganesha Upadhyaya <ganeshrvce@gmail.com>
Date:   Sun Jun 7 23:28:09 2020 -0700

    [core] repair nil pointer fix

commit c65ea5ebc3bebe1d860bd90799b8622fddf5f5cc
Author: Yishuang Chen <yishuangchen17@gmail.com>
Date:   Mon Jun 8 13:08:33 2020 -0700

    [RPC] add input on newRPCTransaction (#3140)

commit 61e1604e66b1c709cac724a6de335fa2bb0d2feb
Author: Leo Chen <leo@harmony.one>
Date:   Sun Jun 7 21:48:23 2020 +0000

    [libp2p] support both local json and remote event tracer
    
    Signed-off-by: Leo Chen <leo@harmony.one>

commit 2f942bc8a2a51760a356631552fc939f2cd53be3
Author: Leo Chen <leo@harmony.one>
Date:   Sat Jun 6 00:03:49 2020 +0000

    [p2p] add remote tracer
    
    Signed-off-by: Leo Chen <leo@harmony.one>

commit e5b0f2cb35fb399621304e48e1c5244427905669
Author: Rongjian Lan <rongjian.lan@gmail.com>
Date:   Fri Jun 5 21:51:43 2020 -0700

    Fix multi-key related issues when keys are not in committee (#3132)
    
    * do not break if leader's multikeys not in committee (#3126)
    
    * do not break on leader commit (#3127)
    
    * Fix multi-key submitVote (#3129)
    
    * Add missing check on viewidbitmap
    
    * correct log level

commit 57f3e029f4a7b05bad77dd108911cb9d14a5ffc6
Author: Leo Chen <leo@harmony.one>
Date:   Thu Jun 4 09:09:08 2020 +0000

    [misc] rename needFriends to enoughMinPeers
    
    Signed-off-by: Leo Chen <leo@harmony.one>

commit 12ccd6bb05805fb61f245d14bc2a09c8e0885825
Author: Leo Chen <leo@harmony.one>
Date:   Sat May 30 06:22:35 2020 +0000

    [go.mod] upgrade libp2p-pubsub to 0.3.1
    
    Signed-off-by: Leo Chen <leo@harmony.one>

commit eee70a2d5fe51d3dc92084171bbec8748ac30561
Author: Ganesha Upadhyaya <ganeshrvce@gmail.com>
Date:   Tue Jun 2 13:06:11 2020 -0700

    [apr] remove temporary fix for correcting previous apr values, no longer needed (#3124)

commit 3cdfdfe88d9a79c7d9b607f727e223079ab5360f
Author: Ganesha Upadhyaya <ganeshrvce@gmail.com>
Date:   Mon Jun 1 21:35:05 2020 -0700

    [blockchain] fix crosslink decoding problem (#3123)

commit e67f46e7c4acfc4ccfa9fd83a47268dcb4cc41a2
Author: Rongjian Lan <rongjian.lan@gmail.com>
Date:   Mon Jun 1 14:32:53 2020 -0700

    Add epoch transition to increase open slots (#3122)
```