### PR TITLE
[rpc] add API to return p2p peer info

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -745,7 +745,7 @@ func main() {
 		).
 		Msg(startMsg)
 
-	nodeconfig.SetPeerID(myHost.GetID().Pretty())
+	nodeconfig.SetPeerID(myHost.GetID())
 
 	go currentNode.SupportSyncing()
 	currentNode.ServiceManagerSetup()

--- a/hmy/api_backend.go
+++ b/hmy/api_backend.go
@@ -36,6 +36,7 @@ import (
 	"github.com/harmony-one/harmony/staking/network"
 	staking "github.com/harmony-one/harmony/staking/types"
 	lru "github.com/hashicorp/golang-lru"
+	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/singleflight"
 )
@@ -862,6 +863,26 @@ func (b *APIBackend) GetNodeMetadata() commonRPC.NodeMetadata {
 		b.hmy.nodeAPI.GetNodeBootTime(),
 		nodeconfig.GetPeerID(),
 		c,
+	}
+}
+
+// GetPeerInfo returns the peer info to the node, including blocked peer, connected peer, number of peers
+func (b *APIBackend) GetPeerInfo() commonRPC.NodePeerInfo {
+
+	topics := b.hmy.nodeAPI.ListTopic()
+	p := make([]commonRPC.P, len(topics))
+
+	for i, t := range topics {
+		topicPeer := b.hmy.nodeAPI.ListPeer(t)
+		p[i].Topic = t
+		p[i].Peers = make([]peer.ID, len(topicPeer))
+		copy(p[i].Peers, topicPeer)
+	}
+
+	return commonRPC.NodePeerInfo{
+		PeerID:       nodeconfig.GetPeerID(),
+		BlockedPeers: b.hmy.nodeAPI.ListBlockedPeer(),
+		P:            p,
 	}
 }
 

--- a/hmy/backend.go
+++ b/hmy/backend.go
@@ -12,6 +12,7 @@ import (
 	"github.com/harmony-one/harmony/core/types"
 	staking "github.com/harmony-one/harmony/staking/types"
 	lru "github.com/hashicorp/golang-lru"
+	"github.com/libp2p/go-libp2p-core/peer"
 )
 
 const (
@@ -56,6 +57,9 @@ type NodeAPI interface {
 	PendingCXReceipts() []*types.CXReceiptsProof
 	GetNodeBootTime() int64
 	PeerConnectivity() (int, int, int)
+	ListPeer(topic string) []peer.ID
+	ListTopic() []string
+	ListBlockedPeer() []peer.ID
 }
 
 // New creates a new Harmony object (including the

--- a/internal/configs/node/config.go
+++ b/internal/configs/node/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/harmony-one/harmony/multibls"
 	"github.com/harmony-one/harmony/webhooks"
 	p2p_crypto "github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/pkg/errors"
 )
 
