### PR TITLE
Postpone second batch of slot increase

### DIFF
--- a/internal/configs/sharding/mainnet.go
+++ b/internal/configs/sharding/mainnet.go
@@ -28,9 +28,9 @@ const (
 	mainnetV1_3Epoch = 36
 	mainnetV1_4Epoch = 46
 	mainnetV1_5Epoch = 54
-	mainnetV2_0Epoch = 185 // prestaking epoch
-	mainnetV2_1Epoch = 208 // open slots increase from 320 - 480
-	mainnetV2_2Epoch = 213 // open slots increase from 480 - 640
+	mainnetV2_0Epoch = 185   // prestaking epoch
+	mainnetV2_1Epoch = 208   // open slots increase from 320 - 480
+	mainnetV2_2Epoch = 10000 // open slots increase from 480 - 640
 
 	// MainNetHTTPPattern is the http pattern for mainnet.
 	MainNetHTTPPattern = "https://api.s%d.t.hmny.io"


### PR DESCRIPTION
The current shard 0 block time is not optimal and network is loaded with invalid messages. We already seen issues after the first batch of slot increase due to increased network scale. It will likely have similar problems in the second batch. So postpone the increase of slots before we further optimize network layer.