### PR TITLE
[node.sh] fix max bls key count 10 cannot be reached

### DIFF
--- a/cmd/harmony/bls.go
+++ b/cmd/harmony/bls.go
@@ -56,7 +56,7 @@ func loadBLSKeys() (multibls.PrivateKeys, error) {
 	if len(keys) == 0 {
 		return nil, fmt.Errorf("0 bls keys loaded")
 	}
-	if len(keys) >= *maxBLSKeysPerNode {
+	if len(keys) > *maxBLSKeysPerNode {
 		return nil, fmt.Errorf("bls keys exceed maximum count %v", *maxBLSKeysPerNode)
 	}
 	return keys, err


### PR DESCRIPTION
## Issue

Fix the problem that max bls key count 10 cannot be reached
