### PR TITLE
[rpc] fix transaction receipt fetch bug

### DIFF
--- a/rpc/transaction.go
+++ b/rpc/transaction.go
@@ -591,6 +591,10 @@ func (s *PublicTransactionService) GetTransactionReceipt(
 		if stx == nil {
 			return nil, nil
 		}
+		// if there both normal and staking transactions, add to index
+		if block, _ := s.hmy.GetBlock(ctx, blockHash); block != nil {
+			index = index + uint64(block.Transactions().Len())
+		}
 	}
 	receipts, err := s.hmy.GetReceipts(ctx, blockHash)
 	if err != nil {

--- a/rpc/v1/types.go
+++ b/rpc/v1/types.go
@@ -301,11 +301,11 @@ func NewReceipt(
 ) (interface{}, error) {
 	plainTx, ok := tx.(*types.Transaction)
 	if ok {
-		return NewTxReceipt(plainTx, blockHash, blockIndex, blockNumber, receipt)
+		return NewTxReceipt(plainTx, blockHash, blockNumber, blockIndex, receipt)
 	}
 	stakingTx, ok := tx.(*staking.StakingTransaction)
 	if ok {
-		return NewStakingTxReceipt(stakingTx, blockHash, blockIndex, blockNumber, receipt)
+		return NewStakingTxReceipt(stakingTx, blockHash, blockNumber, blockIndex, receipt)
 	}
 	return nil, fmt.Errorf("unknown transaction type for RPC receipt")
 }

--- a/rpc/v2/types.go
+++ b/rpc/v2/types.go
@@ -299,11 +299,11 @@ func NewReceipt(
 ) (interface{}, error) {
 	plainTx, ok := tx.(*types.Transaction)
 	if ok {
-		return NewTxReceipt(plainTx, blockHash, blockIndex, blockNumber, receipt)
+		return NewTxReceipt(plainTx, blockHash, blockNumber, blockIndex, receipt)
 	}
 	stakingTx, ok := tx.(*staking.StakingTransaction)
 	if ok {
-		return NewStakingTxReceipt(stakingTx, blockHash, blockIndex, blockNumber, receipt)
+		return NewStakingTxReceipt(stakingTx, blockHash, blockNumber, blockIndex, receipt)
 	}
 	return nil, fmt.Errorf("unknown transaction type for RPC receipt")
 }


### PR DESCRIPTION
This PR fixes the transaction receipt bug that happens when there are both normal and staking transaction. e.g., in https://explorer.harmony.one/#/staking-tx/0xb42e20638347a0296f8b54b0c3381a96ab1e3d9c120cb505eed89a73a0cc5631 the value is shown as Infinity. This happens due to multiple receipt logs wrongly fetched. 

Before
```
./hmy blockchain transaction-receipt 0xb42e20638347a0296f8b54b0c3381a96ab1e3d9c120cb505eed89a73a0cc5631 -n https://api.s0.t.hmny.io
{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "blockHash": "0x66ad6b31d39f89ac68d5d577e38c5df1256148c6de8daec5b1ea5a85811ff113",
    "blockNumber": "0x0",
    "contractAddress": "0x0000000000000000000000000000000000000000",
    "cumulativeGasUsed": "0x1f04d",
    "gasUsed": "0x1f04d",
    "logs": [
      {
        "address": "0x3e37a9c5f2ec88b7566ae68a5d38707e5e25f243",
        "blockHash": "0x66ad6b31d39f89ac68d5d577e38c5df1256148c6de8daec5b1ea5a85811ff113",
        "blockNumber": "0x394031",
        "data": "0x000000000000000000000000000000000000000000000000000000000000003a00000000000000000000000000000000000000000000000000000000000000600000000000000000000000005a486a0f111ccff9dcf73df7760dde868dbebb83000000000000000000000000000000000000000000000000000000000000000b4f6c69766572204b61686e000000000000000000000000000000000000000000",
        "logIndex": "0x0",
        "removed": false,
        "topics": [
          "0xb3b0cf861f168bcdb275c69da97b2543631552ba562628aa3c7317d4a6089ef2"
        ],
        "transactionHash": "0x5fc4f626dfc3aa2f3b78c3b2786d054594fc9e85485a21e14c3727bbc41fd1b2",
        "transactionIndex": "0x0"
      },
      {
        "address": "0x3e37a9c5f2ec88b7566ae68a5d38707e5e25f243",
        "blockHash": "0x66ad6b31d39f89ac68d5d577e38c5df1256148c6de8daec5b1ea5a85811ff113",
        "blockNumber": "0x394031",
        "data": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000005a486a0f111ccff9dcf73df7760dde868dbebb83000000000000000000000000000000000000000000000000000000000000003a",
        "logIndex": "0x1",
        "removed": false,
        "topics": [
          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
        ],
        "transactionHash": "0x5fc4f626dfc3aa2f3b78c3b2786d054594fc9e85485a21e14c3727bbc41fd1b2",
        "transactionIndex": "0x0"
      }
    ],
    "logsBloom": "0x00000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000200000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000",
    "sender": "one1tm2g0vj64jg4gguuvutefygg70dcvnpwskkvyx",
    "status": "0x1",
    "transactionHash": "0xb42e20638347a0296f8b54b0c3381a96ab1e3d9c120cb505eed89a73a0cc5631",
    "transactionIndex": "0x394031",
    "type": 4
  }
}
```

After (ran local node to test rpc fix)
```
./hmy blockchain transaction-receipt 0xb42e20638347a0296f8b54b0c3381a96ab1e3d9c120cb505eed89a73a0cc5631
{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "blockHash": "0x66ad6b31d39f89ac68d5d577e38c5df1256148c6de8daec5b1ea5a85811ff113",
    "blockNumber": "0x394031",
    "contractAddress": "0x0000000000000000000000000000000000000000",
    "cumulativeGasUsed": "0x2482d",
    "gasUsed": "0x57e0",
    "logs": [
      {
        "address": "0x5ed487b25aac9154239c6717949108f3db864c2e",
        "blockHash": "0x66ad6b31d39f89ac68d5d577e38c5df1256148c6de8daec5b1ea5a85811ff113",
        "blockNumber": "0x394031",
        "data": "0xee3773f70baec9",
        "logIndex": "0x2",
        "removed": false,
        "topics": [
          "0xef0a8d7b9b8cbde3c16f5ea86afc300881518ffc9f6e8c8f6984e0037eec16fb"
        ],
        "transactionHash": "0xb42e20638347a0296f8b54b0c3381a96ab1e3d9c120cb505eed89a73a0cc5631",
        "transactionIndex": "0x1"
      }
    ],
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "sender": "one1tm2g0vj64jg4gguuvutefygg70dcvnpwskkvyx",
    "status": "0x1",
    "transactionHash": "0xb42e20638347a0296f8b54b0c3381a96ab1e3d9c120cb505eed89a73a0cc5631",
    "transactionIndex": "0x1",
    "type": 4
  }
}
```