### PR TITLE
[consensus] remove duplicated signature verification

### DIFF
--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -79,14 +79,8 @@ func (consensus *Consensus) HandleMessageUpdate(ctx context.Context, msg *msg_pb
 
 	// Handle leader intended messages now
 	case t == msg_pb.MessageType_PREPARE && intendedForLeader:
-		if !consensus.senderKeySanityChecks(msg, senderKey) {
-			return errVerifyMessageSignature
-		}
 		consensus.onPrepare(msg)
 	case t == msg_pb.MessageType_COMMIT && intendedForLeader:
-		if !consensus.senderKeySanityChecks(msg, senderKey) {
-			return errVerifyMessageSignature
-		}
 		consensus.onCommit(msg)
 
 		// Handle view change messages

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -204,11 +204,6 @@ func (consensus *Consensus) onCommit(msg *msg_pb.Message) {
 	consensus.mutex.Lock()
 	defer consensus.mutex.Unlock()
 
-	// Check for potential double signing
-	if consensus.checkDoubleSign(recvMsg) {
-		return
-	}
-
 	validatorPubKey, commitSig, commitBitmap :=
 		recvMsg.SenderPubkey, recvMsg.Payload, consensus.commitBitmap
 	logger := consensus.getLogger().With().
@@ -241,6 +236,11 @@ func (consensus *Consensus) onCommit(msg *msg_pb.Message) {
 
 	if !sign.VerifyHash(recvMsg.SenderPubkey.Object, commitPayload) {
 		logger.Error().Msg("[OnCommit] Cannot verify commit message")
+		return
+	}
+
+	// Check for potential double signing
+	if consensus.checkDoubleSign(recvMsg) {
 		return
 	}
 


### PR DESCRIPTION
Check the following issue on the detailed explanation of why this commit makes sense.
https://github.com/harmony-one/harmony/issues/3225

The onPrepare and onCommit will do signature verification of the message payload.
So, there is no need to do duplicated sanity check when handling Prepare/Commit messages.

We reserve the signature verification on other messages, as they are not duplicated.
This PR can reduce the CPU load of leader during consensus.

Signed-off-by: Leo Chen <leo@harmony.one>