### PR TITLE
[viewchange] reset view ID per epoch

### DIFF
--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -178,6 +178,19 @@ func (consensus *Consensus) finalizeCommits() {
 		Int("numStakingTxns", len(block.StakingTransactions())).
 		Msg("HOORAY!!!!!!! CONSENSUS REACHED!!!!!!!")
 
+	// reset viewIDs for each epoch
+	isNewEpoch := len(block.Header().ShardState()) > 0
+	if isNewEpoch {
+		consensus.getLogger().Info().
+			Uint64("blockNum", block.NumberU64()).
+			Uint64("epochNum", block.Epoch().Uint64()).
+			Uint64("ViewId", block.Header().ViewID().Uint64()).
+			Uint64("MyCurViewId", consensus.GetCurViewID()).
+			Uint64("MyViewChangingId", consensus.GetViewChangingID()).
+			Msg("Reset View ID per epoch")
+		consensus.SetViewIDs(block.NumberU64() + 1)
+	}
+
 	// Sleep to wait for the full block time
 	consensus.getLogger().Info().Msg("[finalizeCommits] Waiting for Block Time")
 	<-time.After(time.Until(consensus.NextBlockDue))

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -385,6 +385,18 @@ func (node *Node) PostConsensusProcessing(
 				Int("numStakingTxns", len(newBlock.StakingTransactions())).
 				Uint32("numSignatures", node.numSignaturesIncludedInBlock(newBlock)).
 				Msg("BINGO !!! Reached Consensus")
+			// reset viewIDs for each epoch
+			isNewEpoch := len(newBlock.Header().ShardState()) > 0
+			if isNewEpoch {
+				utils.Logger().Info().
+					Uint64("blockNum", newBlock.NumberU64()).
+					Uint64("epochNum", newBlock.Epoch().Uint64()).
+					Uint64("ViewId", newBlock.Header().ViewID().Uint64()).
+					Uint64("MyCurViewId", node.GetConsensusCurViewID()).
+					Uint64("MyViewChangingId", node.GetConsensusViewChangingID()).
+					Msg("Reset View ID per epoch")
+				node.Consensus.SetViewIDs(newBlock.NumberU64() + 1)
+			}
 			// 1% of the validator also need to do broadcasting
 			rand.Seed(time.Now().UTC().UnixNano())
 			rnd := rand.Intn(100)


### PR DESCRIPTION
This PR reset the current view ID and view changing ID at the beginning of each epoch to the block number.
ViewID itself is not saved on-chain, and only used an in-memory data.
So when a node is restarted, it didn't know what's the latest view ID and can only set it to the block height.
On the mainnet, as view change had happened many times, the view ID is far from the latest block number.
During a view change process, when the node is restarted, it fall far behind the latest view ID and took a while to catch up with latest view ID. This can cause a problem for a shard to recovery during view change when many nodes are restarted and they can't agree on the viewID.

Signed-off-by: Leo Chen <leo@harmony.one>
