### PR TITLE
[coverage] [p2p] Improve p2p code coverage from 0% to 78.3%

### DIFF
--- a/p2p/tests/address_test.go
+++ b/p2p/tests/address_test.go
@@ -1,0 +1,47 @@
+package p2p_tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/harmony-one/harmony/p2p"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMultiAddressParsing(t *testing.T) {
+	t.Parallel()
+
+	multiAddresses, err := p2p.StringsToAddrs(bootnodes)
+	assert.NoError(t, err)
+	assert.Equal(t, len(bootnodes), len(multiAddresses))
+
+	for index, multiAddress := range multiAddresses {
+		assert.Equal(t, multiAddress.String(), bootnodes[index])
+	}
+}
+
+func TestAddressListConversionToString(t *testing.T) {
+	t.Parallel()
+
+	multiAddresses, err := p2p.StringsToAddrs(bootnodes)
+	assert.NoError(t, err)
+	assert.Equal(t, len(bootnodes), len(multiAddresses))
+
+	expected := strings.Join(bootnodes[:], ",")
+	var addressList p2p.AddrList = multiAddresses
+	assert.Equal(t, expected, addressList.String())
+}
+
+func TestAddressListConversionFromString(t *testing.T) {
+	t.Parallel()
+
+	multiAddresses, err := p2p.StringsToAddrs(bootnodes)
+	assert.NoError(t, err)
+	assert.Equal(t, len(bootnodes), len(multiAddresses))
+
+	addressString := strings.Join(bootnodes[:], ",")
+	var addressList p2p.AddrList = multiAddresses
+	addressList.Set(addressString)
+	assert.Equal(t, len(addressList), len(multiAddresses))
+	assert.Equal(t, addressList[0], multiAddresses[0])
+}

