### PR TITLE
Fix potential nil pointer on fbft log bls key fields.

### DIFF
--- a/consensus/fbft_log.go
+++ b/consensus/fbft_log.go
@@ -41,14 +41,22 @@ type FBFTMessage struct {
 
 // String ..
 func (m *FBFTMessage) String() string {
+	sender := ""
+	if m.SenderPubkey != nil {
+		sender = m.SenderPubkey.Bytes.Hex()
+	}
+	leader := ""
+	if m.LeaderPubkey != nil {
+		leader = m.LeaderPubkey.Bytes.Hex()
+	}
 	return fmt.Sprintf(
 		"[Type:%s ViewID:%d Num:%d BlockHash:%s Sender:%s Leader:%s]",
 		m.MessageType.String(),
 		m.ViewID,
 		m.BlockNum,
 		m.BlockHash.Hex(),
-		m.SenderPubkey.Bytes.Hex(),
-		m.LeaderPubkey.Bytes.Hex(),
+		sender,
+		leader,
 	)
 }
 


### PR DESCRIPTION
The FBFTMessage.String() func may cause nil pointer if the sender and leader key field is nil.