### PR TITLE
Bind public keys into private key wrapper

### DIFF
--- a/consensus/consensus_service_test.go
+++ b/consensus/consensus_service_test.go
@@ -25,7 +25,7 @@ func TestPopulateMessageFields(t *testing.T) {
 		quorum.SuperMajorityVote, shard.BeaconChainShardID,
 	)
 	consensus, err := New(
-		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKey(blsPriKey), decider,
+		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(blsPriKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
@@ -66,7 +66,7 @@ func TestSignAndMarshalConsensusMessage(t *testing.T) {
 	decider := quorum.NewDecider(quorum.SuperMajorityVote, shard.BeaconChainShardID)
 	blsPriKey := bls.RandPrivateKey()
 	consensus, err := New(
-		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKey(blsPriKey), decider,
+		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(blsPriKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
@@ -97,7 +97,7 @@ func TestSetViewID(t *testing.T) {
 	)
 	blsPriKey := bls.RandPrivateKey()
 	consensus, err := New(
-		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKey(blsPriKey), decider,
+		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(blsPriKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -22,7 +22,7 @@ func TestNew(test *testing.T) {
 		quorum.SuperMajorityVote, shard.BeaconChainShardID,
 	)
 	consensus, err := New(
-		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKey(bls.RandPrivateKey()), decider,
+		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(bls.RandPrivateKey()), decider,
 	)
 	if err != nil {
 		test.Fatalf("Cannot craeate consensus: %v", err)

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -107,10 +107,7 @@ func (consensus *Consensus) finalizeCommits() {
 		return
 	}
 	// Construct committed message
-	// TODO(audit): wrap bls private key with public key
-	leaderPubKeyBytes := shard.BLSPublicKey{}
-	leaderPubKeyBytes.FromLibBLSPublicKey(leaderPriKey.GetPublicKey())
-	network, err := consensus.construct(msg_pb.MessageType_COMMITTED, nil, leaderPubKeyBytes, leaderPriKey)
+	network, err := consensus.construct(msg_pb.MessageType_COMMITTED, nil, leaderPriKey)
 	if err != nil {
 		consensus.getLogger().Warn().Err(err).
 			Msg("[FinalizeCommits] Unable to construct Committed message")
@@ -522,7 +519,7 @@ func (consensus *Consensus) GenerateVrfAndProof(newBlock *types.Block, vrfBlockN
 			Msg("[GenerateVrfAndProof] VRF generation error")
 		return vrfBlockNumbers
 	}
-	sk := vrf_bls.NewVRFSigner(key)
+	sk := vrf_bls.NewVRFSigner(key.Pri)
 	blockHash := [32]byte{}
 	previousHeader := consensus.ChainReader.GetHeaderByNumber(
 		newBlock.NumberU64() - 1,

--- a/consensus/threshold.go
+++ b/consensus/threshold.go
@@ -21,7 +21,7 @@ func (consensus *Consensus) didReachPrepareQuorum() error {
 	}
 	// Construct and broadcast prepared message
 	networkMessage, err := consensus.construct(
-		msg_pb.MessageType_PREPARED, nil, consensus.LeaderPubKey.Bytes, leaderPriKey,
+		msg_pb.MessageType_PREPARED, nil, leaderPriKey,
 	)
 	if err != nil {
 		consensus.getLogger().Err(err).
@@ -50,16 +50,16 @@ func (consensus *Consensus) didReachPrepareQuorum() error {
 
 	// so by this point, everyone has committed to the blockhash of this block
 	// in prepare and so this is the actual block.
-	for i, key := range consensus.PubKey {
-		if err := consensus.commitBitmap.SetKey(key.Object, true); err != nil {
+	for i, key := range consensus.priKey {
+		if err := consensus.commitBitmap.SetKey(key.Pub.Object, true); err != nil {
 			consensus.getLogger().Warn().Msgf("[OnPrepare] Leader commit bitmap set failed for key at index %d", i)
 			continue
 		}
 
 		if _, err := consensus.Decider.AddNewVote(
 			quorum.Commit,
-			key.Bytes,
-			consensus.priKey.PrivateKey[i].SignHash(commitPayload),
+			key.Pub.Bytes,
+			key.Pri.SignHash(commitPayload),
 			blockObj.Hash(),
 			blockObj.NumberU64(),
 			blockObj.Header().ViewID().Uint64(),

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -59,11 +59,11 @@ func (consensus *Consensus) onAnnounce(msg *msg_pb.Message) {
 
 func (consensus *Consensus) prepare() {
 	groupID := []nodeconfig.GroupID{nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(consensus.ShardID))}
-	for i, key := range consensus.PubKey {
-		if !consensus.IsValidatorInCommittee(key.Bytes) {
+	for _, key := range consensus.priKey {
+		if !consensus.IsValidatorInCommittee(key.Pub.Bytes) {
 			continue
 		}
-		networkMessage, err := consensus.construct(msg_pb.MessageType_PREPARE, nil, key.Bytes, consensus.priKey.PrivateKey[i])
+		networkMessage, err := consensus.construct(msg_pb.MessageType_PREPARE, nil, &key)
 		if err != nil {
 			consensus.getLogger().Err(err).
 				Str("message-type", msg_pb.MessageType_PREPARE.String()).
@@ -210,15 +210,15 @@ func (consensus *Consensus) onPrepared(msg *msg_pb.Message) {
 	groupID := []nodeconfig.GroupID{
 		nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(consensus.ShardID)),
 	}
-	for i, key := range consensus.PubKey {
-		if !consensus.IsValidatorInCommittee(key.Bytes) {
+	for _, key := range consensus.priKey {
+		if !consensus.IsValidatorInCommittee(key.Pub.Bytes) {
 			continue
 		}
 
 		networkMessage, _ := consensus.construct(
 			msg_pb.MessageType_COMMIT,
 			commitPayload,
-			key.Bytes, consensus.priKey.PrivateKey[i],
+			&key,
 		)
 
 		if consensus.current.Mode() != Listening {

--- a/crypto/bls/bls.go
+++ b/crypto/bls/bls.go
@@ -96,6 +96,12 @@ func NewMask(publics []*bls.PublicKey, myKey *bls.PublicKey) (*Mask, error) {
 	return m, nil
 }
 
+// Clear clears the existing bits and aggregate public keys.
+func (m *Mask) Clear() {
+	m.Bitmap = make([]byte, m.Len())
+	m.AggregatePublic = &bls.PublicKey{}
+}
+
 // Mask returns a copy of the participation bitmask.
 func (m *Mask) Mask() []byte {
 	clone := make([]byte, len(m.Bitmap))

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -835,9 +835,9 @@ func (b *APIBackend) GetNodeMetadata() commonRPC.NodeMetadata {
 	}
 
 	blsKeys := []string{}
-	if cfg.ConsensusPubKey != nil {
-		for _, key := range cfg.ConsensusPubKey {
-			blsKeys = append(blsKeys, key.Bytes.Hex())
+	if cfg.ConsensusPriKey != nil {
+		for _, key := range cfg.ConsensusPriKey {
+			blsKeys = append(blsKeys, key.Pub.Bytes.Hex())
 		}
 	}
 	c := commonRPC.C{}

--- a/internal/configs/node/config.go
+++ b/internal/configs/node/config.go
@@ -76,8 +76,7 @@ type ConfigType struct {
 	IP              string  // IP of the node.
 	StringRole      string
 	P2PPriKey       p2p_crypto.PrivKey
-	ConsensusPriKey *multibls.PrivateKey
-	ConsensusPubKey multibls.PublicKeys
+	ConsensusPriKey multibls.PrivateKeys
 	// Database directory
 	DBDir            string
 	networkType      NetworkType
@@ -268,7 +267,7 @@ func (conf *ConfigType) ShardIDFromKey(key *bls.PublicKey) (uint32, error) {
 // ShardIDFromConsensusKey returns the shard ID statically determined from the
 // consensus key.
 func (conf *ConfigType) ShardIDFromConsensusKey() (uint32, error) {
-	return conf.ShardIDFromKey(conf.ConsensusPubKey[0].Object)
+	return conf.ShardIDFromKey(conf.ConsensusPriKey[0].Pub.Object)
 }
 
 // ValidateConsensusKeysForSameShard checks if all consensus public keys belong to the same shard

--- a/multibls/multibls.go
+++ b/multibls/multibls.go
@@ -8,10 +8,8 @@ import (
 	"github.com/harmony-one/bls/ffi/go/bls"
 )
 
-// PrivateKey stores the bls secret keys that belongs to the node
-type PrivateKey struct {
-	PrivateKey []*bls.SecretKey
-}
+// PrivateKeys stores the bls secret keys that belongs to the node
+type PrivateKeys []shard.BLSPrivateKeyWrapper
 
 // PublicKeys stores the bls public keys that belongs to the node
 type PublicKeys []shard.BLSPublicKeyWrapper
@@ -38,35 +36,20 @@ func (multiKey PublicKeys) Contains(pubKey *bls.PublicKey) bool {
 	return false
 }
 
-// GetPublicKey wrapper
-func (multiKey PrivateKey) GetPublicKey() PublicKeys {
-	pubKeys := make([]shard.BLSPublicKeyWrapper, len(multiKey.PrivateKey))
-	for i, key := range multiKey.PrivateKey {
-		wrapper := shard.BLSPublicKeyWrapper{Object: key.GetPublicKey()}
-		wrapper.Bytes.FromLibBLSPublicKey(wrapper.Object)
-		pubKeys[i] = wrapper
+// GetPublicKeys wrapper
+func (multiKey PrivateKeys) GetPublicKeys() PublicKeys {
+	pubKeys := make([]shard.BLSPublicKeyWrapper, len(multiKey))
+	for i, key := range multiKey {
+		pubKeys[i] = *key.Pub
 	}
 
 	return pubKeys
 }
 
-// GetPrivateKey creates a multibls PrivateKey using bls.SecretKey
-func GetPrivateKey(key *bls.SecretKey) *PrivateKey {
-	return &PrivateKey{PrivateKey: []*bls.SecretKey{key}}
-}
-
-// GetPublicKey creates a multibls PublicKeys using bls.PublicKeys
-func GetPublicKey(key *bls.PublicKey) PublicKeys {
-	keyBytes := shard.BLSPublicKey{}
-	keyBytes.FromLibBLSPublicKey(key)
-	return PublicKeys{shard.BLSPublicKeyWrapper{Object: key, Bytes: keyBytes}}
-}
-
-// AppendPriKey appends a SecretKey to multibls PrivateKey
-func AppendPriKey(multiKey *PrivateKey, key *bls.SecretKey) {
-	if multiKey != nil {
-		multiKey.PrivateKey = append(multiKey.PrivateKey, key)
-	} else {
-		multiKey = &PrivateKey{PrivateKey: []*bls.SecretKey{key}}
-	}
+// GetPrivateKeys creates a multibls PrivateKeys using bls.SecretKey
+func GetPrivateKeys(key *bls.SecretKey) PrivateKeys {
+	pub := key.GetPublicKey()
+	pubWrapper := shard.BLSPublicKeyWrapper{Object: pub}
+	pubWrapper.Bytes.FromLibBLSPublicKey(pub)
+	return PrivateKeys{shard.BLSPrivateKeyWrapper{Pri: key, Pub: &pubWrapper}}
 }

--- a/node/node.go
+++ b/node/node.go
@@ -577,7 +577,7 @@ func (node *Node) InitConsensusWithValidators() (err error) {
 	}
 
 	for _, key := range pubKeys {
-		if node.Consensus.PubKey.Contains(key) {
+		if node.Consensus.GetPublicKeys().Contains(key) {
 			utils.Logger().Info().
 				Uint64("blockNum", blockNum).
 				Int("numPubKeys", len(pubKeys)).
@@ -683,7 +683,7 @@ func (node *Node) populateSelfAddresses(epoch *big.Int) {
 		return
 	}
 
-	for _, blskey := range node.Consensus.PubKey {
+	for _, blskey := range node.Consensus.GetPublicKeys() {
 		blsStr := blskey.Bytes.Hex()
 		shardkey := shard.FromLibBLSPublicKeyUnsafe(blskey.Object)
 		if shardkey == nil {

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -413,7 +413,7 @@ func (node *Node) numSignaturesIncludedInBlock(block *types.Block) uint32 {
 	if err != nil {
 		return count
 	}
-	for _, key := range node.Consensus.PubKey {
+	for _, key := range node.Consensus.GetPublicKeys() {
 		if ok, err := mask.KeyEnabled(key.Object); err == nil && ok {
 			count++
 		}

--- a/node/node_handler_test.go
+++ b/node/node_handler_test.go
@@ -29,7 +29,7 @@ func TestAddNewBlock(t *testing.T) {
 		quorum.SuperMajorityVote, shard.BeaconChainShardID,
 	)
 	consensus, err := consensus.New(
-		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKey(blsKey), decider,
+		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(blsKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
@@ -69,7 +69,7 @@ func TestVerifyNewBlock(t *testing.T) {
 		quorum.SuperMajorityVote, shard.BeaconChainShardID,
 	)
 	consensus, err := consensus.New(
-		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKey(blsKey), decider,
+		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(blsKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -31,7 +31,7 @@ func TestNewNode(t *testing.T) {
 		quorum.SuperMajorityVote, shard.BeaconChainShardID,
 	)
 	consensus, err := consensus.New(
-		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKey(blsKey), decider,
+		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(blsKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
@@ -201,7 +201,7 @@ func TestAddBeaconPeer(t *testing.T) {
 		quorum.SuperMajorityVote, shard.BeaconChainShardID,
 	)
 	consensus, err := consensus.New(
-		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKey(blsKey), decider,
+		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(blsKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)

--- a/shard/shard_state.go
+++ b/shard/shard_state.go
@@ -37,6 +37,12 @@ type State struct {
 	Shards []Committee `json:"shards"`
 }
 
+// BLSPrivateKeyWrapper combines the bls private key and the corresponding public key
+type BLSPrivateKeyWrapper struct {
+	Pri *bls.SecretKey
+	Pub *BLSPublicKeyWrapper
+}
+
 // BLSPublicKeyWrapper defines the bls public key in both serialized and
 // deserialized form.
 type BLSPublicKeyWrapper struct {

--- a/staking/types/messages_test.go
+++ b/staking/types/messages_test.go
@@ -372,7 +372,7 @@ func cpTestDataSetup() {
 // 	validatorAddress  = common.Address(common.MustBech32ToAddress("one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy"))
 // 	validatorAddress2 = common.Address(common.MustBech32ToAddress("one1d2rngmem4x2c6zxsjjz29dlah0jzkr0k2n88wc"))
 // 	delegatorAddress  = common.Address(common.MustBech32ToAddress("one16qsd5ant9v94jrs89mruzx62h7ekcfxmduh2rx"))
-// 	blsPubKey         = bls.RandPrivateKey().GetPublicKey()
+// 	blsPubKey         = bls.RandPrivateKey().GetPublicKeys()
 // )
 
 // func TestMsgCreateValidatorRLP(t *testing.T) {


### PR DESCRIPTION
Create BLSPrivateKeyWrapper and wrap private and public key together.

Also avoid recreation of BLS Mask for every round of consensus.

Tested locally with consensus and view change.