### PR TITLE
raize txn size limit to 128kb

### DIFF
--- a/core/types/tx_pool.go
+++ b/core/types/tx_pool.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	//MaxPoolTransactionDataSize is a 32KB heuristic data limit for DOS prevention
-	MaxPoolTransactionDataSize = 32 * 1024
+	//MaxPoolTransactionDataSize is a 128KB heuristic data limit for DOS prevention
+	MaxPoolTransactionDataSize = 128 * 1024
 	//MaxEncodedPoolTransactionSize is a heuristic raw/encoded data size limit. It has an additional 10KB for metadata
 	MaxEncodedPoolTransactionSize = MaxPoolTransactionDataSize + (10 * 1024)
 )


### PR DESCRIPTION
Hit transaction over size error when I try to deploy one of the bigger smart contracts (the txn size is 40.1k). 

The original txn size limit is kind of adhoc for ddos prevention, but we eventually shouldn't enforce such limit on the protocol level since many use cases require big txns such as data storage.