### PR TITLE
[cmd] fix localnet syncing provider

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -535,16 +535,16 @@ func setupConsensusAndNode(hc harmonyConfig, nodeConfig *nodeconfig.ConfigType) 
 	}
 
 	if hc.Network.LegacySyncing {
-		currentNode.SyncingPeerProvider = node.NewLegacySyncingPeerProvider(currentNode)
-	} else {
 		if hc.Network.NetworkType == nodeconfig.Localnet {
 			epochConfig := shard.Schedule.InstanceForEpoch(ethCommon.Big0)
 			selfPort := hc.P2P.Port
 			currentNode.SyncingPeerProvider = node.NewLocalSyncingPeerProvider(
 				6000, uint16(selfPort), epochConfig.NumShards(), uint32(epochConfig.NumNodesPerShard()))
 		} else {
-			currentNode.SyncingPeerProvider = node.NewDNSSyncingPeerProvider(hc.Network.DNSZone, syncing.GetSyncingPort(strconv.Itoa(hc.Network.DNSPort)))
+			currentNode.SyncingPeerProvider = node.NewLegacySyncingPeerProvider(currentNode)
 		}
+	} else {
+		currentNode.SyncingPeerProvider = node.NewDNSSyncingPeerProvider(hc.Network.DNSZone, syncing.GetSyncingPort(strconv.Itoa(hc.Network.DNSPort)))
 	}
 
 	// TODO: refactor the creation of blockchain out of node.New()

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -534,15 +534,18 @@ func setupConsensusAndNode(hc harmonyConfig, nodeConfig *nodeconfig.ConfigType) 
 		currentNode.BroadcastInvalidTx = defaultBroadcastInvalidTx
 	}
 
-	if hc.Network.LegacySyncing {
-		if hc.Network.NetworkType == nodeconfig.Localnet {
-			epochConfig := shard.Schedule.InstanceForEpoch(ethCommon.Big0)
-			selfPort := hc.P2P.Port
-			currentNode.SyncingPeerProvider = node.NewLocalSyncingPeerProvider(
-				6000, uint16(selfPort), epochConfig.NumShards(), uint32(epochConfig.NumNodesPerShard()))
-		} else {
-			currentNode.SyncingPeerProvider = node.NewLegacySyncingPeerProvider(currentNode)
-		}
+	// Syncing provider is provided by following rules:
+	//   1. If starting with a localnet, use local sync peers.
+	//   2. If specified with --dns=false, use legacy syncing which is syncing through self-
+	//      discover peers.
+	//   3. Else, use the dns for syncing.
+	if hc.Network.NetworkType == nodeconfig.Localnet {
+		epochConfig := shard.Schedule.InstanceForEpoch(ethCommon.Big0)
+		selfPort := hc.P2P.Port
+		currentNode.SyncingPeerProvider = node.NewLocalSyncingPeerProvider(
+			6000, uint16(selfPort), epochConfig.NumShards(), uint32(epochConfig.NumNodesPerShard()))
+	} else if hc.Network.LegacySyncing {
+		currentNode.SyncingPeerProvider = node.NewLegacySyncingPeerProvider(currentNode)
 	} else {
 		currentNode.SyncingPeerProvider = node.NewDNSSyncingPeerProvider(hc.Network.DNSZone, syncing.GetSyncingPort(strconv.Itoa(hc.Network.DNSPort)))
 	}


### PR DESCRIPTION
## Description

Fix the high CPU usage in Local net. The error is from the wrong intepretation of legacy flag `--dns`. After the fix, the local test `make debug` cost drop from ~80% to ~5% on AWS Linux machine. 

