### PR TITLE
Revert "[travis]integrate with codecov.io"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ install:
 script:
   - ${TEST}
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
   - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
   - chmod +x send.sh
   - ./send.sh success $WEBHOOK_URL

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
 script:
   - ${TEST}
 after_success:
+  - bash <(curl -s https://codecov.io/bash)
   - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh
   - chmod +x send.sh
   - ./send.sh success $WEBHOOK_URL

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 ![Discord](https://img.shields.io/discord/532383335348043777.svg)
 [![Coverage Status](https://coveralls.io/repos/github/harmony-one/harmony/badge.svg?branch=main)](https://coveralls.io/github/harmony-one/harmony?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/harmony-one/harmony)](https://goreportcard.com/report/github.com/harmony-one/harmony)
-[![codecov](https://codecov.io/gh/harmony-one/harmony/branch/main/graph/badge.svg)](https://codecov.io/gh/harmony-one/harmony)
 
 ## General Documentation
 

--- a/scripts/travis_checker.sh
+++ b/scripts/travis_checker.sh
@@ -84,8 +84,6 @@ go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
 if go test -v -count=1 ./...
 then
-	bash <(curl -s https://codecov.io/bash)
-	
 	echo "go test succeeded."
 else
 	echo "go test FAILED!"

--- a/scripts/travis_checker.sh
+++ b/scripts/travis_checker.sh
@@ -80,8 +80,6 @@ else
 fi
 
 echo "Running go test..."
-go test -race -coverprofile=coverage.txt -covermode=atomic ./...
-
 if go test -v -count=1 ./...
 then
 	echo "go test succeeded."


### PR DESCRIPTION
Reverts harmony-one/harmony#3320   We don't have resources to follow all codecov recommendations. But it's causing huge amount of interference for the code reviewer. 

Remove it until we really need it.