### PR TITLE
Rosetta Dockerfile FIX2 (Stage 4 of Node API Overhaul)

### DIFF
--- a/rosetta/infra/Dockerfile
+++ b/rosetta/infra/Dockerfile
@@ -1,7 +1,9 @@
-FROM golang:1.14
+# Build
+FROM golang:1.14 AS build
 
-RUN apt update -y && apt upgrade -y
-RUN apt install libgmp-dev libssl-dev curl git -y
+RUN apt update -y && \
+    apt install libgmp-dev libssl-dev git -y && \
+    apt -y clean all
 
 ENV GOPATH=/root/go
 ENV GO111MODULE=on
@@ -10,17 +12,29 @@ RUN mkdir -p $HMY_PATH
 
 WORKDIR $HMY_PATH
 
-RUN git clone https://github.com/harmony-one/harmony.git
-RUN git clone https://github.com/harmony-one/bls.git
-RUN git clone https://github.com/harmony-one/mcl.git
+RUN git clone https://github.com/harmony-one/harmony.git && \
+    git clone https://github.com/harmony-one/bls.git && \
+    git clone https://github.com/harmony-one/mcl.git
 
 WORKDIR $HMY_PATH/harmony
 
-RUN make linux_static
-RUN mv ./bin/harmony /root/harmony && chmod +x /root/harmony
-RUN mv ./rosetta/infra/run.sh /root/run.sh && chmod +x /root/run.sh
-RUN rm -rf $GOPATH
+RUN make linux_static && \
+    cp ./bin/harmony /root/harmony && \
+    cp ./rosetta/infra/run.sh /root/run.sh
+
+# Execution
+FROM ubuntu:latest
+
+RUN apt update -y && \
+    apt install libgmp-dev libssl-dev -y && \
+    apt -y clean all
 
 WORKDIR /root
 
+COPY --from=build /root/harmony /root/harmony
+COPY --from=build /root/run.sh /root/run.sh
+
+EXPOSE 9500/tcp
+EXPOSE 9700/tcp
+EXPOSE 9800/tcp
 ENTRYPOINT ["/bin/bash","/root/run.sh"]

--- a/rosetta/infra/README.md
+++ b/rosetta/infra/README.md
@@ -1,4 +1,4 @@
-    # Docker deployment of a Rosetta enabled Harmony node
+# Docker deployment of a Rosetta enabled Harmony node
 
 ## Docker Image
 You can choose to build the docker image using the included Dockerfile with the following command:
@@ -29,19 +29,11 @@ docker ps
 You can ensure that your node is running with the following curl command:
 ```bash
 curl -X POST --data '{
-"network_identifier": {
-  "blockchain": "Harmony",
-  "network": "Mainnet",
-  "sub_network_identifier": {
-    "network": "shard 0",
-      "metadata": {
-        "is_beacon": true
-      }
-  }
-}}' http://localhost:9700/network/status
+    "metadata": {}
+}' http://localhost:9700/network/list
 ```
 
-Once can start the node in the offline mode with the following command:
+You can start the node in the offline mode with the following command:
 ```bash
 docker run -d -p 9700:9700 -v "$(pwd)/data:/root/data" harmonyone/explorer-node --run.shard=0 --run.offline 
 ```
@@ -66,7 +58,7 @@ docker stop [CONTAINER ID]
 **Note that all the arguments provided when running the docker img are immediately forwarded to the harmony node binary.**
 > Note that the following args are **appended** to the provided arg when running the image: 
 > `--http.ip "0.0.0.0" --ws.ip "0.0.0.0" --http.rosetta --node_type "explorer" --datadir "./data" --log.dir "./data/logs"`.
-> This effectively makes them args that you cannot change.  
+> This effectively makes them args that you cannot easily change.  
 
 ### Running the node on testnet
 All the args on the image run are forwarded to the harmony node binary. Therefore, you can simply add `-n testnet` to 

--- a/rosetta/infra/README.md
+++ b/rosetta/infra/README.md
@@ -1,20 +1,20 @@
-# Docker deployment of a Rosetta enabled Harmony node
+    # Docker deployment of a Rosetta enabled Harmony node
 
 ## Docker Image
 You can choose to build the docker image using the included Dockerfile with the following command:
 ```bash
-docker build -t harmony-rosetta . 
+docker build -t harmonyone/explorer-node . 
 ```
 
 Or you can download/pull the image from dockerhub with the following command:
 ```bash
-docker pull harmony-rosetta:latest
+docker pull harmonyone/explorer-node:latest
 ```
 
 ## Starting the node
 You can start the node with the following command:
 ```bash
-docker run -d -p 9700:9700 -v "$(pwd)/data:/root/data" harmony-rosetta --run.shard=0 
+docker run -d -p 9700:9700 -v "$(pwd)/data:/root/data" harmonyone/explorer-node --run.shard=0 
 ```
 > This command will create the container of the harmony node on shard 0 in the detached mode, 
 > binding port 9700 (the rosetta port) on the container to the host and mounting the shared 
