### PR TITLE
Remove expensive bls key serialization code and use the cached version

### DIFF
--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -350,14 +350,14 @@ func (consensus *Consensus) getLeaderPubKeyFromCoinbase(
 		if isStaking {
 			// After staking the coinbase address will be the address of bls public key
 			if utils.GetAddressFromBLSPubKeyBytes(member.BLSPublicKey[:]) == header.Coinbase() {
-				if err := member.BLSPublicKey.ToLibBLSPublicKey(committerKey); err != nil {
+				if committerKey, err = bls.BytesToBLSPublicKey(member.BLSPublicKey[:]); err != nil {
 					return nil, err
 				}
 				return &bls.PublicKeyWrapper{Object: committerKey, Bytes: member.BLSPublicKey}, nil
 			}
 		} else {
 			if member.EcdsaAddress == header.Coinbase() {
-				if err := member.BLSPublicKey.ToLibBLSPublicKey(committerKey); err != nil {
+				if committerKey, err = bls.BytesToBLSPublicKey(member.BLSPublicKey[:]); err != nil {
 					return nil, err
 				}
 				return &bls.PublicKeyWrapper{Object: committerKey, Bytes: member.BLSPublicKey}, nil

--- a/crypto/bls/bls.go
+++ b/crypto/bls/bls.go
@@ -82,8 +82,3 @@ func (pk *SerializedPublicKey) FromLibBLSPublicKey(key *bls.PublicKey) error {
 	copy(pk[:], bytes)
 	return nil
 }
-
-// ToLibBLSPublicKey copies the key contents into the given key.
-func (pk *SerializedPublicKey) ToLibBLSPublicKey(key *bls.PublicKey) error {
-	return key.Deserialize(pk[:])
-}

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/harmony-one/bls/ffi/go/bls"
+	bls_core "github.com/harmony-one/bls/ffi/go/bls"
 	"github.com/harmony-one/harmony/api/proto"
 	"github.com/harmony-one/harmony/block"
 	"github.com/harmony-one/harmony/consensus/quorum"
@@ -21,6 +21,7 @@ import (
 	"github.com/harmony-one/harmony/core/state"
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/core/vm"
+	"github.com/harmony-one/harmony/crypto/bls"
 	internal_bls "github.com/harmony-one/harmony/crypto/bls"
 	internal_common "github.com/harmony-one/harmony/internal/common"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
@@ -874,10 +875,11 @@ func (b *APIBackend) GetBlockSigners(ctx context.Context, blockNr rpc.BlockNumbe
 	if err != nil {
 		return nil, nil, err
 	}
-	pubkeys := make([]*bls.PublicKey, len(committee.Slots))
+	pubkeys := make([]*bls_core.PublicKey, len(committee.Slots))
 	for i, validator := range committee.Slots {
-		pubkeys[i] = new(bls.PublicKey)
-		validator.BLSPublicKey.ToLibBLSPublicKey(pubkeys[i])
+		if pubkeys[i], err = bls.BytesToBLSPublicKey(validator.BLSPublicKey[:]); err != nil {
+			return nil, nil, err
+		}
 	}
 	mask, err := internal_bls.NewMask(pubkeys, nil)
 	if err != nil {

--- a/internal/hmyapi/apiv1/blockchain.go
+++ b/internal/hmyapi/apiv1/blockchain.go
@@ -6,11 +6,13 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/harmony-one/harmony/crypto/bls"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/harmony-one/bls/ffi/go/bls"
+	bls_core "github.com/harmony-one/bls/ffi/go/bls"
 	"github.com/harmony-one/harmony/block"
 	"github.com/harmony-one/harmony/common/denominations"
 	"github.com/harmony-one/harmony/consensus/quorum"
@@ -261,8 +263,10 @@ func (s *PublicBlockChainAPI) GetBlockSigners(ctx context.Context, blockNr rpc.B
 		if err != nil {
 			return nil, err
 		}
-		blsPublicKey := new(bls.PublicKey)
-		validator.BLSPublicKey.ToLibBLSPublicKey(blsPublicKey)
+		blsPublicKey := new(bls_core.PublicKey)
+		if blsPublicKey, err = bls.BytesToBLSPublicKey(validator.BLSPublicKey[:]); err != nil {
+			return nil, err
+		}
 		if ok, err := mask.KeyEnabled(blsPublicKey); err == nil && ok {
 			signers = append(signers, oneAddress)
 		}
@@ -284,8 +288,10 @@ func (s *PublicBlockChainAPI) GetBlockSignerKeys(ctx context.Context, blockNr rp
 	}
 	signers := []string{}
 	for _, validator := range slots {
-		blsPublicKey := new(bls.PublicKey)
-		validator.BLSPublicKey.ToLibBLSPublicKey(blsPublicKey)
+		blsPublicKey := new(bls_core.PublicKey)
+		if blsPublicKey, err = bls.BytesToBLSPublicKey(validator.BLSPublicKey[:]); err != nil {
+			return nil, err
+		}
 		if ok, err := mask.KeyEnabled(blsPublicKey); err == nil && ok {
 			signers = append(signers, validator.BLSPublicKey.Hex())
 		}
@@ -313,8 +319,10 @@ func (s *PublicBlockChainAPI) IsBlockSigner(ctx context.Context, blockNr rpc.Blo
 		if oneAddress != address {
 			continue
 		}
-		blsPublicKey := new(bls.PublicKey)
-		validator.BLSPublicKey.ToLibBLSPublicKey(blsPublicKey)
+		blsPublicKey := new(bls_core.PublicKey)
+		if blsPublicKey, err = bls.BytesToBLSPublicKey(validator.BLSPublicKey[:]); err != nil {
+			return false, err
+		}
 		if ok, err := mask.KeyEnabled(blsPublicKey); err == nil && ok {
 			return true, nil
 		}

--- a/internal/hmyapi/apiv2/blockchain.go
+++ b/internal/hmyapi/apiv2/blockchain.go
@@ -6,11 +6,13 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/harmony-one/harmony/crypto/bls"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/harmony-one/bls/ffi/go/bls"
+	bls_core "github.com/harmony-one/bls/ffi/go/bls"
 	"github.com/harmony-one/harmony/block"
 	"github.com/harmony-one/harmony/common/denominations"
 	"github.com/harmony-one/harmony/consensus/quorum"
@@ -224,8 +226,10 @@ func (s *PublicBlockChainAPI) GetBlockSigners(ctx context.Context, blockNr uint6
 		if err != nil {
 			return nil, err
 		}
-		blsPublicKey := new(bls.PublicKey)
-		validator.BLSPublicKey.ToLibBLSPublicKey(blsPublicKey)
+		blsPublicKey := new(bls_core.PublicKey)
+		if blsPublicKey, err = bls.BytesToBLSPublicKey(validator.BLSPublicKey[:]); err != nil {
+			return nil, err
+		}
 		if ok, err := mask.KeyEnabled(blsPublicKey); err == nil && ok {
 			signers = append(signers, oneAddress)
 		}
@@ -247,8 +251,10 @@ func (s *PublicBlockChainAPI) GetBlockSignerKeys(ctx context.Context, blockNr ui
 	}
 	signers := []string{}
 	for _, validator := range slots {
-		blsPublicKey := new(bls.PublicKey)
-		validator.BLSPublicKey.ToLibBLSPublicKey(blsPublicKey)
+		blsPublicKey := new(bls_core.PublicKey)
+		if blsPublicKey, err = bls.BytesToBLSPublicKey(validator.BLSPublicKey[:]); err != nil {
+			return nil, err
+		}
 		if ok, err := mask.KeyEnabled(blsPublicKey); err == nil && ok {
 			signers = append(signers, validator.BLSPublicKey.Hex())
 		}
@@ -276,8 +282,10 @@ func (s *PublicBlockChainAPI) IsBlockSigner(ctx context.Context, blockNr uint64,
 		if oneAddress != address {
 			continue
 		}
-		blsPublicKey := new(bls.PublicKey)
-		validator.BLSPublicKey.ToLibBLSPublicKey(blsPublicKey)
+		blsPublicKey := new(bls_core.PublicKey)
+		if blsPublicKey, err = bls.BytesToBLSPublicKey(validator.BLSPublicKey[:]); err != nil {
+			return false, err
+		}
 		if ok, err := mask.KeyEnabled(blsPublicKey); err == nil && ok {
 			return true, nil
 		}

--- a/shard/shard_state.go
+++ b/shard/shard_state.go
@@ -341,13 +341,12 @@ func lookupBLSPublicKeys(
 		key, func() (interface{}, error) {
 			slice := make([]*bls_core.PublicKey, len(c.Slots))
 			for j := range c.Slots {
-				committerKey := &bls_core.PublicKey{}
-				if err := c.Slots[j].BLSPublicKey.ToLibBLSPublicKey(
-					committerKey,
-				); err != nil {
+				pubKey, err := bls.BytesToBLSPublicKey(c.Slots[j].BLSPublicKey[:])
+				if err != nil {
 					return nil, err
 				}
-				slice[j] = committerKey
+
+				slice[j] = pubKey
 			}
 			// Only made once
 			go func() {

--- a/staking/slash/double-sign.go
+++ b/staking/slash/double-sign.go
@@ -245,10 +245,10 @@ func Verify(
 		if err := signature.Deserialize(ballot.Signature); err != nil {
 			return err
 		}
-		if err := ballot.SignerPubKey.ToLibBLSPublicKey(publicKey); err != nil {
+
+		if publicKey, err = bls.BytesToBLSPublicKey(ballot.SignerPubKey[:]); err != nil {
 			return err
 		}
-
 		// slash verification only happens in staking era, therefore want commit payload for staking epoch
 		commitPayload := consensus_sig.ConstructCommitPayload(chain,
 			candidate.Evidence.Epoch, ballot.BlockHeaderHash, candidate.Evidence.Height, candidate.Evidence.ViewID)

--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -474,8 +474,8 @@ func VerifyBLSKey(pubKey *bls.SerializedPublicKey, pubKeySig *bls.SerializedSign
 		return errBLSKeysNotMatchSigs
 	}
 
-	blsPubKey := new(bls_core.PublicKey)
-	if err := pubKey.ToLibBLSPublicKey(blsPubKey); err != nil {
+	blsPubKey, err := bls.BytesToBLSPublicKey(pubKey[:])
+	if err != nil {
 		return errBLSKeysNotMatchSigs
 	}
 


### PR DESCRIPTION
Remove the usage of ToLibBLSPublicKey and always use BytesToBLSPublicKey which is the cached version.

Tested locally.