### PR TITLE
[core] node stuck fix

### DIFF
--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -703,7 +703,10 @@ func (ss *StateSync) UpdateBlockAndStatus(block *types.Block, bc *core.BlockChai
 			if !verifyAllSig {
 				utils.Logger().Info().Interface("block", bc.CurrentBlock()).Msg("[SYNC] UpdateBlockAndStatus: Rolling back last 99 blocks!")
 				for i := uint64(0); i < verifyHeaderBatchSize-1; i++ {
-					bc.Rollback([]common.Hash{bc.CurrentBlock().Hash()})
+					if rbErr := bc.Rollback([]common.Hash{bc.CurrentBlock().Hash()}); rbErr != nil {
+						utils.Logger().Err(rbErr).Msg("[SYNC] UpdateBlockAndStatus: failed to rollback")
+						return err
+					}
 				}
 			}
 			return err

--- a/common/fdlimit/fdlimit_darwin.go
+++ b/common/fdlimit/fdlimit_darwin.go
@@ -1,0 +1,71 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package fdlimit
+
+import "syscall"
+
+// hardlimit is the number of file descriptors allowed at max by the kernel.
+const hardlimit = 10240
+
+// Raise tries to maximize the file descriptor allowance of this process
+// to the maximum hard-limit allowed by the OS.
+// Returns the size it was set to (may differ from the desired 'max')
+func Raise(max uint64) (uint64, error) {
+	// Get the current limit
+	var limit syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
+		return 0, err
+	}
+	// Try to update the limit to the max allowance
+	limit.Cur = limit.Max
+	if limit.Cur > max {
+		limit.Cur = max
+	}
+	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
+		return 0, err
+	}
+	// MacOS can silently apply further caps, so retrieve the actually set limit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
+		return 0, err
+	}
+	return limit.Cur, nil
+}
+
+// Current retrieves the number of file descriptors allowed to be opened by this
+// process.
+func Current() (int, error) {
+	var limit syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
+		return 0, err
+	}
+	return int(limit.Cur), nil
+}
+
+// Maximum retrieves the maximum number of file descriptors this process is
+// allowed to request for itself.
+func Maximum() (int, error) {
+	// Retrieve the maximum allowed by dynamic OS limits
+	var limit syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
+		return 0, err
+	}
+	// Cap it to OPEN_MAX (10240) because macos is a special snowflake
+	if limit.Max > hardlimit {
+		limit.Max = hardlimit
+	}
+	return int(limit.Max), nil
+}

--- a/common/fdlimit/fdlimit_test.go
+++ b/common/fdlimit/fdlimit_test.go
@@ -1,0 +1,45 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package fdlimit
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestFileDescriptorLimits simply tests whether the file descriptor allowance
+// per this process can be retrieved.
+func TestFileDescriptorLimits(t *testing.T) {
+	target := 4096
+	hardlimit, err := Maximum()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hardlimit < target {
+		t.Skip(fmt.Sprintf("system limit is less than desired test target: %d < %d", hardlimit, target))
+	}
+
+	if limit, err := Current(); err != nil || limit <= 0 {
+		t.Fatalf("failed to retrieve file descriptor limit (%d): %v", limit, err)
+	}
+	if _, err := Raise(uint64(target)); err != nil {
+		t.Fatalf("failed to raise file allowance")
+	}
+	if limit, err := Current(); err != nil || limit < target {
+		t.Fatalf("failed to retrieve raised descriptor limit (have %v, want %v): %v", limit, target, err)
+	}
+}

--- a/common/fdlimit/fdlimit_unix.go
+++ b/common/fdlimit/fdlimit_unix.go
@@ -1,0 +1,65 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// +build linux netbsd openbsd solaris
+
+package fdlimit
+
+import "syscall"
+
+// Raise tries to maximize the file descriptor allowance of this process
+// to the maximum hard-limit allowed by the OS.
+// Returns the size it was set to (may differ from the desired 'max')
+func Raise(max uint64) (uint64, error) {
+	// Get the current limit
+	var limit syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
+		return 0, err
+	}
+	// Try to update the limit to the max allowance
+	limit.Cur = limit.Max
+	if limit.Cur > max {
+		limit.Cur = max
+	}
+	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
+		return 0, err
+	}
+	// MacOS can silently apply further caps, so retrieve the actually set limit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
+		return 0, err
+	}
+	return limit.Cur, nil
+}
+
+// Current retrieves the number of file descriptors allowed to be opened by this
+// process.
+func Current() (int, error) {
+	var limit syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
+		return 0, err
+	}
+	return int(limit.Cur), nil
+}
+
+// Maximum retrieves the maximum number of file descriptors this process is
+// allowed to request for itself.
+func Maximum() (int, error) {
+	var limit syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
+		return 0, err
+	}
+	return int(limit.Max), nil
+}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -3016,6 +3016,18 @@ var (
 	tooManyOpenFilesErrStr = "Too many open files"
 )
 
