### PR TITLE
[consensus] enable the consensus module can spin up doSync

### DIFF
--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -914,10 +914,7 @@ func (ss *StateSync) SyncLoop(bc *core.BlockChain, worker *worker.Worker, isBeac
 	if !isBeacon {
 		ss.RegisterNodeInfo()
 	}
-	// remove SyncLoopFrequency
-	ticker := time.NewTicker(SyncLoopFrequency * time.Second)
-	defer ticker.Stop()
-	for range ticker.C {
+	for {
 		otherHeight := ss.getMaxPeerHeight(isBeacon)
 		currentHeight := bc.CurrentBlock().NumberU64()
 		if currentHeight >= otherHeight {

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -298,7 +298,7 @@ func (consensus *Consensus) onCommitted(msg *msg_pb.Message) {
 		return
 	}
 	// NOTE let it handle its own logs
-	if !consensus.isRightBlockNumCheck(recvMsg) {
+	if !consensus.onCommittedIsRightBlockNumberCheck(recvMsg) {
 		return
 	}
 
@@ -341,7 +341,7 @@ func (consensus *Consensus) onCommitted(msg *msg_pb.Message) {
 	consensus.aggregatedCommitSig = aggSig
 	consensus.commitBitmap = mask
 
-	if recvMsg.BlockNum > consensus.blockNum && recvMsg.BlockNum-consensus.blockNum > consensusBlockNumBuffer {
+	if recvMsg.BlockNum > consensus.blockNum+consensusBlockNumBuffer {
 		consensus.getLogger().Info().Uint64("MsgBlockNum", recvMsg.BlockNum).Msg("[OnCommitted] OUT OF SYNC")
 		go func() {
 			select {
@@ -369,4 +369,14 @@ func (consensus *Consensus) onCommitted(msg *msg_pb.Message) {
 		consensus.getLogger().Debug().Msg("[OnCommitted] Start consensus timer")
 	}
 	consensus.consensusTimeout[timeoutConsensus].Start()
+}
+
+func (consensus *Consensus) onCommittedIsRightBlockNumberCheck(recvMsg *FBFTMessage) bool {
+	if recvMsg.BlockNum < consensus.blockNum {
+		consensus.getLogger().Debug().
+			Uint64("MsgBlockNum", recvMsg.BlockNum).
+			Msg("Wrong BlockNum Received, ignoring!")
+		return false
+	}
+	return true
 }

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -341,7 +341,9 @@ func (consensus *Consensus) onCommitted(msg *msg_pb.Message) {
 	consensus.aggregatedCommitSig = aggSig
 	consensus.commitBitmap = mask
 
-	if recvMsg.BlockNum > consensus.blockNum+consensusBlockNumBuffer {
+	consensus.tryCatchup()
+
+	if recvMsg.BlockNum > consensus.blockNum {
 		consensus.getLogger().Info().Uint64("MsgBlockNum", recvMsg.BlockNum).Msg("[OnCommitted] OUT OF SYNC")
 		go func() {
 			select {
@@ -356,7 +358,6 @@ func (consensus *Consensus) onCommitted(msg *msg_pb.Message) {
 		return
 	}
 
-	consensus.tryCatchup()
 	if consensus.IsViewChangingMode() {
 		consensus.getLogger().Info().Msg("[OnCommitted] Still in ViewChanging mode, Exiting!!")
 		return

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -302,7 +302,7 @@ func (consensus *Consensus) onCommitted(msg *msg_pb.Message) {
 		return
 	}
 	// NOTE let it handle its own logs
-	if !consensus.onCommittedIsRightBlockNumberCheck(recvMsg) {
+	if !consensus.isRightBlockNumCheck(recvMsg) {
 		return
 	}
 
@@ -365,16 +365,6 @@ func (consensus *Consensus) onCommitted(msg *msg_pb.Message) {
 		consensus.getLogger().Debug().Msg("[OnCommitted] Start consensus timer")
 	}
 	consensus.consensusTimeout[timeoutConsensus].Start()
-}
-
-func (consensus *Consensus) onCommittedIsRightBlockNumberCheck(recvMsg *FBFTMessage) bool {
-	if recvMsg.BlockNum < consensus.blockNum {
-		consensus.getLogger().Debug().
-			Uint64("MsgBlockNum", recvMsg.BlockNum).
-			Msg("Wrong BlockNum Received, ignoring!")
-		return false
-	}
-	return true
 }
 
 func (consensus *Consensus) spinUpStateSync() {


### PR DESCRIPTION
## Description

This PR is to enable better coordination between consensus and sync. Two problem is fixed:

1. Logic optimization. Move consensus spin up the state sync after `tryCatchup`. Remove the 2 block delay.
2. Remove an unnecessary time.Ticker in sync logic. Thus will reduce the sync speed (from 3.5s -> 1.5s in local test).

## Test

Test done locally. Test branch: https://github.com/JackyWYX/harmony/tree/sync_consensus_fix_test.

In this branch, Following changes are made:
1. Disable the consensus insertChain logic in `tryCatchup`. So all block update are done in sync module.
2. Added a lot of print logs to observe the behaviour.

Run a local node on 

Following are observed:
1. Consensus module inform sync module upon receiving onCommitted message.
2. Each sync process takes < 1.5s to complete.