### PR TITLE
Rosetta Dockerfile FIX (Stage 4 of Node API Overhaul)

### DIFF
--- a/rosetta/infra/Dockerfile
+++ b/rosetta/infra/Dockerfile
@@ -17,13 +17,10 @@ RUN git clone https://github.com/harmony-one/mcl.git
 WORKDIR $HMY_PATH/harmony
 
 RUN make linux_static
-RUN cp ./bin/harmony /root && chmod +x /root/harmony
-
-WORKDIR $GOPATH
-
-RUN rm -rf *
+RUN mv ./bin/harmony /root/harmony && chmod +x /root/harmony
+RUN mv ./rosetta/infra/run.sh /root/run.sh && chmod +x /root/run.sh
+RUN rm -rf $GOPATH
 
 WORKDIR /root
 
-COPY run.sh run.sh
 ENTRYPOINT ["/bin/bash","/root/run.sh"]


### PR DESCRIPTION
# Stage 4 FIX of [Node API Overhaul](https://github.com/harmony-one/harmony/issues/3210)

This PR is related to #3385

To fully build from source, we cannot copy a local file to create the docker image. Instead, we should pull straight from GitHub. 