### PR TITLE
Postpone redelegation to epoch 290

### DIFF
--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -32,7 +32,7 @@ var (
 		PreStakingEpoch:   big.NewInt(185),
 		QuickUnlockEpoch:  big.NewInt(191),
 		FiveSecondsEpoch:  big.NewInt(230),
-		RedelegationEpoch: big.NewInt(289),
+		RedelegationEpoch: big.NewInt(290),
 		EIP155Epoch:       big.NewInt(28),
 		S3Epoch:           big.NewInt(28),
 		ReceiptLogEpoch:   big.NewInt(101),


### PR DESCRIPTION
due to mainnet upgrade delay, we have to postpone redelegation+7epoch launch by 1 epoch to give more time for validators to upgrade.