### PR TITLE
Viewchange stability

### DIFF
--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -303,6 +303,8 @@ func (consensus *Consensus) startNewView(viewID uint64, newLeaderPriKey *bls.Pri
 		Hex("M1Payload", consensus.vc.GetM1Payload()).
 		Msg("[startNewView] Sent NewView Messge")
 
+	consensus.msgSender.StopRetry(msg_pb.MessageType_VIEWCHANGE)
+
 	consensus.current.SetMode(Normal)
 	consensus.consensusTimeout[timeoutViewChange].Stop()
 	consensus.SetViewIDs(viewID)
@@ -512,6 +514,8 @@ func (consensus *Consensus) onNewView(msg *msg_pb.Message) {
 	consensus.SetViewIDs(recvMsg.ViewID)
 	consensus.LeaderPubKey = senderKey
 	consensus.ResetViewChangeState()
+
+	consensus.msgSender.StopRetry(msg_pb.MessageType_VIEWCHANGE)
 
 	// NewView message is verified, change state to normal consensus
 	if preparedBlock != nil {

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -278,9 +278,17 @@ func (consensus *Consensus) startNewView(viewID uint64, newLeaderPriKey *bls.Pri
 	consensus.mutex.Lock()
 	defer consensus.mutex.Unlock()
 
+	if !consensus.IsViewChangingMode() {
+		return errors.New("not in view changing mode anymore")
+	}
+
 	msgToSend := consensus.constructNewViewMessage(
 		viewID, newLeaderPriKey,
 	)
+	if msgToSend == nil {
+		return errors.New("failed to construct NewView message")
+	}
+
 	if err := consensus.msgSender.SendWithRetry(
 		consensus.blockNum,
 		msg_pb.MessageType_NEWVIEW,

--- a/consensus/view_change_msg.go
+++ b/consensus/view_change_msg.go
@@ -118,6 +118,9 @@ func (consensus *Consensus) constructNewViewMessage(viewID uint64, priKey *bls.P
 	vcMsg.Payload, vcMsg.PreparedBlock = consensus.vc.GetPreparedBlock(consensus.FBFTLog, consensus.blockHash)
 	vcMsg.M2Aggsigs, vcMsg.M2Bitmap = consensus.vc.GetM2Bitmap(viewID)
 	vcMsg.M3Aggsigs, vcMsg.M3Bitmap = consensus.vc.GetM3Bitmap(viewID)
+	if vcMsg.M3Bitmap == nil || vcMsg.M3Aggsigs == nil {
+		return nil
+	}
 
 	marshaledMessage, err := consensus.signAndMarshalConsensusMessage(message, priKey.Pri)
 	if err != nil {


### PR DESCRIPTION
This PR handles a few more corner cases like empty NewView message.

Also, we shall stop sending retry viewchange messages once NewView message sent or received.