### PR TITLE
Offline Node Support

### DIFF
--- a/cmd/harmony/config.go
+++ b/cmd/harmony/config.go
@@ -244,6 +244,9 @@ func loadHarmonyConfig(file string) (harmonyConfig, error) {
 	if config.HTTP.RosettaPort == 0 {
 		config.HTTP.RosettaPort = defaultConfig.HTTP.RosettaPort
 	}
+	if config.P2P.IP == "" {
+		config.P2P.IP = defaultConfig.P2P.IP
+	}
 	return config, nil
 }
 

--- a/cmd/harmony/config.go
+++ b/cmd/harmony/config.go
@@ -44,6 +44,7 @@ type networkConfig struct {
 
 type p2pConfig struct {
 	Port    int
+	IP      string
 	KeyFile string
 }
 

--- a/cmd/harmony/config.go
+++ b/cmd/harmony/config.go
@@ -52,6 +52,7 @@ type generalConfig struct {
 	NoStaking  bool
 	ShardID    int
 	IsArchival bool
+	IsOffline  bool
 	DataDir    string
 }
 

--- a/cmd/harmony/config.go
+++ b/cmd/harmony/config.go
@@ -162,6 +162,10 @@ func validateHarmonyConfig(config harmonyConfig) error {
 		return errors.New("flag --run.shard must be specified for explorer node")
 	}
 
+	if config.General.IsOffline && config.P2P.IP != nodeconfig.DefaultLocalListenIP {
+		return fmt.Errorf("flag --run.offline must have p2p IP be %v", nodeconfig.DefaultLocalListenIP)
+	}
+
 	return nil
 }
 

