### PR TITLE
Rosetta Implementation - pt2 FIX (Stage 3.2 of Node API Overhaul)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,18 +21,16 @@ require (
 	github.com/golang/mock v1.4.0
 	github.com/golang/protobuf v1.4.0
 	github.com/golangci/golangci-lint v1.22.2
-	github.com/gorilla/handlers v1.4.0 // indirect
 	github.com/gorilla/mux v1.7.4
-	github.com/gorilla/websocket v1.4.2
+	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/harmony-ek/gencodec v0.0.0-20190215044613-e6740dbdd846
 	github.com/harmony-one/abool v1.0.1
 	github.com/harmony-one/bls v0.0.6
 	github.com/harmony-one/taggedrlp v0.1.4
 	github.com/harmony-one/vdf v0.0.0-20190924175951-620379da8849
 	github.com/hashicorp/golang-lru v0.5.4
-	github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365
+	github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365 // indirect
 	github.com/ipfs/go-ds-badger v0.2.4
-	github.com/jackpal/gateway v1.0.6 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/karalabe/hid v1.0.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
@@ -41,16 +39,15 @@ require (
 	github.com/libp2p/go-libp2p-core v0.6.1
 	github.com/libp2p/go-libp2p-crypto v0.1.0
 	github.com/libp2p/go-libp2p-discovery v0.5.0
-	github.com/libp2p/go-libp2p-host v0.1.0
+	github.com/libp2p/go-libp2p-host v0.1.0 // indirect
 	github.com/libp2p/go-libp2p-kad-dht v0.8.3
-	github.com/libp2p/go-libp2p-net v0.1.0
-	github.com/libp2p/go-libp2p-peer v0.2.0
-	github.com/libp2p/go-libp2p-peerstore v0.2.6
+	github.com/libp2p/go-libp2p-net v0.1.0 // indirect
+	github.com/libp2p/go-libp2p-peer v0.2.0 // indirect
+	github.com/libp2p/go-libp2p-peerstore v0.2.6 // indirect
 	github.com/libp2p/go-libp2p-pubsub v0.3.3
 	github.com/multiformats/go-multiaddr v0.2.2
 	github.com/multiformats/go-multiaddr-net v0.1.5
 	github.com/natefinch/lumberjack v2.0.0+incompatible
-	github.com/otiai10/copy v1.2.0
 	github.com/pborman/uuid v1.2.0
 	github.com/pelletier/go-toml v1.2.0
 	github.com/pkg/errors v0.9.1
@@ -65,8 +62,6 @@ require (
 	github.com/spf13/viper v1.6.1
 	github.com/stretchr/testify v1.6.1
 	github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d
-	github.com/uber/jaeger-client-go v2.20.1+incompatible // indirect
-	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a

--- a/hmy/blockchain.go
+++ b/hmy/blockchain.go
@@ -48,10 +48,14 @@ func (hmy *Harmony) GetBlockSigners(
 		return nil, nil, err
 	}
 	pubKeys := make([]internal_bls.PublicKeyWrapper, len(committee.Slots))
-	for _, validator := range committee.Slots {
-		wrapper := internal_bls.PublicKeyWrapper{Bytes: validator.BLSPublicKey}
-		if wrapper.Object, err = bls.BytesToBLSPublicKey(wrapper.Bytes[:]); err != nil {
+	for i, validator := range committee.Slots {
+		key, err := bls.BytesToBLSPublicKey(validator.BLSPublicKey[:])
+		if err != nil {
 			return nil, nil, err
+		}
+		pubKeys[i] = internal_bls.PublicKeyWrapper{
+			Bytes:  validator.BLSPublicKey,
+			Object: key,
 		}
 	}
 	mask, err := internal_bls.NewMask(pubKeys, nil)

--- a/rosetta/common/operations.go
+++ b/rosetta/common/operations.go
@@ -17,6 +17,12 @@ const (
 
 	// ContractCreationOperation ..
 	ContractCreationOperation = "ContractCreation"
+
+	// GenesisFundsOperation ..
+	GenesisFundsOperation = "Genesis"
+
+	// PreStakingEraBlockRewardsOperation ..
+	PreStakingEraBlockRewardsOperation = "PreStakingBlockReward"
 )
 
 var (
@@ -26,6 +32,8 @@ var (
 		TransferOperation,
 		CrossShardTransferOperation,
 		ContractCreationOperation,
+		GenesisFundsOperation,
+		PreStakingEraBlockRewardsOperation,
 	}
 
 	// StakingOperationTypes ..

--- a/rosetta/common/operations.go
+++ b/rosetta/common/operations.go
@@ -21,8 +21,8 @@ const (
 	// GenesisFundsOperation ..
 	GenesisFundsOperation = "Genesis"
 
-	// PreStakingEraBlockRewardsOperation ..
-	PreStakingEraBlockRewardsOperation = "PreStakingBlockReward"
+	// PreStakingEraBlockRewardOperation ..
+	PreStakingEraBlockRewardOperation = "PreStakingBlockReward"
 )
 
 var (
@@ -33,7 +33,7 @@ var (
 		CrossShardTransferOperation,
 		ContractCreationOperation,
 		GenesisFundsOperation,
-		PreStakingEraBlockRewardsOperation,
+		PreStakingEraBlockRewardOperation,
 	}
 
 	// StakingOperationTypes ..

--- a/rosetta/common/operations_test.go
+++ b/rosetta/common/operations_test.go
@@ -54,7 +54,7 @@ func TestPlainOperationTypes(t *testing.T) {
 		CrossShardTransferOperation,
 		ContractCreationOperation,
 		GenesisFundsOperation,
-		PreStakingEraBlockRewardsOperation,
+		PreStakingEraBlockRewardOperation,
 	}
 	sort.Strings(referenceOperationTypes)
 	sort.Strings(plainOperationTypes)

--- a/rosetta/common/operations_test.go
+++ b/rosetta/common/operations_test.go
@@ -53,6 +53,8 @@ func TestPlainOperationTypes(t *testing.T) {
 		TransferOperation,
 		CrossShardTransferOperation,
 		ContractCreationOperation,
+		GenesisFundsOperation,
+		PreStakingEraBlockRewardsOperation,
 	}
 	sort.Strings(referenceOperationTypes)
 	sort.Strings(plainOperationTypes)

--- a/rosetta/rosetta.go
+++ b/rosetta/rosetta.go
@@ -53,7 +53,7 @@ func StartServers(hmy *hmy.Harmony, config nodeconfig.RosettaServerConfig) error
 		return err
 	}
 	go newHTTPServer(router).Serve(listener)
-	fmt.Printf("Started Rosetta server at: %v", endpoint)
+	fmt.Printf("Started Rosetta server at: %v\n", endpoint)
 	return nil
 }
 

--- a/rosetta/services/block.go
+++ b/rosetta/services/block.go
@@ -430,8 +430,8 @@ func getBlockSignerInfo(
 			sigInfos[slot.EcdsaAddress] = []bls.SerializedPublicKey{}
 		}
 		if ok, err := mask.KeyEnabled(slot.BLSPublicKey); ok && err == nil {
-			totalSigners += 1
 			sigInfos[slot.EcdsaAddress] = append(sigInfos[slot.EcdsaAddress], slot.BLSPublicKey)
+			totalSigners++
 		}
 	}
 	return &blockSignerInfo{

--- a/rosetta/services/block.go
+++ b/rosetta/services/block.go
@@ -296,7 +296,7 @@ func formatCrossShardReceiverTransaction(
 				Status:  common.SuccessOperationStatus.Status,
 				Account: receiverAccountID,
 				Amount: &types.Amount{
-					Value:    fmt.Sprintf("%v", cxReceipt.Amount.Uint64()),
+					Value:    fmt.Sprintf("%v", cxReceipt.Amount),
 					Currency: &common.Currency,
 				},
 				Metadata: map[string]interface{}{"from_account": senderAccountID},
@@ -416,7 +416,7 @@ func getOperations(
 	}
 
 	// All operations excepts for cross-shard tx payout expend gas
-	gasExpended := receipt.GasUsed * tx.GasPrice().Uint64()
+	gasExpended := new(big.Int).Mul(new(big.Int).SetUint64(receipt.GasUsed), tx.GasPrice())
 	gasOperations := newOperations(gasExpended, accountID)
 
 	// Handle different cases of plain transactions
@@ -453,7 +453,7 @@ func getStakingOperations(
 	}
 
 	// All operations excepts for cross-shard tx payout expend gas
-	gasExpended := receipt.GasUsed * tx.GasPrice().Uint64()
+	gasExpended := new(big.Int).Mul(new(big.Int).SetUint64(receipt.GasUsed), tx.GasPrice())
 	gasOperations := newOperations(gasExpended, accountID)
 
 	// Format staking message for metadata
@@ -525,7 +525,7 @@ func getAmountFromCreateValidatorMessage(data []byte) (*types.Amount, *types.Err
 		})
 	}
 	return &types.Amount{
-		Value:    fmt.Sprintf("-%v", stkMsg.Amount.Uint64()),
+		Value:    fmt.Sprintf("-%v", stkMsg.Amount),
 		Currency: &common.Currency,
 	}, nil
 }
@@ -544,7 +544,7 @@ func getAmountFromDelegateMessage(data []byte) (*types.Amount, *types.Error) {
 		})
 	}
 	return &types.Amount{
-		Value:    fmt.Sprintf("-%v", stkMsg.Amount.Uint64()),
+		Value:    fmt.Sprintf("-%v", stkMsg.Amount),
 		Currency: &common.Currency,
 	}, nil
 }