+// isUnrecoverableErr check whether the input error is not recoverable.
+// When writing db, there could be some possible errors from storage level (leveldb).
+// Known possible leveldb errors are:
+//  1. Leveldb is already closed. (leveldb.ErrClosed)
+//  2. ldb file missing from disk. (leveldb.ErrNotFound)
+//  3. Corrupted db data. (leveldb.errors.ErrCorrupted)
+//  4. OS error when open file (too many open files, ...)
+//  5. OS error when write file (read-only, not enough disk space, ...)
+// Among all the above leveldb errors, only `too many open files` error is known to be recoverable,
+// thus the unrecoverable errors refers to error that is
+//  1. The error is from the lower storage level (from module leveldb)
+//  2. The error is not too many files error.
 func isUnrecoverableErr(err error) bool {
 	isLeveldbErr := strings.Contains(err.Error(), leveldbErrSpec)
 	isTooManyOpenFiles := strings.Contains(err.Error(), tooManyOpenFilesErrStr)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1088,9 +1088,11 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 			batch.Reset()
 		}
 	}
-	bytes += batch.ValueSize()
-	if err := batch.Write(); err != nil {
-		return 0, err
+	if batch.ValueSize() > 0 {
+		bytes += batch.ValueSize()
+		if err := batch.Write(); err != nil {
+			return 0, err
+		}
 	}
 
 	// Update the head fast sync block if better

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -345,7 +346,9 @@ func (bc *BlockChain) loadLastState() error {
 	//	}
 	//}
 	currentHeader := currentBlock.Header()
-	bc.hc.SetCurrentHeader(currentHeader)
+	if err := bc.hc.SetCurrentHeader(currentHeader); err != nil {
+		return errors.Wrap(err, "headerChain SetCurrentHeader")
+	}
 
 	// Restore the last known head fast block
 	bc.currentFastBlock.Store(currentBlock)
@@ -395,10 +398,12 @@ func (bc *BlockChain) SetHead(head uint64) error {
 	defer bc.mu.Unlock()
 
 	// Rewind the header chain, deleting all block bodies until then
-	delFn := func(db rawdb.DatabaseDeleter, hash common.Hash, num uint64) {
-		rawdb.DeleteBody(db, hash, num)
+	delFn := func(db rawdb.DatabaseDeleter, hash common.Hash, num uint64) error {
+		return rawdb.DeleteBody(db, hash, num)
 	}
-	bc.hc.SetHead(head, delFn)
+	if err := bc.hc.SetHead(head, delFn); err != nil {
+		return errors.Wrap(err, "headerChain SetHeader")
+	}
 	currentHeader := bc.hc.CurrentHeader()
 
 	// Clear out any stale content from the caches
@@ -433,8 +438,12 @@ func (bc *BlockChain) SetHead(head uint64) error {
 	currentBlock := bc.CurrentBlock()
 	currentFastBlock := bc.CurrentFastBlock()
 
-	rawdb.WriteHeadBlockHash(bc.db, currentBlock.Hash())
-	rawdb.WriteHeadFastBlockHash(bc.db, currentFastBlock.Hash())
+	if err := rawdb.WriteHeadBlockHash(bc.db, currentBlock.Hash()); err != nil {
+		return err
+	}
+	if err := rawdb.WriteHeadFastBlockHash(bc.db, currentFastBlock.Hash()); err != nil {
+		return err
+	}
 
 	return bc.loadLastState()
 }
@@ -516,13 +525,19 @@ func (bc *BlockChain) ResetWithGenesisBlock(genesis *types.Block) error {
 	defer bc.mu.Unlock()
 
 	// Prepare the genesis block and reinitialise the chain
-	rawdb.WriteBlock(bc.db, genesis)
+	if err := rawdb.WriteBlock(bc.db, genesis); err != nil {
+		return err
+	}
 
 	bc.genesisBlock = genesis
-	bc.insert(bc.genesisBlock)
-	bc.currentBlock.Store(bc.genesisBlock)
+	if err := bc.insert(bc.genesisBlock); err != nil {
+		return err
+	}
 	bc.hc.SetGenesis(bc.genesisBlock.Header())
-	bc.hc.SetCurrentHeader(bc.genesisBlock.Header())
+	if err := bc.hc.SetCurrentHeader(bc.genesisBlock.Header()); err != nil {
+		return err
+	}
+	bc.currentBlock.Store(bc.genesisBlock)
 	bc.currentFastBlock.Store(bc.genesisBlock)
 
 	return nil
@@ -587,8 +602,7 @@ func (bc *BlockChain) removeInValidatorList(toRemove map[common.Address]struct{}
 			newVals = append(newVals, addr)
 		}
 	}
-	bc.WriteValidatorList(bc.db, newVals)
-	return nil
+	return bc.WriteValidatorList(bc.db, newVals)
 }
 
 // Export writes the active chain to the given writer.
@@ -627,24 +641,37 @@ func (bc *BlockChain) ExportN(w io.Writer, first uint64, last uint64) error {
 	return nil
 }
 
-// similar to insert, but add to the db writer.
-func (bc *BlockChain) insertWithWriter(batch rawdb.DatabaseWriter, block *types.Block) {
+// writeHeadBlock writes a new head block
+func (bc *BlockChain) writeHeadBlock(block *types.Block) error {
 	// If the block is on a side chain or an unknown one, force other heads onto it too
 	updateHeads := rawdb.ReadCanonicalHash(bc.db, block.NumberU64()) != block.Hash()
 
 	// Add the block to the canonical chain number scheme and mark as the head
-	rawdb.WriteCanonicalHash(batch, block.Hash(), block.NumberU64())
-	rawdb.WriteHeadBlockHash(batch, block.Hash())
+	batch := bc.ChainDb().NewBatch()
+	if err := rawdb.WriteCanonicalHash(batch, block.Hash(), block.NumberU64()); err != nil {
+		return err
+	}
+	if err := rawdb.WriteHeadBlockHash(batch, block.Hash()); err != nil {
+		return err
+	}
+	if err := batch.Write(); err != nil {
+		return err
+	}
 
 	bc.currentBlock.Store(block)
 
 	// If the block is better than our head or is on a different chain, force update heads
 	if updateHeads {
-		bc.hc.SetCurrentHeader(block.Header())
-		rawdb.WriteHeadFastBlockHash(batch, block.Hash())
+		if err := bc.hc.SetCurrentHeader(block.Header()); err != nil {
+			return errors.Wrap(err, "HeaderChain SetCurrentHeader")
+		}
+		if err := rawdb.WriteHeadFastBlockHash(bc.db, block.Hash()); err != nil {
+			return err
+		}
 
 		bc.currentFastBlock.Store(block)
 	}
+	return nil
 }
 
 // insert injects a new head block into the current block chain. This method
@@ -653,8 +680,8 @@ func (bc *BlockChain) insertWithWriter(batch rawdb.DatabaseWriter, block *types.
 // or if they are on a different side chain.
 //
 // Note, this function assumes that the `mu` mutex is held!
-func (bc *BlockChain) insert(block *types.Block) {
-	bc.insertWithWriter(bc.db, block)
+func (bc *BlockChain) insert(block *types.Block) error {
+	return bc.writeHeadBlock(block)
 }
 
 // Genesis retrieves the chain's genesis block.
@@ -890,7 +917,7 @@ const (
 
 // Rollback is designed to remove a chain of links from the database that aren't
 // certain enough to be valid.
-func (bc *BlockChain) Rollback(chain []common.Hash) {
+func (bc *BlockChain) Rollback(chain []common.Hash) error {
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
 
@@ -902,7 +929,9 @@ func (bc *BlockChain) Rollback(chain []common.Hash) {
 		if currentHeader != nil && currentHeader.Hash() == hash {
 			parentHeader := bc.GetHeader(currentHeader.ParentHash(), currentHeader.Number().Uint64()-1)
 			if parentHeader != nil {
-				bc.hc.SetCurrentHeader(parentHeader)
+				if err := bc.hc.SetCurrentHeader(parentHeader); err != nil {
+					return errors.Wrap(err, "HeaderChain SetCurrentHeader")
+				}
 			}
 		}
 		if currentFastBlock := bc.CurrentFastBlock(); currentFastBlock != nil && currentFastBlock.Hash() == hash {
@@ -916,7 +945,9 @@ func (bc *BlockChain) Rollback(chain []common.Hash) {
 			newBlock := bc.GetBlock(currentBlock.ParentHash(), currentBlock.NumberU64()-1)
 			if newBlock != nil {
 				bc.currentBlock.Store(newBlock)
-				rawdb.WriteHeadBlockHash(bc.db, newBlock.Hash())
+				if err := rawdb.WriteHeadBlockHash(bc.db, newBlock.Hash()); err != nil {
+					return err
+				}
 
 				for _, stkTxn := range currentBlock.StakingTransactions() {
 					if stkTxn.StakingType() == staking.DirectiveCreateValidator {
@@ -928,7 +959,7 @@ func (bc *BlockChain) Rollback(chain []common.Hash) {
 			}
 		}
 	}
-	bc.removeInValidatorList(valsToRemove)
+	return bc.removeInValidatorList(valsToRemove)
 }
 
 // SetReceiptsData computes all the non-consensus fields of the receipts
@@ -1022,7 +1053,7 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 		}
 		// Short circuit if the owner header is unknown
 		if !bc.HasHeader(block.Hash(), block.NumberU64()) {
-			return i, fmt.Errorf("containing header #%d [%x…] unknown", block.Number(), block.Hash().Bytes()[:4])
+			return 0, fmt.Errorf("containing header #%d [%x…] unknown", block.Number(), block.Hash().Bytes()[:4])
 		}
 		// Skip if the entire data is already known
 		if bc.HasBlock(block.Hash(), block.NumberU64()) {
@@ -1031,12 +1062,21 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 		}
 		// Compute all the non-consensus fields of the receipts
 		if err := SetReceiptsData(bc.chainConfig, block, receipts); err != nil {
-			return i, fmt.Errorf("failed to set receipts data: %v", err)
+			return 0, fmt.Errorf("failed to set receipts data: %v", err)
 		}
 		// Write all the data out into the database
-		rawdb.WriteBody(batch, block.Hash(), block.NumberU64(), block.Body())
-		rawdb.WriteReceipts(batch, block.Hash(), block.NumberU64(), receipts)
-		rawdb.WriteTxLookupEntries(batch, block)
+		if err := rawdb.WriteBody(batch, block.Hash(), block.NumberU64(), block.Body()); err != nil {
+			return 0, err
+		}
+		if err := rawdb.WriteReceipts(batch, block.Hash(), block.NumberU64(), receipts); err != nil {
+			return 0, err
+		}
+		if err := rawdb.WriteBlockTxLookUpEntries(batch, block); err != nil {
+			return 0, err
+		}
+		if err := rawdb.WriteBlockStxLookUpEntries(batch, block); err != nil {
+			return 0, err
+		}
 
 		stats.processed++
 
@@ -1048,11 +1088,9 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 			batch.Reset()
 		}
 	}
-	if batch.ValueSize() > 0 {
-		bytes += batch.ValueSize()
-		if err := batch.Write(); err != nil {
-			return 0, err
-		}
+	bytes += batch.ValueSize()
+	if err := batch.Write(); err != nil {
+		return 0, err
 	}
 
 	// Update the head fast sync block if better
@@ -1092,7 +1130,9 @@ func (bc *BlockChain) WriteBlockWithoutState(block *types.Block, td *big.Int) (e
 	if err := bc.hc.WriteTd(block.Hash(), block.NumberU64(), td); err != nil {
 		return err
 	}
-	rawdb.WriteBlock(bc.db, block)
+	if err := rawdb.WriteBlock(bc.db, block); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -1126,6 +1166,10 @@ func (bc *BlockChain) WriteBlockWithState(
 	triedb := bc.stateCache.TrieDB()
 	if bc.cacheConfig.Disabled || len(block.Header().ShardState()) > 0 {
 		if err := triedb.Commit(root, false); err != nil {
+			if isUnrecoverableErr(err) {
+				fmt.Printf("Unrecoverable error when committing triedb: %v\nExitting\n", err)
+				os.Exit(1)
+			}
 			return NonStatTy, err
 		}
 	} else {
@@ -1181,7 +1225,9 @@ func (bc *BlockChain) WriteBlockWithState(
 
 	batch := bc.db.NewBatch()
 	// Write the raw block
-	rawdb.WriteBlock(batch, block)
+	if err := rawdb.WriteBlock(batch, block); err != nil {
+		return NonStatTy, err
+	}
 
 	// Write offchain data
 	if status, err := bc.CommitOffChainData(
@@ -1192,15 +1238,30 @@ func (bc *BlockChain) WriteBlockWithState(
 	}
 
 	// Write the positional metadata for transaction/receipt lookups and preimages
-	rawdb.WriteTxLookupEntries(batch, block)
-	rawdb.WriteCxLookupEntries(batch, block)
-	rawdb.WritePreimages(batch, block.NumberU64(), state.Preimages())
-
-	// Update current block
-	bc.insertWithWriter(batch, block)
+	if err := rawdb.WriteBlockTxLookUpEntries(batch, block); err != nil {
+		return NonStatTy, err
+	}
+	if err := rawdb.WriteBlockStxLookUpEntries(batch, block); err != nil {
+		return NonStatTy, err
+	}
+	if err := rawdb.WriteCxLookupEntries(batch, block); err != nil {
+		return NonStatTy, err
+	}
+	if err := rawdb.WritePreimages(batch, block.NumberU64(), state.Preimages()); err != nil {
+		return NonStatTy, err
+	}
 
 	if err := batch.Write(); err != nil {
+		if isUnrecoverableErr(err) {
+			fmt.Printf("Unrecoverable error when writing leveldb: %v\nExitting\n", err)
+			os.Exit(1)
+		}
 		return NonStatTy, err
+	}
+
+	// Update current block
+	if err := bc.writeHeadBlock(block); err != nil {
+		return NonStatTy, errors.Wrap(err, "writeHeadBlock")
 	}
 
 	bc.futureBlocks.Remove(block.Hash())
@@ -2203,10 +2264,13 @@ func (bc *BlockChain) CXMerkleProof(toShardID uint32, block *types.Block) (*type
 
 // WriteCXReceiptsProofSpent mark the CXReceiptsProof list with given unspent status
 // true: unspent, false: spent
-func (bc *BlockChain) WriteCXReceiptsProofSpent(db rawdb.DatabaseWriter, cxps []*types.CXReceiptsProof) {
+func (bc *BlockChain) WriteCXReceiptsProofSpent(db rawdb.DatabaseWriter, cxps []*types.CXReceiptsProof) error {
 	for _, cxp := range cxps {
-		rawdb.WriteCXReceiptsProofSpent(db, cxp)
+		if err := rawdb.WriteCXReceiptsProofSpent(db, cxp); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // IsSpent checks whether a CXReceiptsProof is unspent
@@ -2943,4 +3007,15 @@ func (bc *BlockChain) SuperCommitteeForNextEpoch(
 
 	}
 	return nextCommittee, err
+}
+
+var (
+	leveldbErrSpec         = "leveldb"
+	tooManyOpenFilesErrStr = "Too many open files"
+)
+
+func isUnrecoverableErr(err error) bool {
+	isLeveldbErr := strings.Contains(err.Error(), leveldbErrSpec)
+	isTooManyOpenFiles := strings.Contains(err.Error(), tooManyOpenFilesErrStr)
+	return isLeveldbErr && !isTooManyOpenFiles
 }

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -282,11 +282,21 @@ func (g *Genesis) Commit(db ethdb.Database) (*types.Block, error) {
 		return nil, fmt.Errorf("can't commit genesis block with number > 0")
 	}
 
-	rawdb.WriteBlock(db, block)
-	rawdb.WriteReceipts(db, block.Hash(), block.NumberU64(), nil)
-	rawdb.WriteCanonicalHash(db, block.Hash(), block.NumberU64())
-	rawdb.WriteHeadBlockHash(db, block.Hash())
-	rawdb.WriteHeadHeaderHash(db, block.Hash())
+	if err := rawdb.WriteBlock(db, block); err != nil {
+		return nil, err
+	}
+	if err := rawdb.WriteReceipts(db, block.Hash(), block.NumberU64(), nil); err != nil {
+		return nil, err
+	}
+	if err := rawdb.WriteCanonicalHash(db, block.Hash(), block.NumberU64()); err != nil {
+		return nil, err
+	}
+	if err := rawdb.WriteHeadBlockHash(db, block.Hash()); err != nil {
+		return nil, err
+	}
+	if err := rawdb.WriteHeadHeaderHash(db, block.Hash()); err != nil {
+		return nil, err
+	}
 
 	err := rawdb.WriteShardStateBytes(db, block.Header().Epoch(), block.Header().ShardState())
 

--- a/core/offchain.go
+++ b/core/offchain.go
@@ -32,7 +32,9 @@ func (bc *BlockChain) CommitOffChainData(
 	state *state.DB,
 ) (status WriteStatus, err error) {
 	// Write receipts of the block
-	rawdb.WriteReceipts(batch, block.Hash(), block.NumberU64(), receipts)
+	if err := rawdb.WriteReceipts(batch, block.Hash(), block.NumberU64(), receipts); err != nil {
+		return NonStatTy, err
+	}
 	isBeaconChain := bc.CurrentHeader().ShardID() == shard.BeaconChainShardID
 	isStaking := bc.chainConfig.IsStaking(block.Epoch())
 	isPreStaking := bc.chainConfig.IsPreStaking(block.Epoch())
@@ -60,7 +62,9 @@ func (bc *BlockChain) CommitOffChainData(
 			}
 		}
 		// Mark incomingReceipts in the block as spent
-		bc.WriteCXReceiptsProofSpent(batch, block.IncomingReceipts())
+		if err := bc.WriteCXReceiptsProofSpent(batch, block.IncomingReceipts()); err != nil {
+			return NonStatTy, err
+		}
 	}
 
 	// VRF + VDF

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -313,7 +313,9 @@ func TestBlockReceiptStorage(t *testing.T) {
 		t.Fatalf("non existent receipts returned: %v", rs)
 	}
 	// Insert the receipt slice into the database and check presence
-	WriteReceipts(db, hash, 0, receipts)
+	if err := WriteReceipts(db, hash, 0, receipts); err != nil {
+		t.Fatalf("write receipts")
+	}
 	if rs := ReadReceipts(db, hash, 0); len(rs) == 0 {
 		t.Fatalf("no receipts returned")
 	} else {

--- a/core/rawdb/accessors_indexes_test.go
+++ b/core/rawdb/accessors_indexes_test.go
@@ -74,7 +74,12 @@ func TestLookupStorage(t *testing.T) {
 	}
 	// Insert all the transactions into the database, and verify contents
 	WriteBlock(db, block)
-	WriteTxLookupEntries(db, block)
+	if err := WriteBlockTxLookUpEntries(db, block); err != nil {
+		t.Fatalf("WriteBlockTxLookUpEntries: %v", err)
+	}
+	if err := WriteBlockStxLookUpEntries(db, block); err != nil {
+		t.Fatalf("WriteBlockStxLookUpEntries: %v", err)
+	}
 
 	for i, tx := range txs {
 		if txn, hash, number, index := ReadTransaction(db, tx.Hash()); txn == nil {
@@ -126,8 +131,15 @@ func TestMixedLookupStorage(t *testing.T) {
 	header := blockfactory.NewTestHeader().With().Number(big.NewInt(314)).Header()
 	block := types.NewBlock(header, txs, types.Receipts{&types.Receipt{}, &types.Receipt{}}, nil, nil, stxs)
 
-	WriteBlock(db, block)
-	WriteTxLookupEntries(db, block)
+	if err := WriteBlock(db, block); err != nil {
+		t.Fatalf("WriteBlock: %v", err)
+	}
+	if err := WriteBlockTxLookUpEntries(db, block); err != nil {
+		t.Fatalf("WriteBlockStxLookUpEntries: %v", err)
+	}
+	if err := WriteBlockStxLookUpEntries(db, block); err != nil {
+		t.Fatalf("WriteBlockStxLookUpEntries: %v", err)
+	}
 
 	if recTx, _, _, _ := ReadStakingTransaction(db, tx.Hash()); recTx != nil {
 		t.Fatal("got staking transactions with plain tx hash")

--- a/core/rawdb/accessors_offchain.go
+++ b/core/rawdb/accessors_offchain.go
@@ -124,14 +124,20 @@ func ReadCXReceiptsProofSpent(db DatabaseReader, shardID uint32, number uint64) 
 func WriteCXReceiptsProofSpent(dbw DatabaseWriter, cxp *types.CXReceiptsProof) error {
 	shardID := cxp.MerkleProof.ShardID
 	blockNum := cxp.MerkleProof.BlockNum.Uint64()
-	return dbw.Put(cxReceiptSpentKey(shardID, blockNum), []byte{SpentByte})
+	if err := dbw.Put(cxReceiptSpentKey(shardID, blockNum), []byte{SpentByte}); err != nil {
+		utils.Logger().Error().Msg("Failed to write CX receipt proof")
+		return err
+	}
+	return nil
 }
 
 // DeleteCXReceiptsProofSpent removes unspent indicator of a given blockHash
-func DeleteCXReceiptsProofSpent(db DatabaseDeleter, shardID uint32, number uint64) {
+func DeleteCXReceiptsProofSpent(db DatabaseDeleter, shardID uint32, number uint64) error {
 	if err := db.Delete(cxReceiptSpentKey(shardID, number)); err != nil {
 		utils.Logger().Error().Msg("Failed to delete receipts unspent indicator")
+		return err
 	}
+	return nil
 }
 
 // ReadValidatorSnapshot retrieves validator's snapshot by its address
@@ -169,17 +175,21 @@ func WriteValidatorSnapshot(batch DatabaseWriter, v *staking.ValidatorWrapper, e
 }
 
 // DeleteValidatorSnapshot removes the validator's snapshot by its address
-func DeleteValidatorSnapshot(db DatabaseDeleter, addr common.Address, epoch *big.Int) {
+func DeleteValidatorSnapshot(db DatabaseDeleter, addr common.Address, epoch *big.Int) error {
 	if err := db.Delete(validatorSnapshotKey(addr, epoch)); err != nil {
 		utils.Logger().Error().Msg("Failed to delete snapshot of a validator")
+		return err
 	}
+	return nil
 }
 
 // DeleteValidatorStats ..
-func DeleteValidatorStats(db DatabaseDeleter, addr common.Address) {
+func DeleteValidatorStats(db DatabaseDeleter, addr common.Address) error {
 	if err := db.Delete(validatorStatsKey(addr)); err != nil {
 		utils.Logger().Error().Msg("Failed to delete stats of a validator")
+		return err
 	}
+	return nil
 }
 
 // ReadValidatorStats retrieves validator's stats by its address,

--- a/hmy/bloombits.go
+++ b/hmy/bloombits.go
@@ -134,7 +134,10 @@ func (b *BloomIndexer) Commit() error {
 		if err != nil {
 			return err
 		}
-		rawdb.WriteBloomBits(batch, uint(i), b.section, b.head, bitutil.CompressBytes(bits))
+		err = rawdb.WriteBloomBits(batch, uint(i), b.section, b.head, bitutil.CompressBytes(bits))
+		if err != nil {
+			return err
+		}
 	}
 	return batch.Write()
 }

--- a/internal/utils/singleton.go
+++ b/internal/utils/singleton.go
@@ -40,7 +40,7 @@ var (
 func SetLogContext(_port, _ip string) {
 	port = _port
 	ip = _ip
-	setZeroLogContext(_port, _ip)
+	setZeroLogContext(_ip, _port)
 }
 
 // SetLogVerbosity specifies the verbosity of global logger


### PR DESCRIPTION
## Issue

Previously, it could happen that the node can fall out of sync when leveldb get an error `too many open files`. Sometimes the error will cause node stuck because the non-atomic operation in `WriteBlockWithState`. This PR aims to fix this error. 

1. Modify `WriteBlockWithState` logic to make db write operations atomic.
2. Add error handling to all rawdb related operations, which allows node to continue running if `too many open files` error happens.
3. Add fdlimit module to raise nofile limit for the process, which is effective for macos.

## Test

Tested locally on both MacOs and Linux machine. After running for about 1 days, there is no more too many open files error.