### PR TITLE
[node.sh] Remove self ip probe in node.sh

### DIFF
--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -36,34 +36,6 @@ random() {
    echo $(( b + rand ))
 }
 
-# https://www.linuxjournal.com/content/validating-ip-address-bash-script
-function valid_ip()
-{
-    local  ip=$1
-    local  stat=1
-
-    if [[ $ip =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-        OIFS=$IFS
-        IFS='.'
-        ip=($ip)
-        IFS=$OIFS
-        [[ ${ip[0]} -le 255 && ${ip[1]} -le 255 \
-            && ${ip[2]} -le 255 && ${ip[3]} -le 255 ]]
-        stat=$?
-    fi
-    return $stat
-}
-
-function myip() {
-# get ipv4 address only, right now only support ipv4 addresses
-   PUB_IP=$(dig -4 @resolver1.opendns.com ANY myip.opendns.com +short)
-   if valid_ip $PUB_IP; then
-      msg "public IP address autodetected: $PUB_IP"
-   else
-      err 1 "NO valid public IP found: $PUB_IP"
-   fi
-}
-
 function check_root
 {
    if [[ $EUID -ne 0 ]]; then
@@ -596,7 +568,6 @@ else
 fi
 
 NODE_PORT=${pub_port:-9000}
-PUB_IP=
 
 if [ "$OS" == "Linux" ]; then
    if ${run_as_root}; then
@@ -605,7 +576,6 @@ if [ "$OS" == "Linux" ]; then
 fi
 
 # find my public ip address
-myip
 check_pkg_management
 
 unset -v BN_MA bn
@@ -830,7 +800,6 @@ do
    msg "############### Running Harmony Process ###############"
    args=(
       -bootnodes "${BN_MA}"
-      -ip "${PUB_IP}"
       -port "${NODE_PORT}"
       -network_type="${network_type}"
       -dns_zone="${dns_zone}"


### PR DESCRIPTION
## Issue

This is another PR for #3110. Remove the self IP probe logic, and use 127.0.0.1 as default is fine. Libp2p will auto detect IP to listen.

## Test

Tested with branch: https://github.com/JackyWYX/harmony/tree/nodesh_remove_ip_test, in which added some print message when handling pubsub message. 

1. When starting with new node.sh (without specifying ip), pubsub message is correctly listened from print message, meaning the p2p network is joined.
2. The test is done both on local macbook and AWS instance.

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

