### PR TITLE
RPC - Fix null undelegations in delegator info

### DIFF
--- a/rpc/staking.go
+++ b/rpc/staking.go
@@ -453,10 +453,10 @@ func (s *PublicStakingService) GetDelegationsByDelegator(
 		undelegations := make([]Undelegation, len(delegation.Undelegations))
 
 		for j := range delegation.Undelegations {
-			undelegations = append(undelegations, Undelegation{
+			undelegations[j] = Undelegation{
 				Amount: delegation.Undelegations[j].Amount,
 				Epoch:  delegation.Undelegations[j].Epoch,
-			})
+			}
 		}
 		valAddr, _ := internal_common.AddressToBech32(validators[i])
 		delAddr, _ := internal_common.AddressToBech32(delegatorAddress)
@@ -546,13 +546,13 @@ func (s *PublicStakingService) GetDelegationsByValidator(
 	result := []StructuredResponse{}
 	for i := range delegations {
 		delegation := delegations[i]
-		undelegations := []Undelegation{}
+		undelegations := make([]Undelegation, len(delegation.Undelegations))
 
 		for j := range delegation.Undelegations {
-			undelegations = append(undelegations, Undelegation{
+			undelegations[j] = Undelegation{
 				Amount: delegation.Undelegations[j].Amount,
 				Epoch:  delegation.Undelegations[j].Epoch,
-			})
+			}
 		}
 		valAddr, _ := internal_common.AddressToBech32(validatorAddress)
 		delAddr, _ := internal_common.AddressToBech32(delegation.DelegatorAddress)
@@ -592,14 +592,13 @@ func (s *PublicStakingService) GetDelegationByDelegatorAndValidator(
 			continue
 		}
 		delegation := delegations[i]
-
-		undelegations := []Undelegation{}
+		undelegations := make([]Undelegation, len(delegation.Undelegations))
 
 		for j := range delegation.Undelegations {
-			undelegations = append(undelegations, Undelegation{
+			undelegations[j] = Undelegation{
 				Amount: delegation.Undelegations[j].Amount,
 				Epoch:  delegation.Undelegations[j].Epoch,
-			})
+			}
 		}
 		valAddr, _ := internal_common.AddressToBech32(validatorAddress)
 		delAddr, _ := internal_common.AddressToBech32(delegatorAddress)


### PR DESCRIPTION
Currently, the `Undelegations` field for delegator info can return null due to improper construction of the undelegations JSON array. This PR fixes this bug. Moreover, tests were added [here](https://github.com/harmony-one/harmony-test/commit/f704c8969fe1745c94e1cd7dfd2942e85c7b43b3) to ensure this does not happen again. 