### PR TITLE
Refactor bls public key into a wrapper

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/harmony-one/abool
+	"github.com/harmony-one/abool"
 	"github.com/harmony-one/bls/ffi/go/bls"
 	"github.com/harmony-one/harmony/consensus/quorum"
 	"github.com/harmony-one/harmony/core"
@@ -14,7 +14,7 @@ import (
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/multibls"
 	"github.com/harmony-one/harmony/p2p"
-  "github.com/harmony-one/harmony/shard"
+	"github.com/harmony-one/harmony/shard"
 	"github.com/harmony-one/harmony/staking/slash"
 	"github.com/pkg/errors"
 )

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/harmony-one/harmony/shard"
+
 	"github.com/harmony-one/bls/ffi/go/bls"
 	"github.com/harmony-one/harmony/consensus/quorum"
 	"github.com/harmony-one/harmony/core"
@@ -75,9 +77,9 @@ type Consensus struct {
 	pubKeyLock sync.Mutex
 	// private/public keys of current node
 	priKey *multibls.PrivateKey
-	PubKey *multibls.PublicKey
+	PubKey multibls.PublicKeys
 	// the publickey of leader
-	LeaderPubKey *bls.PublicKey
+	LeaderPubKey *shard.BLSPublicKeyWrapper
 	viewID       uint64
 	// Blockhash - 32 byte
 	blockHash [32]byte
@@ -154,8 +156,8 @@ func (consensus *Consensus) VdfSeedSize() int {
 
 // GetLeaderPrivateKey returns leader private key if node is the leader
 func (consensus *Consensus) GetLeaderPrivateKey(leaderKey *bls.PublicKey) (*bls.SecretKey, error) {
-	for i, key := range consensus.PubKey.PublicKey {
-		if key.IsEqual(leaderKey) {
+	for i, key := range consensus.PubKey {
+		if key.Object.IsEqual(leaderKey) {
 			return consensus.priKey.PrivateKey[i], nil
 		}
 	}
@@ -164,7 +166,7 @@ func (consensus *Consensus) GetLeaderPrivateKey(leaderKey *bls.PublicKey) (*bls.
 
 // GetConsensusLeaderPrivateKey returns consensus leader private key if node is the leader
 func (consensus *Consensus) GetConsensusLeaderPrivateKey() (*bls.SecretKey, error) {
-	return consensus.GetLeaderPrivateKey(consensus.LeaderPubKey)
+	return consensus.GetLeaderPrivateKey(consensus.LeaderPubKey.Object)
 }
 
 // TODO: put shardId into chain reader's chain config

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -84,9 +84,13 @@ func (consensus *Consensus) UpdatePublicKeys(pubKeys []*bls.PublicKey) int64 {
 			Str("BLSPubKey", pubKeys[i].SerializeToHexStr()).
 			Msg("Member")
 	}
-	consensus.LeaderPubKey = pubKeys[0]
-	utils.Logger().Info().
-		Str("info", consensus.LeaderPubKey.SerializeToHexStr()).Msg("My Leader")
+
+	allKeys := consensus.Decider.Participants()
+	if len(allKeys) != 0 {
+		consensus.LeaderPubKey = &allKeys[0]
+		utils.Logger().Info().
+			Str("info", consensus.LeaderPubKey.Bytes.Hex()).Msg("My Leader")
+	}
 	consensus.pubKeyLock.Unlock()
 	// reset states after update public keys
 	consensus.ResetState()
@@ -150,8 +154,12 @@ func (consensus *Consensus) ResetState() {
 	consensus.block = []byte{}
 	consensus.Decider.ResetPrepareAndCommitVotes()
 	members := consensus.Decider.Participants()
-	prepareBitmap, _ := bls_cosi.NewMask(members, nil)
-	commitBitmap, _ := bls_cosi.NewMask(members, nil)
+	publicKeys := []*bls.PublicKey{}
+	for _, key := range members {
+		publicKeys = append(publicKeys, key.Object)
+	}
+	prepareBitmap, _ := bls_cosi.NewMask(publicKeys, nil)
+	commitBitmap, _ := bls_cosi.NewMask(publicKeys, nil)
 	consensus.prepareBitmap = prepareBitmap
 	consensus.commitBitmap = commitBitmap
 	consensus.aggregatedPrepareSig = nil
@@ -166,12 +174,8 @@ func (consensus *Consensus) ToggleConsensusCheck() {
 }
 
 // IsValidatorInCommittee returns whether the given validator BLS address is part of my committee
-func (consensus *Consensus) IsValidatorInCommittee(pubKey *bls.PublicKey) bool {
-	pubKeyBytes := shard.FromLibBLSPublicKeyUnsafe(pubKey)
-	if pubKeyBytes == nil {
-		return false
-	}
-	return consensus.Decider.IndexOf(*pubKeyBytes) != -1
+func (consensus *Consensus) IsValidatorInCommittee(pubKey shard.BLSPublicKey) bool {
+	return consensus.Decider.IndexOf(pubKey) != -1
 }
 
 // IsValidatorInCommitteeBytes returns whether the given validator BLS address is part of my committee
@@ -212,17 +216,15 @@ func (consensus *Consensus) verifySenderKey(msg *msg_pb.Message) error {
 	return nil
 }
 
-func (consensus *Consensus) verifyViewChangeSenderKey(msg *msg_pb.Message) (*bls.PublicKey, error) {
+func (consensus *Consensus) verifyViewChangeSenderKey(msg *msg_pb.Message) error {
 	vcMsg := msg.GetViewchange()
-	senderKey, err := bls_cosi.BytesToBLSPublicKey(vcMsg.SenderPubkey)
-	if err != nil {
-		return nil, err
-	}
+	senderKey := shard.BLSPublicKey{}
+	copy(senderKey[:], vcMsg.SenderPubkey)
 
 	if !consensus.IsValidatorInCommittee(senderKey) {
-		return nil, shard.ErrValidNotInCommittee
+		return shard.ErrValidNotInCommittee
 	}
-	return senderKey, nil
+	return nil
 }
 
 // SetViewID set the viewID to the height of the blockchain
@@ -265,7 +267,7 @@ func (consensus *Consensus) checkViewID(msg *FBFTMessage) error {
 		consensus.consensusTimeout[timeoutConsensus].Start()
 		utils.Logger().Debug().
 			Uint64("viewID", consensus.viewID).
-			Str("leaderKey", consensus.LeaderPubKey.SerializeToHexStr()[:20]).
+			Str("leaderKey", consensus.LeaderPubKey.Bytes.Hex()).
 			Msg("viewID and leaderKey override")
 		utils.Logger().Debug().
 			Uint64("viewID", consensus.viewID).
@@ -293,8 +295,15 @@ func (consensus *Consensus) ReadSignatureBitmapPayload(
 		return nil, nil, errors.New("payload not have enough length")
 	}
 	sigAndBitmapPayload := recvPayload[offset:]
+
+	// TODO(audit): keep a Mask in the Decider so it won't be reconstructed on the fly.
+	members := consensus.Decider.Participants()
+	publicKeys := []*bls.PublicKey{}
+	for _, key := range members {
+		publicKeys = append(publicKeys, key.Object)
+	}
 	return chain.ReadSignatureBitmapByPublicKeys(
-		sigAndBitmapPayload, consensus.Decider.Participants(),
+		sigAndBitmapPayload, publicKeys,
 	)
 }
 
@@ -312,7 +321,7 @@ func (consensus *Consensus) getLogger() *zerolog.Logger {
 // retrieve corresponding blsPublicKey from Coinbase Address
 func (consensus *Consensus) getLeaderPubKeyFromCoinbase(
 	header *block.Header,
-) (*bls.PublicKey, error) {
+) (*shard.BLSPublicKeyWrapper, error) {
 	shardState, err := consensus.ChainReader.ReadShardState(header.Epoch())
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot read shard state %v %s",
@@ -335,14 +344,14 @@ func (consensus *Consensus) getLeaderPubKeyFromCoinbase(
 				if err := member.BLSPublicKey.ToLibBLSPublicKey(committerKey); err != nil {
 					return nil, err
 				}
-				return committerKey, nil
+				return &shard.BLSPublicKeyWrapper{Object: committerKey, Bytes: member.BLSPublicKey}, nil
 			}
 		} else {
 			if member.EcdsaAddress == header.Coinbase() {
 				if err := member.BLSPublicKey.ToLibBLSPublicKey(committerKey); err != nil {
 					return nil, err
 				}
-				return committerKey, nil
+				return &shard.BLSPublicKeyWrapper{Object: committerKey, Bytes: member.BLSPublicKey}, nil
 			}
 		}
 	}
@@ -387,7 +396,7 @@ func (consensus *Consensus) UpdateConsensusInformation() Mode {
 	// Only happens once, the flip-over to a new Decider policy
 	if isFirstTimeStaking || haventUpdatedDecider {
 		decider := quorum.NewDecider(quorum.SuperMajorityStake, consensus.ShardID)
-		decider.SetMyPublicKeyProvider(func() (*multibls.PublicKey, error) {
+		decider.SetMyPublicKeyProvider(func() (multibls.PublicKeys, error) {
 			return consensus.PubKey, nil
 		})
 		consensus.Decider = decider
@@ -489,7 +498,7 @@ func (consensus *Consensus) UpdateConsensusInformation() Mode {
 			hasError = true
 		} else {
 			consensus.getLogger().Debug().
-				Str("leaderPubKey", leaderPubKey.SerializeToHexStr()).
+				Str("leaderPubKey", leaderPubKey.Bytes.Hex()).
 				Msg("[UpdateConsensusInformation] Most Recent LeaderPubKey Updated Based on BlockChain")
 			consensus.LeaderPubKey = leaderPubKey
 		}
@@ -503,7 +512,7 @@ func (consensus *Consensus) UpdateConsensusInformation() Mode {
 			}
 
 			// If the leader changed and I myself become the leader
-			if !consensus.LeaderPubKey.IsEqual(oldLeader) && consensus.IsLeader() {
+			if !consensus.LeaderPubKey.Object.IsEqual(oldLeader.Object) && consensus.IsLeader() {
 				go func() {
 					utils.Logger().Debug().
 						Str("myKey", consensus.PubKey.SerializeToHexStr()).
@@ -523,8 +532,8 @@ func (consensus *Consensus) UpdateConsensusInformation() Mode {
 // IsLeader check if the node is a leader or not by comparing the public key of
 // the node with the leader public key
 func (consensus *Consensus) IsLeader() bool {
-	for _, key := range consensus.PubKey.PublicKey {
-		if key.IsEqual(consensus.LeaderPubKey) {
+	for _, key := range consensus.PubKey {
+		if key.Object.IsEqual(consensus.LeaderPubKey.Object) {
 			return true
 		}
 	}
@@ -542,6 +551,10 @@ func (consensus *Consensus) NeedsRandomNumberGeneration(epoch *big.Int) bool {
 
 func (consensus *Consensus) addViewIDKeyIfNotExist(viewID uint64) {
 	members := consensus.Decider.Participants()
+	publicKeys := []*bls.PublicKey{}
+	for _, key := range members {
+		publicKeys = append(publicKeys, key.Object)
+	}
 	if _, ok := consensus.bhpSigs[viewID]; !ok {
 		consensus.bhpSigs[viewID] = map[string]*bls.Sign{}
 	}
@@ -552,15 +565,15 @@ func (consensus *Consensus) addViewIDKeyIfNotExist(viewID uint64) {
 		consensus.viewIDSigs[viewID] = map[string]*bls.Sign{}
 	}
 	if _, ok := consensus.bhpBitmap[viewID]; !ok {
-		bhpBitmap, _ := bls_cosi.NewMask(members, nil)
+		bhpBitmap, _ := bls_cosi.NewMask(publicKeys, nil)
 		consensus.bhpBitmap[viewID] = bhpBitmap
 	}
 	if _, ok := consensus.nilBitmap[viewID]; !ok {
-		nilBitmap, _ := bls_cosi.NewMask(members, nil)
+		nilBitmap, _ := bls_cosi.NewMask(publicKeys, nil)
 		consensus.nilBitmap[viewID] = nilBitmap
 	}
 	if _, ok := consensus.viewIDBitmap[viewID]; !ok {
-		viewIDBitmap, _ := bls_cosi.NewMask(members, nil)
+		viewIDBitmap, _ := bls_cosi.NewMask(publicKeys, nil)
 		consensus.viewIDBitmap[viewID] = viewIDBitmap
 	}
 }

--- a/consensus/consensus_service_test.go
+++ b/consensus/consensus_service_test.go
@@ -40,8 +40,10 @@ func TestPopulateMessageFields(t *testing.T) {
 		},
 	}
 
+	keyBytes := shard.BLSPublicKey{}
+	keyBytes.FromLibBLSPublicKey(blsPriKey.GetPublicKey())
 	consensusMsg := consensus.populateMessageFields(msg.GetConsensus(), consensus.blockHash[:],
-		blsPriKey.GetPublicKey())
+		keyBytes)
 
 	if consensusMsg.ViewId != 2 {
 		t.Errorf("Consensus ID is not populated correctly")

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -111,7 +111,10 @@ func (consensus *Consensus) finalizeCommits() {
 		return
 	}
 	// Construct committed message
-	network, err := consensus.construct(msg_pb.MessageType_COMMITTED, nil, leaderPriKey.GetPublicKey(), leaderPriKey)
+	// TODO(audit): wrap bls private key with public key
+	leaderPubKeyBytes := shard.BLSPublicKey{}
+	leaderPubKeyBytes.FromLibBLSPublicKey(leaderPriKey.GetPublicKey())
+	network, err := consensus.construct(msg_pb.MessageType_COMMITTED, nil, leaderPubKeyBytes, leaderPriKey)
 	if err != nil {
 		consensus.getLogger().Warn().Err(err).
 			Msg("[FinalizeCommits] Unable to construct Committed message")
@@ -548,7 +551,7 @@ func (consensus *Consensus) GenerateVrfAndProof(newBlock *types.Block, vrfBlockN
 
 // ValidateVrfAndProof validates a VRF/Proof from hash of previous block
 func (consensus *Consensus) ValidateVrfAndProof(headerObj *block.Header) bool {
-	vrfPk := vrf_bls.NewVRFVerifier(consensus.LeaderPubKey)
+	vrfPk := vrf_bls.NewVRFVerifier(consensus.LeaderPubKey.Object)
 	var blockHash [32]byte
 	previousHeader := consensus.ChainReader.GetHeaderByNumber(
 		headerObj.Number().Uint64() - 1,

--- a/consensus/consensus_viewchange_msg.go
+++ b/consensus/consensus_viewchange_msg.go
@@ -3,6 +3,8 @@ package consensus
 import (
 	"encoding/binary"
 
+	"github.com/harmony-one/harmony/shard"
+
 	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/harmony-one/bls/ffi/go/bls"
@@ -30,7 +32,7 @@ func (consensus *Consensus) constructViewChangeMessage(pubKey *bls.PublicKey, pr
 	vcMsg.SenderPubkey = pubKey.Serialize()
 
 	// next leader key already updated
-	vcMsg.LeaderPubkey = consensus.LeaderPubKey.Serialize()
+	vcMsg.LeaderPubkey = consensus.LeaderPubKey.Bytes[:]
 
 	preparedMsgs := consensus.FBFTLog.GetMessagesByTypeSeq(
 		msg_pb.MessageType_PREPARED, consensus.blockNum,
@@ -98,7 +100,7 @@ func (consensus *Consensus) constructViewChangeMessage(pubKey *bls.PublicKey, pr
 }
 
 // new leader construct newview message
-func (consensus *Consensus) constructNewViewMessage(viewID uint64, pubKey *bls.PublicKey, priKey *bls.SecretKey) []byte {
+func (consensus *Consensus) constructNewViewMessage(viewID uint64, pubKey shard.BLSPublicKey, priKey *bls.SecretKey) []byte {
 	message := &msg_pb.Message{
 		ServiceType: msg_pb.ServiceType_CONSENSUS,
 		Type:        msg_pb.MessageType_NEWVIEW,
@@ -112,7 +114,7 @@ func (consensus *Consensus) constructNewViewMessage(viewID uint64, pubKey *bls.P
 	vcMsg.BlockNum = consensus.blockNum
 	vcMsg.ShardId = consensus.ShardID
 	// sender address
-	vcMsg.SenderPubkey = pubKey.Serialize()
+	vcMsg.SenderPubkey = pubKey[:]
 	vcMsg.Payload = consensus.m1Payload
 	if len(consensus.m1Payload) != 0 {
 		block := consensus.FBFTLog.GetBlockByHash(consensus.blockHash)

--- a/consensus/construct.go
+++ b/consensus/construct.go
@@ -3,6 +3,8 @@ package consensus
 import (
 	"bytes"
 
+	"github.com/harmony-one/harmony/shard"
+
 	"github.com/harmony-one/bls/ffi/go/bls"
 	"github.com/harmony-one/harmony/api/proto"
 	msg_pb "github.com/harmony-one/harmony/api/proto/message"
@@ -22,7 +24,7 @@ type NetworkMessage struct {
 
 // Populates the common basic fields for all consensus message.
 func (consensus *Consensus) populateMessageFields(
-	request *msg_pb.ConsensusRequest, blockHash []byte, pubKey *bls.PublicKey,
+	request *msg_pb.ConsensusRequest, blockHash []byte, pubKey shard.BLSPublicKey,
 ) *msg_pb.ConsensusRequest {
 	request.ViewId = consensus.viewID
 	request.BlockNum = consensus.blockNum
@@ -30,13 +32,13 @@ func (consensus *Consensus) populateMessageFields(
 	// 32 byte block hash
 	request.BlockHash = blockHash
 	// sender address
-	request.SenderPubkey = pubKey.Serialize()
+	request.SenderPubkey = pubKey[:]
 	return request
 }
 
 // construct is the single creation point of messages intended for the wire.
 func (consensus *Consensus) construct(
-	p msg_pb.MessageType, payloadForSign []byte, pubKey *bls.PublicKey, priKey *bls.SecretKey,
+	p msg_pb.MessageType, payloadForSign []byte, pubKey shard.BLSPublicKey, priKey *bls.SecretKey,
 ) (*NetworkMessage, error) {
 	message := &msg_pb.Message{
 		ServiceType: msg_pb.ServiceType_CONSENSUS,

--- a/consensus/construct_test.go
+++ b/consensus/construct_test.go
@@ -32,7 +32,9 @@ func TestConstructAnnounceMessage(test *testing.T) {
 		test.Fatalf("Cannot create consensus: %v", err)
 	}
 	consensus.blockHash = [32]byte{}
-	if _, err = consensus.construct(msg_pb.MessageType_ANNOUNCE, nil, blsPriKey.GetPublicKey(), blsPriKey); err != nil {
+	keyBytes := shard.BLSPublicKey{}
+	keyBytes.FromLibBLSPublicKey(blsPriKey.GetPublicKey())
+	if _, err = consensus.construct(msg_pb.MessageType_ANNOUNCE, nil, keyBytes, blsPriKey); err != nil {
 		test.Fatalf("could not construct announce: %v", err)
 	}
 }
@@ -94,7 +96,9 @@ func TestConstructPreparedMessage(test *testing.T) {
 		test.Log(errors.New("prepareBitmap.SetKey"))
 	}
 
-	network, err := consensus.construct(msg_pb.MessageType_PREPARED, nil, blsPriKey.GetPublicKey(), blsPriKey)
+	keyBytes := shard.BLSPublicKey{}
+	keyBytes.FromLibBLSPublicKey(blsPriKey.GetPublicKey())
+	network, err := consensus.construct(msg_pb.MessageType_PREPARED, nil, keyBytes, blsPriKey)
 	if err != nil {
 		test.Errorf("Error when creating prepared message")
 	}

--- a/consensus/double_sign.go
+++ b/consensus/double_sign.go
@@ -13,11 +13,11 @@ import (
 func (consensus *Consensus) checkDoubleSign(recvMsg *FBFTMessage) bool {
 	if consensus.couldThisBeADoubleSigner(recvMsg) {
 		if alreadyCastBallot := consensus.Decider.ReadBallot(
-			quorum.Commit, recvMsg.SenderPubkeyBytes,
+			quorum.Commit, recvMsg.SenderPubkey.Bytes,
 		); alreadyCastBallot != nil {
 			firstPubKey := bls.PublicKey{}
 			alreadyCastBallot.SignerPubKey.ToLibBLSPublicKey(&firstPubKey)
-			if recvMsg.SenderPubkey.IsEqual(&firstPubKey) {
+			if recvMsg.SenderPubkey.Object.IsEqual(&firstPubKey) {
 				for _, blk := range consensus.FBFTLog.GetBlocksByNumber(recvMsg.BlockNum) {
 					firstSignedBlock := blk.Header()
 					areHeightsEqual := firstSignedBlock.Number().Uint64() == recvMsg.BlockNum
@@ -45,7 +45,7 @@ func (consensus *Consensus) checkDoubleSign(recvMsg *FBFTMessage) bool {
 								Msg("could not read shard state")
 							return true
 						}
-						offender := shard.FromLibBLSPublicKeyUnsafe(recvMsg.SenderPubkey)
+						offender := shard.FromLibBLSPublicKeyUnsafe(recvMsg.SenderPubkey.Object)
 						if offender == nil {
 							consensus.getLogger().Error().
 								Str("msg", recvMsg.String()).
@@ -69,7 +69,7 @@ func (consensus *Consensus) checkDoubleSign(recvMsg *FBFTMessage) bool {
 							return true
 						}
 
-						leaderShardKey := shard.FromLibBLSPublicKeyUnsafe(consensus.LeaderPubKey)
+						leaderShardKey := shard.FromLibBLSPublicKeyUnsafe(consensus.LeaderPubKey.Object)
 						if leaderShardKey == nil {
 							consensus.getLogger().Error().
 								Str("msg", recvMsg.String()).

--- a/consensus/double_sign.go
+++ b/consensus/double_sign.go
@@ -4,7 +4,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/bls/ffi/go/bls"
 	"github.com/harmony-one/harmony/consensus/quorum"
-	"github.com/harmony-one/harmony/shard"
 	"github.com/harmony-one/harmony/staking/slash"
 )
 
@@ -45,13 +44,7 @@ func (consensus *Consensus) checkDoubleSign(recvMsg *FBFTMessage) bool {
 								Msg("could not read shard state")
 							return true
 						}
-						offender := shard.FromLibBLSPublicKeyUnsafe(recvMsg.SenderPubkey.Object)
-						if offender == nil {
-							consensus.getLogger().Error().
-								Str("msg", recvMsg.String()).
-								Msg("could not get shard key from sender's key")
-							return true
-						}
+
 						subComm, err := committee.FindCommitteeByID(
 							consensus.ShardID,
 						)
@@ -62,21 +55,14 @@ func (consensus *Consensus) checkDoubleSign(recvMsg *FBFTMessage) bool {
 							return true
 						}
 
-						addr, err := subComm.AddressForBLSKey(*offender)
+						addr, err := subComm.AddressForBLSKey(recvMsg.SenderPubkey.Bytes)
 						if err != nil {
 							consensus.getLogger().Err(err).Str("msg", recvMsg.String()).
 								Msg("could not find address for bls key")
 							return true
 						}
 
-						leaderShardKey := shard.FromLibBLSPublicKeyUnsafe(consensus.LeaderPubKey.Object)
-						if leaderShardKey == nil {
-							consensus.getLogger().Error().
-								Str("msg", recvMsg.String()).
-								Msg("could not get shard key from leader's key")
-							return true
-						}
-						leaderAddr, err := subComm.AddressForBLSKey(*leaderShardKey)
+						leaderAddr, err := subComm.AddressForBLSKey(consensus.LeaderPubKey.Bytes)
 						if err != nil {
 							consensus.getLogger().Err(err).Str("msg", recvMsg.String()).
 								Msg("could not find address for leader bls key")
@@ -92,7 +78,7 @@ func (consensus *Consensus) checkDoubleSign(recvMsg *FBFTMessage) bool {
 										alreadyCastBallot.Signature,
 									},
 									SecondVote: slash.Vote{
-										*offender,
+										recvMsg.SenderPubkey.Bytes,
 										recvMsg.BlockHash,
 										common.Hex2Bytes(doubleSign.SerializeToHexStr()),
 									}},

--- a/consensus/quorum/one-node-one-vote.go
+++ b/consensus/quorum/one-node-one-vote.go
@@ -91,7 +91,7 @@ func (v *uniformVoteWeight) MarshalJSON() ([]byte, error) {
 	keysDump := v.Participants()
 	keys := make([]string, len(keysDump))
 	for i := range keysDump {
-		keys[i] = keysDump[i].SerializeToHexStr()
+		keys[i] = keysDump[i].Bytes.Hex()
 	}
 
 	return json.Marshal(t{v.Policy().String(), len(keys), keys})
@@ -104,9 +104,9 @@ func (v *uniformVoteWeight) AmIMemberOfCommitee() bool {
 	}
 	identity, _ := pubKeyFunc()
 	everyone := v.Participants()
-	for _, key := range identity.PublicKey {
+	for _, key := range identity {
 		for i := range everyone {
-			if key.IsEqual(everyone[i]) {
+			if key.Object.IsEqual(everyone[i].Object) {
 				return true
 			}
 		}

--- a/consensus/threshold.go
+++ b/consensus/threshold.go
@@ -21,7 +21,7 @@ func (consensus *Consensus) didReachPrepareQuorum() error {
 	}
 	// Construct and broadcast prepared message
 	networkMessage, err := consensus.construct(
-		msg_pb.MessageType_PREPARED, nil, consensus.LeaderPubKey, leaderPriKey,
+		msg_pb.MessageType_PREPARED, nil, consensus.LeaderPubKey.Bytes, leaderPriKey,
 	)
 	if err != nil {
 		consensus.getLogger().Err(err).
@@ -50,15 +50,15 @@ func (consensus *Consensus) didReachPrepareQuorum() error {
 
 	// so by this point, everyone has committed to the blockhash of this block
 	// in prepare and so this is the actual block.
-	for i, key := range consensus.PubKey.PublicKey {
-		if err := consensus.commitBitmap.SetKey(key, true); err != nil {
+	for i, key := range consensus.PubKey {
+		if err := consensus.commitBitmap.SetKey(key.Object, true); err != nil {
 			consensus.getLogger().Warn().Msgf("[OnPrepare] Leader commit bitmap set failed for key at index %d", i)
 			continue
 		}
 
 		if _, err := consensus.Decider.AddNewVote(
 			quorum.Commit,
-			consensus.PubKey.PublicKeyBytes[i],
+			key.Bytes,
 			consensus.priKey.PrivateKey[i].SignHash(commitPayload),
 			blockObj.Hash(),
 			blockObj.NumberU64(),

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -59,11 +59,11 @@ func (consensus *Consensus) onAnnounce(msg *msg_pb.Message) {
 
 func (consensus *Consensus) prepare() {
 	groupID := []nodeconfig.GroupID{nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(consensus.ShardID))}
-	for i, key := range consensus.PubKey.PublicKey {
-		if !consensus.IsValidatorInCommittee(key) {
+	for i, key := range consensus.PubKey {
+		if !consensus.IsValidatorInCommittee(key.Bytes) {
 			continue
 		}
-		networkMessage, err := consensus.construct(msg_pb.MessageType_PREPARE, nil, key, consensus.priKey.PrivateKey[i])
+		networkMessage, err := consensus.construct(msg_pb.MessageType_PREPARE, nil, key.Bytes, consensus.priKey.PrivateKey[i])
 		if err != nil {
 			consensus.getLogger().Err(err).
 				Str("message-type", msg_pb.MessageType_PREPARE.String()).
@@ -210,15 +210,15 @@ func (consensus *Consensus) onPrepared(msg *msg_pb.Message) {
 	groupID := []nodeconfig.GroupID{
 		nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(consensus.ShardID)),
 	}
-	for i, key := range consensus.PubKey.PublicKey {
-		if !consensus.IsValidatorInCommittee(key) {
+	for i, key := range consensus.PubKey {
+		if !consensus.IsValidatorInCommittee(key.Bytes) {
 			continue
 		}
 
 		networkMessage, _ := consensus.construct(
 			msg_pb.MessageType_COMMIT,
 			commitPayload,
-			key, consensus.priKey.PrivateKey[i],
+			key.Bytes, consensus.priKey.PrivateKey[i],
 		)
 
 		if consensus.current.Mode() != Listening {

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -836,8 +836,8 @@ func (b *APIBackend) GetNodeMetadata() commonRPC.NodeMetadata {
 
 	blsKeys := []string{}
 	if cfg.ConsensusPubKey != nil {
-		for _, key := range cfg.ConsensusPubKey.PublicKey {
-			blsKeys = append(blsKeys, key.SerializeToHexStr())
+		for _, key := range cfg.ConsensusPubKey {
+			blsKeys = append(blsKeys, key.Bytes.Hex())
 		}
 	}
 	c := commonRPC.C{}

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -209,7 +209,7 @@ func (e *engineImpl) VerifySeal(chain engine.ChainReader, header *block.Header) 
 		d := quorum.NewDecider(
 			quorum.SuperMajorityStake, subComm.ShardID,
 		)
-		d.SetMyPublicKeyProvider(func() (*multibls.PublicKey, error) {
+		d.SetMyPublicKeyProvider(func() (multibls.PublicKeys, error) {
 			return nil, nil
 		})
 
@@ -524,7 +524,7 @@ func (e *engineImpl) VerifyHeaderWithSignature(chain engine.ChainReader, header 
 		}
 		// TODO(audit): reuse a singleton decider and not recreate it for every single block
 		d := quorum.NewDecider(quorum.SuperMajorityStake, subComm.ShardID)
-		d.SetMyPublicKeyProvider(func() (*multibls.PublicKey, error) {
+		d.SetMyPublicKeyProvider(func() (multibls.PublicKeys, error) {
 			return nil, nil
 		})
 

--- a/internal/configs/node/config.go
+++ b/internal/configs/node/config.go
@@ -77,7 +77,7 @@ type ConfigType struct {
 	StringRole      string
 	P2PPriKey       p2p_crypto.PrivKey
 	ConsensusPriKey *multibls.PrivateKey
-	ConsensusPubKey *multibls.PublicKey
+	ConsensusPubKey multibls.PublicKeys
 	// Database directory
 	DBDir            string
 	networkType      NetworkType
@@ -268,15 +268,15 @@ func (conf *ConfigType) ShardIDFromKey(key *bls.PublicKey) (uint32, error) {
 // ShardIDFromConsensusKey returns the shard ID statically determined from the
 // consensus key.
 func (conf *ConfigType) ShardIDFromConsensusKey() (uint32, error) {
-	return conf.ShardIDFromKey(conf.ConsensusPubKey.PublicKey[0])
+	return conf.ShardIDFromKey(conf.ConsensusPubKey[0].Object)
 }
 
 // ValidateConsensusKeysForSameShard checks if all consensus public keys belong to the same shard
-func (conf *ConfigType) ValidateConsensusKeysForSameShard(pubkeys []*bls.PublicKey, sID uint32) error {
+func (conf *ConfigType) ValidateConsensusKeysForSameShard(pubkeys multibls.PublicKeys, sID uint32) error {
 	keyShardStrs := []string{}
 	isSameShard := true
 	for _, key := range pubkeys {
-		shardID, err := conf.ShardIDFromKey(key)
+		shardID, err := conf.ShardIDFromKey(key.Object)
 		if err != nil {
 			return err
 		}
@@ -285,7 +285,7 @@ func (conf *ConfigType) ValidateConsensusKeysForSameShard(pubkeys []*bls.PublicK
 		}
 		keyShardStrs = append(
 			keyShardStrs,
-			fmt.Sprintf("key: %s, shard id: %d", key.SerializeToHexStr(), shardID),
+			fmt.Sprintf("key: %s, shard id: %d", key.Bytes.Hex(), shardID),
 		)
 	}
 	if !isSameShard {

--- a/internal/configs/node/config_test.go
+++ b/internal/configs/node/config_test.go
@@ -3,7 +3,9 @@ package nodeconfig
 import (
 	"testing"
 
-	"github.com/harmony-one/bls/ffi/go/bls"
+	"github.com/harmony-one/harmony/multibls"
+	"github.com/harmony-one/harmony/shard"
+
 	"github.com/harmony-one/harmony/internal/blsgen"
 	shardingconfig "github.com/harmony-one/harmony/internal/configs/sharding"
 	"github.com/pkg/errors"
@@ -69,9 +71,13 @@ func TestValidateConsensusKeysForSameShard(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	keys := []*bls.PublicKey{}
-	keys = append(keys, pubKey1)
-	keys = append(keys, pubKey2)
+	keys := multibls.PublicKeys{}
+	dummyKey := shard.BLSPublicKey{}
+	dummyKey.FromLibBLSPublicKey(pubKey1)
+	keys = append(keys, shard.BLSPublicKeyWrapper{Object: pubKey1, Bytes: dummyKey})
+	dummyKey = shard.BLSPublicKey{}
+	dummyKey.FromLibBLSPublicKey(pubKey2)
+	keys = append(keys, shard.BLSPublicKeyWrapper{Object: pubKey2, Bytes: dummyKey})
 	if err := GetDefaultConfig().ValidateConsensusKeysForSameShard(keys, 0); err != nil {
 		t.Error("expected", nil, "got", err)
 	}
@@ -82,7 +88,9 @@ func TestValidateConsensusKeysForSameShard(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	keys = append(keys, pubKey3)
+	dummyKey = shard.BLSPublicKey{}
+	dummyKey.FromLibBLSPublicKey(pubKey3)
+	keys = append(keys, shard.BLSPublicKeyWrapper{Object: pubKey3, Bytes: dummyKey})
 	if err := GetDefaultConfig().ValidateConsensusKeysForSameShard(keys, 0); err == nil {
 		e := errors.New("bls keys do not belong to the same shard")
 		t.Error("expected", e, "got", nil)

--- a/node/node.go
+++ b/node/node.go
@@ -714,9 +714,9 @@ func (node *Node) populateSelfAddresses(epoch *big.Int) {
 		return
 	}
 
-	for _, blskey := range node.Consensus.PubKey.PublicKey {
-		blsStr := blskey.SerializeToHexStr()
-		shardkey := shard.FromLibBLSPublicKeyUnsafe(blskey)
+	for _, blskey := range node.Consensus.PubKey {
+		blsStr := blskey.Bytes.Hex()
+		shardkey := shard.FromLibBLSPublicKeyUnsafe(blskey.Object)
 		if shardkey == nil {
 			utils.Logger().Error().
 				Int64("epoch", epoch.Int64()).

--- a/node/node_cross_link.go
+++ b/node/node_cross_link.go
@@ -185,7 +185,7 @@ func (node *Node) lookupDecider(
 				quorum.SuperMajorityStake, committee.ShardID,
 			)
 
-			decider.SetMyPublicKeyProvider(func() (*multibls.PublicKey, error) {
+			decider.SetMyPublicKeyProvider(func() (multibls.PublicKeys, error) {
 				return nil, nil
 			})
 

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -89,14 +89,14 @@ func (node *Node) proposeNewBlock() (*types.Block, error) {
 	// Update worker's current header and
 	// state data in preparation to propose/process new transactions
 	var (
-		coinbase    = node.GetAddressForBLSKey(node.Consensus.LeaderPubKey, header.Epoch())
+		coinbase    = node.GetAddressForBLSKey(node.Consensus.LeaderPubKey.Object, header.Epoch())
 		beneficiary = coinbase
 		err         error
 	)
 
 	// After staking, all coinbase will be the address of bls pub key
 	if node.Blockchain().Config().IsStaking(header.Epoch()) {
-		blsPubKeyBytes := node.Consensus.LeaderPubKey.GetAddress()
+		blsPubKeyBytes := node.Consensus.LeaderPubKey.Object.GetAddress()
 		coinbase.SetBytes(blsPubKeyBytes[:])
 	}
 

--- a/shard/shard_state.go
+++ b/shard/shard_state.go
@@ -37,8 +37,14 @@ type State struct {
 	Shards []Committee `json:"shards"`
 }
 
-// BLSPublicKey defines the bls public key
-// TODO(audit): wrap c bls key object with the raw bytes
+// BLSPublicKeyWrapper defines the bls public key in both serialized and
+// deserialized form.
+type BLSPublicKeyWrapper struct {
+	Bytes  BLSPublicKey
+	Object *bls.PublicKey
+}
+
+// BLSPublicKey defines the serialized bls public key
 type BLSPublicKey [PublicKeySizeInBytes]byte
 
 // BLSSignature defines the bls signature


### PR DESCRIPTION
Bind the C bls public key object with the serialized shard.BLSPublicKey bytes to avoid many unnecessary conversion between the two.

Tested locally.