### PR TITLE
Refresh acc timeout beat each time a tx is added

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -967,6 +967,9 @@ func (pool *TxPool) add(tx types.PoolTransaction, local bool) (bool, error) {
 		pool.priced.Put(tx)
 		pool.journalTx(from, tx)
 
+		// Set or refresh beat for account timeout eviction
+		pool.beats[from] = time.Now()
+
 		logger.Info().
 			Str("hash", tx.Hash().Hex()).
 			Interface("from", from).
@@ -992,6 +995,9 @@ func (pool *TxPool) add(tx types.PoolTransaction, local bool) (bool, error) {
 		}
 	}
 	pool.journalTx(from, tx)
+
+	// Set or refresh beat for account timeout eviction
+	pool.beats[from] = time.Now()
 
 	logger.Info().
 		Str("hash", hash.Hex()).


### PR DESCRIPTION
This PR closes #3329

Currently, we only add an account to the beat map if it is executable, but it is possible to only add a non-executable transaction (i.e: a 'pooled future transaction') having never submitted an executable transaction, thus never getting an initial beat --> never getting timeout evicted from the pool.

This PR adds a tx's sender address to the beat map after successfully adding the transaction to the pool. 