### PR TITLE
[config] Add flag to enable debug APIs

### DIFF
--- a/cmd/harmony/config.go
+++ b/cmd/harmony/config.go
@@ -119,7 +119,7 @@ type wsConfig struct {
 }
 
 type rpcOptConfig struct {
-	Enabled bool
+	DebugEnabled bool // Enables PrivateDebugService APIs, including the EVM tracer
 }
 
 type devnetConfig struct {

--- a/cmd/harmony/config.go
+++ b/cmd/harmony/config.go
@@ -23,6 +23,7 @@ type harmonyConfig struct {
 	P2P       p2pConfig
 	HTTP      httpConfig
 	WS        wsConfig
+	RPCOpt    rpcOptConfig
 	BLSKeys   blsConfig
 	TxPool    txPoolConfig
 	Pprof     pprofConfig
@@ -115,6 +116,10 @@ type wsConfig struct {
 	Enabled bool
 	IP      string
 	Port    int
+}
+
+type rpcOptConfig struct {
+	Enabled bool
 }
 
 type devnetConfig struct {

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -36,6 +36,9 @@ var defaultConfig = harmonyConfig{
 		IP:      "127.0.0.1",
 		Port:    nodeconfig.DefaultWSPort,
 	},
+	RPCOpt: rpcOptConfig{
+		Enabled: false,
+	},
 	BLSKeys: blsConfig{
 		KeyDir:   "./.hmy/blskeys",
 		KeyFiles: []string{},

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -37,7 +37,7 @@ var defaultConfig = harmonyConfig{
 		Port:    nodeconfig.DefaultWSPort,
 	},
 	RPCOpt: rpcOptConfig{
-		Enabled: false,
+		DebugEnabled: false,
 	},
 	BLSKeys: blsConfig{
 		KeyDir:   "./.hmy/blskeys",

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -513,14 +513,14 @@ var (
 	rpcDebugEnabledFlag = cli.BoolFlag{
 		Name:     "rpc.debug",
 		Usage:    "enable private debug apis",
-		DefValue: defaultConfig.RPCOpt.Enabled,
+		DefValue: defaultConfig.RPCOpt.DebugEnabled,
 		Hidden:   true,
 	}
 )
 
 func applyRPCOptFlags(cmd *cobra.Command, config *harmonyConfig) {
 	if cli.IsFlagChanged(cmd, rpcDebugEnabledFlag) {
-		config.RPCOpt.Enabled = cli.GetBoolFlagValue(cmd, rpcDebugEnabledFlag)
+		config.RPCOpt.DebugEnabled = cli.GetBoolFlagValue(cmd, rpcDebugEnabledFlag)
 	}
 }
 

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -59,6 +59,10 @@ var (
 		wsPortFlag,
 	}
 
+	rpcOptFlags = []cli.Flag{
+		rpcDebugEnabledFlag,
+	}
+
 	blsFlags = append(newBLSFlags, legacyBLSFlags...)
 
 	newBLSFlags = []cli.Flag{
@@ -236,6 +240,7 @@ func getRootFlags() []cli.Flag {
 	flags = append(flags, p2pFlags...)
 	flags = append(flags, httpFlags...)
 	flags = append(flags, wsFlags...)
+	flags = append(flags, rpcOptFlags...)
 	flags = append(flags, blsFlags...)
 	flags = append(flags, consensusFlags...)
 	flags = append(flags, txPoolFlags...)
@@ -500,6 +505,22 @@ func applyWSFlags(cmd *cobra.Command, config *harmonyConfig) {
 	}
 	if cli.IsFlagChanged(cmd, wsPortFlag) {
 		config.WS.Port = cli.GetIntFlagValue(cmd, wsPortFlag)
+	}
+}
+
+// rpc opt flags
+var (
+	rpcDebugEnabledFlag = cli.BoolFlag{
+		Name:     "rpc.debug",
+		Usage:    "enable private debug apis",
+		DefValue: defaultConfig.RPCOpt.Enabled,
+		Hidden:   true,
+	}
+)
+
+func applyRPCOptFlags(cmd *cobra.Command, config *harmonyConfig) {
+	if cli.IsFlagChanged(cmd, rpcDebugEnabledFlag) {
+		config.RPCOpt.Enabled = cli.GetBoolFlagValue(cmd, rpcDebugEnabledFlag)
 	}
 }
 

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -484,7 +484,7 @@ func TestWSFlags(t *testing.T) {
 }
 
 func TestRPCOptFlags(t *testing.T) {
-	tests := []struct{
+	tests := []struct {
 		args      []string
 		expConfig rpcOptConfig
 	}{

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -491,7 +491,7 @@ func TestRPCOptFlags(t *testing.T) {
 		{
 			args: []string{"--rpc.debug"},
 			expConfig: rpcOptConfig{
-				Enabled: true,
+				DebugEnabled: true,
 			},
 		},
 	}

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -483,6 +483,31 @@ func TestWSFlags(t *testing.T) {
 	}
 }
 
+func TestRPCOptFlags(t *testing.T) {
+	tests := []struct{
+		args      []string
+		expConfig rpcOptConfig
+	}{
+		{
+			args: []string{"--rpc.debug"},
+			expConfig: rpcOptConfig{
+				Enabled: true,
+			},
+		},
+	}
+	for i, test := range tests {
+		ts := newFlagTestSuite(t, rpcOptFlags, applyRPCOptFlags)
+
+		hc, _ := ts.run(test.args)
+
+		if !reflect.DeepEqual(hc.RPCOpt, test.expConfig) {
+			t.Errorf("Test %v: \n\t%+v\n\t%+v", i, hc.RPCOpt, test.expConfig)
+		}
+
+		ts.tearDown()
+	}
+}
+
 func TestBLSFlags(t *testing.T) {
 	tests := []struct {
 		args      []string

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -191,6 +191,7 @@ func applyRootFlags(cmd *cobra.Command, config *harmonyConfig) {
 	applyP2PFlags(cmd, config)
 	applyHTTPFlags(cmd, config)
 	applyWSFlags(cmd, config)
+	applyRPCOptFlags(cmd, config)
 	applyBLSFlags(cmd, config)
 	applyConsensusFlags(cmd, config)
 	applyTxPoolFlags(cmd, config)
@@ -306,12 +307,13 @@ func setupNodeAndRun(hc harmonyConfig) {
 
 	// Parse RPC config
 	nodeConfig.RPCServer = nodeconfig.RPCServerConfig{
-		HTTPEnabled: hc.HTTP.Enabled,
-		HTTPIp:      hc.HTTP.IP,
-		HTTPPort:    hc.HTTP.Port,
-		WSEnabled:   hc.WS.Enabled,
-		WSIp:        hc.WS.IP,
-		WSPort:      hc.WS.Port,
+		HTTPEnabled:  hc.HTTP.Enabled,
+		HTTPIp:       hc.HTTP.IP,
+		HTTPPort:     hc.HTTP.Port,
+		WSEnabled:    hc.WS.Enabled,
+		WSIp:         hc.WS.IP,
+		WSPort:       hc.WS.Port,
+		DebugEnabled: hc.RPCOpt.Enabled,
 	}
 	if nodeConfig.ShardID != shard.BeaconChainShardID {
 		utils.Logger().Info().

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -313,7 +313,7 @@ func setupNodeAndRun(hc harmonyConfig) {
 		WSEnabled:    hc.WS.Enabled,
 		WSIp:         hc.WS.IP,
 		WSPort:       hc.WS.Port,
-		DebugEnabled: hc.RPCOpt.Enabled,
+		DebugEnabled: hc.RPCOpt.DebugEnabled,
 	}
 	if nodeConfig.ShardID != shard.BeaconChainShardID {
 		utils.Logger().Info().

--- a/internal/configs/node/config.go
+++ b/internal/configs/node/config.go
@@ -103,6 +103,8 @@ type RPCServerConfig struct {
 	WSEnabled bool
 	WSIp      string
 	WSPort    int
+
+	DebugEnabled bool
 }
 
 // RosettaServerConfig is the config for the rosetta server


### PR DESCRIPTION
* Disable debug APIs by default
* New hidden `--rpc.debug` flag

Example usage:
```
./harmony --testnet --run=explorer --run.shard=0 --rpc.debug
```