### PR TITLE
[viewchange] time-based synchronuous view change

### DIFF
--- a/consensus/checks.go
+++ b/consensus/checks.go
@@ -92,7 +92,7 @@ func (consensus *Consensus) onAnnounceSanityChecks(recvMsg *FBFTMessage) bool {
 					"[OnAnnounce] Already in ViewChanging mode, conflicing announce, doing noop",
 				)
 			} else {
-				consensus.startViewChange(consensus.GetCurBlockViewID() + 1)
+				consensus.startViewChange(consensus.GetCurBlockViewID())
 			}
 		}
 		consensus.getLogger().Debug().

--- a/consensus/checks.go
+++ b/consensus/checks.go
@@ -92,7 +92,7 @@ func (consensus *Consensus) onAnnounceSanityChecks(recvMsg *FBFTMessage) bool {
 					"[OnAnnounce] Already in ViewChanging mode, conflicing announce, doing noop",
 				)
 			} else {
-				consensus.startViewChange(consensus.GetCurBlockViewID())
+				consensus.startViewChange()
 			}
 		}
 		consensus.getLogger().Debug().

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -81,7 +81,7 @@ func (consensus *Consensus) UpdatePublicKeys(pubKeys []bls_cosi.PublicKeyWrapper
 	consensus.Decider.UpdateParticipants(pubKeys)
 	utils.Logger().Info().Msg("My Committee updated")
 	for i := range pubKeys {
-		utils.Logger().Debug().
+		utils.Logger().Info().
 			Int("index", i).
 			Str("BLSPubKey", pubKeys[i].Bytes.Hex()).
 			Msg("Member")

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -95,7 +95,6 @@ func (consensus *Consensus) UpdatePublicKeys(pubKeys []bls_cosi.PublicKeyWrapper
 	} else {
 		utils.Logger().Error().
 			Msg("[UpdatePublicKeys] Participants is empty")
-		consensus.pubKeyLock.Unlock()
 	}
 	consensus.pubKeyLock.Unlock()
 	// reset states after update public keys

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -92,6 +92,10 @@ func (consensus *Consensus) UpdatePublicKeys(pubKeys []bls_cosi.PublicKeyWrapper
 		consensus.LeaderPubKey = &allKeys[0]
 		utils.Logger().Info().
 			Str("info", consensus.LeaderPubKey.Bytes.Hex()).Msg("My Leader")
+	} else {
+		utils.Logger().Error().
+			Msg("[UpdatePublicKeys] Participants is empty")
+		consensus.pubKeyLock.Unlock()
 	}
 	consensus.pubKeyLock.Unlock()
 	// reset states after update public keys

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -265,12 +265,12 @@ func (consensus *Consensus) Start(
 					if k != timeoutViewChange {
 						consensus.getLogger().Warn().Msg("[ConsensusMainLoop] Ops Consensus Timeout!!!")
 						viewID := consensus.GetCurBlockViewID()
-						consensus.startViewChange(viewID + 1)
+						consensus.startViewChange(viewID)
 						break
 					} else {
 						consensus.getLogger().Warn().Msg("[ConsensusMainLoop] Ops View Change Timeout!!!")
 						viewID := consensus.GetViewChangingID()
-						consensus.startViewChange(viewID + 1)
+						consensus.startViewChange(viewID)
 						break
 					}
 				}

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -264,13 +264,12 @@ func (consensus *Consensus) Start(
 					}
 					if k != timeoutViewChange {
 						consensus.getLogger().Warn().Msg("[ConsensusMainLoop] Ops Consensus Timeout!!!")
-						viewID := consensus.GetCurBlockViewID()
-						consensus.startViewChange(viewID)
+						consensus.SetViewChangingID(consensus.GetCurBlockViewID())
+						consensus.startViewChange()
 						break
 					} else {
 						consensus.getLogger().Warn().Msg("[ConsensusMainLoop] Ops View Change Timeout!!!")
-						viewID := consensus.GetViewChangingID()
-						consensus.startViewChange(viewID)
+						consensus.startViewChange()
 						break
 					}
 				}

--- a/consensus/quorum/quorum.go
+++ b/consensus/quorum/quorum.go
@@ -10,6 +10,7 @@ import (
 	bls_core "github.com/harmony-one/bls/ffi/go/bls"
 	"github.com/harmony-one/harmony/consensus/votepower"
 	bls_cosi "github.com/harmony-one/harmony/crypto/bls"
+	shardingconfig "github.com/harmony-one/harmony/internal/configs/sharding"
 	"github.com/harmony-one/harmony/multibls"
 	"github.com/harmony-one/harmony/numeric"
 	"github.com/harmony-one/harmony/shard"
@@ -73,6 +74,7 @@ type ParticipantTracker interface {
 	IndexOf(bls.SerializedPublicKey) int
 	ParticipantsCount() int64
 	NthNext(*bls.PublicKeyWrapper, int) (bool, *bls.PublicKeyWrapper)
+	NthNextHmy(shardingconfig.Instance, *bls.PublicKeyWrapper, int) (bool, *bls.PublicKeyWrapper)
 	UpdateParticipants(pubKeys []bls.PublicKeyWrapper)
 }
 
@@ -214,7 +216,29 @@ func (s *cIdentities) NthNext(pubKey *bls.PublicKeyWrapper, next int) (bool, *bl
 	if idx != -1 {
 		found = true
 	}
-	idx = (idx + next) % int(s.ParticipantsCount())
+	numNodes := int(s.ParticipantsCount())
+	// sanity check to avoid out of bound access
+	if numNodes <= 0 || numNodes > len(s.publicKeys) {
+		numNodes = len(s.publicKeys)
+	}
+	idx = (idx + next) % numNodes
+	return found, &s.publicKeys[idx]
+}
+
+// NthNextHmy return the Nth next pubkey of Harmony nodes, next can be negative number
+func (s *cIdentities) NthNextHmy(instance shardingconfig.Instance, pubKey *bls.PublicKeyWrapper, next int) (bool, *bls.PublicKeyWrapper) {
+	found := false
+
+	idx := s.IndexOf(pubKey.Bytes)
+	if idx != -1 {
+		found = true
+	}
+	numNodes := instance.NumHarmonyOperatedNodesPerShard()
+	// sanity check to avoid out of bound access
+	if numNodes <= 0 || numNodes > len(s.publicKeys) {
+		numNodes = len(s.publicKeys)
+	}
+	idx = (idx + next) % numNodes
 	return found, &s.publicKeys[idx]
 }
 

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	msg_pb "github.com/harmony-one/harmony/api/proto/message"
 	"github.com/harmony-one/harmony/consensus/quorum"
-	"github.com/harmony-one/harmony/core"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
@@ -182,7 +181,7 @@ func (consensus *Consensus) getNextLeaderKey(viewID uint64) *bls.PublicKeyWrappe
 			// use the LeaderPubKey as the base of the next leader
 			// as we shouldn't use lastLeader from coinbase as the base.
 			// The LeaderPubKey should be updated to the index 0 of the committee
-			if core.IsEpochBlockByNumber(consensus.blockNum) {
+			if curHeader.IsLastBlockInEpoch() {
 				consensus.getLogger().Info().Msg("[getNextLeaderKey] view change in the first block of new epoch")
 				lastLeaderPubKey = consensus.LeaderPubKey
 			}

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -133,9 +133,6 @@ func (consensus *Consensus) getNextViewID(viewID uint64) (uint64, time.Duration)
 	totalNode := consensus.Decider.ParticipantsCount()
 	// diff is at least 1, and it won't exceeded the totalNode
 	diff := uint64(((curTimestamp - blockTimestamp) / viewChangeTimeout) % int64(totalNode))
-	if diff == 0 {
-		diff = 1
-	}
 	nextViewID := diff + consensus.current.GetCurBlockViewID()
 
 	consensus.getLogger().Info().

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	msg_pb "github.com/harmony-one/harmony/api/proto/message"
 	"github.com/harmony-one/harmony/consensus/quorum"
+	"github.com/harmony-one/harmony/core"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
@@ -172,6 +173,14 @@ func (consensus *Consensus) getNextLeaderKey(viewID uint64) *bls.PublicKeyWrappe
 			if err != nil || lastLeaderPubKey == nil {
 				consensus.getLogger().Error().Err(err).
 					Msg("[getNextLeaderKey] Unable to get leaderPubKey from coinbase. Set it to consensus.LeaderPubKey")
+				lastLeaderPubKey = consensus.LeaderPubKey
+			}
+			// viewchange happened at the first block of new epoch
+			// use the LeaderPubKey as the base of the next leader
+			// as we shouldn't use lastLeader from coinbase as the base.
+			// The LeaderPubKey should be updated to the index 0 of the committee
+			if core.IsEpochBlockByNumber(consensus.blockNum) {
+				consensus.getLogger().Info().Msg("[getNextLeaderKey] view change in the first block of new epoch")
 				lastLeaderPubKey = consensus.LeaderPubKey
 			}
 		}

--- a/consensus/view_change_test.go
+++ b/consensus/view_change_test.go
@@ -87,7 +87,7 @@ func TestGetNextLeaderKeyShouldFailForStandardGeneratedConsensus(t *testing.T) {
 
 	// The below results in: "panic: runtime error: integer divide by zero"
 	// This happens because there's no check for if there are any participants or not in https://github.com/harmony-one/harmony/blob/main/consensus/quorum/quorum.go#L188-L197
-	assert.Panics(t, func() { consensus.GetNextLeaderKey(uint64(1)) })
+	assert.Panics(t, func() { consensus.getNextLeaderKey(uint64(1)) })
 }
 
 func TestGetNextLeaderKeyShouldSucceed(t *testing.T) {
@@ -115,7 +115,7 @@ func TestGetNextLeaderKeyShouldSucceed(t *testing.T) {
 	assert.Equal(t, keyCount, consensus.Decider.ParticipantsCount())
 
 	consensus.LeaderPubKey = &wrappedBLSKeys[0]
-	nextKey := consensus.GetNextLeaderKey(uint64(1))
+	nextKey := consensus.getNextLeaderKey(uint64(1))
 
 	assert.Equal(t, nextKey, &wrappedBLSKeys[1])
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -293,16 +293,6 @@ func IsEpochBlock(block *types.Block) bool {
 	return shard.Schedule.IsLastBlock(block.NumberU64() - 1)
 }
 
-// IsEpochBlockByNumber returns whether this block is the first block of an epoch.
-// by checking the block number
-func IsEpochBlockByNumber(blockNum uint64) bool {
-	if blockNum == 0 {
-		// genesis block is the first epoch block
-		return true
-	}
-	return shard.Schedule.IsLastBlock(blockNum - 1)
-}
-
 // EpochFirstBlock returns the block number of the first block of an epoch.
 // TODO: instead of using fixed epoch schedules, determine the first block by epoch changes.
 func EpochFirstBlock(epoch *big.Int) *big.Int {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -293,6 +293,16 @@ func IsEpochBlock(block *types.Block) bool {
 	return shard.Schedule.IsLastBlock(block.NumberU64() - 1)
 }
 
+// IsEpochBlockByNumber returns whether this block is the first block of an epoch.
+// by checking the block number
+func IsEpochBlockByNumber(blockNum uint64) bool {
+	if blockNum == 0 {
+		// genesis block is the first epoch block
+		return true
+	}
+	return shard.Schedule.IsLastBlock(blockNum - 1)
+}
+
 // EpochFirstBlock returns the block number of the first block of an epoch.
 // TODO: instead of using fixed epoch schedules, determine the first block by epoch changes.
 func EpochFirstBlock(epoch *big.Int) *big.Int {


### PR DESCRIPTION
For view change, the view change ID is the key to determine which node
will be next leader. In our original algorithm, the view ID always increased one step
at a time. The view change period increased exponetially based on the square of
the gap between current view changing ID and previous known block view change ID.

However, it is very slow to converge the view change if multiple nodes are offline and
view change can't be reached. Especially, during the shard down event, multiple nodes
are offline and other nodes have advanced their current view changing ID.

The new time-baed synchronuous view change algorithm uses the local timestamp and
the timestamp of the block to calculate the expected view changing ID. In this case,
offline nodes can immediately catch up with the latest view changing ID as long as
the offline nodes have the latest sync'ed block and relatively acturate local
clock. This algorithm will converge the view change faster in one or two view change
duration.

Signed-off-by: Leo Chen <leo@harmony.one>
