### PR TITLE
Refactor quorum calculation and signature submission process

### DIFF
--- a/consensus/construct_test.go
+++ b/consensus/construct_test.go
@@ -63,9 +63,13 @@ func TestConstructPreparedMessage(test *testing.T) {
 	consensus.blockHash = [32]byte{}
 
 	message := "test string"
+	leaderKey := shard.BLSPublicKey{}
+	leaderKey.FromLibBLSPublicKey(leaderPubKey)
+	validatorKey := shard.BLSPublicKey{}
+	validatorKey.FromLibBLSPublicKey(validatorPubKey)
 	consensus.Decider.SubmitVote(
 		quorum.Prepare,
-		leaderPubKey,
+		leaderKey,
 		leaderPriKey.Sign(message),
 		common.BytesToHash(consensus.blockHash[:]),
 		consensus.blockNum,
@@ -73,7 +77,7 @@ func TestConstructPreparedMessage(test *testing.T) {
 	)
 	if _, err := consensus.Decider.SubmitVote(
 		quorum.Prepare,
-		validatorPubKey,
+		validatorKey,
 		validatorPriKey.Sign(message),
 		common.BytesToHash(consensus.blockHash[:]),
 		consensus.blockNum,

--- a/consensus/double_sign.go
+++ b/consensus/double_sign.go
@@ -13,7 +13,7 @@ import (
 func (consensus *Consensus) checkDoubleSign(recvMsg *FBFTMessage) bool {
 	if consensus.couldThisBeADoubleSigner(recvMsg) {
 		if alreadyCastBallot := consensus.Decider.ReadBallot(
-			quorum.Commit, recvMsg.SenderPubkey,
+			quorum.Commit, recvMsg.SenderPubkeyBytes,
 		); alreadyCastBallot != nil {
 			firstPubKey := bls.PublicKey{}
 			alreadyCastBallot.SignerPubKey.ToLibBLSPublicKey(&firstPubKey)

--- a/consensus/quorum/one-node-one-vote.go
+++ b/consensus/quorum/one-node-one-vote.go
@@ -4,6 +4,10 @@ import (
 	"encoding/json"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/harmony-one/bls/ffi/go/bls"
+	"github.com/harmony-one/harmony/consensus/votepower"
+
 	bls_cosi "github.com/harmony-one/harmony/crypto/bls"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/numeric"
@@ -19,6 +23,15 @@ type uniformVoteWeight struct {
 // Policy ..
 func (v *uniformVoteWeight) Policy() Policy {
 	return SuperMajorityVote
+}
+
+// AddNewVote ..
+func (v *uniformVoteWeight) AddNewVote(
+	p Phase, pubKeyBytes shard.BLSPublicKey,
+	sig *bls.Sign, headerHash common.Hash,
+	height, viewID uint64) (*votepower.Ballot, error) {
+
+	return v.SubmitVote(p, pubKeyBytes, sig, headerHash, height, viewID)
 }
 
 // IsQuorumAchieved ..

--- a/consensus/quorum/one-node-staked-vote_test.go
+++ b/consensus/quorum/one-node-staked-vote_test.go
@@ -105,11 +105,10 @@ func setupEdgeCase() (Decider, *TallyResult, shard.SlotList, secretKeyMap) {
 }
 
 func sign(d Decider, k secretKeyMap, p Phase) {
-	for _, v := range k {
-		pubKey := v.GetPublicKey()
+	for k, v := range k {
 		sig := v.Sign(msg)
 		// TODO Make upstream test provide meaningful test values
-		d.SubmitVote(p, pubKey, sig, common.Hash{}, 0, 0)
+		d.AddNewVote(p, k, sig, common.Hash{}, 0, 0)
 	}
 }
 

--- a/consensus/threshold.go
+++ b/consensus/threshold.go
@@ -56,9 +56,9 @@ func (consensus *Consensus) didReachPrepareQuorum() error {
 			continue
 		}
 
-		if _, err := consensus.Decider.SubmitVote(
+		if _, err := consensus.Decider.AddNewVote(
 			quorum.Commit,
-			key,
+			consensus.PubKey.PublicKeyBytes[i],
 			consensus.priKey.PrivateKey[i].SignHash(commitPayload),
 			blockObj.Hash(),
 			blockObj.NumberU64(),

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -345,6 +345,7 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 				preparedMsg.Payload = make([]byte, len(recvMsg.Payload)-32)
 				copy(preparedMsg.Payload[:], recvMsg.Payload[32:])
 				preparedMsg.SenderPubkey = newLeaderKey
+				copy(preparedMsg.SenderPubkeyBytes[:], newLeaderKey.Serialize())
 				consensus.getLogger().Info().Msg("[onViewChange] New Leader Prepared Message Added")
 				consensus.FBFTLog.AddMessage(&preparedMsg)
 
@@ -432,7 +433,7 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 				priKey := consensus.priKey.PrivateKey[i]
 				if _, err := consensus.Decider.SubmitVote(
 					quorum.Commit,
-					key,
+					consensus.PubKey.PublicKeyBytes[i],
 					priKey.SignHash(commitPayload),
 					common.BytesToHash(consensus.blockHash[:]),
 					block.NumberU64(),
@@ -597,6 +598,7 @@ func (consensus *Consensus) onNewView(msg *msg_pb.Message) {
 		preparedMsg.Payload = make([]byte, len(recvMsg.Payload)-32)
 		copy(preparedMsg.Payload[:], recvMsg.Payload[32:])
 		preparedMsg.SenderPubkey = senderKey
+		preparedMsg.SenderPubkeyBytes = recvMsg.SenderPubkeyBytes
 		consensus.FBFTLog.AddMessage(&preparedMsg)
 
 		if hasBlock {

--- a/multibls/multibls.go
+++ b/multibls/multibls.go
@@ -3,6 +3,8 @@ package multibls
 import (
 	"strings"
 
+	"github.com/harmony-one/harmony/shard"
+
 	"github.com/harmony-one/bls/ffi/go/bls"
 )
 
@@ -13,7 +15,8 @@ type PrivateKey struct {
 
 // PublicKey stores the bls public keys that belongs to the node
 type PublicKey struct {
-	PublicKey []*bls.PublicKey
+	PublicKey      []*bls.PublicKey
+	PublicKeyBytes []shard.BLSPublicKey
 }
 
 // SerializeToHexStr wrapper
@@ -41,10 +44,13 @@ func (multiKey PublicKey) Contains(pubKey *bls.PublicKey) bool {
 // GetPublicKey wrapper
 func (multiKey PrivateKey) GetPublicKey() *PublicKey {
 	pubKeys := make([]*bls.PublicKey, len(multiKey.PrivateKey))
+	pubKeysBytes := make([]shard.BLSPublicKey, len(multiKey.PrivateKey))
 	for i, key := range multiKey.PrivateKey {
 		pubKeys[i] = key.GetPublicKey()
+		pubKeysBytes[i].FromLibBLSPublicKey(pubKeys[i])
 	}
-	return &PublicKey{PublicKey: pubKeys}
+
+	return &PublicKey{PublicKey: pubKeys, PublicKeyBytes: pubKeysBytes}
 }
 
 // GetPrivateKey creates a multibls PrivateKey using bls.SecretKey

--- a/node/node_explorer.go
+++ b/node/node_explorer.go
@@ -231,7 +231,7 @@ func (node *Node) GetTransactionsCount(address, txType string) (uint64, error) {
 	key := explorer.GetAddressKey(address)
 	bytes, err := explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port).GetDB().Get([]byte(key), nil)
 	if err != nil {
-		utils.Logger().Error().Err(err).Msg("[Explorer] Cannot get storage db instance")
+		utils.Logger().Error().Err(err).Str("addr", address).Msg("[Explorer] Address not found")
 		return 0, nil
 	}
 	if err = rlp.DecodeBytes(bytes, &addressData); err != nil {
@@ -254,7 +254,7 @@ func (node *Node) GetStakingTransactionsCount(address, txType string) (uint64, e
 	key := explorer.GetAddressKey(address)
 	bytes, err := explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port).GetDB().Get([]byte(key), nil)
 	if err != nil {
-		utils.Logger().Error().Err(err).Msg("[Explorer] Cannot get storage db instance")
+		utils.Logger().Error().Err(err).Str("addr", address).Msg("[Explorer] Address not found")
 		return 0, nil
 	}
 	if err = rlp.DecodeBytes(bytes, &addressData); err != nil {

--- a/shard/shard_state.go
+++ b/shard/shard_state.go
@@ -38,6 +38,7 @@ type State struct {
 }
 
 // BLSPublicKey defines the bls public key
+// TODO(audit): wrap c bls key object with the raw bytes
 type BLSPublicKey [PublicKeySizeInBytes]byte
 
 // BLSSignature defines the bls signature


### PR DESCRIPTION
IsQuorumAchieved() is a pretty costly function as it loops through all votes and sum up the voting powers. It is called twice for every consensus messages, which can be a huge amount of CPU drain on the leader.

This PR refactor the whole leader consensus checking process to avoid redundant work on quorum checking and also BLS key serialization/deserialization.

Tested locally.

This PR is fully compatible in terms of onchain logic.