### PR TITLE
View Change Revamp 2

### DIFF
--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -43,6 +43,13 @@ func (consensus *Consensus) HandleMessageUpdate(ctx context.Context, msg *msg_pb
 		return nil
 	}
 
+	// when node is not in ViewChanging mode, ignore viewchange / newview messages
+	if !consensus.IsViewChangingMode() &&
+		(msg.Type == msg_pb.MessageType_VIEWCHANGE ||
+			msg.Type == msg_pb.MessageType_NEWVIEW) {
+		return nil
+	}
+
 	intendedForValidator, intendedForLeader :=
 		!consensus.IsLeader(),
 		consensus.IsLeader()

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -43,13 +43,6 @@ func (consensus *Consensus) HandleMessageUpdate(ctx context.Context, msg *msg_pb
 		return nil
 	}
 
-	// when node is not in ViewChanging mode, ignore viewchange / newview messages
-	if !consensus.IsViewChangingMode() &&
-		(msg.Type == msg_pb.MessageType_VIEWCHANGE ||
-			msg.Type == msg_pb.MessageType_NEWVIEW) {
-		return nil
-	}
-
 	intendedForValidator, intendedForLeader :=
 		!consensus.IsLeader(),
 		consensus.IsLeader()

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -102,11 +102,15 @@ func (consensus *Consensus) sendCommitMessages(blockObj *types.Block) {
 			continue
 		}
 
-		networkMessage, _ := consensus.construct(
+		networkMessage, err := consensus.construct(
 			msg_pb.MessageType_COMMIT,
 			commitPayload,
 			&key,
 		)
+		if err != nil {
+			consensus.getLogger().Warn().Msg("[sendCommitMessages] cannot construct network message")
+			continue
+		}
 
 		if consensus.current.Mode() != Listening {
 			if err := consensus.msgSender.SendWithoutRetry(

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -230,8 +230,8 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 
 	// received enough view change messages, change state to normal consensus
 	if consensus.Decider.IsQuorumAchievedByMask(consensus.vc.GetViewIDBitmap(recvMsg.ViewID)) {
-		consensus.getLogger().Info().Msg("[onViewChange] View Change Message Quorum Reached")
 		consensus.current.SetMode(Normal)
+		consensus.getLogger().Info().Msg("[onViewChange] View Change Message Quorum Reached")
 		consensus.LeaderPubKey = newLeaderKey
 		consensus.ResetState()
 		if consensus.vc.IsM1PayloadEmpty() {

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -157,11 +157,16 @@ func (consensus *Consensus) startViewChange(viewID uint64) {
 			continue
 		}
 		msgToSend := consensus.constructViewChangeMessage(&key)
-		consensus.host.SendMessageToGroups([]nodeconfig.GroupID{
-			nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(consensus.ShardID)),
-		},
+		if err := consensus.msgSender.SendWithRetry(
+			consensus.blockNum,
+			msg_pb.MessageType_VIEWCHANGE,
+			[]nodeconfig.GroupID{
+				nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(consensus.ShardID))},
 			p2p.ConstructMessage(msgToSend),
-		)
+		); err != nil {
+			consensus.getLogger().Err(err).
+				Msg("could not send out the ViewChange message")
+		}
 	}
 }
 

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -203,6 +203,9 @@ func (consensus *Consensus) startNewView(viewID uint64, newLeaderPriKey *bls.Pri
 		Str("myKey", newLeaderPriKey.Pub.Bytes.Hex()).
 		Msg("[startNewView] viewChange stopped. I am the New Leader")
 
+	consensus.ResetState()
+	consensus.LeaderPubKey = newLeaderPriKey.Pub
+
 	return nil
 }
 
@@ -250,7 +253,7 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 		recvMsg.ViewID,
 		recvMsg.BlockNum,
 		consensus.priKey); err != nil {
-		consensus.getLogger().Error().Err(err).Msg("Init Payload Error")
+		consensus.getLogger().Error().Err(err).Msg("[onViewChange] Init Payload Error")
 		return
 	}
 
@@ -260,7 +263,7 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 			Uint64("viewID", recvMsg.ViewID).
 			Uint64("blockNum", recvMsg.BlockNum).
 			Str("msgSender", recvMsg.SenderPubkey.Bytes.Hex()).
-			Msg("Verify View Change Message Error")
+			Msg("[onViewChange] process View Change message error")
 		return
 	}
 
@@ -273,8 +276,6 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 				consensus.getLogger().Error().Err(err).Msg("[onViewChange] startNewView failed")
 				return
 			}
-			consensus.ResetState()
-			consensus.LeaderPubKey = newLeaderKey
 
 			go func() {
 				consensus.ReadySignal <- struct{}{}
@@ -291,8 +292,6 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 			consensus.getLogger().Error().Err(err).Msg("[onViewChange] startNewView failed")
 			return
 		}
