### PR TITLE
[ntp] do not exit if ntp query failed

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -278,9 +278,13 @@ func setupNodeAndRun(hc harmonyConfig) {
 	// Check NTP configuration
 	accurate, err := ntp.CheckLocalTimeAccurate(nodeConfig.NtpServer)
 	if !accurate {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		fmt.Fprintf(os.Stderr, "Error: local timeclock is not accurate. Please config NTP properly.\n")
-		os.Exit(1)
+		if os.IsTimeout(err) {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			fmt.Fprintf(os.Stderr, "NTP query timed out. Continuing.\n")
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error: local timeclock is not accurate. Please config NTP properly.\n")
+		}
 	}
 	if err != nil {
 		utils.Logger().Warn().Err(err).Msg("Check Local Time Accuracy Error")

--- a/common/ntp/ntp.go
+++ b/common/ntp/ntp.go
@@ -20,7 +20,8 @@ var (
 
 // CheckLocalTimeAccurate returns whether the local clock accurate or not
 func CheckLocalTimeAccurate(ntpServer string) (bool, error) {
-	response, err := beevik_ntp.Query(ntpServer)
+	options := beevik_ntp.QueryOptions{Timeout: 10 * time.Second}
+	response, err := beevik_ntp.QueryWithOptions(ntpServer, options)
 	// failed to query ntp time
 	if err != nil {
 		return false, err


### PR DESCRIPTION
In case of ntp server is busy, we added the following
protection.

* increase timeout of ntp query
* ignore timeout error for ntp query

Signed-off-by: Leo Chen <leo@harmony.one>