### PR TITLE
reduce file handle needed for level db

### DIFF
--- a/internal/shardchain/dbfactory.go
+++ b/internal/shardchain/dbfactory.go
@@ -22,7 +22,7 @@ type LDBFactory struct {
 // NewChainDB returns a new LDB for the blockchain for given shard.
 func (f *LDBFactory) NewChainDB(shardID uint32) (ethdb.Database, error) {
 	dir := path.Join(f.RootDir, fmt.Sprintf("harmony_db_%d", shardID))
-	return ethdb.NewLDBDatabase(dir, 128, 1024)
+	return ethdb.NewLDBDatabase(dir, 128, 64)
 }
 
 // MemDBFactory is a memory-backed blockchain database factory.


### PR DESCRIPTION
It has been causing many issues for validators with "too many open files" error, which causes significant downside for signing. Reduce the file handle needed for level db so it won't cause trouble easily for validators.