-		consensus.ResetState()
-		consensus.LeaderPubKey = newLeaderKey
 	}
 }
 

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -172,6 +172,9 @@ func (consensus *Consensus) startViewChange(viewID uint64) {
 
 // stopViewChange stops the current view change
 func (consensus *Consensus) stopViewChange(viewID uint64, newLeaderPriKey *bls.PrivateKeyWrapper) error {
+	consensus.mutex.Lock()
+	defer consensus.mutex.Unlock()
+
 	msgToSend := consensus.constructNewViewMessage(
 		viewID, newLeaderPriKey,
 	)
@@ -379,6 +382,9 @@ func (consensus *Consensus) onNewView(msg *msg_pb.Message) {
 		consensus.getLogger().Info().Msg("Not in ViewChanging Mode.")
 		return
 	}
+
+	consensus.mutex.Lock()
+	defer consensus.mutex.Unlock()
 
 	consensus.consensusTimeout[timeoutViewChange].Stop()
 

--- a/consensus/view_change_construct.go
+++ b/consensus/view_change_construct.go
@@ -113,18 +113,19 @@ func (vc *viewChange) GetPreparedBlock(fbftlog *FBFTLog, hash [32]byte) ([]byte,
 	vc.vcLock.RLock()
 	defer vc.vcLock.RUnlock()
 
-	if !vc.isM1PayloadEmpty() {
-		block := fbftlog.GetBlockByHash(hash)
-		if block != nil {
-			encodedBlock, err := rlp.EncodeToBytes(block)
-			if err != nil || len(encodedBlock) == 0 {
-				vc.getLogger().Err(err).Msg("[GetPreparedBlock] Failed encoding prepared block")
-				return vc.m1Payload, nil
-			}
-			return vc.m1Payload, encodedBlock
-		}
+	if vc.isM1PayloadEmpty() {
+		return nil, nil
 	}
-	return vc.m1Payload, nil
+
+	if block := fbftlog.GetBlockByHash(hash); block != nil {
+		encodedBlock, err := rlp.EncodeToBytes(block)
+		if err != nil || len(encodedBlock) == 0 {
+			return nil, nil
+		}
+		return vc.m1Payload, encodedBlock
+	}
+
+	return nil, nil
 }
 
 // GetM2Bitmap returns the nilBitmap as M2Bitmap

--- a/consensus/view_change_construct.go
+++ b/consensus/view_change_construct.go
@@ -438,6 +438,7 @@ func (vc *viewChange) InitPayload(
 }
 
 // isM1PayloadEmpty returns true if m1Payload is not set
+// this is an unlocked internal function call
 func (vc *viewChange) isM1PayloadEmpty() bool {
 	return len(vc.m1Payload) == 0
 }
@@ -458,6 +459,8 @@ func (vc *viewChange) GetViewIDBitmap(viewID uint64) *bls_cosi.Mask {
 
 // GetM1Payload returns the m1Payload
 func (vc *viewChange) GetM1Payload() []byte {
+	vc.vcLock.RLock()
+	defer vc.vcLock.RUnlock()
 	return vc.m1Payload
 }
 

--- a/consensus/view_change_msg.go
+++ b/consensus/view_change_msg.go
@@ -106,7 +106,7 @@ func (consensus *Consensus) constructNewViewMessage(viewID uint64, priKey *bls.P
 		Type:        msg_pb.MessageType_NEWVIEW,
 		Request: &msg_pb.Message_Viewchange{
 			Viewchange: &msg_pb.ViewChangeRequest{
-				ViewId:       consensus.GetViewChangingID(),
+				ViewId:       viewID,
 				BlockNum:     consensus.blockNum,
 				ShardId:      consensus.ShardID,
 				SenderPubkey: priKey.Pub.Bytes[:],

--- a/node/node.go
+++ b/node/node.go
@@ -461,9 +461,9 @@ func (node *Node) validateShardBoundMessage(
 			return nil, nil, true, nil
 		}
 	} else {
-		// ignore newview message if the node is not in viewchanging mode
+		// ignore viewchange/newview message if the node is not in viewchanging mode
 		switch m.Type {
-		case msg_pb.MessageType_NEWVIEW:
+		case msg_pb.MessageType_NEWVIEW, msg_pb.MessageType_VIEWCHANGE:
 			return nil, nil, true, nil
 		}
 	}


### PR DESCRIPTION
This set of PR further improves the stability of the view change process.

The enhancement includes:

* retry sending view change messages, in case the new leader started view change process slower than the other validators that may miss a few view change messages. This commit can reduce another round of view change process.
* ignore viewchange/newview message if the validator is not in viewchanging mode
* RLock to protect the reading of m1Payload
* use consistent data to construct the newview message
* use sendCommitMessages functions to reduce code duplication onViewChange
* further protection of consensus data change during view change process using consensus.mutex
