### PR TITLE
Revert "[consensus] enable the consensus module can spin up doSync"

### DIFF
--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -914,7 +914,10 @@ func (ss *StateSync) SyncLoop(bc *core.BlockChain, worker *worker.Worker, isBeac
 	if !isBeacon {
 		ss.RegisterNodeInfo()
 	}
-	for {
+	// remove SyncLoopFrequency
+	ticker := time.NewTicker(SyncLoopFrequency * time.Second)
+	defer ticker.Stop()
+	for range ticker.C {
 		otherHeight := ss.getMaxPeerHeight(isBeacon)
 		currentHeight := bc.CurrentBlock().NumberU64()
 		if currentHeight >= otherHeight {

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -188,10 +188,6 @@ func (consensus *Consensus) onPrepared(msg *msg_pb.Message) {
 
 	// tryCatchup is also run in onCommitted(), so need to lock with commitMutex.
 	consensus.tryCatchup()
-	if recvMsg.BlockNum > consensus.blockNum {
-		consensus.getLogger().Info().Uint64("MsgBlockNum", recvMsg.BlockNum).Msg("[OnPrepared] OUT OF SYNC")
-		go consensus.spinUpStateSync()
-	}
 
 	if consensus.current.Mode() != Normal {
 		// don't sign the block that is not verified
@@ -345,14 +341,22 @@ func (consensus *Consensus) onCommitted(msg *msg_pb.Message) {
 	consensus.aggregatedCommitSig = aggSig
 	consensus.commitBitmap = mask
 
-	consensus.tryCatchup()
-
-	if recvMsg.BlockNum > consensus.blockNum {
+	if recvMsg.BlockNum > consensus.blockNum && recvMsg.BlockNum-consensus.blockNum > consensusBlockNumBuffer {
 		consensus.getLogger().Info().Uint64("MsgBlockNum", recvMsg.BlockNum).Msg("[OnCommitted] OUT OF SYNC")
-		go consensus.spinUpStateSync()
+		go func() {
+			select {
+			case consensus.BlockNumLowChan <- struct{}{}:
+				consensus.current.SetMode(Syncing)
+				for _, v := range consensus.consensusTimeout {
+					v.Stop()
+				}
+			case <-time.After(1 * time.Second):
+			}
+		}()
 		return
 	}
 
+	consensus.tryCatchup()
 	if consensus.IsViewChangingMode() {
 		consensus.getLogger().Info().Msg("[OnCommitted] Still in ViewChanging mode, Exiting!!")
 		return
@@ -365,15 +369,4 @@ func (consensus *Consensus) onCommitted(msg *msg_pb.Message) {
 		consensus.getLogger().Debug().Msg("[OnCommitted] Start consensus timer")
 	}
 	consensus.consensusTimeout[timeoutConsensus].Start()
-}
-
-func (consensus *Consensus) spinUpStateSync() {
-	select {
-	case consensus.BlockNumLowChan <- struct{}{}:
-		consensus.current.SetMode(Syncing)
-		for _, v := range consensus.consensusTimeout {
-			v.Stop()
-		}
-	case <-time.After(1 * time.Second):
-	}
 }


### PR DESCRIPTION
Reverts harmony-one/harmony#3340. Out of sync is flooding testnet. May research more later.