### PR TITLE
[rpc] Always display transaction status in the receipt

### DIFF
--- a/rpc/v1/types.go
+++ b/rpc/v1/types.go
@@ -179,8 +179,8 @@ type TxReceipt struct {
 	ShardID           uint32         `json:"shardID"`
 	From              string         `json:"from"`
 	To                string         `json:"to"`
-	Root              hexutil.Bytes  `json:"root,omitempty"`
-	Status            hexutil.Uint   `json:"status,omitempty"`
+	Root              hexutil.Bytes  `json:"root"`
+	Status            hexutil.Uint   `json:"status"`
 }
 
 // StakingTxReceipt represents a staking transaction receipt that will serialize to the RPC representation.
@@ -196,8 +196,8 @@ type StakingTxReceipt struct {
 	LogsBloom         ethtypes.Bloom    `json:"logsBloom"`
 	Sender            string            `json:"sender"`
 	Type              staking.Directive `json:"type"`
-	Root              hexutil.Bytes     `json:"root,omitempty"`
-	Status            hexutil.Uint      `json:"status,omitempty"`
+	Root              hexutil.Bytes     `json:"root"`
+	Status            hexutil.Uint      `json:"status"`
 }
 
 // CxReceipt represents a CxReceipt that will serialize to the RPC representation of a CxReceipt
@@ -349,13 +349,8 @@ func NewTxReceipt(
 		ShardID:           tx.ShardID(),
 		From:              sender,
 		To:                receiver,
-	}
-
-	// Set optionals
-	if len(receipt.PostState) > 0 {
-		txReceipt.Root = receipt.PostState
-	} else {
-		txReceipt.Status = hexutil.Uint(receipt.Status)
+		Root:              receipt.PostState,
+		Status:            hexutil.Uint(receipt.Status),
 	}
 
 	// Set empty array for empty logs
@@ -396,13 +391,8 @@ func NewStakingTxReceipt(
 		LogsBloom:         receipt.Bloom,
 		Sender:            sender,
 		Type:              tx.StakingType(),
-	}
-
-	// Set optionals
-	if len(receipt.PostState) > 0 {
-		txReceipt.Root = receipt.PostState
-	} else {
-		txReceipt.Status = hexutil.Uint(receipt.Status)
+		Root:              receipt.PostState,
+		Status:            hexutil.Uint(receipt.Status),
 	}
 
 	// Set empty array for empty logs

--- a/rpc/v2/types.go
+++ b/rpc/v2/types.go
@@ -178,8 +178,8 @@ type TxReceipt struct {
 	ShardID           uint32         `json:"shardID"`
 	From              string         `json:"from"`
 	To                string         `json:"to"`
-	Root              hexutil.Bytes  `json:"root,omitempty"`
-	Status            uint           `json:"status,omitempty"`
+	Root              hexutil.Bytes  `json:"root"`
+	Status            uint           `json:"status"`
 }
 
 // StakingTxReceipt represents a staking transaction receipt that will serialize to the RPC representation.
@@ -195,8 +195,8 @@ type StakingTxReceipt struct {
 	LogsBloom         ethtypes.Bloom    `json:"logsBloom"`
 	Sender            string            `json:"sender"`
 	Type              staking.Directive `json:"type"`
-	Root              hexutil.Bytes     `json:"root,omitempty"`
-	Status            uint              `json:"status,omitempty"`
+	Root              hexutil.Bytes     `json:"root"`
+	Status            uint              `json:"status"`
 }
 
 // CxReceipt represents a CxReceipt that will serialize to the RPC representation of a CxReceipt
@@ -347,6 +347,8 @@ func NewTxReceipt(
 		ShardID:           tx.ShardID(),
 		From:              sender,
 		To:                receiver,
+		Root:              receipt.PostState,
+		Status:            uint(receipt.Status),
 	}
 
 	// Set optionals
@@ -394,13 +396,8 @@ func NewStakingTxReceipt(
 		LogsBloom:         receipt.Bloom,
 		Sender:            sender,
 		Type:              tx.StakingType(),
-	}
-
-	// Set optionals
-	if len(receipt.PostState) > 0 {
-		txReceipt.Root = receipt.PostState
-	} else {
-		txReceipt.Status = uint(receipt.Status)
+		Root:              receipt.PostState,
+		Status:            uint(receipt.Status),
 	}
 
 	// Set empty array for empty logs


### PR DESCRIPTION
Display failing transaction status in transaction receipt.

Example (receipt hash from Seb's message in Discord):
```
$ ./hmy blockchain transaction-receipt 0xd3ce842e3f7f52ef4b8118463db2a3ad09c9fea1e4a823bac2f1b6988fd867bc
{
  "id": "1",
  "jsonrpc": "2.0",
  "result": {
    "blockHash": "0x5ff2b50a8f11320f1a8be8d2c6f3c2b95fe69f6d8810964d733e633f81c8d6c7",
    "blockNumber": "0x1eb0fd",
    "contractAddress": "0x0000000000000000000000000000000000000000",
    "cumulativeGasUsed": "0x856c",
    "from": "one1u6c4wer2dkm767hmjeehnwu6tqqur62gx9vqsd",
    "gasUsed": "0x856c",
    "logs": [],
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "root": "0x",
    "shardID": 0,
    "status": "0x0",
    "to": "one1a0jr8algpm7r8x2y200v288s2ghjawlv8mtzlx",
    "transactionHash": "0xd3ce842e3f7f52ef4b8118463db2a3ad09c9fea1e4a823bac2f1b6988fd867bc",
    "transactionIndex": "0x0"
  }
}
```