### PR TITLE
enable mainnet redelegation+7epoch locking at epoch 289

### DIFF
--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -32,7 +32,7 @@ var (
 		PreStakingEpoch:   big.NewInt(185),
 		QuickUnlockEpoch:  big.NewInt(191),
 		FiveSecondsEpoch:  big.NewInt(230),
-		RedelegationEpoch: big.NewInt(10000000),
+		RedelegationEpoch: big.NewInt(289),
 		EIP155Epoch:       big.NewInt(28),
 		S3Epoch:           big.NewInt(28),
 		ReceiptLogEpoch:   big.NewInt(101),


### PR DESCRIPTION
redelegation and 7 epoch locking have been tested in testnet manually and also tested with regression tests. Epoch 289 happens around 9PM Thursday. 

also refer to https://medium.com/harmony-one/restore-7-epochs-locking-period-with-redelegation-6b15c47c532c