### PR TITLE
Add one-off fork for testnet adjusted reward

### DIFF
--- a/internal/chain/reward.go
+++ b/internal/chain/reward.go
@@ -2,9 +2,10 @@ package chain
 
 import (
 	"fmt"
-	"github.com/harmony-one/harmony/internal/params"
 	"math/big"
 	"sort"
+
+	"github.com/harmony-one/harmony/internal/params"
 
 	lru "github.com/hashicorp/golang-lru"
 

--- a/internal/chain/reward.go
+++ b/internal/chain/reward.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"fmt"
+	"github.com/harmony-one/harmony/internal/params"
 	"math/big"
 	"sort"
 
@@ -138,7 +139,12 @@ func AccumulateRewardsAndCountSigs(
 		defaultReward := network.BaseStakedReward
 
 		// After block time is reduced to 5 seconds, the block reward is adjusted accordingly
-		if bc.Config().IsFiveSeconds(header.Epoch()) {
+		if bc.Config().ChainID == params.TestnetChainID && bc.Config().FiveSecondsEpoch.Cmp(big.NewInt(16500)) == 0 {
+			// This is testnet requiring the one-off forking logic
+			if blockNum > 634644 {
+				defaultReward = network.FiveSecondsBaseStakedReward
+			}
+		} else if bc.Config().IsFiveSeconds(header.Epoch()) {
 			defaultReward = network.FiveSecondsBaseStakedReward
 		}
 

--- a/internal/chain/reward.go
+++ b/internal/chain/reward.go
@@ -143,6 +143,12 @@ func AccumulateRewardsAndCountSigs(
 			// This is testnet requiring the one-off forking logic
 			if blockNum > 634644 {
 				defaultReward = network.FiveSecondsBaseStakedReward
+				if blockNum > 636507 {
+					defaultReward = network.BaseStakedReward
+					if blockNum > 639341 {
+						defaultReward = network.FiveSecondsBaseStakedReward
+					}
+				}
 			}
 		} else if bc.Config().IsFiveSeconds(header.Epoch()) {
 			defaultReward = network.FiveSecondsBaseStakedReward


### PR DESCRIPTION
To fix https://github.com/harmony-one/harmony/issues/3292

Tested with testnet node which fully sync'ed without issues.