### PR TITLE
Add nil check on leader checks

### DIFF
--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -510,7 +510,8 @@ func (consensus *Consensus) UpdateConsensusInformation() Mode {
 			}
 
 			// If the leader changed and I myself become the leader
-			if !consensus.LeaderPubKey.Object.IsEqual(oldLeader.Object) && consensus.IsLeader() {
+			if (oldLeader != nil && consensus.LeaderPubKey != nil &&
+				!consensus.LeaderPubKey.Object.IsEqual(oldLeader.Object)) && consensus.IsLeader() {
 				go func() {
 					utils.Logger().Debug().
 						Str("myKey", consensus.PubKey.SerializeToHexStr()).


### PR DESCRIPTION
OldLeader can be nill when the node is first started. This wasn't a problem because since the IsEqual works with nil param. But now we are dereferencing the Object from the oldLeader, and it needs a nil check.