--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -99,6 +99,9 @@ func TestV1_0_0Config(t *testing.T) {
 	if config.HTTP.RosettaEnabled {
 		t.Errorf("Expected rosetta http server to be disabled when loading old config")
 	}
+	if config.General.IsOffline {
+		t.Errorf("Expect node to de online when loading old config")
+	}
 	if config.Version != "1.0.0" {
 		t.Errorf("Expected config version: 1.0.0, not %v", config.Version)
 	}

--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -102,6 +102,9 @@ func TestV1_0_0Config(t *testing.T) {
 	if config.General.IsOffline {
 		t.Errorf("Expect node to de online when loading old config")
 	}
+	if config.P2P.IP != defaultConfig.P2P.IP {
+		t.Errorf("Expect default p2p IP if old config is provided")
+	}
 	if config.Version != "1.0.0" {
 		t.Errorf("Expected config version: 1.0.0, not %v", config.Version)
 	}

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -2,7 +2,7 @@ package main
 
 import nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 
-const tomlConfigVersion = "1.0.1"
+const tomlConfigVersion = "1.0.2"
 
 const (
 	defNetworkType = nodeconfig.Mainnet

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -15,6 +15,7 @@ var defaultConfig = harmonyConfig{
 		NoStaking:  false,
 		ShardID:    -1,
 		IsArchival: false,
+		IsOffline:  false,
 		DataDir:    "./",
 	},
 	Network: getDefaultNetworkConfig(defNetworkType),

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -21,6 +21,7 @@ var defaultConfig = harmonyConfig{
 	Network: getDefaultNetworkConfig(defNetworkType),
 	P2P: p2pConfig{
 		Port:    nodeconfig.DefaultP2PPort,
+		IP:      nodeconfig.DefaultPublicListenIP,
 		KeyFile: "./.hmykey",
 	},
 	HTTP: httpConfig{
@@ -144,9 +145,4 @@ const (
 	legacyBLSKmsTypePrompt  = "prompt"
 	legacyBLSKmsTypeFile    = "file"
 	legacyBLSKmsTypeNone    = "none"
-)
-
-const (
-	localListenIP  = "127.0.0.1"
-	publicListenIP = "0.0.0.0"
 )

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -396,6 +396,9 @@ func applyP2PFlags(cmd *cobra.Command, config *harmonyConfig) {
 	if cli.IsFlagChanged(cmd, p2pIPFlag) {
 		config.P2P.IP = cli.GetStringFlagValue(cmd, p2pIPFlag)
 	}
+	if config.General.IsOffline {
+		config.P2P.IP = nodeconfig.DefaultLocalListenIP
+	}
 
 	if cli.IsFlagChanged(cmd, p2pKeyFileFlag) {
 		config.P2P.KeyFile = cli.GetStringFlagValue(cmd, p2pKeyFileFlag)

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -15,6 +15,7 @@ var (
 		noStakingFlag,
 		shardIDFlag,
 		isArchiveFlag,
+		isOfflineFlag,
 		dataDirFlag,
 
 		legacyNodeTypeFlag,
@@ -178,6 +179,11 @@ var (
 		Usage:    "run node in archive mode",
 		DefValue: defaultConfig.General.IsArchival,
 	}
+	isOfflineFlag = cli.BoolFlag{
+		Name:     "run.offline",
+		Usage:    "run node in offline mode",
+		DefValue: defaultConfig.General.IsOffline,
+	}
 	dataDirFlag = cli.StringFlag{
 		Name:     "datadir",
 		Usage:    "directory of chain database",
@@ -270,6 +276,10 @@ func applyGeneralFlags(cmd *cobra.Command, config *harmonyConfig) {
 		config.General.DataDir = cli.GetStringFlagValue(cmd, dataDirFlag)
 	} else if cli.IsFlagChanged(cmd, legacyDataDirFlag) {
 		config.General.DataDir = cli.GetStringFlagValue(cmd, legacyDataDirFlag)
+	}
+
+	if cli.IsFlagChanged(cmd, isOfflineFlag) {
+		config.General.IsOffline = cli.GetBoolFlagValue(cmd, isOfflineFlag)
 	}
 }
 

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -39,6 +39,7 @@ var (
 
 	p2pFlags = []cli.Flag{
 		p2pPortFlag,
+		p2pIpFlag,
 		p2pKeyFileFlag,
 
 		legacyKeyFileFlag,
@@ -370,6 +371,11 @@ var (
 		Usage:    "port to listen for p2p protocols",
 		DefValue: defaultConfig.P2P.Port,
 	}
+	p2pIpFlag = cli.StringFlag{
+		Name:     "p2p.ip",
+		Usage:    "ip to listen for p2p protocols",
+		DefValue: defaultConfig.P2P.IP,
+	}
 	p2pKeyFileFlag = cli.StringFlag{
 		Name:     "p2p.keyfile",
 		Usage:    "the p2p key file of the harmony node",
@@ -386,6 +392,9 @@ var (
 func applyP2PFlags(cmd *cobra.Command, config *harmonyConfig) {
 	if cli.IsFlagChanged(cmd, p2pPortFlag) {
 		config.P2P.Port = cli.GetIntFlagValue(cmd, p2pPortFlag)
+	}
+	if cli.IsFlagChanged(cmd, p2pIpFlag) {
+		config.P2P.IP = cli.GetStringFlagValue(cmd, p2pIpFlag)
 	}
 
 	if cli.IsFlagChanged(cmd, p2pKeyFileFlag) {
@@ -1078,11 +1087,11 @@ func applyLegacyMiscFlags(cmd *cobra.Command, config *harmonyConfig) {
 
 	if cli.IsFlagChanged(cmd, legacyPublicRPCFlag) {
 		if !cli.GetBoolFlagValue(cmd, legacyPublicRPCFlag) {
-			config.HTTP.IP = localListenIP
-			config.WS.IP = localListenIP
+			config.HTTP.IP = nodeconfig.DefaultLocalListenIP
+			config.WS.IP = nodeconfig.DefaultLocalListenIP
 		} else {
-			config.HTTP.IP = publicListenIP
-			config.WS.IP = publicListenIP
+			config.HTTP.IP = nodeconfig.DefaultPublicListenIP
+			config.WS.IP = nodeconfig.DefaultPublicListenIP
 		}
 	}
 

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -39,7 +39,7 @@ var (
 
 	p2pFlags = []cli.Flag{
 		p2pPortFlag,
-		p2pIpFlag,
+		p2pIPFlag,
 		p2pKeyFileFlag,
 
 		legacyKeyFileFlag,
@@ -371,7 +371,7 @@ var (
 		Usage:    "port to listen for p2p protocols",
 		DefValue: defaultConfig.P2P.Port,
 	}
-	p2pIpFlag = cli.StringFlag{
+	p2pIPFlag = cli.StringFlag{
 		Name:     "p2p.ip",
 		Usage:    "ip to listen for p2p protocols",
 		DefValue: defaultConfig.P2P.IP,
@@ -393,8 +393,8 @@ func applyP2PFlags(cmd *cobra.Command, config *harmonyConfig) {
 	if cli.IsFlagChanged(cmd, p2pPortFlag) {
 		config.P2P.Port = cli.GetIntFlagValue(cmd, p2pPortFlag)
 	}
-	if cli.IsFlagChanged(cmd, p2pIpFlag) {
-		config.P2P.IP = cli.GetStringFlagValue(cmd, p2pIpFlag)
+	if cli.IsFlagChanged(cmd, p2pIPFlag) {
+		config.P2P.IP = cli.GetStringFlagValue(cmd, p2pIPFlag)
 	}
 
 	if cli.IsFlagChanged(cmd, p2pKeyFileFlag) {

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -51,6 +51,7 @@ func TestHarmonyFlags(t *testing.T) {
 				},
 				P2P: p2pConfig{
 					Port:    9000,
+					IP:      defaultConfig.P2P.IP,
 					KeyFile: defaultConfig.P2P.KeyFile,
 				},
 				HTTP: httpConfig{
@@ -299,6 +300,7 @@ func TestP2PFlags(t *testing.T) {
 			args: []string{"--p2p.port", "9001", "--p2p.keyfile", "./key.file"},
 			expConfig: p2pConfig{
 				Port:    9001,
+				IP:      nodeconfig.DefaultPublicListenIP,
 				KeyFile: "./key.file",
 			},
 		},
@@ -306,6 +308,7 @@ func TestP2PFlags(t *testing.T) {
 			args: []string{"--port", "9001", "--key", "./key.file"},
 			expConfig: p2pConfig{
 				Port:    9001,
+				IP:      nodeconfig.DefaultPublicListenIP,
 				KeyFile: "./key.file",
 			},
 		},
@@ -388,7 +391,7 @@ func TestRPCFlags(t *testing.T) {
 			expConfig: httpConfig{
 				Enabled:        true,
 				RosettaEnabled: false,
-				IP:             publicListenIP,
+				IP:             nodeconfig.DefaultPublicListenIP,
 				Port:           9501,
 				RosettaPort:    9701,
 			},
@@ -448,7 +451,7 @@ func TestWSFlags(t *testing.T) {
 			args: []string{"--ip", "8.8.8.8", "--port", "9001", "--public_rpc"},
 			expConfig: wsConfig{
 				Enabled: true,
-				IP:      publicListenIP,
+				IP:      nodeconfig.DefaultPublicListenIP,
 				Port:    9801,
 			},
 		},

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -370,7 +370,9 @@ func setupNodeAndRun(hc harmonyConfig) {
 
 	if err := currentNode.BootstrapConsensus(); err != nil {
 		fmt.Println("could not bootstrap consensus", err.Error())
-		os.Exit(-1)
+		if !currentNode.NodeConfig.IsOffline {
+			os.Exit(-1)
+		}
 	}
 
 	if err := currentNode.Start(); err != nil {

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -271,6 +271,7 @@ func setupNodeAndRun(hc harmonyConfig) {
 	}
 	currentNode := setupConsensusAndNode(hc, nodeConfig)
 	nodeconfig.GetDefaultConfig().ShardID = nodeConfig.ShardID
+	nodeconfig.GetDefaultConfig().IsOffline = nodeConfig.IsOffline
 
 	// Prepare for graceful shutdown from os signals
 	osSignal := make(chan os.Signal)
@@ -494,6 +495,7 @@ func createGlobalConfig(hc harmonyConfig) (*nodeconfig.ConfigType, error) {
 	netType := nodeconfig.NetworkType(hc.Network.NetworkType)
 	nodeconfig.SetNetworkType(netType) // sets for both global and shard configs
 	nodeConfig.SetArchival(hc.General.IsArchival)
+	nodeConfig.IsOffline = hc.General.IsOffline
 
 	// P2P private key is used for secure message transfer between p2p nodes.
 	nodeConfig.P2PPriKey, _, err = utils.LoadKeyFromFile(hc.P2P.KeyFile)

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -178,10 +178,6 @@ func getHarmonyConfig(cmd *cobra.Command) (harmonyConfig, error) {
 		return harmonyConfig{}, err
 	}
 
-	if config.General.IsOffline {
-		config.P2P.IP = nodeconfig.DefaultLocalListenIP
-	}
-
 	return config, nil
 }
 

--- a/internal/configs/node/config.go
+++ b/internal/configs/node/config.go
@@ -78,6 +78,7 @@ type ConfigType struct {
 	IP              string              // IP of the node.
 	RPCServer       RPCServerConfig     // RPC server port and ip
 	RosettaServer   RosettaServerConfig // rosetta server port and ip
+	IsOffline       bool
 	StringRole      string
 	P2PPriKey       p2p_crypto.PrivKey
 	ConsensusPriKey multibls.PrivateKeys

--- a/internal/configs/node/network.go
+++ b/internal/configs/node/network.go
@@ -39,9 +39,9 @@ const (
 )
 
 const (
-	// DefaultLocalListenIP ..
+	// DefaultLocalListenIP is the IP used for local hosting
 	DefaultLocalListenIP = "127.0.0.1"
-	// DefaultPublicListenIP ..
+	// DefaultPublicListenIP is the IP used for public hosting
 	DefaultPublicListenIP = "0.0.0.0"
 	// DefaultP2PPort is the key to be used for p2p communication
 	DefaultP2PPort = 9000

--- a/internal/configs/node/network.go
+++ b/internal/configs/node/network.go
@@ -39,6 +39,10 @@ const (
 )
 
 const (
+	// DefaultLocalListenIP ..
+	DefaultLocalListenIP = "127.0.0.1"
+	// DefaultPublicListenIP ..
+	DefaultPublicListenIP = "0.0.0.0"
 	// DefaultP2PPort is the key to be used for p2p communication
 	DefaultP2PPort = 9000
 	// DefaultDNSPort is the default DNS port. The actual port used is DNSPort - 3000. This is a

--- a/node/node.go
+++ b/node/node.go
@@ -601,10 +601,6 @@ func (node *Node) Start() error {
 
 	isThisNodeAnExplorerNode := node.NodeConfig.Role() == nodeconfig.ExplorerNode
 
-	if node.NodeConfig.IsOffline {
-		select {} // sleep until program is terminated
-	}
-
 	for i := range allTopics {
 		sub, err := allTopics[i].Topic.Subscribe()
 		if err != nil {

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -173,6 +173,10 @@ func (p *LocalSyncingPeerProvider) SyncingPeers(shardID uint32) (peers []p2p.Pee
 
 // DoBeaconSyncing update received beaconchain blocks and downloads missing beacon chain blocks
 func (node *Node) DoBeaconSyncing() {
+	if node.NodeConfig.IsOffline {
+		return
+	}
+
 	go func(node *Node) {
 		// TODO ek – infinite loop; add shutdown/cleanup logic
 		for beaconBlock := range node.BeaconBlockChannel {
@@ -218,6 +222,10 @@ func (node *Node) DoBeaconSyncing() {
 
 // DoSyncing keep the node in sync with other peers, willJoinConsensus means the node will try to join consensus after catch up
 func (node *Node) DoSyncing(bc *core.BlockChain, worker *worker.Worker, willJoinConsensus bool) {
+	if node.NodeConfig.IsOffline {
+		return
+	}
+
 	ticker := time.NewTicker(time.Duration(SyncFrequency) * time.Second)
 	// TODO ek – infinite loop; add shutdown/cleanup logic
 	for {
@@ -349,6 +357,10 @@ func (node *Node) SendNewBlockToUnsync() {
 // CalculateResponse implements DownloadInterface on Node object.
 func (node *Node) CalculateResponse(request *downloader_pb.DownloaderRequest, incomingPeer string) (*downloader_pb.DownloaderResponse, error) {
 	response := &downloader_pb.DownloaderResponse{}
+	if node.NodeConfig.IsOffline {
+		return response, nil
+	}
+
 	switch request.Type {
 	case downloader_pb.DownloaderRequest_BLOCKHASH:
 		if request.BlockHash == nil {

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -13,7 +13,7 @@ import (
 	"github.com/harmony-one/bls/ffi/go/bls"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
-	libp2p "github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p"
 	libp2p_crypto "github.com/libp2p/go-libp2p-core/crypto"
 	libp2p_host "github.com/libp2p/go-libp2p-core/host"
 	libp2p_network "github.com/libp2p/go-libp2p-core/network"
@@ -65,7 +65,7 @@ const (
 
 // NewHost ..
 func NewHost(self *Peer, key libp2p_crypto.PrivKey) (Host, error) {
-	listenAddr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/0.0.0.0/tcp/%s", self.Port))
+	listenAddr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%s", self.IP, self.Port))
 	if err != nil {
 		return nil, errors.Wrapf(err,
 			"cannot create listen multiaddr from port %#v", self.Port)

--- a/p2p/tests/host_test.go
+++ b/p2p/tests/host_test.go
@@ -77,6 +77,7 @@ func TestConnectionToInvalidPeer(t *testing.T) {
 	assert.NotEmpty(t, discoveredHost.GetID())
 
 	discoveredPeer := discoveredHost.GetSelfPeer()
+	discoveredPeer.IP = "8.8.8.8" // force invalid peer
 
 	err = host.ConnectHostPeer(discoveredPeer)
 	assert.Error(t, err)

--- a/rosetta/common/config.go
+++ b/rosetta/common/config.go
@@ -50,14 +50,14 @@ type SyncStatus int
 
 // Sync status enum
 const (
-	SyncingStartup SyncStatus = iota
+	SyncingUnknown SyncStatus = iota
 	SyncingNewBlock
 	SyncingFinish
 )
 
 // String ..
 func (s SyncStatus) String() string {
-	return [...]string{"booting syncing service", "syncing new block(s)", "fully synced"}[s]
+	return [...]string{"unknown", "syncing new block(s)", "fully synced"}[s]
 }
 
 // SubNetworkMetadata for the sub network identifier of a shard

--- a/rosetta/services/network.go
+++ b/rosetta/services/network.go
@@ -76,7 +76,7 @@ func (s *NetworkAPI) NetworkStatus(
 	if s.hmy.NodeAPI.IsOutOfSync(s.hmy.BlockChain) {
 		syncStatus = common.SyncingNewBlock
 	} else if targetHeight == 0 {
-		syncStatus = common.SyncingStartup
+		syncStatus = common.SyncingUnknown
 	}
 	stage := syncStatus.String()
 

--- a/test/helpers/p2p.go
+++ b/test/helpers/p2p.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"github.com/harmony-one/bls/ffi/go/bls"
 	harmony_bls "github.com/harmony-one/harmony/crypto/bls"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/p2p"
 	libp2p_crypto "github.com/libp2p/go-libp2p-crypto"
 	"github.com/pkg/errors"
@@ -25,8 +26,8 @@ var (
 
 func init() {
 	Hosts = []Host{
-		{IP: "127.0.0.1", Port: "9000"},
-		{IP: "8.8.8.8", Port: "9001"},
+		{IP: nodeconfig.DefaultLocalListenIP, Port: "9000"},
+		{IP: nodeconfig.DefaultLocalListenIP, Port: "9001"},
 	}
 
 	Topics = []string{


### PR DESCRIPTION
This feature is needed for a correct deployment of a rosetta 'offline' node. That said, it is a perfectly reasonable feature to have on its own - rosetta notwithstanding. I imagine that it would great for debugging / devs. 

One can run a node in offline mode by adding the `--run.offline` option. This option has been tested to be backwards compatible with older config files. It defaults to an 'online' setting if the option/config is not provided. 

An offline node simply means that it does not sync & is not subscribed to any p2p topic or has any p2p peers. 
I've had to keep some service instantiations to ensure other services don't crash from a nil pointer.