### PR TITLE
Fix number return types of all RPCs

### DIFF
--- a/rpc/types.go
+++ b/rpc/types.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"math/big"
@@ -62,7 +63,10 @@ func NewStructuredResponse(input interface{}) (StructuredResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := json.Unmarshal(dat, &objMap); err != nil {
+	d := json.NewDecoder(bytes.NewReader(dat))
+	d.UseNumber()
+	err = d.Decode(&objMap)
+	if err != nil {
 		return nil, err
 	}
 	return objMap, nil


### PR DESCRIPTION
This is a fix for #3259.

As is, the RPC can return really large or small numbers in scientific notation. This can break some existing behavior (as caught in our testnet regression test [here](https://jenkins.harmony.one/job/regression_test/122/) (internal link)). This PR forces the use of JSON numbers in the RPC return's unmarshall. This should preserve old behavior. 