### PR TITLE
fix view change race issue

### DIFF
--- a/consensus/checks.go
+++ b/consensus/checks.go
@@ -190,7 +190,7 @@ func (consensus *Consensus) onViewChangeSanityCheck(recvMsg *FBFTMessage) bool {
 }
 
 func (consensus *Consensus) onNewViewSanityCheck(recvMsg *FBFTMessage) bool {
-	if recvMsg.ViewID <= consensus.viewID {
+	if recvMsg.ViewID < consensus.viewID {
 		consensus.getLogger().Warn().
 			Uint64("LastSuccessfulConsensusViewID", consensus.viewID).
 			Uint64("MsgViewChangingID", recvMsg.ViewID).

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -98,7 +98,10 @@ func (consensus *Consensus) UpdatePublicKeys(pubKeys []*bls_core.PublicKey) int6
 	// reset states after update public keys
 	consensus.UpdateBitmaps()
 	consensus.ResetState()
+
+	consensus.vcLock.Lock()
 	consensus.ResetViewChangeState()
+	consensus.vcLock.Unlock()
 	return consensus.Decider.ParticipantsCount()
 }
 


### PR DESCRIPTION
The signature map can be reset if without the lock (https://github.com/harmony-one/harmony/issues/3222)

Also correct the condition of sanity check to avoid the problems that cause view change to stuck.

Tested locally.