### PR TITLE
[cmd] if running explorer node, set archive to true

### DIFF
--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -244,6 +244,10 @@ func applyGeneralFlags(cmd *cobra.Command, config *harmonyConfig) {
 		config.General.NodeType = cli.GetStringFlagValue(cmd, legacyNodeTypeFlag)
 	}
 
+	if config.General.NodeType == nodeTypeExplorer {
+		config.General.IsArchival = true
+	}
+
 	if cli.IsFlagChanged(cmd, shardIDFlag) {
 		config.General.ShardID = cli.GetIntFlagValue(cmd, shardIDFlag)
 	} else if cli.IsFlagChanged(cmd, legacyShardIDFlag) {

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -174,6 +174,16 @@ func TestGeneralFlags(t *testing.T) {
 				DataDir:    "./",
 			},
 		},
+		{
+			args: []string{"--run", "explorer", "--run.shard", "0", "--run.archive=false"},
+			expConfig: generalConfig{
+				NodeType:   "explorer",
+				NoStaking:  false,
+				ShardID:    0,
+				IsArchival: false,
+				DataDir:    "./",
+			},
+		},
 	}
 	for i, test := range tests {
 		ts := newFlagTestSuite(t, generalFlags, applyGeneralFlags)

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -164,6 +164,16 @@ func TestGeneralFlags(t *testing.T) {
 				DataDir:    "./",
 			},
 		},
+		{
+			args: []string{"--run", "explorer", "--run.shard", "0"},
+			expConfig: generalConfig{
+				NodeType:   "explorer",
+				NoStaking:  false,
+				ShardID:    0,
+				IsArchival: true,
+				DataDir:    "./",
+			},
+		},
 	}
 	for i, test := range tests {
 		ts := newFlagTestSuite(t, generalFlags, applyGeneralFlags)

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -63,7 +63,7 @@ Examples usage:
     ./harmony --http.ip=0.0.0.0 --http.port=[http_port] --ws.ip=0.0.0.0 --ws.port=[ws_port]
 
 # start an explorer node
-    ./harmony --run=explorer --run.archive --run.shard=[shard_id]
+    ./harmony --run=explorer --run.shard=[shard_id]
 
 # start a harmony internal node on testnet
     ./harmony --run.legacy --network


### PR DESCRIPTION
## Description

Command line fix for explorer node. (https://github.com/harmony-one/harmony/pull/3304) Archive mode is now default to enabled when running explorer node.

## Testing

Two test cases added for explorer archival mode.