### PR TITLE
Remove all wrong usage of singlr flight; also fix voting power cache key

### DIFF
--- a/internal/utils/singleton.go
+++ b/internal/utils/singleton.go
@@ -13,7 +13,6 @@ import (
 	"github.com/natefinch/lumberjack"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/diode"
-	"golang.org/x/sync/singleflight"
 )
 
 var (
@@ -119,34 +118,12 @@ const (
 	dataScienceTopic = "ds"
 )
 
-var (
-	loggersByTopic singleflight.Group
-)
-
-func lookupLogger(key string) (*zerolog.Logger, error) {
-	results, err, _ := loggersByTopic.Do(
-		key, func() (interface{}, error) {
-			log := Logger().With().
-				Str("log-topic", dataScienceTopic).
-				Timestamp().
-				Logger()
-			return &log, nil
-		},
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return results.(*zerolog.Logger), nil
-}
-
 func ds() *zerolog.Logger {
-	logger, err := lookupLogger(dataScienceTopic)
-	if err != nil {
-		return Logger()
-	}
-	return logger
+	logger := Logger().With().
+		Str("log-topic", dataScienceTopic).
+		Timestamp().
+		Logger()
+	return &logger
 }
 
 // AnalysisStart ..


### PR DESCRIPTION
Single flight is meant for duplicate func call avoidance (same-time duplicate calls). it's not cache. The func call results are not cached (https://medium.com/@vCabbage/go-avoid-duplicate-requests-with-sync-singleflight-311601b3068b)

Found the issue after seeing lots of accumulated pending goroutines in our node. They are caused by the sleep() and forget() part of singleFlight. Since it's not cache, actually the func got called many times: 
![image](https://user-images.githubusercontent.com/1042540/87734430-7410ec80-c787-11ea-931c-e2c026b8cd5c.png)


Besides the rpc layer, all other part of the singleFlight usage are wrong. Should instead just use lru cache.

This PR also fix the cache key on voting power cache which was hidden due to that single flight didn't do the cache work for voting power.

Tested locally.