### PR TITLE
[cmd] increase timeout in TestPromptACProvider_prompt

### DIFF
--- a/internal/blsgen/kms_test.go
+++ b/internal/blsgen/kms_test.go
@@ -138,12 +138,12 @@ func TestPromptACProvider_prompt(t *testing.T) {
 	}{
 		{
 			delay:   100 * time.Microsecond,
-			timeout: 1000 * time.Microsecond,
+			timeout: 1 * time.Second,
 			expErr:  nil,
 		},
 		{
-			delay:   2000 * time.Microsecond,
-			timeout: 1000 * time.Microsecond,
+			delay:   2 * time.Second,
+			timeout: 1 * time.Second,
 			expErr:  errors.New("timed out"),
 		},
 	}


### PR DESCRIPTION
## Issue

Travis server occasionally failed in a timeout test due to virtual machine's performance. (https://travis-ci.com/github/harmony-one/harmony/jobs/366673332#L2067).

Increase the timeout to 1 second to avoid performance could impact test result.