@@ -43,7 +43,7 @@ curl -X POST --data '{
 
 Once can start the node in the offline mode with the following command:
 ```bash
-docker run -d -p 9700:9700 -v "$(pwd)/data:/root/data" harmony-rosetta --run.shard=0 --run.offline 
+docker run -d -p 9700:9700 -v "$(pwd)/data:/root/data" harmonyone/explorer-node --run.shard=0 --run.offline 
 ```
 > The offline mode implies that the node will not connect to any p2p peer or sync.
 
@@ -72,27 +72,27 @@ docker stop [CONTAINER ID]
 All the args on the image run are forwarded to the harmony node binary. Therefore, you can simply add `-n testnet` to 
 run the node for testnet. For example:
 ```bash 
-docker run -d -p 9700:9700 -v "$(pwd)/data:/root/data" harmony-rosetta --run.shard=0 -n testnet
+docker run -d -p 9700:9700 -v "$(pwd)/data:/root/data" harmonyone/explorer-node --run.shard=0 -n testnet
 ```
 
 ### Running the node with the http RPC capabilities 
 Similar to running a node on testnet, once can simply add `--http` to enable the rpc server. Then you have to forward
 the host port to the container's rpc server port.
 ```bash
-docker run -d -p 9700:9700 -p 9500:9500 -v "$(pwd)/data:/root/data" harmony-rosetta --run.shard=0 -n testnet --http
+docker run -d -p 9700:9700 -p 9500:9500 -v "$(pwd)/data:/root/data" harmonyone/explorer-node --run.shard=0 -n testnet --http
 ```
 
 ### Running the node with the web socket RPC capabilities 
 Similar to running a node on testnet, once can simply add `--ws` to enable the rpc server. Then you have to forward
 the host port to the container's rpc server port.
 ```bash
-docker run -d -p 9700:9700 -p 9800:9900 -v "$(pwd)/data:/root/data" harmony-rosetta --run.shard=0 -n testnet --ws
+docker run -d -p 9700:9700 -p 9800:9900 -v "$(pwd)/data:/root/data" harmonyone/explorer-node --run.shard=0 -n testnet --ws
 ```
 
 ### Running the node in non-archival mode
 One can append `--run.archive=false` to the docker run command to run the node in non-archival mode. For example:
 ```bash 
-docker run -d -p 9700:9700 -v "$(pwd)/data:/root/data" harmony-rosetta --run.shard=0 -n testnet --run.archive=false
+docker run -d -p 9700:9700 -v "$(pwd)/data:/root/data" harmonyone/explorer-node --run.shard=0 -n testnet --run.archive=false
 ```
 
 ### Running a node with a rcloned DB
@@ -100,7 +100,7 @@ Note that all node data will be stored in the `/root/data` directory within the 
 the `harmony_db_*` directory to some directory (i.e: `./data`) and mount the volume on the docker run. 
 This way, the node will use DB in the volume that is shared between the container and host. For example: 
 ```bash 
-docker run -d -p 9700:9700 -v "$(pwd)/data:/root/data" harmony-rosetta --run.shard=0
+docker run -d -p 9700:9700 -v "$(pwd)/data:/root/data" harmonyone/explorer-node --run.shard=0
 ```
 
 Note that the directory structure for `/root/data` (== `./data`) should look something like:

--- a/rosetta/infra/run.sh
+++ b/rosetta/infra/run.sh
@@ -8,4 +8,5 @@ BASE_ARGS=(--http.ip "0.0.0.0" --ws.ip "0.0.0.0" --http.rosetta --node_type "exp
 
 mkdir -p "$LOGS"
 echo -e NODE ARGS: \" "$@"  "${BASE_ARGS[@]}" \"
+echo "NODE VERSION: $(./harmony --version)"
 "$DIR/harmony" "$@" "${BASE_ARGS[@]}"


### PR DESCRIPTION
# Stage 4 FIX2 of [Node API Overhaul](https://github.com/harmony-one/harmony/issues/3210)

This PR is related to #3385

This PR greatly reduces the size of the built docker image to about 156MB (down from 1.7GB). It also fixes the documentation to match the release pipeline.