### PR TITLE
Rosetta Implementation Cleanup FIX (Stage 3 of Node API Overhaul)

### DIFF
--- a/hmy/blockchain.go
+++ b/hmy/blockchain.go
@@ -19,6 +19,8 @@ import (
 	"github.com/harmony-one/harmony/internal/params"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/shard"
+	"github.com/harmony-one/harmony/staking/availability"
+	stakingNetwork "github.com/harmony-one/harmony/staking/network"
 	"github.com/pkg/errors"
 )
 
@@ -75,15 +77,10 @@ func (hmy *Harmony) GetBlockSigners(
 
 // DetailedBlockSignerInfo contains all of the block singing information
 type DetailedBlockSignerInfo struct {
-	// Signers is a map of addresses in the Signers for the block to
-	// all of the serialized BLS keys that signed said block.
-	Signers map[common.Address][]bls.SerializedPublicKey
+	// Signers are all the signers for the block
+	Signers shard.SlotList
 	// Committee when the block was signed.
 	Committee shard.SlotList
-	// TotalKeysSigned is the total number of bls keys that signed the block.
-	TotalKeysSigned uint
-	// Mask is the bitmap Mask for the block.
-	Mask      *bls.Mask
 	BlockHash common.Hash
 }
 
@@ -91,31 +88,60 @@ type DetailedBlockSignerInfo struct {
 func (hmy *Harmony) GetDetailedBlockSignerInfo(
 	ctx context.Context, blk *types.Block,
 ) (*DetailedBlockSignerInfo, error) {
-	slotList, mask, err := hmy.GetBlockSigners(
-		ctx, rpc.BlockNumber(blk.Number().Uint64()),
-	)
+	parentBlk, err := hmy.BlockByNumber(ctx, rpc.BlockNumber(blk.NumberU64()-1))
 	if err != nil {
 		return nil, err
 	}
-
-	totalSigners := uint(0)
-	sigInfos := map[common.Address][]bls.SerializedPublicKey{}
-	for _, slot := range slotList {
-		if _, ok := sigInfos[slot.EcdsaAddress]; !ok {
-			sigInfos[slot.EcdsaAddress] = []bls.SerializedPublicKey{}
-		}
-		if ok, err := mask.KeyEnabled(slot.BLSPublicKey); ok && err == nil {
-			sigInfos[slot.EcdsaAddress] = append(sigInfos[slot.EcdsaAddress], slot.BLSPublicKey)
-			totalSigners++
-		}
+	parentShardState, err := hmy.BlockChain.ReadShardState(parentBlk.Epoch())
+	if err != nil {
+		return nil, err
 	}
+	committee, signers, _, err := availability.BallotResult(
+		parentBlk.Header(), blk.Header(), parentShardState, blk.ShardID(),
+	)
 	return &DetailedBlockSignerInfo{
-		Signers:         sigInfos,
-		Committee:       slotList,
-		TotalKeysSigned: totalSigners,
-		Mask:            mask,
-		BlockHash:       blk.Hash(),
+		Signers:   signers,
+		Committee: committee,
+		BlockHash: blk.Hash(),
 	}, nil
+}
+
+// PreStakingBlockRewards are the rewards for a block in the pre-staking era (epoch < staking epoch).
+type PreStakingBlockRewards map[common.Address]*big.Int
+
+// GetPreStakingBlockRewards for the given block number.
+// Calculated rewards are done exactly like chain.AccumulateRewardsAndCountSigs.
+func (hmy *Harmony) GetPreStakingBlockRewards(
+	ctx context.Context, blk *types.Block,
+) (PreStakingBlockRewards, error) {
+	if hmy.IsStakingEpoch(blk.Epoch()) {
+		return nil, fmt.Errorf("block %v is in staking era", blk.Number())
+	}
+
+	if cachedReward, ok := hmy.preStakingBlockRewardsCache.Get(blk.Hash()); ok {
+		return cachedReward.(PreStakingBlockRewards), nil
+	}
+	rewards := PreStakingBlockRewards{}
+
+	sigInfo, err := hmy.GetDetailedBlockSignerInfo(ctx, blk)
+	if err != nil {
+		return nil, err
+	}
+	last := big.NewInt(0)
+	count := big.NewInt(int64(len(sigInfo.Signers)))
+	for i, slot := range sigInfo.Signers {
+		rewardsForThisAddr, ok := rewards[slot.EcdsaAddress]
+		if !ok {
+			rewardsForThisAddr = big.NewInt(0)
+		}
+		cur := big.NewInt(0)
+		cur.Mul(stakingNetwork.BlockReward, big.NewInt(int64(i+1))).Div(cur, count)
+		reward := big.NewInt(0).Sub(cur, last)
+		rewards[slot.EcdsaAddress] = new(big.Int).Add(reward, rewardsForThisAddr)
+		last = cur
+	}
+	hmy.preStakingBlockRewardsCache.Add(blk.Hash(), rewards)
+	return rewards, nil
 }
 
 // GetLatestChainHeaders ..


### PR DESCRIPTION
# Stage 3 Cleanup FIX of [Node API Overhaul](https://github.com/harmony-one/harmony/issues/3210)

This is related to #3390 

In the clean-up PR, I attempted to fix the pre-staking block 'off-by-one' errors that I got in my testing using the rosetta-cli. However, in further fuzzing-esk testing (different committee sizes, different transactions going off in the pre-staking era, etc...) I found that in some (rare) cases, there would still be an off-by-one error.

I've now changed the pre-staking block reward calculations to call the exact same functions as in `chain.AccumulateRewardsAndCountSigs`, even when fetching the block signers. I've tested this fix against said test and it appears to work. 