### PR TITLE
[sync] Fix sync stuck issue.

### DIFF
--- a/api/service/syncing/downloader/client.go
+++ b/api/service/syncing/downloader/client.go
@@ -21,8 +21,11 @@ type Client struct {
 func ClientSetup(ip, port string) *Client {
 	client := Client{}
 	client.opts = append(client.opts, grpc.WithInsecure())
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
 	var err error
-	client.conn, err = grpc.Dial(fmt.Sprintf(ip+":"+port), client.opts...)
+	client.conn, err = grpc.DialContext(ctx, fmt.Sprintf(ip+":"+port), client.opts...)
 	if err != nil {
 		utils.Logger().Error().Err(err).Str("ip", ip).Msg("[SYNC] client.go:ClientSetup fail to dial")
 		return nil


### PR DESCRIPTION
## Issue

Some node occasionally get stuck in the syncing process. There is no log message with `[SYNC]` presented in the log, so I guess there is some code get stuck in function `doSync` (node/node_syncing.go:226). 

After checking the the whole logic, found that the only place that might get stuck is the GRPC dial - dial is not set a timeout. So this PR is proposed to fix this issue.

## Test

Done in local node connected to testnet. The sync process can proceed as it used to.
