### PR TITLE
Increase crosslink catching rate, expect to have equillibrium at 5 block delay

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -245,7 +245,7 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 		ret, st.gas, vmerr = evm.Call(sender, st.to(), st.data, st.gas, st.value)
 	}
 	if vmerr != nil {
-		utils.Logger().Debug().Err(vmerr).Msg("VM returned with error")
+		utils.Logger().Info().Err(vmerr).Msg("VM returned with error")
 		// The only possible consensus-error would be if there wasn't
 		// sufficient balance to make the transfer happen. The first
 		// balance transfer may never fail.

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -212,8 +212,8 @@ func (node *Node) BroadcastCrossLink() {
 		batchSize := crossLinkBatchSize
 		diff := curBlock.Number().Uint64() - latestBlockNum
 
-		// Increase batch size by 1 for every 100 blocks beyond
-		batchSize += int(diff) / 100
+		// Increase batch size by 1 for every 5 blocks behind
+		batchSize += int(diff) / 5
 
 		// Cap at a sane size to avoid overload network
 		if batchSize > crossLinkBatchSize*2 {


### PR DESCRIPTION
Currently the block link delay stays at around 100 blocks between beacon chain and shard chain for both testnet and mainnet.

We can see that the crosslink relay will slowly catchup if it sends 4 blocks in a batch, and will slowly fall behind if it sends 3 blocks in a batch.

So basically the condition to increase the catch up speed from 3 blocks to 4 blocks in the batch is the stable equilibrium for crosslink relay.

This PR change the stepping function's condition from 100 blocks to 5 blocks. Expect this to shorten the crosslink delay from ~100 blocks to roughly 5 blocks.

Tagged along in this PR is the change to print evm error as Info() for better troubleshooting.