### PR TITLE
[rpc]  Add sync check RPCs

### DIFF
--- a/hmy/hmy.go
+++ b/hmy/hmy.go
@@ -79,6 +79,7 @@ type NodeAPI interface {
 	GetTransactionsCount(address, txType string) (uint64, error)
 	GetStakingTransactionsCount(address, txType string) (uint64, error)
 	IsCurrentlyLeader() bool
+	IsOutOfSync(*core.BlockChain) bool
 	ReportStakingErrorSink() types.TransactionErrorReports
 	ReportPlainErrorSink() types.TransactionErrorReports
 	PendingCXReceipts() []*types.CXReceiptsProof

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -523,6 +523,7 @@ func (node *Node) getEncodedBlockByHash(hash common.Hash) ([]byte, error) {
 	return b, nil
 }
 
+// IsOutOfSync ...
 func (node *Node) IsOutOfSync(bc *core.BlockChain) bool {
 	return node.stateSync.IsOutOfSync(bc)
 }

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -522,3 +522,7 @@ func (node *Node) getEncodedBlockByHash(hash common.Hash) ([]byte, error) {
 	blockReqCache.Add(hash, b)
 	return b, nil
 }
+
+func (node *Node) IsOutOfSync(bc *core.BlockChain) bool {
+	return node.stateSync.IsOutOfSync(bc)
+}

--- a/rpc/blockchain.go
+++ b/rpc/blockchain.go
@@ -656,6 +656,16 @@ func (s *PublicBlockchainService) GetStakingNetworkInfo(
 	})
 }
 
+// InSync returns if shard chain is syncing
+func (s *PublicBlockchainService) InSync(ctx context.Context) (bool, error) {
+	return !s.hmy.NodeAPI.IsOutOfSync(s.hmy.BlockChain), nil
+}
+
+// BeaconInSync returns if beacon chain is syncing
+func (s *PublicBlockchainService) BeaconInSync(ctx context.Context) (bool, error) {
+	return !s.hmy.NodeAPI.IsOutOfSync(s.hmy.BeaconChain), nil
+}
+
 func isBlockGreaterThanLatest(hmy *hmy.Harmony, blockNum rpc.BlockNumber) bool {
 	// rpc.BlockNumber is int64 (latest = -1. pending = -2) and currentBlockNum is uint64.
 	if blockNum == rpc.PendingBlockNumber {


### PR DESCRIPTION
[rpc] Add inSync & beaconInSync RPCs to check if node blockchains are in sync
[syncing] Expose IsOutOfSync
[hmy] Add IsOutOfSync to NodeAPI

Example:
```
$ curl --location --request POST 'http://localhost:9500' --header 'Content-Type: application/json' --data-raw '{"jsonrpc": "2.0", "method": "hmy_inSync", "params": [], "id": 1}' | jq 

{
  "jsonrpc": "2.0",
  "id": 1,
  "result": true
}
```

```
$ curl --location --request POST 'http://localhost:9500' --header 'Content-Type: application/json' --data-raw '{"jsonrpc": "2.0","method": "hmy_beaconInSync","params": [],"id": 1}' | jq

{
  "jsonrpc": "2.0",
  "id": 1,
  "result": true
}
```