### PR TITLE
Fix fetching past event logs using block ranges

### DIFF
--- a/hmy/bloombits.go
+++ b/hmy/bloombits.go
@@ -1,0 +1,139 @@
+// Copyright 2017 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package hmy
+
+import (
+	"context"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/bitutil"
+	"github.com/ethereum/go-ethereum/core/bloombits"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/harmony-one/harmony/block"
+	"github.com/harmony-one/harmony/core"
+	"github.com/harmony-one/harmony/core/rawdb"
+	"github.com/harmony-one/harmony/core/types"
+)
+
+const (
+	// bloomServiceThreads is the number of goroutines used globally by an Ethereum
+	// instance to service bloombits lookups for all running filters.
+	bloomServiceThreads = 16
+
+	// bloomFilterThreads is the number of goroutines used locally per filter to
+	// multiplex requests onto the global servicing goroutines.
+	bloomFilterThreads = 3
+
+	// bloomRetrievalBatch is the maximum number of bloom bit retrievals to service
+	// in a single batch.
+	bloomRetrievalBatch = 16
+
+	// bloomRetrievalWait is the maximum time to wait for enough bloom bit requests
+	// to accumulate request an entire batch (avoiding hysteresis).
+	bloomRetrievalWait = time.Duration(0)
+)
+
+// startBloomHandlers starts a batch of goroutines to accept bloom bit database
+// retrievals from possibly a range of filters and serving the data to satisfy.
+func (hmy *Harmony) startBloomHandlers(sectionSize uint64) {
+	for i := 0; i < bloomServiceThreads; i++ {
+		go func() {
+			for {
+				select {
+				case <-hmy.ShutdownChan:
+					return
+
+				case request := <-hmy.BloomRequests:
+					task := <-request
+					task.Bitsets = make([][]byte, len(task.Sections))
+					for i, section := range task.Sections {
+						head := rawdb.ReadCanonicalHash(hmy.chainDb, (section+1)*sectionSize-1)
+						if compVector, err := rawdb.ReadBloomBits(hmy.chainDb, task.Bit, section, head); err == nil {
+							if blob, err := bitutil.DecompressBytes(compVector, int(sectionSize/8)); err == nil {
+								task.Bitsets[i] = blob
+							} else {
+								task.Error = err
+							}
+						} else {
+							task.Error = err
+						}
+					}
+					request <- task
+				}
+			}
+		}()
+	}
+}
+
+const (
+	// bloomThrottling is the time to wait between processing two consecutive index
+	// sections. It's useful during chain upgrades to prevent disk overload.
+	bloomThrottling = 100 * time.Millisecond
+)
+
+// BloomIndexer implements a core.ChainIndexer, building up a rotated bloom bits index
+// for the Ethereum header bloom filters, permitting blazing fast filtering.
+type BloomIndexer struct {
+	size    uint64               // section size to generate bloombits for
+	db      ethdb.Database       // database instance to write index data and metadata into
+	gen     *bloombits.Generator // generator to rotate the bloom bits crating the bloom index
+	section uint64               // Section is the section number being processed currently
+	head    common.Hash          // Head is the hash of the last header processed
+}
+
+// NewBloomIndexer returns a chain indexer that generates bloom bits data for the
+// canonical chain for fast logs filtering.
+func NewBloomIndexer(db ethdb.Database, size, confirms uint64) *core.ChainIndexer {
+	backend := &BloomIndexer{
+		db:   db,
+		size: size,
+	}
+	table := ethdb.NewTable(db, string(rawdb.BloomBitsIndexPrefix))
+
+	return core.NewChainIndexer(db, table, backend, size, confirms, bloomThrottling, "bloombits")
+}
+
+// Reset implements core.ChainIndexerBackend, starting a new bloombits index
+// section.
+func (b *BloomIndexer) Reset(ctx context.Context, section uint64, lastSectionHead common.Hash) error {
+	gen, err := bloombits.NewGenerator(uint(b.size))
+	b.gen, b.section, b.head = gen, section, common.Hash{}
+	return err
+}
+
+// Process implements core.ChainIndexerBackend, adding a new header's bloom into
+// the index.
+func (b *BloomIndexer) Process(ctx context.Context, header *block.Header) error {
+	b.gen.AddBloom(uint(header.Number().Uint64()-b.section*b.size), header.Bloom())
+	b.head = header.Hash()
+	return nil
+}
+
+// Commit implements core.ChainIndexerBackend, finalizing the bloom section and
+// writing it out into the database.
+func (b *BloomIndexer) Commit() error {
+	batch := b.db.NewBatch()
+	for i := 0; i < types.BloomBitLength; i++ {
+		bits, err := b.gen.Bitset(uint(i))
+		if err != nil {
+			return err
+		}
+		rawdb.WriteBloomBits(batch, uint(i), b.section, b.head, bitutil.CompressBytes(bits))
+	}
+	return batch.Write()
+}

--- a/hmy/hmy.go
+++ b/hmy/hmy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/bloombits"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/harmony-one/harmony/api/proto"
 	"github.com/harmony-one/harmony/block"
 	"github.com/harmony-one/harmony/core"
@@ -96,9 +97,12 @@ func New(
 	chainDb := nodeAPI.Blockchain().ChainDB()
 	leaderCache, _ := lru.New(leaderCacheSize)
 	totalStakeCache := newTotalStakeCache(totalStakeCacheDuration)
+	bloomIndexer := NewBloomIndexer(chainDb, params.BloomBitsBlocks, params.BloomConfirms)
+	bloomIndexer.Start(nodeAPI.Blockchain())
 	return &Harmony{
 		ShutdownChan:    make(chan bool),
 		BloomRequests:   make(chan chan *bloombits.Retrieval),
+		BloomIndexer:    bloomIndexer,
 		BlockChain:      nodeAPI.Blockchain(),
 		BeaconChain:     nodeAPI.Beaconchain(),
 		TxPool:          txPool,


### PR DESCRIPTION
This PR fixes fetching past event logs using block number ranges. Tested locally.
```
blockchain
  .logs({
    fromBlock: "0x23",
    toBlock: "latest",
    address: contractor
  })
```
output
```
{ address: '0x486d25ffee86070f122376ec5eac73ab29bd4569',
  topics:
   [ '0x064b1e66d8d787e36504c45aac3405f69335030ab8dc365a34919de13b61799c' ],
  data:
   '0x000000000000000000000000c162199cdaeaa5a82f00651dd4536f5d2d4277c5',
  blockNumber: '0x23',
  transactionHash:
   '0xf311682e9f43b2a5dabe5ef567de0961b145e7e7ee4af5bd25112f3b2c459730',
  transactionIndex: '0x0',
  blockHash:
   '0xb7023b64fd0be0de4e268cb08dbecc47d1d4be9d3702c633d2c98f43c000123c',
  logIndex: '0x0',
  removed: false }
{ address: '0x486d25ffee86070f122376ec5eac73ab29bd4569',
  topics:
   [ '0x064b1e66d8d787e36504c45aac3405f69335030ab8dc365a34919de13b61799c' ],
  data:
   '0x000000000000000000000000c162199cdaeaa5a82f00651dd4536f5d2d4277c5',
  blockNumber: '0x34',
  transactionHash:
   '0xba7fdf0e53dee408b25821af3ae152849dbf76dafd0e955fb631e092d5c5e1d6',
  transactionIndex: '0x0',
  blockHash:
   '0xbdd85aec861bbf33b8ae3d610a250657dbabb2e649a44e4976efd7233c3b2269',
  logIndex: '0x0',
  removed: false }
```