### PR TITLE
[rpc] Add RPC to return pool of locked undelegated tokens

### DIFF
--- a/rpc/staking.go
+++ b/rpc/staking.go
@@ -615,6 +615,26 @@ func (s *PublicStakingService) GetDelegationByDelegatorAndValidator(
 	return nil, nil
 }
 
+// GetUndelegationPool returns the amount of locked undelegated tokens
+func (s *PublicStakingService) GetUndelegationPool(
+	ctx context.Context, address string,
+) (*big.Int, error) {
+	if !isBeaconShard(s.hmy) {
+		return nil, ErrNotBeaconShard
+	}
+
+	delegatorAddr := internal_common.ParseAddr(address)
+	_, delegations := s.hmy.GetDelegationsByDelegator(delegatorAddr)
+
+	undelegationTotal := big.NewInt(0)
+	for _, d := range delegations {
+		for _, u := range d.Undelegations {
+			undelegationTotal.Add(undelegationTotal, u.Amount)
+		}
+	}
+	return undelegationTotal, nil
+}
+
 func isBeaconShard(hmy *hmy.Harmony) bool {
 	return hmy.ShardID == shard.BeaconChainShardID
 }


### PR DESCRIPTION
Example:

```
$ curl --location --request POST 'http://localhost:9500' --header 'Content-Type: application/json' --data-raw '{ "jsonrpc": "2.0", "method": "hmy_getUndelegationPool", "params": ["one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur"], "id": 1}' | jq
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": 0
}
```