### PR TITLE
Avoid validator sending msgs if the key is not in committee

### DIFF
--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -60,6 +60,9 @@ func (consensus *Consensus) onAnnounce(msg *msg_pb.Message) {
 func (consensus *Consensus) prepare() {
 	groupID := []nodeconfig.GroupID{nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(consensus.ShardID))}
 	for i, key := range consensus.PubKey.PublicKey {
+		if !consensus.IsValidatorInCommittee(key) {
+			continue
+		}
 		networkMessage, err := consensus.construct(msg_pb.MessageType_PREPARE, nil, key, consensus.priKey.PrivateKey[i])
 		if err != nil {
 			consensus.getLogger().Err(err).
@@ -208,6 +211,10 @@ func (consensus *Consensus) onPrepared(msg *msg_pb.Message) {
 		nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(consensus.ShardID)),
 	}
 	for i, key := range consensus.PubKey.PublicKey {
+		if !consensus.IsValidatorInCommittee(key) {
+			continue
+		}
+
 		networkMessage, _ := consensus.construct(
 			msg_pb.MessageType_COMMIT,
 			commitPayload,

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -136,6 +136,9 @@ func (consensus *Consensus) startViewChange(viewID uint64) {
 		Msg("[startViewChange]")
 
 	for i, key := range consensus.PubKey.PublicKey {
+		if !consensus.IsValidatorInCommittee(key) {
+			continue
+		}
 		msgToSend := consensus.constructViewChangeMessage(key, consensus.priKey.PrivateKey[i])
 		consensus.host.SendMessageToGroups([]nodeconfig.GroupID{
 			nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(consensus.ShardID)),
@@ -624,6 +627,9 @@ func (consensus *Consensus) onNewView(msg *msg_pb.Message) {
 		groupID := []nodeconfig.GroupID{
 			nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(consensus.ShardID))}
 		for i, key := range consensus.PubKey.PublicKey {
+			if !consensus.IsValidatorInCommittee(key) {
+				continue
+			}
 			network, err := consensus.construct(
 				msg_pb.MessageType_COMMIT,
 				commitPayload,


### PR DESCRIPTION
Validator shouldn't send out msges if the key is not in committee.