### PR TITLE
[Uptime] Compute and return lastest 30 epoch signing information

### DIFF
--- a/hmy/staking.go
+++ b/hmy/staking.go
@@ -199,6 +199,33 @@ func (hmy *Harmony) GetAllValidatorAddresses() []common.Address {
 	return hmy.BlockChain.ValidatorCandidates()
 }
 
+var (
+	epochBlocksMap = map[uint64]staking.EpochSigningEntry{}
+)
+
+func (hmy *Harmony) getEpochSigning(epoch *big.Int, addr common.Address) (staking.EpochSigningEntry, error) {
+	entry := staking.EpochSigningEntry{}
+	if val, ok := epochBlocksMap[epoch.Uint64()]; ok {
+		return val, nil
+	}
+
+	snapshot, err := hmy.BlockChain.ReadValidatorSnapshotAtEpoch(epoch, addr)
+	if err != nil {
+		return entry, err
+	}
+
+	// the signing information is for the previous epoch
+	entry.Epoch = big.NewInt(0).Sub(epoch, common.Big1)
+	entry.Blocks = snapshot.Validator.Counters
+
+	// update map when adding new entry, also remove an entry beyond last 30
+	epochBlocksMap[epoch.Uint64()] = entry
+	epochMinus30 := big.NewInt(0).Sub(epoch, big.NewInt(staking.SigningHistoryLength))
+	delete(epochBlocksMap, epochMinus30.Uint64())
+
+	return entry, nil
+}
+
 // GetValidatorInformation returns the information of validator
 func (hmy *Harmony) GetValidatorInformation(
 	addr common.Address, block *types.Block,
@@ -319,6 +346,22 @@ func (hmy *Harmony) GetValidatorInformation(
 	// } else {
 	// 	defaultReply.Lifetime.APR = avgAPR.(numeric.Dec)
 	// }
+
+	epochBlocks := []staking.EpochSigningEntry{}
+	epochFrom := bc.Config().StakingEpoch
+	nowMinus := big.NewInt(0).Sub(now, big.NewInt(staking.SigningHistoryLength))
+	if nowMinus.Cmp(epochFrom) > 0 {
+		epochFrom = nowMinus
+	}
+	for i := now.Int64(); i > epochFrom.Int64(); i-- {
+		epoch := big.NewInt(i)
+		entry, err := hmy.getEpochSigning(epoch, addr)
+		if err != nil {
+			break
+		}
+		epochBlocks = append(epochBlocks, entry)
+	}
+	defaultReply.Lifetime.EpochBlocks = epochBlocks
 
 	if defaultReply.CurrentlyInCommittee {
 		defaultReply.ComputedMetrics = stats

--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -30,6 +30,7 @@ const (
 	BLSVerificationStr       = "harmony-one"
 	TenThousand              = 10000
 	APRHistoryLength         = 30
+	SigningHistoryLength     = 30
 )
 
 var (
@@ -156,10 +157,11 @@ type ValidatorRPCEnhanced struct {
 
 // AccumulatedOverLifetime ..
 type AccumulatedOverLifetime struct {
-	BlockReward *big.Int    `json:"reward-accumulated"`
-	Signing     counters    `json:"blocks"`
-	APR         numeric.Dec `json:"apr"`
-	EpochAPRs   []APREntry  `json:"epoch-apr"`
+	BlockReward *big.Int            `json:"reward-accumulated"`
+	Signing     counters            `json:"blocks"`
+	APR         numeric.Dec         `json:"apr"`
+	EpochAPRs   []APREntry          `json:"epoch-apr"`
+	EpochBlocks []EpochSigningEntry `json:"epoch-blocks"`
 }
 
 func (w ValidatorWrapper) String() string {
@@ -188,8 +190,14 @@ type VoteWithCurrentEpochEarning struct {
 
 // APREntry ..
 type APREntry struct {
-	Epoch *big.Int
-	Value numeric.Dec
+	Epoch *big.Int    `json:"epoch"`
+	Value numeric.Dec `json:"apr"`
+}
+
+// EpochSigningEntry ..
+type EpochSigningEntry struct {
+	Epoch  *big.Int `json:"epoch"`
+	Blocks counters `json:"blocks"`
 }
 
 // ValidatorStats to record validator's performance and history records


### PR DESCRIPTION
This PR adds signing information for the latest 30 epochs to validator information such that dashboard (other clients) can compute uptime for the last 30 epochs (or even less if required) instead of only lifetime uptime information.

Tested by running a node for mainnet:

```
        ...
        {
          "apr": "0.113261084045153310",
          "epoch": 224
        },
        {
          "apr": "0.109502671104892448",
          "epoch": 225
        }
      ],
      "epoch-blocks": [
        {
          "blocks": {
            "signed": 5159258,
            "to-sign": 5193708
          },
          "epoch": 225
        },
        {
          "blocks": {
            "signed": 4995768,
            "to-sign": 5029868
          },
          "epoch": 224
        },
        {
          "blocks": {
            "signed": 4832097,
            "to-sign": 4866028
          },
          "epoch": 223
        },
       ...
```