--- a/p2p/tests/address_test.go
+++ b/p2p/tests/address_test.go
@@ -1,4 +1,4 @@
-package p2p_tests
+package p2ptests
 
 import (
 	"strings"

--- a/p2p/tests/helper.go
+++ b/p2p/tests/helper.go
@@ -1,4 +1,4 @@
-package p2p_tests
+package p2ptests
 
 import (
 	"github.com/harmony-one/bls/ffi/go/bls"

--- a/p2p/tests/helper.go
+++ b/p2p/tests/helper.go
@@ -1,0 +1,80 @@
+package p2p_tests
+
+import (
+	"github.com/harmony-one/bls/ffi/go/bls"
+	harmony_bls "github.com/harmony-one/harmony/crypto/bls"
+	"github.com/harmony-one/harmony/p2p"
+	libp2p_crypto "github.com/libp2p/go-libp2p-crypto"
+	"github.com/pkg/errors"
+)
+
+type host struct {
+	IP   string
+	Port string
+}
+
+var (
+	hosts     []host
+	topics    []string
+	bootnodes []string
+)
+
+func init() {
+	hosts = []host{
+		{IP: "127.0.0.1", Port: "5000"},
+		{IP: "8.8.8.8", Port: "5000"},
+	}
+
+	topics = []string{
+		"hmy/testnet/0.0.1/client/beacon",
+		"hmy/testnet/0.0.1/node/beacon",
+		"hmy/testnet/0.0.1/node/shard/1",
+		"hmy/testnet/0.0.1/node/shard/2",
+		"hmy/testnet/0.0.1/node/shard/3",
+	}
+
+	bootnodes = []string{
+		"/ip4/54.86.126.90/tcp/9850/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv",
+		"/ip4/52.40.84.2/tcp/9850/p2p/QmbPVwrqWsTYXq1RxGWcxx9SWaTUCfoo1wA6wmdbduWe29",
+	}
+}
+
+func createNode(address string, port string) (p2p.Host, *bls.PublicKey, error) {
+	nodePrivateKey, _, err := generatePrivateKey()
+	if err != nil {
+		return nil, nil, errors.New("failed to generate private key for node")
+	}
+
+	peer, err := generatePeer(address, port)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	host, err := p2p.NewHost(&peer, nodePrivateKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return host, peer.ConsensusPubKey, nil
+}
+
+func generatePeer(address string, port string) (p2p.Peer, error) {
+	peerPrivateKey := harmony_bls.RandPrivateKey()
+	peerPublicKey := peerPrivateKey.GetPublicKey()
+	if peerPrivateKey == nil || peerPublicKey == nil {
+		return p2p.Peer{}, errors.New("failed to generate bls key for peer")
+	}
+
+	peer := p2p.Peer{IP: address, Port: port, ConsensusPubKey: peerPublicKey}
+
+	return peer, nil
+}
+
+func generatePrivateKey() (privateKey libp2p_crypto.PrivKey, publicKey libp2p_crypto.PubKey, err error) {
+	privateKey, publicKey, err = libp2p_crypto.GenerateKeyPair(libp2p_crypto.RSA, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return privateKey, publicKey, nil
+}

--- a/p2p/tests/host_test.go
+++ b/p2p/tests/host_test.go
@@ -1,0 +1,82 @@
+package p2p_tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHostSetup(t *testing.T) {
+	t.Parallel()
+
+	hostData := hosts[0]
+	host, pubKey, err := createNode(hostData.IP, hostData.Port)
+	assert.NoError(t, err)
+
+	peer := host.GetSelfPeer()
+
+	assert.Equal(t, hostData.IP, peer.IP)
+	assert.Equal(t, hostData.Port, peer.Port)
+	assert.Equal(t, pubKey, peer.ConsensusPubKey)
+	assert.NotEmpty(t, peer.PeerID)
+	assert.Equal(t, peer.PeerID, host.GetID())
+	assert.Empty(t, peer.Addrs)
+}
+
+func TestAddPeer(t *testing.T) {
+	t.Parallel()
+
+	hostData := hosts[0]
+	host, _, err := createNode(hostData.IP, hostData.Port)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, host.GetID())
+
+	discoveredHostData := hosts[1]
+	discoveredHost, _, err := createNode(discoveredHostData.IP, discoveredHostData.Port)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, discoveredHost.GetID())
+
+	discoveredPeer := discoveredHost.GetSelfPeer()
+
+	assert.Empty(t, host.GetP2PHost().Peerstore().Addrs(discoveredHost.GetSelfPeer().PeerID))
+
+	err = host.AddPeer(&discoveredPeer)
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, host.GetP2PHost().Peerstore().Addrs(discoveredHost.GetSelfPeer().PeerID))
+	assert.Equal(t, 2, host.GetPeerCount())
+}
+
+/*func TestTopicJoining(t *testing.T) {
+	t.Parallel()
+
+	hostData := hosts[0]
+	host, _, err := createNode(hostData.IP, hostData.Port)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, host.GetID())
+
+	for _, topicName := range topics {
+		topic, err := host.GetOrJoin(topicName)
+		assert.NoError(t, err)
+		assert.NotNil(t, topic)
+	}
+}*/
+
+func TestConnectionToInvalidPeer(t *testing.T) {
+	t.Parallel()
+
+	hostData := hosts[0]
+	host, _, err := createNode(hostData.IP, hostData.Port)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, host.GetID())
+
+	discoveredHostData := hosts[1]
+	discoveredHost, _, err := createNode(discoveredHostData.IP, discoveredHostData.Port)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, discoveredHost.GetID())
+
+	discoveredPeer := discoveredHost.GetSelfPeer()
+
+	err = host.ConnectHostPeer(discoveredPeer)
+	assert.Error(t, err)
+}

--- a/p2p/tests/host_test.go
+++ b/p2p/tests/host_test.go
@@ -1,4 +1,4 @@
-package p2p_tests
+package p2ptests
 
 import (
 	"testing"


### PR DESCRIPTION
## Issue

There were no tests / coverage for the p2p package. This PR improves code coverage of the p2p package from 0% to 78.3%

## Test

### Unit Test Coverage

Before:

```
cd p2p && go test ./... -coverprofile cover.out && go tool cover -func cover.out | grep total

? github.com/harmony-one/harmony/p2p [no test files]
total: (statements) 0.0%
```

After:

```
cd p2p && go test ./... -coverprofile cover.out && go tool cover -func cover.out | grep total

total:							(statements)		78.3%
```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

9. **Does the existing `node.sh` continue to work with this change?**

    **YES**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**
