### PR TITLE
[consensus] fix leader change during epoch change

### DIFF
--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -521,6 +521,10 @@ func (consensus *Consensus) commitBlock(blk *types.Block, committedMsg *FBFTMess
 	atomic.AddUint64(&consensus.blockNum, 1)
 	consensus.SetCurBlockViewID(committedMsg.ViewID + 1)
 	consensus.LeaderPubKey = committedMsg.SenderPubkeys[0]
+	// Update consensus keys at last so the change of leader status doesn't mess up normal flow
+	if blk.IsLastBlockInEpoch() {
+		consensus.SetMode(consensus.UpdateConsensusInformation())
+	}
 	consensus.ResetState()
 	return nil
 }

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -395,10 +395,6 @@ func (node *Node) PostConsensusProcessing(newBlock *types.Block) error {
 	// Broadcast client requested missing cross shard receipts if there is any
 	node.BroadcastMissingCXReceipts()
 
-	// Update consensus keys at last so the change of leader status doesn't mess up normal flow
-	if newBlock.IsLastBlockInEpoch() {
-		node.Consensus.SetMode(node.Consensus.UpdateConsensusInformation())
-	}
 	if h := node.NodeConfig.WebHooks.Hooks; h != nil {
 		if h.Availability != nil {
 			for _, addr := range node.GetAddresses(newBlock.Epoch()) {


### PR DESCRIPTION
## Issue 

#3399 Sync consensus fix branch breaks the leader change during epoch change. The reason is that the leader public key was overwritten by fbft message sender key. After this fix, the leader will be automatically switched to index 0 bls key after epoch change.

## Test

Tested on stn shard 1. The epoch change can restore the leader key. 