### PR TITLE
Rosetta Implementation - pt2 FIX2 (Stage 3.2 of Node API Overhaul)

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -161,13 +161,14 @@ type BlockChain struct {
 	procInterrupt int32          // interrupt signaler for block processing
 	wg            sync.WaitGroup // chain processing wait group for shutting down
 
-	engine         consensus_engine.Engine
-	processor      Processor // block processor interface
-	validator      Validator // block and state validator interface
-	vmConfig       vm.Config
-	badBlocks      *lru.Cache              // Bad block cache
-	shouldPreserve func(*types.Block) bool // Function used to determine whether should preserve the given block.
-	pendingSlashes slash.Records
+	engine                  consensus_engine.Engine
+	processor               Processor // block processor interface
+	validator               Validator // block and state validator interface
+	vmConfig                vm.Config
+	badBlocks               *lru.Cache              // Bad block cache
+	shouldPreserve          func(*types.Block) bool // Function used to determine whether should preserve the given block.
+	pendingSlashes          slash.Records
+	lastGarbCollectedBlkNum int64
 }
 
 // NewBlockChain returns a fully initialised block chain using information
@@ -228,6 +229,7 @@ func NewBlockChain(
 		vmConfig:                      vmConfig,
 		badBlocks:                     badBlocks,
 		pendingSlashes:                slash.Records{},
+		lastGarbCollectedBlkNum:       -1,
 	}
 	bc.SetValidator(NewBlockValidator(chainConfig, bc, engine))
 	bc.SetProcessor(NewStateProcessor(chainConfig, bc, engine))
@@ -1168,6 +1170,9 @@ func (bc *BlockChain) WriteBlockWithState(
 						bc.triegc.Push(root, number)
 						break
 					}
+					if -number > bc.lastGarbCollectedBlkNum {
+						bc.lastGarbCollectedBlkNum = -number
+					}
 					triedb.Dereference(root.(common.Hash))
 				}
 			}
@@ -1200,6 +1205,11 @@ func (bc *BlockChain) WriteBlockWithState(
 
 	bc.futureBlocks.Remove(block.Hash())
 	return CanonStatTy, nil
+}
+
+// GetLastGarbageCollectedBlockNumber ..
+func (bc *BlockChain) GetLastGarbageCollectedBlockNumber() int64 {
+	return bc.lastGarbCollectedBlkNum
 }
 
 // InsertChain attempts to insert the given batch of blocks in to the canonical
