### PR TITLE
Do not reinit the explorer db every restart

### DIFF
--- a/api/service/explorer/service.go
+++ b/api/service/explorer/service.go
@@ -51,7 +51,7 @@ func New(selfPeer *p2p.Peer) *Service {
 // StartService starts explorer service.
 func (s *Service) StartService() {
 	utils.Logger().Info().Msg("Starting explorer service.")
-	s.Init(true)
+	s.Init()
 	s.server = s.Run()
 }
 
@@ -75,8 +75,8 @@ func GetExplorerPort(nodePort string) string {
 }
 
 // Init is to initialize for ExplorerService.
-func (s *Service) Init(remove bool) {
-	s.Storage = GetStorageInstance(s.IP, s.Port, remove)
+func (s *Service) Init() {
+	s.Storage = GetStorageInstance(s.IP, s.Port)
 }
 
 // Run is to run serving explorer.

--- a/api/service/explorer/storage_test.go
+++ b/api/service/explorer/storage_test.go
@@ -16,7 +16,7 @@ func TestGetAddressKey(t *testing.T) {
 // TestInit ..
 func TestInit(t *testing.T) {
 	nodeconfig.GetDefaultConfig().DBDir = "/tmp"
-	ins := GetStorageInstance("1.1.1.1", "3333", true)
+	ins := GetStorageInstance("1.1.1.1", "3333")
 	if err := ins.GetDB().Put([]byte{1}, []byte{2}, nil); err != nil {
 		t.Fatal("(*LDBDatabase).Put failed:", err)
 	}

--- a/node/node_explorer.go
+++ b/node/node_explorer.go
@@ -133,7 +133,7 @@ func (node *Node) AddNewBlockForExplorer(block *types.Block) {
 				Msg("[Explorer] Populating explorer data from state synced blocks")
 			go func() {
 				for blockHeight := int64(block.NumberU64()) - 1; blockHeight >= 0; blockHeight-- {
-					explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port, true).Dump(
+					explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port).Dump(
 						node.Blockchain().GetBlockByNumber(uint64(blockHeight)), uint64(blockHeight))
 				}
 			}()
@@ -150,7 +150,7 @@ func (node *Node) commitBlockForExplorer(block *types.Block) {
 	}
 	// Dump new block into level db.
 	utils.Logger().Info().Uint64("blockNum", block.NumberU64()).Msg("[Explorer] Committing block into explorer DB")
-	explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port, true).Dump(block, block.NumberU64())
+	explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port).Dump(block, block.NumberU64())
 
 	curNum := block.NumberU64()
 	if curNum-100 > 0 {
@@ -163,7 +163,7 @@ func (node *Node) commitBlockForExplorer(block *types.Block) {
 func (node *Node) GetTransactionsHistory(address, txType, order string) ([]common.Hash, error) {
 	addressData := &explorer.Address{}
 	key := explorer.GetAddressKey(address)
-	bytes, err := explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port, false).GetDB().Get([]byte(key), nil)
+	bytes, err := explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port).GetDB().Get([]byte(key), nil)
 	if err != nil {
 		utils.Logger().Debug().Err(err).
 			Msgf("[Explorer] Error retrieving transaction history for address %s", address)
@@ -196,7 +196,7 @@ func (node *Node) GetTransactionsHistory(address, txType, order string) ([]commo
 func (node *Node) GetStakingTransactionsHistory(address, txType, order string) ([]common.Hash, error) {
 	addressData := &explorer.Address{}
 	key := explorer.GetAddressKey(address)
-	bytes, err := explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port, false).GetDB().Get([]byte(key), nil)
+	bytes, err := explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port).GetDB().Get([]byte(key), nil)
 	if err != nil {
 		utils.Logger().Debug().Err(err).
 			Msgf("[Explorer] Staking transaction history for address %s not found", address)
@@ -229,7 +229,7 @@ func (node *Node) GetStakingTransactionsHistory(address, txType, order string) (
 func (node *Node) GetTransactionsCount(address, txType string) (uint64, error) {
 	addressData := &explorer.Address{}
 	key := explorer.GetAddressKey(address)
-	bytes, err := explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port, false).GetDB().Get([]byte(key), nil)
+	bytes, err := explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port).GetDB().Get([]byte(key), nil)
 	if err != nil {
 		utils.Logger().Error().Err(err).Msg("[Explorer] Cannot get storage db instance")
 		return 0, nil
@@ -252,7 +252,7 @@ func (node *Node) GetTransactionsCount(address, txType string) (uint64, error) {
 func (node *Node) GetStakingTransactionsCount(address, txType string) (uint64, error) {
 	addressData := &explorer.Address{}
 	key := explorer.GetAddressKey(address)
-	bytes, err := explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port, false).GetDB().Get([]byte(key), nil)
+	bytes, err := explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port).GetDB().Get([]byte(key), nil)
 	if err != nil {
 		utils.Logger().Error().Err(err).Msg("[Explorer] Cannot get storage db instance")
 		return 0, nil


### PR DESCRIPTION
Do not reinit explorer db for every node restart to make explorer node troubleshooting easier.