### PR TITLE
[sync] fix testnet syncing panic issue

### DIFF
--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -102,6 +102,7 @@ func CreateStateSync(ip string, port string, peerHash [20]byte) *StateSync {
 	stateSync.selfPeerHash = peerHash
 	stateSync.commonBlocks = make(map[int]*types.Block)
 	stateSync.lastMileBlocks = []*types.Block{}
+	stateSync.syncConfig = &SyncConfig{}
 	return stateSync
 }
 
@@ -243,10 +244,6 @@ func (ss *StateSync) CreateSyncConfig(peers []p2p.Peer, isBeacon bool) error {
 	if len(peers) == 0 {
 		return errors.New("[SYNC] no peers to connect to")
 	}
-	if ss.syncConfig != nil {
-		ss.syncConfig.CloseConnections()
-	}
-	ss.syncConfig = &SyncConfig{}
 
 	var wg sync.WaitGroup
 	for _, peer := range peers {

--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -244,6 +244,10 @@ func (ss *StateSync) CreateSyncConfig(peers []p2p.Peer, isBeacon bool) error {
 	if len(peers) == 0 {
 		return errors.New("[SYNC] no peers to connect to")
 	}
+	if ss.syncConfig != nil {
+		ss.syncConfig.CloseConnections()
+	}
+	ss.syncConfig = &SyncConfig{}
 
 	var wg sync.WaitGroup
 	for _, peer := range peers {


### PR DESCRIPTION
## Issue

Fix the testnet DNS being panic during bootstrap. The problem is that some new block are submitted to the DNS nodes while DNS syncing is not prepared for receiving this data. 

![](https://cdn.discordapp.com/attachments/743472509231562885/746150618141425764/unknown.png)

Note: this is just a temporary fix since pushing new block shall be removed. Also, if we switch to distributed syncing we can get rid of the DNS stuff totally. 

## Test

Not done yet. Need to test on testnet.
