### PR TITLE
Rosetta Dockerfile (Stage 4 of Node API Overhaul)

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -904,6 +904,7 @@ func New(
 		node.BeaconBlockChannel = make(chan *types.Block)
 		txPoolConfig := core.DefaultTxPoolConfig
 		txPoolConfig.Blacklist = blacklist
+		txPoolConfig.Journal = fmt.Sprintf("%v/%v", node.NodeConfig.DBDir, txPoolConfig.Journal)
 		node.TxPool = core.NewTxPool(txPoolConfig, node.Blockchain().Config(), blockchain, node.TransactionErrorSink)
 		node.CxPool = core.NewCxPool(core.CxPoolSize)
 		node.Worker = worker.New(node.Blockchain().Config(), blockchain, chain.Engine)

--- a/rosetta/infra/Dockerfile
+++ b/rosetta/infra/Dockerfile
@@ -26,13 +26,4 @@ RUN rm -rf *
 WORKDIR /root
 
 COPY run.sh run.sh
-#ENTRYPOINT ["/bin/bash","/root/run.sh"]
-
-
-
-
-
-
-
-
-
+ENTRYPOINT ["/bin/bash","/root/run.sh"]

--- a/rosetta/infra/Dockerfile
+++ b/rosetta/infra/Dockerfile
@@ -1,0 +1,38 @@
+FROM golang:1.14
+
+RUN apt update -y && apt upgrade -y
+RUN apt install libgmp-dev libssl-dev curl git -y
+
+ENV GOPATH=/root/go
+ENV GO111MODULE=on
+ENV HMY_PATH=${GOPATH}/src/github.com/harmony-one
+RUN mkdir -p $HMY_PATH
+
+WORKDIR $HMY_PATH
+
+RUN git clone https://github.com/harmony-one/harmony.git
+RUN git clone https://github.com/harmony-one/bls.git
+RUN git clone https://github.com/harmony-one/mcl.git
+
+WORKDIR $HMY_PATH/harmony
+
+RUN make linux_static
+RUN cp ./bin/harmony /root && chmod +x /root/harmony
+
+WORKDIR $GOPATH
+
+RUN rm -rf *
+
+WORKDIR /root
+
+COPY run.sh run.sh
+#ENTRYPOINT ["/bin/bash","/root/run.sh"]
+
+
+
+
+
+
+
+
+

--- a/rosetta/infra/README.md
+++ b/rosetta/infra/README.md
@@ -19,7 +19,7 @@ docker run -d -p 9700:9700 -v "$(pwd)/data:/root/data" harmony-rosetta --run.sha
 > This command will create the container of the harmony node on shard 0 in the detached mode, 
 > binding port 9700 (the rosetta port) on the container to the host and mounting the shared 
 > `./data` directory on the host to `/root/data` on the container. Note that the container
-> uses `/root/data` for all data storage.
+> uses `/root/data` for all data storage (this is where the `harmony_db_*` directories will be stored).
 
 You can view your container with the following command:
 ```bash
@@ -88,6 +88,36 @@ the host port to the container's rpc server port.
 ```bash
 docker run -d -p 9700:9700 -p 9800:9900 -v "$(pwd)/data:/root/data" harmony-rosetta --run.shard=0 -n testnet --ws
 ```
+
+### Running the node in non-archival mode
+One can append `--run.archive=false` to the docker run command to run the node in non-archival mode. For example:
+```bash 
+docker run -d -p 9700:9700 -v "$(pwd)/data:/root/data" harmony-rosetta --run.shard=0 -n testnet --run.archive=false
+```
+
+### Running a node with a rcloned DB
+Note that all node data will be stored in the `/root/data` directory within the container. Therefore, you can rclone
+the `harmony_db_*` directory to some directory (i.e: `./data`) and mount the volume on the docker run. 
+This way, the node will use DB in the volume that is shared between the container and host. For example: 
+```bash 
+docker run -d -p 9700:9700 -v "$(pwd)/data:/root/data" harmony-rosetta --run.shard=0
+```
+
+Note that the directory structure for `/root/data` (== `./data`) should look something like:
+```
+.
+├── explorer_storage_127.0.0.1_9000
+├── harmony_db_0
+├── harmony_db_1
+├── logs
+│    ├── node_execution.log
+│    └── zerolog-harmony.log
+└── transactions.rlp
+``` 
+
+### Inspecting Logs
+If you mount `./data` on the host to `/root/data` in the container, you van view the harmony node logs at
+`./data/logs/` on your host machine.
 
 ### View rosetta request logs
 You can view all the rosetta endpoint requests with the following command:

--- a/rosetta/infra/README.md
+++ b/rosetta/infra/README.md
@@ -1,0 +1,14 @@
+# Docker deployment of a Rosetta enabled Harmony node
+
+## Docker Image
+One can choose to build the docker image using the included Dockerfile with the following command:
+```bash
+
+```
+
+Or one can download/pull the image from dockerhub with the following command:
+```bash
+
+```
+
+## Starting the node

--- a/rosetta/infra/README.md
+++ b/rosetta/infra/README.md
@@ -1,14 +1,97 @@
 # Docker deployment of a Rosetta enabled Harmony node
 
 ## Docker Image
-One can choose to build the docker image using the included Dockerfile with the following command:
+You can choose to build the docker image using the included Dockerfile with the following command:
 ```bash
-
+docker build -t harmony-rosetta . 
 ```
 
-Or one can download/pull the image from dockerhub with the following command:
+Or you can download/pull the image from dockerhub with the following command:
 ```bash
-
+docker pull harmony-rosetta:latest
 ```
 
 ## Starting the node
+You can start the node with the following command:
+```bash
+docker run -d -p 9700:9700 -v "$(pwd)/data:/root/data" harmony-rosetta --run.shard=0 
+```
+> This command will create the container of the harmony node on shard 0 in the detached mode, 
+> binding port 9700 (the rosetta port) on the container to the host and mounting the shared 
+> `./data` directory on the host to `/root/data` on the container. Note that the container
+> uses `/root/data` for all data storage.
+
+You can view your container with the following command:
+```bash
+docker ps 
+```
+
+You can ensure that your node is running with the following curl command:
+```bash
+curl -X POST --data '{
+"network_identifier": {
+  "blockchain": "Harmony",
+  "network": "Mainnet",
+  "sub_network_identifier": {
+    "network": "shard 0",
+      "metadata": {
+        "is_beacon": true
+      }
+  }
+}}' http://localhost:9700/network/status
+```
+
+Once can start the node in the offline mode with the following command:
+```bash
+docker run -d -p 9700:9700 -v "$(pwd)/data:/root/data" harmony-rosetta --run.shard=0 --run.offline 
+```
+> The offline mode implies that the node will not connect to any p2p peer or sync.
+
+
+## Stopping the node
+First get your `CONTAINER ID` using the following command:
+```bash
+docker ps
+```
+> Note that if you do not see your node in the list, then your node is not running.
+> You can verify this with the `docker ps -a` command.
+
+Once you have your `CONTAINER ID`, you can stop it with the following command:
+```bash
+docker stop [CONTAINER ID]
+```
+
+## Details
+
+**Note that all the arguments provided when running the docker img are immediately forwarded to the harmony node binary.**
+> Note that the following args are **appended** to the provided arg when running the image: 
+> `--http.ip "0.0.0.0" --ws.ip "0.0.0.0" --http.rosetta --node_type "explorer" --datadir "./data" --log.dir "./data/logs"`.
+> This effectively makes them args that you cannot change.  
+
+### Running the node on testnet
+All the args on the image run are forwarded to the harmony node binary. Therefore, you can simply add `-n testnet` to 
+run the node for testnet. For example:
+```bash 
+docker run -d -p 9700:9700 -v "$(pwd)/data:/root/data" harmony-rosetta --run.shard=0 -n testnet
+```
+
+### Running the node with the http RPC capabilities 
+Similar to running a node on testnet, once can simply add `--http` to enable the rpc server. Then you have to forward
+the host port to the container's rpc server port.
+```bash
+docker run -d -p 9700:9700 -p 9500:9500 -v "$(pwd)/data:/root/data" harmony-rosetta --run.shard=0 -n testnet --http
+```
+
+### Running the node with the web socket RPC capabilities 
+Similar to running a node on testnet, once can simply add `--ws` to enable the rpc server. Then you have to forward
+the host port to the container's rpc server port.
+```bash
+docker run -d -p 9700:9700 -p 9800:9900 -v "$(pwd)/data:/root/data" harmony-rosetta --run.shard=0 -n testnet --ws
+```
+
+### View rosetta request logs
+You can view all the rosetta endpoint requests with the following command:
+```bash
+docker logs [CONTAINER ID]
+```
+> The `[CONTAINER ID]` can be found with this command: `docker ps`

--- a/rosetta/infra/run.sh
+++ b/rosetta/infra/run.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-# TODO: implement running a node in offline mode b4 continuing
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DATA="$DIR/data"
+LOGS="$DATA/logs"
+BASE_ARGS=(--http.ip "0.0.0.0" --ws.ip "0.0.0.0" --http.rosetta --node_type "explorer" --datadir "$DATA" --log.dir "$LOGS")
 
-./harmony -n testnet --http --http.ip 0.0.0.0 --http.rosetta --node_type=explorer --shard_id=0 --run.archive --ws.ip 0.0.0.0 --datadir ./data --log.dir ./data/logs
+mkdir -p "$LOGS"
+echo -e NODE ARGS: \" "$@"  "${BASE_ARGS[@]}" \"
+"$DIR/harmony" "$@" "${BASE_ARGS[@]}"

--- a/rosetta/infra/run.sh
+++ b/rosetta/infra/run.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+# TODO: implement running a node in offline mode b4 continuing
+
+./harmony -n testnet --http --http.ip 0.0.0.0 --http.rosetta --node_type=explorer --shard_id=0 --run.archive --ws.ip 0.0.0.0 --datadir ./data --log.dir ./data/logs


### PR DESCRIPTION
# Stage 4 of [Node API Overhaul](https://github.com/harmony-one/harmony/issues/3210)

This PR adds the Docker file and relevant README to deploy a rosetta enabled Harmony node. 

I had to make the pool's `transaction.rlp` file dependent on the `datadir` param to ensure that the path of that file can be determined by said param. This should not break any existing node deployment, as the default directory is the same as the `harmony_db_*` directory. In the worst case, a user would have to re-submit their transaction (if the `datadir` was used prior).

## TODO
* Add uploading to dockerhub to the release pipeline. 