### PR TITLE
[logs] disable log log filtering based on the bloom bits indexed and just do raw block iteration and bloom matching

### DIFF
--- a/rpc/filters/filter.go
+++ b/rpc/filters/filter.go
@@ -149,17 +149,17 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 		logs []*types.Log
 		err  error
 	)
-	size, sections := f.backend.BloomStatus()
-	if indexed := sections * size; indexed > uint64(f.begin) {
-		if indexed > end {
-			logs, err = f.indexedLogs(ctx, end)
-		} else {
-			logs, err = f.indexedLogs(ctx, indexed-1)
-		}
-		if err != nil {
-			return logs, err
-		}
-	}
+	// size, sections := f.backend.BloomStatus()
+	// if indexed := sections * size; indexed > uint64(f.begin) {
+	// 	if indexed > end {
+	// 		logs, err = f.indexedLogs(ctx, end)
+	// 	} else {
+	// 		logs, err = f.indexedLogs(ctx, indexed-1)
+	// 	}
+	// 	if err != nil {
+	// 		return logs, err
+	// 	}
+	// }
 	rest, err := f.unindexedLogs(ctx, end)
 	logs = append(logs, rest...)
 	return logs, err


### PR DESCRIPTION
jellyswap reported issue where getting old logs like past 1000+ blocks times out. I was able to verify this and this seems to happen due to expensive `indexedLogs` call, which is not really needed and we could simply get the `unindexedLogs` which is sufficient.  