### PR TITLE
[rpc] change default transaction limit to 1000

### DIFF
--- a/internal/hmyapi/apiv1/util.go
+++ b/internal/hmyapi/apiv1/util.go
@@ -13,7 +13,7 @@ import (
 
 // defaultPageSize is to have default pagination.
 const (
-	defaultPageSize = uint32(100)
+	defaultPageSize = uint32(1000)
 )
 
 // ReturnWithPagination returns result with pagination (offset, page in TxHistoryArgs).

--- a/internal/hmyapi/apiv2/util.go
+++ b/internal/hmyapi/apiv2/util.go
@@ -13,7 +13,7 @@ import (
 
 // defaultPageSize is to have default pagination.
 const (
-	defaultPageSize = uint32(100)
+	defaultPageSize = uint32(1000)
 )
 
 // ReturnWithPagination returns result with pagination (offset, page in TxHistoryArgs).


### PR DESCRIPTION
When no pageSize is passed from clients like explorer dashboard, it only lists 100 transactions on account page. By the specification, the default should be 1000. 