### PR TITLE
[RPC] Fix block "miner" field

### DIFF
--- a/hmy/backend.go
+++ b/hmy/backend.go
@@ -11,6 +11,11 @@ import (
 	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/core/types"
 	staking "github.com/harmony-one/harmony/staking/types"
+	lru "github.com/hashicorp/golang-lru"
+)
+
+const (
+	leaderCacheSize = 250 // Approx number of BLS keys in committee
 )
 
 // Harmony implements the Harmony full node service.
@@ -73,7 +78,9 @@ func New(
 		networkID:     1, // TODO(ricl): this should be from config
 		shardID:       shardID,
 	}
-	hmy.APIBackend = &APIBackend{hmy: hmy,
+	cache, _ := lru.New(leaderCacheSize)
+	hmy.APIBackend = &APIBackend{
+		hmy: hmy,
 		TotalStakingCache: struct {
 			sync.Mutex
 			BlockHeight  int64
@@ -82,6 +89,7 @@ func New(
 			BlockHeight:  -1,
 			TotalStaking: big.NewInt(0),
 		},
+		LeaderCache: cache,
 	}
 	return hmy, nil
 }

--- a/internal/hmyapi/apiv1/backend.go
+++ b/internal/hmyapi/apiv1/backend.go
@@ -94,4 +94,5 @@ type Backend interface {
 	GetNodeMetadata() commonRPC.NodeMetadata
 	GetBlockSigners(ctx context.Context, blockNr rpc.BlockNumber) (shard.SlotList, *bls.Mask, error)
 	IsStakingEpoch(epoch *big.Int) bool
+	GetLeaderAddress(a common.Address, e *big.Int) string
 }

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -85,7 +85,7 @@ func (s *PublicBlockChainAPI) GetBlockByNumber(ctx context.Context, blockNr rpc.
 	block, err := s.b.BlockByNumber(ctx, blockNr)
 	if block != nil {
 		blockArgs := BlockArgs{WithSigners: false, InclTx: true, FullTx: fullTx, InclStaking: true}
-		response, err := RPCMarshalBlock(block, blockArgs)
+		response, err := RPCMarshalBlock(block, blockArgs, s.b.IsStakingEpoch(block.Header().Epoch()))
 		if err == nil && blockNr == rpc.PendingBlockNumber {
 			// Pending blocks need to nil out a few fields
 			for _, field := range []string{"hash", "nonce", "miner"} {
@@ -103,7 +103,7 @@ func (s *PublicBlockChainAPI) GetBlockByHash(ctx context.Context, blockHash comm
 	block, err := s.b.GetBlock(ctx, blockHash)
 	if block != nil {
 		blockArgs := BlockArgs{WithSigners: false, InclTx: true, FullTx: fullTx, InclStaking: true}
-		return RPCMarshalBlock(block, blockArgs)
+		return RPCMarshalBlock(block, blockArgs, s.b.IsStakingEpoch(block.Header().Epoch()))
 	}
 	return nil, err
 }
@@ -124,7 +124,7 @@ func (s *PublicBlockChainAPI) GetBlockByNumberNew(ctx context.Context, blockNr r
 		}
 	}
 	if block != nil {
-		response, err := RPCMarshalBlock(block, blockArgs)
+		response, err := RPCMarshalBlock(block, blockArgs, s.b.IsStakingEpoch(block.Header().Epoch()))
 		if err == nil && blockNr == rpc.PendingBlockNumber {
 			// Pending blocks need to nil out a few fields
 			for _, field := range []string{"hash", "nonce", "miner"} {
@@ -149,7 +149,7 @@ func (s *PublicBlockChainAPI) GetBlockByHashNew(ctx context.Context, blockHash c
 		}
 	}
 	if block != nil {
-		return RPCMarshalBlock(block, blockArgs)
+		return RPCMarshalBlock(block, blockArgs, s.b.IsStakingEpoch(block.Header().Epoch()))
 	}
 	return nil, err
 }
@@ -167,7 +167,7 @@ func (s *PublicBlockChainAPI) GetBlocks(ctx context.Context, blockStart rpc.Bloc
 			}
 		}
 		if block != nil {
-			rpcBlock, err := RPCMarshalBlock(block, blockArgs)
+			rpcBlock, err := RPCMarshalBlock(block, blockArgs, s.b.IsStakingEpoch(block.Header().Epoch()))
 			if err == nil && i == rpc.PendingBlockNumber {
 				// Pending blocks need to nil out a few fields
 				for _, field := range []string{"hash", "nonce", "miner"} {

--- a/internal/hmyapi/apiv1/types.go
+++ b/internal/hmyapi/apiv1/types.go
@@ -2,21 +2,48 @@ package apiv1
 
 import (
 	"encoding/hex"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/harmony-one/harmony/numeric"
 	"math/big"
 	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/harmony-one/harmony/block"
 	"github.com/harmony-one/harmony/core/types"
 	internal_common "github.com/harmony-one/harmony/internal/common"
-	"github.com/harmony-one/harmony/numeric"
 	"github.com/harmony-one/harmony/shard"
 	staking "github.com/harmony-one/harmony/staking/types"
 )
+
+// RPCBlock represents a block that will serialize to the RPC representation of a block
+type RPCBlock struct {
+	Number           *hexutil.Big     `json:"number"`
+	ViewID           *hexutil.Big     `json:"viewID"`
+	Epoch            *hexutil.Big     `json:"epoch"`
+	Hash             common.Hash      `json:"hash"`
+	ParentHash       common.Hash      `json:"parentHash"`
+	Nonce            types.BlockNonce `json:"nonce"`
+	MixHash          common.Hash      `json:"mixHash"`
+	LogsBloom        ethtypes.Bloom   `json:"logsBloom"`
+	StateRoot        common.Hash      `json:"stateRoot"`
+	Miner            common.Address   `json:"miner"`
+	Difficulty       *hexutil.Big     `json:"difficulty"`
+	ExtraData        []byte           `json:"extraData"`
+	Size             hexutil.Uint64   `json:"size"`
+	GasLimit         hexutil.Uint64   `json:"gasLimit"`
+	GasUsed          hexutil.Uint64   `json:"gasUsed"`
+	Timestamp        *big.Int         `json:"timestamp"`
+	TransactionsRoot common.Hash      `json:"transactionsRoot"`
+	ReceiptsRoot     common.Hash      `json:"receiptsRoot"`
+	Transactions     []interface{}    `json:"transactions"`
+	StakingTxs       []interface{}    `json:"stakingTxs"`
+	Uncles           []common.Hash    `json:"uncles"`
+	TotalDifficulty  *big.Int         `json:"totalDifficulty"`
+	Signers          []string         `json:"signers"`
+}
 
 // RPCTransaction represents a transaction that will serialize to the RPC representation of a transaction
 type RPCTransaction struct {
@@ -97,6 +124,25 @@ type RPCDelegation struct {
 type RPCUndelegation struct {
 	Amount *big.Int
 	Epoch  *big.Int
+}
+
+// CallArgs represents the arguments for a call.
+type CallArgs struct {
+	From     *common.Address `json:"from"`
+	To       *common.Address `json:"to"`
+	Gas      *hexutil.Uint64 `json:"gas"`
+	GasPrice *hexutil.Big    `json:"gasPrice"`
+	Value    *hexutil.Big    `json:"value"`
+	Data     *hexutil.Bytes  `json:"data"`
+}
+
+// StakingNetworkInfo returns global staking info.
+type StakingNetworkInfo struct {
+	TotalSupply       numeric.Dec `json:"total-supply"`
+	CirculatingSupply numeric.Dec `json:"circulating-supply"`
+	EpochLastBlock    uint64      `json:"epoch-last-block"`
+	TotalStaking      *big.Int    `json:"total-staking"`
+	MedianRawStake    numeric.Dec `json:"median-raw-stake"`
 }
 
 func newHeaderInformation(header *block.Header, isStaking bool) *HeaderInformation {
@@ -377,33 +423,6 @@ func newRPCStakingTransaction(tx *staking.StakingTransaction, blockHash common.H
 	return result
 }
 
-// RPCBlock represents a block that will serialize to the RPC representation of a block
-type RPCBlock struct {
-	Number           *hexutil.Big     `json:"number"`
-	ViewID           *hexutil.Big     `json:"viewID"`
-	Epoch            *hexutil.Big     `json:"epoch"`
-	Hash             common.Hash      `json:"hash"`
-	ParentHash       common.Hash      `json:"parentHash"`
-	Nonce            types.BlockNonce `json:"nonce"`
-	MixHash          common.Hash      `json:"mixHash"`
-	LogsBloom        ethtypes.Bloom   `json:"logsBloom"`
-	StateRoot        common.Hash      `json:"stateRoot"`
-	Miner            common.Address   `json:"miner"`
-	Difficulty       *hexutil.Big     `json:"difficulty"`
-	ExtraData        []byte           `json:"extraData"`
-	Size             hexutil.Uint64   `json:"size"`
-	GasLimit         hexutil.Uint64   `json:"gasLimit"`
-	GasUsed          hexutil.Uint64   `json:"gasUsed"`
-	Timestamp        *big.Int         `json:"timestamp"`
-	TransactionsRoot common.Hash      `json:"transactionsRoot"`
-	ReceiptsRoot     common.Hash      `json:"receiptsRoot"`
-	Transactions     []interface{}    `json:"transactions"`
-	StakingTxs       []interface{}    `json:"stakingTxs"`
-	Uncles           []common.Hash    `json:"uncles"`
-	TotalDifficulty  *big.Int         `json:"totalDifficulty"`
-	Signers          []string         `json:"signers"`
-}
-
 // RPCMarshalBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
 // returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
 // transaction hashes.
@@ -518,25 +537,6 @@ func newRPCStakingTransactionFromBlockIndex(b *types.Block, index uint64) *RPCSt
 		return nil
 	}
 	return newRPCStakingTransaction(txs[index], b.Hash(), b.NumberU64(), b.Time().Uint64(), index)
-}
-
-// CallArgs represents the arguments for a call.
-type CallArgs struct {
-	From     *common.Address `json:"from"`
-	To       *common.Address `json:"to"`
-	Gas      *hexutil.Uint64 `json:"gas"`
-	GasPrice *hexutil.Big    `json:"gasPrice"`
-	Value    *hexutil.Big    `json:"value"`
-	Data     *hexutil.Bytes  `json:"data"`
-}
-
-// StakingNetworkInfo returns global staking info.
-type StakingNetworkInfo struct {
-	TotalSupply       numeric.Dec `json:"total-supply"`
-	CirculatingSupply numeric.Dec `json:"circulating-supply"`
-	EpochLastBlock    uint64      `json:"epoch-last-block"`
-	TotalStaking      *big.Int    `json:"total-staking"`
-	MedianRawStake    numeric.Dec `json:"median-raw-stake"`
 }
 
 // getRPCLeader returns either the leader one address (before staking)

--- a/internal/hmyapi/apiv1/types.go
+++ b/internal/hmyapi/apiv1/types.go
@@ -145,7 +145,7 @@ type StakingNetworkInfo struct {
 	MedianRawStake    numeric.Dec `json:"median-raw-stake"`
 }
 
-func newHeaderInformation(header *block.Header, isStaking bool) *HeaderInformation {
+func newHeaderInformation(header *block.Header, leader string) *HeaderInformation {
 	if header == nil {
 		return nil
 	}
@@ -154,6 +154,7 @@ func newHeaderInformation(header *block.Header, isStaking bool) *HeaderInformati
 		BlockHash:        header.Hash(),
 		BlockNumber:      header.Number().Uint64(),
 		ShardID:          header.ShardID(),
+		Leader:           leader,
 		ViewID:           header.ViewID().Uint64(),
 		Epoch:            header.Epoch().Uint64(),
 		UnixTime:         header.Time().Uint64(),
@@ -163,8 +164,6 @@ func newHeaderInformation(header *block.Header, isStaking bool) *HeaderInformati
 
 	sig := header.LastCommitSignature()
 	result.LastCommitSig = hex.EncodeToString(sig[:])
-
-	result.Leader = getRPCLeader(header, isStaking)
 
 	if header.ShardID() == shard.BeaconChainShardID {
 		decodedCrossLinks := &types.CrossLinks{}
@@ -426,7 +425,7 @@ func newRPCStakingTransaction(tx *staking.StakingTransaction, blockHash common.H
 // RPCMarshalBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
 // returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
 // transaction hashes.
-func RPCMarshalBlock(b *types.Block, blockArgs BlockArgs, isStaking bool) (map[string]interface{}, error) {
+func RPCMarshalBlock(b *types.Block, blockArgs BlockArgs, leader string) (map[string]interface{}, error) {
 	head := b.Header() // copies the header once
 	fields := map[string]interface{}{
 		"number":           (*hexutil.Big)(head.Number()),
@@ -438,6 +437,7 @@ func RPCMarshalBlock(b *types.Block, blockArgs BlockArgs, isStaking bool) (map[s
 		"mixHash":          head.MixDigest(),
 		"logsBloom":        head.Bloom(),
 		"stateRoot":        head.Root(),
+		"miner":			leader,
 		"difficulty":       0, // Remove this because we don't have it in our header
 		"extraData":        hexutil.Bytes(head.Extra()),
 		"size":             hexutil.Uint64(b.Size()),
@@ -447,8 +447,6 @@ func RPCMarshalBlock(b *types.Block, blockArgs BlockArgs, isStaking bool) (map[s
 		"transactionsRoot": head.TxHash(),
 		"receiptsRoot":     head.ReceiptHash(),
 	}
-
-	fields["miner"] = getRPCLeader(head, isStaking)
 
 	if blockArgs.InclTx {
 		formatTx := func(tx *types.Transaction) (interface{}, error) {
@@ -537,18 +535,4 @@ func newRPCStakingTransactionFromBlockIndex(b *types.Block, index uint64) *RPCSt
 		return nil
 	}
 	return newRPCStakingTransaction(txs[index], b.Hash(), b.NumberU64(), b.Time().Uint64(), index)
-}
-
-// getRPCLeader returns either the leader one address (before staking)
-// or the first 20 bytes of the leader bls public key (after staking)
-func getRPCLeader(h *block.Header, isStaking bool) string {
-	if isStaking {
-		return strings.ToLower(h.Coinbase().Hex())
-	} else {
-		addr, err := internal_common.AddressToBech32(h.Coinbase())
-		if err != nil {
-			addr = h.Coinbase().Hex()
-		}
-		return addr
-	}
 }

--- a/internal/hmyapi/apiv2/backend.go
+++ b/internal/hmyapi/apiv2/backend.go
@@ -90,4 +90,5 @@ type Backend interface {
 	GetNodeMetadata() commonRPC.NodeMetadata
 	GetBlockSigners(ctx context.Context, blockNr rpc.BlockNumber) (shard.SlotList, *bls.Mask, error)
 	IsStakingEpoch(epoch *big.Int) bool
+	GetLeaderAddress(a common.Address, e *big.Int) string
 }

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -86,7 +86,8 @@ func (s *PublicBlockChainAPI) GetBlockByNumber(ctx context.Context, blockNr uint
 				return nil, err
 			}
 		}
-		response, err := RPCMarshalBlock(block, blockArgs, s.b.IsStakingEpoch(block.Header().Epoch()))
+		leader := s.b.GetLeaderAddress(block.Header().Coinbase(), block.Header().Epoch())
+		response, err := RPCMarshalBlock(block, blockArgs, leader)
 		if err == nil && rpc.BlockNumber(blockNr) == rpc.PendingBlockNumber {
 			// Pending blocks need to nil out a few fields
 			for _, field := range []string{"hash", "nonce", "miner"} {
@@ -111,7 +112,8 @@ func (s *PublicBlockChainAPI) GetBlockByHash(ctx context.Context, blockHash comm
 				return nil, err
 			}
 		}
-		return RPCMarshalBlock(block, blockArgs, s.b.IsStakingEpoch(block.Header().Epoch()))
+		leader := s.b.GetLeaderAddress(block.Header().Coinbase(), block.Header().Epoch())
+		return RPCMarshalBlock(block, blockArgs, leader)
 	}
 	return nil, err
 }
@@ -129,7 +131,8 @@ func (s *PublicBlockChainAPI) GetBlocks(ctx context.Context, blockStart, blockEn
 			}
 		}
 		if block != nil {
-			rpcBlock, err := RPCMarshalBlock(block, blockArgs, s.b.IsStakingEpoch(block.Header().Epoch()))
+			leader := s.b.GetLeaderAddress(block.Header().Coinbase(), block.Header().Epoch())
+			rpcBlock, err := RPCMarshalBlock(block, blockArgs, leader)
 			if err == nil && rpc.BlockNumber(i) == rpc.PendingBlockNumber {
 				// Pending blocks need to nil out a few fields
 				for _, field := range []string{"hash", "nonce", "miner"} {
@@ -518,7 +521,8 @@ func doCall(ctx context.Context, b Backend, args CallArgs, blockNr rpc.BlockNumb
 // LatestHeader returns the latest header information
 func (s *PublicBlockChainAPI) LatestHeader(ctx context.Context) *HeaderInformation {
 	header, _ := s.b.HeaderByNumber(context.Background(), rpc.LatestBlockNumber) // latest header should always be available
-	return newHeaderInformation(header, s.b.IsStakingEpoch(header.Epoch()))
+	leader := s.b.GetLeaderAddress(header.Coinbase(), header.Epoch())
+	return newHeaderInformation(header, leader)
 }
 
 // GetHeaderByNumber returns block header at given number
@@ -530,7 +534,8 @@ func (s *PublicBlockChainAPI) GetHeaderByNumber(ctx context.Context, blockNum ui
 	if err != nil {
 		return nil, err
 	}
-	return newHeaderInformation(header, s.b.IsStakingEpoch(header.Epoch())), nil
+	leader := s.b.GetLeaderAddress(header.Coinbase(), header.Epoch())
+	return newHeaderInformation(header, leader), nil
 }
 
 // GetTotalStaking returns total staking by validators, only meant to be called on beaconchain

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -86,7 +86,7 @@ func (s *PublicBlockChainAPI) GetBlockByNumber(ctx context.Context, blockNr uint
 				return nil, err
 			}
 		}
-		response, err := RPCMarshalBlock(block, blockArgs)
+		response, err := RPCMarshalBlock(block, blockArgs, s.b.IsStakingEpoch(block.Header().Epoch()))
 		if err == nil && rpc.BlockNumber(blockNr) == rpc.PendingBlockNumber {
 			// Pending blocks need to nil out a few fields
 			for _, field := range []string{"hash", "nonce", "miner"} {
@@ -111,7 +111,7 @@ func (s *PublicBlockChainAPI) GetBlockByHash(ctx context.Context, blockHash comm
 				return nil, err
 			}
 		}
-		return RPCMarshalBlock(block, blockArgs)
+		return RPCMarshalBlock(block, blockArgs, s.b.IsStakingEpoch(block.Header().Epoch()))
 	}
 	return nil, err
 }
@@ -129,7 +129,7 @@ func (s *PublicBlockChainAPI) GetBlocks(ctx context.Context, blockStart, blockEn
 			}
 		}
 		if block != nil {
-			rpcBlock, err := RPCMarshalBlock(block, blockArgs)
+			rpcBlock, err := RPCMarshalBlock(block, blockArgs, s.b.IsStakingEpoch(block.Header().Epoch()))
 			if err == nil && rpc.BlockNumber(i) == rpc.PendingBlockNumber {
 				// Pending blocks need to nil out a few fields
 				for _, field := range []string{"hash", "nonce", "miner"} {

--- a/internal/hmyapi/apiv2/types.go
+++ b/internal/hmyapi/apiv2/types.go
@@ -39,7 +39,7 @@ type RPCBlock struct {
 	TransactionsRoot common.Hash      `json:"transactionsRoot"`
 	ReceiptsRoot     common.Hash      `json:"receiptsRoot"`
 	Transactions     []interface{}    `json:"transactions"`
-	StakingTxs       []interface{}    `json:"stakingTxs`
+	StakingTxs       []interface{}    `json:"stakingTxs"`
 	Uncles           []common.Hash    `json:"uncles"`
 	TotalDifficulty  *big.Int         `json:"totalDifficulty"`
 	Signers          []string         `json:"signers"`
@@ -145,7 +145,7 @@ type StakingNetworkInfo struct {
 	MedianRawStake    numeric.Dec `json:"median-raw-stake"`
 }
 
-func newHeaderInformation(header *block.Header, isStaking bool) *HeaderInformation {
+func newHeaderInformation(header *block.Header, leader string) *HeaderInformation {
 	if header == nil {
 		return nil
 	}
@@ -154,6 +154,7 @@ func newHeaderInformation(header *block.Header, isStaking bool) *HeaderInformati
 		BlockHash:        header.Hash(),
 		BlockNumber:      header.Number().Uint64(),
 		ShardID:          header.ShardID(),
+		Leader:           leader,
 		ViewID:           header.ViewID().Uint64(),
 		Epoch:            header.Epoch().Uint64(),
 		UnixTime:         header.Time().Uint64(),
@@ -163,8 +164,6 @@ func newHeaderInformation(header *block.Header, isStaking bool) *HeaderInformati
 
 	sig := header.LastCommitSignature()
 	result.LastCommitSig = hex.EncodeToString(sig[:])
-
-	result.Leader = getRPCLeader(header, isStaking)
 
 	if header.ShardID() == shard.BeaconChainShardID {
 		decodedCrossLinks := &types.CrossLinks{}
@@ -427,7 +426,7 @@ func newRPCStakingTransaction(
 // RPCMarshalBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
 // returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
 // transaction hashes.
-func RPCMarshalBlock(b *types.Block, blockArgs BlockArgs, isStaking bool) (map[string]interface{}, error) {
+func RPCMarshalBlock(b *types.Block, blockArgs BlockArgs, leader string) (map[string]interface{}, error) {
 	head := b.Header() // copies the header once
 	fields := map[string]interface{}{
 		"number":           (*big.Int)(head.Number()),
@@ -439,6 +438,7 @@ func RPCMarshalBlock(b *types.Block, blockArgs BlockArgs, isStaking bool) (map[s
 		"mixHash":          head.MixDigest(),
 		"logsBloom":        head.Bloom(),
 		"stateRoot":        head.Root(),
+		"miner":            leader,
 		"difficulty":       0, // Remove this because we don't have it in our header
 		"extraData":        hexutil.Bytes(head.Extra()),
 		"size":             uint64(b.Size()),
@@ -448,8 +448,6 @@ func RPCMarshalBlock(b *types.Block, blockArgs BlockArgs, isStaking bool) (map[s
 		"transactionsRoot": head.TxHash(),
 		"receiptsRoot":     head.ReceiptHash(),
 	}
-
-	fields["miner"] = getRPCLeader(head, isStaking)
 
 	if blockArgs.InclTx {
 		formatTx := func(tx *types.Transaction) (interface{}, error) {
@@ -538,18 +536,4 @@ func newRPCStakingTransactionFromBlockIndex(b *types.Block, index uint64) *RPCSt
 		return nil
 	}
 	return newRPCStakingTransaction(txs[index], b.Hash(), b.NumberU64(), b.Time().Uint64(), index)
-}
-
-// getRPCLeader returns either the leader one address (before staking)
-// or the first 20 bytes of the leader bls public key (after staking)
-func getRPCLeader(h *block.Header, isStaking bool) string {
-	if isStaking {
-		return strings.ToLower(h.Coinbase().Hex())
-	} else {
-		addr, err := internal_common.AddressToBech32(h.Coinbase())
-		if err != nil {
-			addr = h.Coinbase().Hex()
-		}
-		return addr
-	}
 }

--- a/internal/hmyapi/apiv2/types.go
+++ b/internal/hmyapi/apiv2/types.go
@@ -2,21 +2,48 @@ package apiv2
 
 import (
 	"encoding/hex"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/harmony-one/harmony/numeric"
 	"math/big"
 	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/harmony-one/harmony/block"
 	"github.com/harmony-one/harmony/core/types"
 	internal_common "github.com/harmony-one/harmony/internal/common"
-	"github.com/harmony-one/harmony/numeric"
 	"github.com/harmony-one/harmony/shard"
 	staking "github.com/harmony-one/harmony/staking/types"
 )
+
+// RPCBlock represents a block that will serialize to the RPC representation of a block
+type RPCBlock struct {
+	Number           *big.Int         `json:"number"`
+	ViewID           *big.Int         `json:"viewID"`
+	Epoch            *big.Int         `json:"epoch"`
+	Hash             common.Hash      `json:"hash"`
+	ParentHash       common.Hash      `json:"parentHash"`
+	Nonce            types.BlockNonce `json:"nonce"`
+	MixHash          common.Hash      `json:"mixHash"`
+	LogsBloom        ethtypes.Bloom   `json:"logsBloom"`
+	StateRoot        common.Hash      `json:"stateRoot"`
+	Miner            string           `json:"miner"`
+	Difficulty       *big.Int         `json:"difficulty"`
+	ExtraData        []byte           `json:"extraData"`
+	Size             uint64           `json:"size"`
+	GasLimit         uint64           `json:"gasLimit"`
+	GasUsed          uint64           `json:"gasUsed"`
+	Timestamp        *big.Int         `json:"timestamp"`
+	TransactionsRoot common.Hash      `json:"transactionsRoot"`
+	ReceiptsRoot     common.Hash      `json:"receiptsRoot"`
+	Transactions     []interface{}    `json:"transactions"`
+	StakingTxs       []interface{}    `json:"stakingTxs`
+	Uncles           []common.Hash    `json:"uncles"`
+	TotalDifficulty  *big.Int         `json:"totalDifficulty"`
+	Signers          []string         `json:"signers"`
+}
 
 // RPCTransaction represents a transaction that will serialize to the RPC representation of a transaction
 type RPCTransaction struct {
@@ -97,6 +124,25 @@ type RPCDelegation struct {
 type RPCUndelegation struct {
 	Amount *big.Int
 	Epoch  *big.Int
+}
+
+// CallArgs represents the arguments for a call.
+type CallArgs struct {
+	From     *common.Address `json:"from"`
+	To       *common.Address `json:"to"`
+	Gas      *hexutil.Uint64 `json:"gas"`
+	GasPrice *hexutil.Big    `json:"gasPrice"`
+	Value    *hexutil.Big    `json:"value"`
+	Data     *hexutil.Bytes  `json:"data"`
+}
+
+// StakingNetworkInfo returns global staking info.
+type StakingNetworkInfo struct {
+	TotalSupply       numeric.Dec `json:"total-supply"`
+	CirculatingSupply numeric.Dec `json:"circulating-supply"`
+	EpochLastBlock    uint64      `json:"epoch-last-block"`
+	TotalStaking      *big.Int    `json:"total-staking"`
+	MedianRawStake    numeric.Dec `json:"median-raw-stake"`
 }
 
 func newHeaderInformation(header *block.Header, isStaking bool) *HeaderInformation {
@@ -378,33 +424,6 @@ func newRPCStakingTransaction(
 	return result
 }
 
-// RPCBlock represents a block that will serialize to the RPC representation of a block
-type RPCBlock struct {
-	Number           *big.Int         `json:"number"`
-	ViewID           *big.Int         `json:"viewID"`
-	Epoch            *big.Int         `json:"epoch"`
-	Hash             common.Hash      `json:"hash"`
-	ParentHash       common.Hash      `json:"parentHash"`
-	Nonce            types.BlockNonce `json:"nonce"`
-	MixHash          common.Hash      `json:"mixHash"`
-	LogsBloom        ethtypes.Bloom   `json:"logsBloom"`
-	StateRoot        common.Hash      `json:"stateRoot"`
-	Miner            string           `json:"miner"`
-	Difficulty       *big.Int         `json:"difficulty"`
-	ExtraData        []byte           `json:"extraData"`
-	Size             uint64           `json:"size"`
-	GasLimit         uint64           `json:"gasLimit"`
-	GasUsed          uint64           `json:"gasUsed"`
-	Timestamp        *big.Int         `json:"timestamp"`
-	TransactionsRoot common.Hash      `json:"transactionsRoot"`
-	ReceiptsRoot     common.Hash      `json:"receiptsRoot"`
-	Transactions     []interface{}    `json:"transactions"`
-	StakingTxs       []interface{}    `json:"stakingTxs`
-	Uncles           []common.Hash    `json:"uncles"`
-	TotalDifficulty  *big.Int         `json:"totalDifficulty"`
-	Signers          []string         `json:"signers"`
-}
-
 // RPCMarshalBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
 // returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
 // transaction hashes.
@@ -519,25 +538,6 @@ func newRPCStakingTransactionFromBlockIndex(b *types.Block, index uint64) *RPCSt
 		return nil
 	}
 	return newRPCStakingTransaction(txs[index], b.Hash(), b.NumberU64(), b.Time().Uint64(), index)
-}
-
-// CallArgs represents the arguments for a call.
-type CallArgs struct {
-	From     *common.Address `json:"from"`
-	To       *common.Address `json:"to"`
-	Gas      *hexutil.Uint64 `json:"gas"`
-	GasPrice *hexutil.Big    `json:"gasPrice"`
-	Value    *hexutil.Big    `json:"value"`
-	Data     *hexutil.Bytes  `json:"data"`
-}
-
-// StakingNetworkInfo returns global staking info.
-type StakingNetworkInfo struct {
-	TotalSupply       numeric.Dec `json:"total-supply"`
-	CirculatingSupply numeric.Dec `json:"circulating-supply"`
-	EpochLastBlock    uint64      `json:"epoch-last-block"`
-	TotalStaking      *big.Int    `json:"total-staking"`
-	MedianRawStake    numeric.Dec `json:"median-raw-stake"`
 }
 
 // getRPCLeader returns either the leader one address (before staking)

--- a/internal/hmyapi/backend.go
+++ b/internal/hmyapi/backend.go
@@ -84,6 +84,7 @@ type Backend interface {
 	GetNodeMetadata() commonRPC.NodeMetadata
 	GetBlockSigners(ctx context.Context, blockNr rpc.BlockNumber) (shard.SlotList, *bls.Mask, error)
 	IsStakingEpoch(epoch *big.Int) bool
+	GetLeaderAddress(a common.Address, e *big.Int) string
 }
 
 // GetAPIs returns all the APIs.


### PR DESCRIPTION
Fetch leader address from the API Backend Leader LRU cache.
If not found in cache, then search through committee slots until found.

Refactor to the `types.go` file to have all type definitions before functions