### PR TITLE
Use finer grained RWMutex for consensus logic

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -139,8 +139,8 @@ func initSetup() {
 	utils.SetLogVerbosity(log.Lvl(*verbosity))
 	utils.AddLogFile(fmt.Sprintf("%v/validator-%v-%v.log", *logFolder, *ip, *port), *logMaxSize)
 
-	// Add GOMAXPROCS to achieve max performance.
-	runtime.GOMAXPROCS(runtime.NumCPU() * 4)
+	// Don't set higher than num of CPU. It will make go scheduler slower.
+	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	// Set port and ip to global config.
 	nodeconfig.GetDefaultConfig().Port = *port

--- a/consensus/checks.go
+++ b/consensus/checks.go
@@ -63,7 +63,7 @@ func (consensus *Consensus) isRightBlockNumAndViewID(recvMsg *FBFTMessage,
 			Uint64("MsgBlockNum", recvMsg.BlockNum).
 			Uint64("blockNum", consensus.blockNum).
 			Str("ValidatorPubKey", recvMsg.SenderPubkey.Bytes.Hex()).
-			Msg("[OnCommit] BlockNum/viewID not match")
+			Msg("BlockNum/viewID not match")
 		return false
 	}
 	return true

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -77,6 +77,7 @@ func (consensus *Consensus) GetViewID() uint64 {
 // UpdatePublicKeys updates the PublicKeys for
 // quorum on current subcommittee, protected by a mutex
 func (consensus *Consensus) UpdatePublicKeys(pubKeys []*bls_core.PublicKey) int64 {
+	// TODO: use mutex for updating public keys pointer. No need to lock on all these logic.
 	consensus.pubKeyLock.Lock()
 	consensus.Decider.UpdateParticipants(pubKeys)
 	utils.Logger().Info().Msg("My Committee updated")
@@ -168,7 +169,6 @@ func (consensus *Consensus) ResetState() {
 		Msg("[ResetState] Resetting consensus state")
 	consensus.switchPhase(FBFTAnnounce, true)
 	consensus.blockHash = [32]byte{}
-	consensus.blockHeader = []byte{}
 	consensus.block = []byte{}
 	consensus.Decider.ResetPrepareAndCommitVotes()
 	if consensus.prepareBitmap != nil {

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -1,7 +1,6 @@
 package consensus
 
 import (
-	"sync"
 	"testing"
 	"time"
 
@@ -20,8 +19,6 @@ import (
 func TestConsensusInitialization(t *testing.T) {
 	host, multiBLSPrivateKey, consensus, decider, err := GenerateConsensusForTesting()
 	assert.NoError(t, err)
-
-	peer := host.GetSelfPeer()
 
 	messageSender := &MessageSender{host: host, retryTimes: int(phaseDuration.Seconds()) / RetryIntervalInSec}
 	fbtLog := NewFBFTLog()
@@ -55,21 +52,6 @@ func TestConsensusInitialization(t *testing.T) {
 		assert.Equal(t, timeouts[timeoutType].Duration().Nanoseconds(), duration.Nanoseconds())
 		assert.Equal(t, timeout.Nanoseconds(), duration.Nanoseconds())
 	}
-
-	// Validators sync.Map
-	assert.IsType(t, sync.Map{}, consensus.validators)
-	assert.NotEmpty(t, consensus.validators)
-
-	validatorLength := 0
-	consensus.validators.Range(func(_, _ interface{}) bool {
-		validatorLength++
-		return true
-	})
-
-	assert.Equal(t, 1, validatorLength)
-	retrievedPeer, loadedOk := consensus.validators.Load(peer.ConsensusPubKey.SerializeToHexStr())
-	assert.Equal(t, true, loadedOk)
-	assert.Equal(t, retrievedPeer, peer)
 
 	// MultiBLS
 	assert.Equal(t, multiBLSPrivateKey, consensus.priKey)

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -283,10 +283,8 @@ func (consensus *Consensus) tryCatchup() {
 		}
 		consensus.getLogger().Info().Msg("[TryCatchup] prepared message found to commit")
 
-		// TODO(Chao): Explain the reasoning for these code
-		consensus.blockHash = [32]byte{}
 		atomic.AddUint64(&consensus.blockNum, 1)
-		consensus.viewID = committedMsg.ViewID + 1
+		atomic.StoreUint64(&consensus.viewID, committedMsg.ViewID+1)
 		consensus.LeaderPubKey = committedMsg.SenderPubkey
 
 		consensus.getLogger().Info().Msg("[TryCatchup] Adding block to chain")
@@ -493,8 +491,8 @@ func (consensus *Consensus) Start(
 
 				// Only Leader execute this condition
 				func() {
-					consensus.mutex.Lock()
-					defer consensus.mutex.Unlock()
+					consensus.commitMutex.Lock()
+					defer consensus.commitMutex.Unlock()
 					if viewID == consensus.viewID {
 						consensus.finalizeCommits()
 					}

--- a/consensus/quorum/one-node-staked-vote.go
+++ b/consensus/quorum/one-node-staked-vote.go
@@ -61,6 +61,7 @@ func (v *stakedVoteWeight) AddNewVote(
 	sig *bls_core.Sign, headerHash common.Hash,
 	height, viewID uint64) (*votepower.Ballot, error) {
 
+	// TODO(audit): pass in sig as byte[] too, so no need to serialize
 	ballet, err := v.SubmitVote(p, pubKeyBytes, sig, headerHash, height, viewID)
 
 	if err != nil {

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -17,7 +17,6 @@ import (
 
 // Constants of proposing a new block
 const (
-	SleepPeriod           = 20 * time.Millisecond
 	IncomingReceiptsLimit = 6000 // 2000 * (numShards - 1)
 )
 
@@ -42,8 +41,6 @@ func (node *Node) WaitForConsensusReadyV2(readySignal chan struct{}, stopChan ch
 				return
 			case <-readySignal:
 				for node.Consensus != nil && node.Consensus.IsLeader() {
-					time.Sleep(SleepPeriod)
-
 					utils.Logger().Info().
 						Uint64("blockNum", node.Blockchain().CurrentBlock().NumberU64()+1).
 						Msg("PROPOSING NEW BLOCK ------------------------------------------------")


### PR DESCRIPTION
Instead of locking on on all consensus logic with a single mutex. Use more fine grained RWMutex to lock on Read and Write separately, and also make signature checking not locked to parallelize the heavy CPU process.

Tested locally.

Did more benchmarking on the code.

Compared to the version without this change. This PR makes the CPU usage lower by around **10%**.

However, on my instrumented node, I didn't see obvious improvement on the speed of processing consensus messages between code with and without this PR. It could be because the instrumented node can not exercise all operations of a real leader.

But compared to the mainnet leader node on shard 0, the instrumented node did perform about 20% better in consensus message processing.
