### PR TITLE
[node] fix print message if db already occupied

### DIFF
--- a/internal/shardchain/shardchains.go
+++ b/internal/shardchain/shardchains.go
@@ -77,7 +77,7 @@ func (sc *CollectionImpl) ShardChain(shardID uint32) (*core.BlockChain, error) {
 		// NewChainDB may return incompletely initialized DB;
 		// avoid closing it.
 		db = nil
-		return nil, errors.New("cannot open chain database")
+		return nil, errors.Wrap(err, "cannot open chain database")
 	}
 	if rawdb.ReadCanonicalHash(db, 0) == (common.Hash{}) {
 		utils.Logger().Info().

--- a/node/node.go
+++ b/node/node.go
@@ -880,16 +880,15 @@ func New(
 		blockchain := node.Blockchain() // this also sets node.isFirstTime if the DB is fresh
 		beaconChain := node.Beaconchain()
 		if b1, b2 := beaconChain == nil, blockchain == nil; b1 || b2 {
-
-			shardID := node.NodeConfig.ShardID
-			// HACK get the real error reason
-			_, err := node.shardChains.ShardChain(shardID)
-
-			fmt.Fprintf(
-				os.Stderr,
-				"reason:%s beaconchain-is-nil:%t shardchain-is-nil:%t",
-				err.Error(), b1, b2,
-			)
+			var err error
+			if blockchain == nil {
+				shardID := node.NodeConfig.ShardID
+				// HACK get the real error reason
+				_, err = node.shardChains.ShardChain(shardID)
+			} else {
+				_, err = node.shardChains.ShardChain(shard.BeaconChainShardID)
+			}
+			fmt.Fprintf(os.Stderr, "Cannot initialize node: %v\n", err)
 			os.Exit(-1)
 		}
 

--- a/node/node.go
+++ b/node/node.go
@@ -881,7 +881,7 @@ func New(
 		beaconChain := node.Beaconchain()
 		if b1, b2 := beaconChain == nil, blockchain == nil; b1 || b2 {
 			var err error
-			if blockchain == nil {
+			if b2 {
 				shardID := node.NodeConfig.ShardID
 				// HACK get the real error reason
 				_, err = node.shardChains.ShardChain(shardID)


### PR DESCRIPTION
## Issue

When beacon chain db is already occupied, the node panic and exit without giving a well defined print message. This PR handles the error case that beacon chain cannot be initialized due to db already occupied. 

Before:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x4d5fae5]

goroutine 1 [running]:
github.com/harmony-one/harmony/node.New(0x55e4ee0, 0xc0000d4140, 0xc0000dcf00, 0x55adb00, 0xc0003b2d90, 0x0, 0x1, 0x50d7349)
	/Users/yanxiangwang/go/src/github.com/harmony-one/harmony/node/node.go:911 +0xd65
main.setupConsensusAndNode(0x50da132, 0x5, 0x7ffeefbff5f0, 0x8, 0x0, 0x3, 0x1, 0x50d7349, 0x2, 0x50dd66a, ...)
	/Users/yanxiangwang/go/src/github.com/harmony-one/harmony/cmd/harmony/main.go:547 +0x302
main.setupNodeAndRun(0x50da132, 0x5, 0x7ffeefbff5f0, 0x8, 0x0, 0x3, 0x1, 0x50d7349, 0x2, 0x50dd66a, ...)
	/Users/yanxiangwang/go/src/github.com/harmony-one/harmony/cmd/harmony/main.go:254 +0x644
main.runHarmonyNode(0x60d62c0, 0xc000174a20, 0x0, 0x3)
	/Users/yanxiangwang/go/src/github.com/harmony-one/harmony/cmd/harmony/main.go:122 +0x1fb
github.com/spf13/cobra.(*Command).execute(0x60d62c0, 0xc00003c090, 0x3, 0x3, 0x60d62c0, 0xc00003c090)
	/Users/yanxiangwang/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:830 +0x29d
github.com/spf13/cobra.(*Command).ExecuteC(0x60d62c0, 0x0, 0x1, 0xc000100058)
	/Users/yanxiangwang/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fb
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/yanxiangwang/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main()
	/Users/yanxiangwang/go/src/github.com/harmony-one/harmony/cmd/harmony/main.go:97 +0x2d
```

After

```
Cannot initialize node: cannot open chain database: resource temporarily unavailable
```