### PR TITLE
Explorer node return errors

### DIFF
--- a/node/node_explorer.go
+++ b/node/node_explorer.go
@@ -28,6 +28,9 @@ var (
 	errFailFindingValidCommit = errors.New(
 		"explorer failed finding a valid committed message",
 	)
+	errAddressNotFound = errors.New(
+		"address not found",
+	)
 )
 
 // explorerMessageHandler passes received message in node_handler to explorer service
@@ -235,7 +238,7 @@ func (node *Node) GetTransactionsCount(address, txType string) (uint64, error) {
 	bytes, err := explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port).GetDB().Get([]byte(key), nil)
 	if err != nil {
 		utils.Logger().Error().Err(err).Str("addr", address).Msg("[Explorer] Address not found")
-		return 0, nil
+		return 0, errAddressNotFound
 	}
 	if err = rlp.DecodeBytes(bytes, &addressData); err != nil {
 		utils.Logger().Error().Err(err).Msg("[Explorer] Cannot convert address data from DB")
@@ -258,7 +261,7 @@ func (node *Node) GetStakingTransactionsCount(address, txType string) (uint64, e
 	bytes, err := explorer.GetStorageInstance(node.SelfPeer.IP, node.SelfPeer.Port).GetDB().Get([]byte(key), nil)
 	if err != nil {
 		utils.Logger().Error().Err(err).Str("addr", address).Msg("[Explorer] Address not found")
-		return 0, nil
+		return 0, errAddressNotFound
 	}
 	if err = rlp.DecodeBytes(bytes, &addressData); err != nil {
 		utils.Logger().Error().Err(err).Msg("[Explorer] Cannot convert address data from DB")

--- a/node/node_explorer.go
+++ b/node/node_explorer.go
@@ -31,6 +31,9 @@ var (
 	errAddressNotFound = errors.New(
 		"address not found",
 	)
+	errRetrievingHistory = errors.New(
+		"explorer failed to retrieve history",
+	)
 )
 
 // explorerMessageHandler passes received message in node_handler to explorer service
@@ -173,7 +176,7 @@ func (node *Node) GetTransactionsHistory(address, txType, order string) ([]commo
 	if err != nil {
 		utils.Logger().Debug().Err(err).
 			Msgf("[Explorer] Error retrieving transaction history for address %s", address)
-		return make([]common.Hash, 0), nil
+		return make([]common.Hash, 0), errRetrievingHistory
 	}
 	if err = rlp.DecodeBytes(bytes, &addressData); err != nil {
 		utils.Logger().Error().Err(err).Msg("[Explorer] Cannot convert address data from DB")
@@ -206,7 +209,7 @@ func (node *Node) GetStakingTransactionsHistory(address, txType, order string) (
 	if err != nil {
 		utils.Logger().Debug().Err(err).
 			Msgf("[Explorer] Staking transaction history for address %s not found", address)
-		return make([]common.Hash, 0), nil
+		return make([]common.Hash, 0), errRetrievingHistory
 	}
 	if err = rlp.DecodeBytes(bytes, &addressData); err != nil {
 		utils.Logger().Error().Err(err).Msg("[Explorer] Cannot convert address data from DB")


### PR DESCRIPTION
Found many repeated "Address not found" error messages on explorer node, but it didn't return error to the caller.  So, return errors to the caller.