@@ -2021,10 +2031,10 @@ func (bc *BlockChain) ReadPendingCrossLinks() ([]types.CrossLink, error) {
 // WritePendingCrossLinks saves the pending crosslinks
 func (bc *BlockChain) WritePendingCrossLinks(crossLinks []types.CrossLink) error {
 	// deduplicate crosslinks if any
-	m := map[uint32]map[uint64](types.CrossLink){}
+	m := map[uint32]map[uint64]types.CrossLink{}
 	for _, cl := range crossLinks {
 		if _, ok := m[cl.ShardID()]; !ok {
-			m[cl.ShardID()] = map[uint64](types.CrossLink){}
+			m[cl.ShardID()] = map[uint64]types.CrossLink{}
 		}
 		m[cl.ShardID()][cl.BlockNum()] = cl
 	}
@@ -2111,10 +2121,10 @@ func (bc *BlockChain) DeleteFromPendingCrossLinks(crossLinks []types.CrossLink) 
 		return 0, err
 	}
 
-	m := map[uint32]map[uint64](struct{}){}
+	m := map[uint32]map[uint64]struct{}{}
 	for _, cl := range crossLinks {
 		if _, ok := m[cl.ShardID()]; !ok {
-			m[cl.ShardID()] = map[uint64](struct{}){}
+			m[cl.ShardID()] = map[uint64]struct{}{}
 		}
 		m[cl.ShardID()][cl.BlockNum()] = struct{}{}
 	}

--- a/hmy/staking.go
+++ b/hmy/staking.go
@@ -24,7 +24,8 @@ import (
 )
 
 var (
-	zero = numeric.ZeroDec()
+	zero    = numeric.ZeroDec()
+	bigZero = big.NewInt(0)
 )
 
 func (hmy *Harmony) readAndUpdateRawStakes(
@@ -534,9 +535,8 @@ func (hmy *Harmony) GetUndelegationPayouts(
 		}
 		for _, delegation := range wrapper.Delegations {
 			withdraw := delegation.RemoveUnlockedUndelegations(epoch, wrapper.LastEpochInCommittee, lockingPeriod)
-			if withdraw.Cmp(big.NewInt(0)) == 1 {
-				totalPayout, ok := undelegationPayouts[delegation.DelegatorAddress]
-				if ok {
+			if withdraw.Cmp(bigZero) == 1 {
+				if totalPayout, ok := undelegationPayouts[delegation.DelegatorAddress]; ok {
 					undelegationPayouts[delegation.DelegatorAddress] = new(big.Int).Add(totalPayout, withdraw)
 				} else {
 					undelegationPayouts[delegation.DelegatorAddress] = withdraw

--- a/hmy/staking.go
+++ b/hmy/staking.go
@@ -509,8 +509,8 @@ func (hmy *Harmony) GetUndelegationPayouts(
 	}
 
 	undelegationPayouts := map[common.Address]*big.Int{}
+	// require second to last block as saved undelegations are AFTER undelegations are payed out
 	blockNumber := shard.Schedule.EpochLastBlock(epoch.Uint64()) - 1
-	fmt.Printf("block num: %v\n", blockNumber)
 	undelegationPayoutBlock, err := hmy.BlockByNumber(ctx, rpc.BlockNumber(blockNumber))
 	if err != nil || undelegationPayoutBlock == nil {
 		// Block not found, so no undelegated undelegationPayouts (not an error)
@@ -521,7 +521,7 @@ func (hmy *Harmony) GetUndelegationPayouts(
 	for _, validator := range hmy.GetAllValidatorAddresses() {
 		wrapper, err := hmy.BlockChain.ReadValidatorInformationAt(validator, undelegationPayoutBlock.Root())
 		if err != nil || wrapper == nil {
-			continue // Not a validator at this epoch or unable to fetch validator info because of non-archival DB.
+			continue // Not a validator at this epoch or unable to fetch validator info because of pruned state.
 		}
 		for _, delegation := range wrapper.Delegations {
 			withdraw := delegation.RemoveUnlockedUndelegations(epoch, wrapper.LastEpochInCommittee, lockingPeriod)

--- a/hmy/staking.go
+++ b/hmy/staking.go
@@ -11,7 +11,8 @@ import (
 	"github.com/harmony-one/harmony/consensus/quorum"
 	"github.com/harmony-one/harmony/core/rawdb"
 	"github.com/harmony-one/harmony/core/types"
-	internal_common "github.com/harmony-one/harmony/internal/common"
+	"github.com/harmony-one/harmony/internal/chain"
+	internalCommon "github.com/harmony-one/harmony/internal/common"
 	"github.com/harmony-one/harmony/numeric"
 	commonRPC "github.com/harmony-one/harmony/rpc/common"
 	"github.com/harmony-one/harmony/shard"
@@ -133,10 +134,7 @@ func (hmy *Harmony) IsPreStakingEpoch(epoch *big.Int) bool {
 
 // GetDelegationLockingPeriodInEpoch ...
 func (hmy *Harmony) GetDelegationLockingPeriodInEpoch(epoch *big.Int) int {
-	if hmy.BlockChain.Config().IsQuickUnlock(epoch) {
-		return staking.LockPeriodInEpochV2
-	}
-	return staking.LockPeriodInEpoch
+	return chain.GetLockPeriodInEpoch(hmy.BlockChain, epoch)
 }
 
 // SendStakingTx adds a staking transaction
@@ -266,7 +264,7 @@ func (hmy *Harmony) GetValidatorInformation(
 	bc := hmy.BlockChain
 	wrapper, err := bc.ReadValidatorInformationAt(addr, block.Root())
 	if err != nil {
-		s, _ := internal_common.AddressToBech32(addr)
+		s, _ := internalCommon.AddressToBech32(addr)
 		return nil, errors.Wrapf(err, "not found address in current state %s", s)
 	}
 

--- a/hmy/staking.go
+++ b/hmy/staking.go
@@ -498,10 +498,13 @@ func (hmy *Harmony) GetDelegationsByDelegatorByBlock(
 	return addresses, delegations
 }
 
+// UndelegationPayouts ..
+type UndelegationPayouts map[common.Address]*big.Int
+
 // GetUndelegationPayouts returns the undelegation payouts for each delegator
 func (hmy *Harmony) GetUndelegationPayouts(
 	ctx context.Context, epoch *big.Int,
-) (map[common.Address]*big.Int, error) {
+) (UndelegationPayouts, error) {
 	if !hmy.IsPreStakingEpoch(epoch) {
 		return nil, fmt.Errorf("not pre-staking epoch or later")
 	}

--- a/hmy/staking.go
+++ b/hmy/staking.go
@@ -522,7 +522,7 @@ func (hmy *Harmony) GetUndelegationPayouts(
 	blockNumber := shard.Schedule.EpochLastBlock(epoch.Uint64()) - 1
 	undelegationPayoutBlock, err := hmy.BlockByNumber(ctx, rpc.BlockNumber(blockNumber))
 	if err != nil || undelegationPayoutBlock == nil {
-		// Block not found, so no undelegated undelegationPayouts (not an error)
+		// Block not found, so no undelegationPayouts (not an error)
 		return undelegationPayouts, nil
 	}
 

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -292,12 +292,7 @@ func payoutUndelegations(
 				"[Finalize] failed to get validator from state to finalize",
 			)
 		}
-		lockPeriod := staking.LockPeriodInEpoch
-		if chain.Config().IsRedelegation(header.Epoch()) {
-			lockPeriod = staking.LockPeriodInEpoch
-		} else if chain.Config().IsQuickUnlock(header.Epoch()) {
-			lockPeriod = staking.LockPeriodInEpochV2
-		}
+		lockPeriod := GetLockPeriodInEpoch(chain, header.Epoch())
 		for i := range wrapper.Delegations {
 			delegation := &wrapper.Delegations[i]
 			totalWithdraw := delegation.RemoveUnlockedUndelegations(
@@ -546,4 +541,15 @@ func GetPublicKeys(
 		)
 	}
 	return subCommittee.BLSPublicKeys()
+}
+
+// GetLockPeriodInEpoch returns the delegation lock period for the given chain
+func GetLockPeriodInEpoch(chain engine.ChainReader, epoch *big.Int) int {
+	lockPeriod := staking.LockPeriodInEpoch
+	if chain.Config().IsRedelegation(epoch) {
+		lockPeriod = staking.LockPeriodInEpoch
+	} else if chain.Config().IsQuickUnlock(epoch) {
+		lockPeriod = staking.LockPeriodInEpochV2
+	}
+	return lockPeriod
 }

--- a/rosetta/common/errors.go
+++ b/rosetta/common/errors.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"fmt"
+
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/harmony-one/harmony/rpc"
 )
@@ -65,15 +67,14 @@ var (
 
 // NewError create a new error with a given detail structure
 func NewError(rosettaError types.Error, detailStructure interface{}) *types.Error {
+	newError := rosettaError
 	details, err := rpc.NewStructuredResponse(detailStructure)
 	if err != nil {
-		newError := CatchAllError
-		CatchAllError.Details = map[string]interface{}{
-			"message": err.Error(),
+		newError.Details = map[string]interface{}{
+			"message": fmt.Sprintf("unable to get error details: %v", err.Error()),
 		}
-		return &newError
+	} else {
+		newError.Details = details
 	}
-	newError := rosettaError
-	newError.Details = details
 	return &newError
 }

--- a/rosetta/common/operations.go
+++ b/rosetta/common/operations.go
@@ -21,8 +21,11 @@ const (
 	// GenesisFundsOperation ..
 	GenesisFundsOperation = "Genesis"
 
-	// PreStakingEraBlockRewardOperation ..
-	PreStakingEraBlockRewardOperation = "PreStakingBlockReward"
+	// PreStakingBlockRewardOperation ..
+	PreStakingBlockRewardOperation = "PreOpenStakingBlockReward"
+
+	// UndelegationPayoutOperation ..
+	UndelegationPayoutOperation = "UndelegationPayout"
 )
 
 var (
@@ -33,7 +36,8 @@ var (
 		CrossShardTransferOperation,
 		ContractCreationOperation,
 		GenesisFundsOperation,
-		PreStakingEraBlockRewardOperation,
+		PreStakingBlockRewardOperation,
+		UndelegationPayoutOperation,
 	}
 
 	// StakingOperationTypes ..

--- a/rosetta/common/operations_test.go
+++ b/rosetta/common/operations_test.go
@@ -54,7 +54,8 @@ func TestPlainOperationTypes(t *testing.T) {
 		CrossShardTransferOperation,
 		ContractCreationOperation,
 		GenesisFundsOperation,
-		PreStakingEraBlockRewardOperation,
+		PreStakingBlockRewardOperation,
+		UndelegationPayoutOperation,
 	}
 	sort.Strings(referenceOperationTypes)
 	sort.Strings(plainOperationTypes)

--- a/rosetta/services/block.go
+++ b/rosetta/services/block.go
@@ -519,7 +519,7 @@ func getPseudoTransactionForGenesis(spec *core.Genesis) []*hmytypes.Transaction 
 	return txs
 }
 
-// SpecialTransactionSuffix
+// SpecialTransactionSuffix ..
 type SpecialTransactionSuffix uint
 
 // Special transaction suffixes that are specific to the Rosetta Implementation

--- a/rosetta/services/block.go
+++ b/rosetta/services/block.go
@@ -435,6 +435,9 @@ func (s *BlockAPI) getBlock(
 			"message": err.Error(),
 		})
 	}
+	if blk == nil {
+		return nil, &common.BlockNotFoundError
+	}
 	return blk, nil
 }
 

--- a/rosetta/services/block.go
+++ b/rosetta/services/block.go
@@ -522,7 +522,7 @@ func getPseudoTransactionForGenesis(spec *core.Genesis) []*hmytypes.Transaction 
 // SpecialTransactionSuffix ..
 type SpecialTransactionSuffix uint
 
-// Special transaction suffixes that are specific to the Rosetta Implementation
+// Special transaction suffixes that are specific to the rosetta package
 const (
 	SpecialGenesisTxID SpecialTransactionSuffix = iota
 	SpecialPreStakingRewardTxID

--- a/rosetta/services/block_test.go
+++ b/rosetta/services/block_test.go
@@ -271,8 +271,9 @@ func TestFormatPreStakingBlockRewardsTransactionSuccess(t *testing.T) {
 		totalKeysSigned: 150,
 		blockHash:       ethcommon.HexToHash("0x1a06b0378d63bf589282c032f0c85b32827e3a2317c2f992f45d8f07d0caa238"),
 	}
-	refTxID := getSpecialCaseTransactionIdentifier(testBlockSigInfo.blockHash, testB32Addr)
-	tx, rosettaError := formatPreStakingBlockRewardsTransaction(testB32Addr, testBlockSigInfo)
+	testSuffix := fmt.Sprintf("%v%v", testB32Addr, preStakingBlockRewardTxIDSuffix)
+	refTxID := getSpecialCaseTransactionIdentifier(testBlockSigInfo.blockHash, testSuffix)
+	tx, rosettaError := formatPreStakingBlockRewardsTransaction(refTxID, testBlockSigInfo)
 	if rosettaError != nil {
 		t.Fatal(rosettaError)
 	}
@@ -318,7 +319,9 @@ func TestFormatPreStakingBlockRewardsTransactionFail(t *testing.T) {
 		totalKeysSigned: 150,
 		blockHash:       ethcommon.HexToHash("0x1a06b0378d63bf589282c032f0c85b32827e3a2317c2f992f45d8f07d0caa238"),
 	}
-	_, rosettaError := formatPreStakingBlockRewardsTransaction(testB32Addr, testBlockSigInfo)
+	testSuffix := fmt.Sprintf("%v%v", testB32Addr, preStakingBlockRewardTxIDSuffix)
+	testTxID := getSpecialCaseTransactionIdentifier(testBlockSigInfo.blockHash, testSuffix)
+	_, rosettaError := formatPreStakingBlockRewardsTransaction(testTxID, testBlockSigInfo)
 	if rosettaError == nil {
 		t.Fatal("expected rosetta error")
 	}
@@ -331,7 +334,7 @@ func TestFormatPreStakingBlockRewardsTransactionFail(t *testing.T) {
 		totalKeysSigned: 150,
 		blockHash:       ethcommon.HexToHash("0x1a06b0378d63bf589282c032f0c85b32827e3a2317c2f992f45d8f07d0caa238"),
 	}
-	_, rosettaError = formatPreStakingBlockRewardsTransaction(testB32Addr, testBlockSigInfo)
+	_, rosettaError = formatPreStakingBlockRewardsTransaction(testTxID, testBlockSigInfo)
 	if rosettaError == nil {
 		t.Fatal("expected rosetta error")
 	}

--- a/rosetta/services/network.go
+++ b/rosetta/services/network.go
@@ -88,16 +88,20 @@ func (s *NetworkAPI) NetworkStatus(
 	// Only applicable to non-archival nodes
 	var oldestBlockIdentifier *types.BlockIdentifier
 	if !nodeconfig.GetDefaultConfig().GetArchival() {
-		oldestBlockInMemory := s.hmy.BlockChain.GetLastGarbageCollectedBlockNumber() + 1
-		oldestBlockHeader, err := s.hmy.HeaderByNumber(ctx, rpc.BlockNumber(oldestBlockInMemory))
-		if err != nil {
-			return nil, common.NewError(common.CatchAllError, map[string]interface{}{
-				"message": fmt.Sprintf("unable to get oldest block header: %v", err.Error()),
-			})
-		}
-		oldestBlockIdentifier = &types.BlockIdentifier{
-			Index: oldestBlockHeader.Number().Int64(),
-			Hash:  oldestBlockHeader.Hash().String(),
+		lastGarbCollectedBlockNum := s.hmy.BlockChain.GetLastGarbageCollectedBlockNumber()
+		if lastGarbCollectedBlockNum == -1 {
+			oldestBlockIdentifier = currentBlockIdentifier
+		} else {
+			oldestBlockHeader, err := s.hmy.HeaderByNumber(ctx, rpc.BlockNumber(lastGarbCollectedBlockNum+1))
+			if err != nil {
+				return nil, common.NewError(common.CatchAllError, map[string]interface{}{
+					"message": fmt.Sprintf("unable to get oldest block header: %v", err.Error()),
+				})
+			}
+			oldestBlockIdentifier = &types.BlockIdentifier{
+				Index: oldestBlockHeader.Number().Int64(),
+				Hash:  oldestBlockHeader.Hash().String(),
+			}
 		}
 	}
 

--- a/rosetta/services/network.go
+++ b/rosetta/services/network.go
@@ -88,11 +88,11 @@ func (s *NetworkAPI) NetworkStatus(
 	// Only applicable to non-archival nodes
 	var oldestBlockIdentifier *types.BlockIdentifier
 	if !nodeconfig.GetDefaultConfig().GetArchival() {
-		lastGarbCollectedBlockNum := s.hmy.BlockChain.GetLastGarbageCollectedBlockNumber()
-		if lastGarbCollectedBlockNum == -1 {
+		maxGarbCollectedBlockNum := s.hmy.BlockChain.GetMaxGarbageCollectedBlockNumber()
+		if maxGarbCollectedBlockNum == -1 || maxGarbCollectedBlockNum >= currentHeader.Number().Int64() {
 			oldestBlockIdentifier = currentBlockIdentifier
 		} else {
-			oldestBlockHeader, err := s.hmy.HeaderByNumber(ctx, rpc.BlockNumber(lastGarbCollectedBlockNum+1))
+			oldestBlockHeader, err := s.hmy.HeaderByNumber(ctx, rpc.BlockNumber(maxGarbCollectedBlockNum+1))
 			if err != nil {
 				return nil, common.NewError(common.CatchAllError, map[string]interface{}{
 					"message": fmt.Sprintf("unable to get oldest block header: %v", err.Error()),


### PR DESCRIPTION
# Stage 3.2 FIX2 of [Node API Overhaul](https://github.com/harmony-one/harmony/issues/3210)

This PR is related to #3312 .

TLDR: This fixes the Undelegation reward operation as well as correctly accounts for the redelegation balance changes. This also adds an info dump for the last block that was garbage collected for non-archival DBs. 

## Details

Previously, the Undelegation transaction would result in a balance changing operation (other than gas). As this is not the case due to the locking period, the balance at a given block could be different than what it is on-chain. Therefore a 'special' transaction is added to the implementation to account for the Undelegation payouts at the last block of an epoch (similar to the pre-staking era block rewards). 

Note that all nodes (archival & pruned) store the last block of an epoch, however, the Undelegations saved for the said block are **after** the Undelegations have been paid out. Since the unpaid Undelegations are needed to recompute the paid out amount for each delegator, the state of the *second to the last block* of an epoch is required. This means that the non-archival nodes/DBs will not be able to provide this data unless the state is still in memory. This is why I have added the 'oldest block identifier' on the `network` endpoint for nodes running in the non-archival mode. 

The oldest block number is computed from the biggest block number that has been garbage collected plus 1. Since the block garbage collection is done monotonically w.r.t. block number, this should always give a block number that is in memory.

Lastly, I used the transaction receipt to report how much of the redelegation took from the account's balance. As well as did some general refactoring/clean-up given the new functions & variables.

All logic was tested using localnet as well as testnet using the [rosetta-cli](https://github.com/Daniel-VDM/rosetta-cli/tree/harmony).