@@ -63,7 +64,7 @@ const (
 
 var version string
 var publicRPC bool // enable public RPC access
-var peerID string  // PeerID of the node
+var peerID peer.ID // PeerID of the node
 
 // ConfigType is the structure of all node related configuration variables
 type ConfigType struct {
@@ -224,12 +225,12 @@ func GetVersion() string {
 }
 
 // SetPeerID set the peer ID of the node
-func SetPeerID(pid string) {
+func SetPeerID(pid peer.ID) {
 	peerID = pid
 }
 
 // GetPeerID returns the peer ID of the node
-func GetPeerID() string {
+func GetPeerID() peer.ID {
 	return peerID
 }
 

--- a/internal/hmyapi/apiv1/backend.go
+++ b/internal/hmyapi/apiv1/backend.go
@@ -95,4 +95,5 @@ type Backend interface {
 	GetBlockSigners(ctx context.Context, blockNr rpc.BlockNumber) (shard.SlotList, *bls.Mask, error)
 	IsStakingEpoch(epoch *big.Int) bool
 	GetLeaderAddress(a common.Address, e *big.Int) string
+	GetPeerInfo() commonRPC.NodePeerInfo
 }

--- a/internal/hmyapi/apiv1/harmony.go
+++ b/internal/hmyapi/apiv1/harmony.go
@@ -47,3 +47,8 @@ func (s *PublicHarmonyAPI) GasPrice(ctx context.Context) (*hexutil.Big, error) {
 func (s *PublicHarmonyAPI) GetNodeMetadata() commonRPC.NodeMetadata {
 	return s.b.GetNodeMetadata()
 }
+
+// GetPeerInfo produces a NodePeerInfo record
+func (s *PublicHarmonyAPI) GetPeerInfo() commonRPC.NodePeerInfo {
+	return s.b.GetPeerInfo()
+}

--- a/internal/hmyapi/apiv2/backend.go
+++ b/internal/hmyapi/apiv2/backend.go
@@ -91,4 +91,5 @@ type Backend interface {
 	GetBlockSigners(ctx context.Context, blockNr rpc.BlockNumber) (shard.SlotList, *bls.Mask, error)
 	IsStakingEpoch(epoch *big.Int) bool
 	GetLeaderAddress(a common.Address, e *big.Int) string
+	GetPeerInfo() commonRPC.NodePeerInfo
 }

--- a/internal/hmyapi/apiv2/harmony.go
+++ b/internal/hmyapi/apiv2/harmony.go
@@ -62,3 +62,8 @@ type NodeMetadata struct {
 func (s *PublicHarmonyAPI) GetNodeMetadata() commonRPC.NodeMetadata {
 	return s.b.GetNodeMetadata()
 }
+
+// GetPeerInfo produces a NodePeerInfo record, containing peer info of the node
+func (s *PublicHarmonyAPI) GetPeerInfo() commonRPC.NodePeerInfo {
+	return s.b.GetPeerInfo()
+}

--- a/internal/hmyapi/backend.go
+++ b/internal/hmyapi/backend.go
@@ -85,6 +85,7 @@ type Backend interface {
 	GetBlockSigners(ctx context.Context, blockNr rpc.BlockNumber) (shard.SlotList, *bls.Mask, error)
 	IsStakingEpoch(epoch *big.Int) bool
 	GetLeaderAddress(a common.Address, e *big.Int) string
+	GetPeerInfo() commonRPC.NodePeerInfo
 }
 
 // GetAPIs returns all the APIs.

--- a/internal/hmyapi/common/types.go
+++ b/internal/hmyapi/common/types.go
@@ -1,6 +1,9 @@
 package common
 
-import "github.com/harmony-one/harmony/internal/params"
+import (
+	"github.com/harmony-one/harmony/internal/params"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
 
 // C ..
 type C struct {
@@ -23,6 +26,19 @@ type NodeMetadata struct {
 	DNSZone        string             `json:"dns-zone"`
 	Archival       bool               `json:"is-archival"`
 	NodeBootTime   int64              `json:"node-unix-start-time"`
-	PeerID         string             `json:"peerid"`
+	PeerID         peer.ID            `json:"peerid"`
 	C              C                  `json:"p2p-connectivity"`
+}
+
+// P captures the connected peers per topic
+type P struct {
+	Topic string    `json:"topic"`
+	Peers []peer.ID `json:"peers"`
+}
+
+// NodePeerInfo captures the peer connectivity info of the node
+type NodePeerInfo struct {
+	PeerID       peer.ID   `json:"peerid"`
+	BlockedPeers []peer.ID `json:"blocked-peers"`
+	P            []P       `json:"connected-peers"`
 }

--- a/node/rpc.go
+++ b/node/rpc.go
@@ -16,6 +16,7 @@ import (
 	"github.com/harmony-one/harmony/internal/hmyapi/apiv2"
 	"github.com/harmony-one/harmony/internal/hmyapi/filters"
 	"github.com/harmony-one/harmony/internal/utils"
+	"github.com/libp2p/go-libp2p-core/peer"
 )
 
 const (
@@ -46,6 +47,21 @@ func (node *Node) IsCurrentlyLeader() bool {
 // PeerConnectivity ..
 func (node *Node) PeerConnectivity() (int, int, int) {
 	return node.host.C()
+}
+
+// ListPeer return list of peers for a certain topic
+func (node *Node) ListPeer(topic string) []peer.ID {
+	return node.host.ListPeer(topic)
+}
+
+// ListTopic return list of topics the node subscribed
+func (node *Node) ListTopic() []string {
+	return node.host.ListTopic()
+}
+
+// ListBlockedPeer return list of blocked peers
+func (node *Node) ListBlockedPeer() []peer.ID {
+	return node.host.ListBlockedPeer()
 }
 
 // PendingCXReceipts returns node.pendingCXReceiptsProof


### PR DESCRIPTION
support both apiv1 and apiv2

Examples on localnet:

curl -s --request POST 'http://127.0.0.1:9500/' \
	--header 'Content-Type: application/json' \
	--data-raw '{ "jsonrpc": "2.0", "method": "hmyv2_getPeerInfo", "params": [""], "id": 1}'

curl -s --request POST 'http://127.0.0.1:9500/' \
	--header 'Content-Type: application/json' \
	--data-raw '{ "jsonrpc": "2.0", "method": "hmy_getPeerInfo", "params": [""], "id": 1}'

Signed-off-by: Leo Chen <leo@harmony.one>