@@ -563,7 +563,7 @@ func getAmountFromUndelegateMessage(data []byte) (*types.Amount, *types.Error) {
 		})
 	}
 	return &types.Amount{
-		Value:    fmt.Sprintf("%v", stkMsg.Amount.Uint64()),
+		Value:    fmt.Sprintf("%v", stkMsg.Amount),
 		Currency: &common.Currency,
 	}, nil
 }
@@ -576,7 +576,7 @@ func getAmountFromCollectRewards(
 	for _, log := range logs {
 		if log.Address == senderAddress {
 			amount = &types.Amount{
-				Value:    fmt.Sprintf("%v", big.NewInt(0).SetBytes(log.Data).Uint64()),
+				Value:    fmt.Sprintf("%v", big.NewInt(0).SetBytes(log.Data)),
 				Currency: &common.Currency,
 			}
 			break
@@ -778,7 +778,7 @@ func newAccountIdentifier(
 // newOperations creates a new operation with the gas fee as the first operation.
 // Note: the gas fee is gasPrice * gasUsed.
 func newOperations(
-	gasFeeInATTO uint64, accountID *types.AccountIdentifier,
+	gasFeeInATTO *big.Int, accountID *types.AccountIdentifier,
 ) []*types.Operation {
 	return []*types.Operation{
 		{

--- a/rosetta/services/block.go
+++ b/rosetta/services/block.go
@@ -575,6 +575,11 @@ func formatPreStakingBlockRewardsTransaction(
 		}
 		if sigAddr == addr {
 			rewardsForThisBlock = rewardsForThisAddr
+			if !(rewardsForThisAddr.Cmp(big.NewInt(0)) > 0) {
+				return nil, common.NewError(common.SanityCheckError, map[string]interface{}{
+					"message": "expected non-zero block reward in pre-staking ear for block signer",
+				})
+			}
 			break
 		}
 	}

--- a/rosetta/services/block_test.go
+++ b/rosetta/services/block_test.go
@@ -322,7 +322,7 @@ func TestGetStakingOperationsFromCreateValidator(t *testing.T) {
 	}
 
 	gasUsed := uint64(1e5)
-	gasFee := new(big.Int).Mul(gasPrice, big.NewInt(int64(gasUsed))).Uint64()
+	gasFee := new(big.Int).Mul(gasPrice, big.NewInt(int64(gasUsed)))
 	receipt := &hmytypes.Receipt{
 		Status:  hmytypes.ReceiptStatusSuccessful, // Failed staking transaction are never saved on-chain
 		GasUsed: gasUsed,
@@ -383,7 +383,7 @@ func TestGetStakingOperationsFromDelegate(t *testing.T) {
 	}
 
 	gasUsed := uint64(1e5)
-	gasFee := new(big.Int).Mul(gasPrice, big.NewInt(int64(gasUsed))).Uint64()
+	gasFee := new(big.Int).Mul(gasPrice, big.NewInt(int64(gasUsed)))
 	receipt := &hmytypes.Receipt{
 		Status:  hmytypes.ReceiptStatusSuccessful, // Failed staking transaction are never saved on-chain
 		GasUsed: gasUsed,
@@ -444,7 +444,7 @@ func TestGetStakingOperationsFromUndelegate(t *testing.T) {
 	}
 
 	gasUsed := uint64(1e5)
-	gasFee := new(big.Int).Mul(gasPrice, big.NewInt(int64(gasUsed))).Uint64()
+	gasFee := new(big.Int).Mul(gasPrice, big.NewInt(int64(gasUsed)))
 	receipt := &hmytypes.Receipt{
 		Status:  hmytypes.ReceiptStatusSuccessful, // Failed staking transaction are never saved on-chain
 		GasUsed: gasUsed,
@@ -498,7 +498,7 @@ func TestGetStakingOperationsFromCollectRewards(t *testing.T) {
 	}
 
 	gasUsed := uint64(1e5)
-	gasFee := new(big.Int).Mul(gasPrice, big.NewInt(int64(gasUsed))).Uint64()
+	gasFee := new(big.Int).Mul(gasPrice, big.NewInt(int64(gasUsed)))
 	receipt := &hmytypes.Receipt{
 		Status:  hmytypes.ReceiptStatusSuccessful, // Failed staking transaction are never saved on-chain
 		GasUsed: gasUsed,
@@ -559,7 +559,7 @@ func TestGetStakingOperationsFromEditValidator(t *testing.T) {
 	}
 
 	gasUsed := uint64(1e5)
-	gasFee := new(big.Int).Mul(gasPrice, big.NewInt(int64(gasUsed))).Uint64()
+	gasFee := new(big.Int).Mul(gasPrice, big.NewInt(int64(gasUsed)))
 	receipt := &hmytypes.Receipt{
 		Status:  hmytypes.ReceiptStatusSuccessful, // Failed staking transaction are never saved on-chain
 		GasUsed: gasUsed,
@@ -891,7 +891,7 @@ func TestNewOperations(t *testing.T) {
 	accountID := &types.AccountIdentifier{
 		Address: "test-address",
 	}
-	gasFee := uint64(1e18)
+	gasFee := big.NewInt(int64(1e18))
 	amount := &types.Amount{
 		Value:    fmt.Sprintf("-%v", gasFee),
 		Currency: &common.Currency,

--- a/rosetta/services/block_test.go
+++ b/rosetta/services/block_test.go
@@ -262,7 +262,7 @@ func TestFormatPreStakingBlockRewardsTransactionSuccess(t *testing.T) {
 		t.Fatal(err)
 	}
 	testBlockSigInfo := &blockSignerInfo{
-		committee: map[ethcommon.Address][]bls.SerializedPublicKey{
+		signers: map[ethcommon.Address][]bls.SerializedPublicKey{
 			testAddr: { // Only care about length for this test
 				bls.SerializedPublicKey{},
 				bls.SerializedPublicKey{},
@@ -312,7 +312,7 @@ func TestFormatPreStakingBlockRewardsTransactionFail(t *testing.T) {
 		t.Fatal(err)
 	}
 	testBlockSigInfo := &blockSignerInfo{
-		committee: map[ethcommon.Address][]bls.SerializedPublicKey{
+		signers: map[ethcommon.Address][]bls.SerializedPublicKey{
 			testAddr: {},
 		},
 		totalKeysSigned: 150,
@@ -327,7 +327,7 @@ func TestFormatPreStakingBlockRewardsTransactionFail(t *testing.T) {
 	}
 
 	testBlockSigInfo = &blockSignerInfo{
-		committee:       map[ethcommon.Address][]bls.SerializedPublicKey{},
+		signers:         map[ethcommon.Address][]bls.SerializedPublicKey{},
 		totalKeysSigned: 150,
 		blockHash:       ethcommon.HexToHash("0x1a06b0378d63bf589282c032f0c85b32827e3a2317c2f992f45d8f07d0caa238"),
 	}

--- a/rosetta/services/block_test.go
+++ b/rosetta/services/block_test.go
@@ -1163,4 +1163,14 @@ func TestSpecialCaseTransactionIdentifier(t *testing.T) {
 	if unpackedBlkHash.String() != testBlkHash.String() {
 		t.Errorf("expected blk hash to be %v not %v", unpackedBlkHash.String(), testBlkHash.String())
 	}
+
+	_, _, rosettaError = unpackSpecialCaseTransactionIdentifier(
+		&types.TransactionIdentifier{Hash: ""},
+	)
+	if rosettaError == nil {
+		t.Fatal("expected rosetta error")
+	}
+	if rosettaError.Code != common.CatchAllError.Code {
+		t.Error("expected error code to be catch call error")
+	}
 }

--- a/rosetta/services/network.go
+++ b/rosetta/services/network.go
@@ -73,7 +73,7 @@ func (s *NetworkAPI) NetworkStatus(
 	}
 	targetHeight := int64(s.hmy.NodeAPI.GetMaxPeerHeight())
 	syncStatus := common.SyncingFinish
-	if s.hmy.NodeAPI.IsOutOfSync(s.hmy.BeaconChain) {
+	if s.hmy.NodeAPI.IsOutOfSync(s.hmy.BlockChain) {
 		syncStatus = common.SyncingNewBlock
 	} else if targetHeight == 0 {
 		syncStatus = common.SyncingStartup

--- a/staking/network/reward.go
+++ b/staking/network/reward.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	// BlockReward is the block reward, to be split evenly among block signers.
+	// BlockReward is the block reward, to be split evenly among block signers in pre-staking era.
 	BlockReward = new(big.Int).Mul(big.NewInt(24), big.NewInt(denominations.One))
 	// BaseStakedReward is the flat-rate block reward for epos staking launch.
 	// 28 ONE per block


### PR DESCRIPTION
# Stage 3.2 FIX of [Node API Overhaul](https://github.com/harmony-one/harmony/issues/3210)

This PR is related to #3312 .

This fixes some decimal precision errors as well as add 'accounting' transactions for block rewards in the pre-staking era. 
Block reward operations on respective blocks/transactions will look a little something like this:
```json
{
  "Type": "PreStakingBlockReward",
  "Operations": [
   {
    "operation_identifier": {
     "index": 0
    },
    "type": "PreStakingBlockReward",
    "status": "success",
    "account": {
     "address": "one13rnn8uawlpqpcsh0hpm2k26xxusq639wkvl7r5",
     "metadata": {
      "hex_address": "0x88E733F3AEF8401c42EfB876Ab2B4637200d44AE"
     }
    },
    "amount": {
     "value": "113207547169811320",
     "currency": {
      "symbol": "ONE",
      "decimals": 18
     }
    }
   }
  ],
  "Currencies": [
   {
    "symbol": "ONE",
    "decimals": 18
   }
  ],
  "NilAmountPresent": false
 }
```
This PR also refactors 'special' transactions (genesis & block rewards) into their own functions for clarity.

This PR changes the special transaction identifier to fit the format: `<block_hash>_<Bech-32_Address>`. The related machinery has been made to easily change this format, should we want to change it before release.  

This PR also fixes the `getBlockSigners` RPC, with an added test [here](https://github.com/harmony-one/harmony-test/commit/ed3a601f7fece849938fe67649b19f2aad55a47a).

This PR also updates the go.mod file as I could not build on my machine without re-syncing dependencies (to get the go.mod file in this PR). 