### PR TITLE
Add localnet only testing account in genesis conf

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -128,6 +128,13 @@ func NewGenesisSpec(netType nodeconfig.NetworkType, shardID uint32) *Genesis {
 			contractDeployerFunds, big.NewInt(denominations.One),
 		)
 		genesisAlloc[contractDeployerAddress] = GenesisAccount{Balance: contractDeployerFunds}
+
+		// Localnet only testing account
+		if netType == nodeconfig.Localnet {
+			// PK: 1f84c95ac16e6a50f08d44c7bde7aff8742212fda6e4321fde48bf83bef266dc
+			testAddress := common.HexToAddress("0xA5241513DA9F4463F1d4874b548dFBAC29D91f34")
+			genesisAlloc[testAddress] = GenesisAccount{Balance: contractDeployerFunds}
+		}
 	}
 
 	return &Genesis{

--- a/rosetta/services/block.go
+++ b/rosetta/services/block.go
@@ -1079,5 +1079,8 @@ func getGenesisSpec(shardID uint32) *core.Genesis {
 	if shard.Schedule.GetNetworkID() == shardingconfig.MainNet {
 		return core.NewGenesisSpec(nodeconfig.Mainnet, shardID)
 	}
+	if shard.Schedule.GetNetworkID() == shardingconfig.LocalNet {
+		return core.NewGenesisSpec(nodeconfig.Localnet, shardID)
+	}
 	return core.NewGenesisSpec(nodeconfig.Testnet, shardID)
 }


### PR DESCRIPTION
This PR adds a test account that is specific to localnet for devs to use when building locally. This is needed, for example, in our [multichain](https://github.com/harmony-one/multichain) integration.

The account's private key is:
```
1f84c95ac16e6a50f08d44c7bde7aff8742212fda6e4321fde48bf83bef266dc
```

The account's address is: 
```
one155jp2y76nazx8uw5sa94fr0m4s5aj8e5xm6fu3
```

I've also updated the Rosetta genesis block logic to correctly report localnet genesis funds. 