### PR TITLE
Update viewchangingid; Keep block hash in the case of m1 view change

### DIFF
--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -554,6 +554,9 @@ func (consensus *Consensus) selfCommit(payload []byte) error {
 	consensus.mutex.Lock()
 	defer consensus.mutex.Unlock()
 
+	// Have to keep the block hash so the leader can finish the commit phase of prepared block
+	consensus.ResetState()
+
 	copy(consensus.blockHash[:], blockHash[:])
 	consensus.switchPhase("selfCommit", FBFTCommit)
 	consensus.aggregatedPrepareSig = aggSig

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -517,7 +517,7 @@ func (consensus *Consensus) commitBlock(blk *types.Block, committedMsg *FBFTMess
 	}
 
 	atomic.AddUint64(&consensus.blockNum, 1)
-	consensus.SetCurBlockViewID(committedMsg.ViewID + 1)
+	consensus.SetViewIDs(committedMsg.ViewID + 1)
 	consensus.LeaderPubKey = committedMsg.SenderPubkeys[0]
 	// Update consensus keys at last so the change of leader status doesn't mess up normal flow
 	if blk.IsLastBlockInEpoch() {

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -517,7 +517,7 @@ func (consensus *Consensus) commitBlock(blk *types.Block, committedMsg *FBFTMess
 	}
 
 	atomic.AddUint64(&consensus.blockNum, 1)
-	consensus.SetViewIDs(committedMsg.ViewID + 1)
+	consensus.SetCurBlockViewID(committedMsg.ViewID + 1)
 	consensus.LeaderPubKey = committedMsg.SenderPubkeys[0]
 	// Update consensus keys at last so the change of leader status doesn't mess up normal flow
 	if blk.IsLastBlockInEpoch() {

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -274,7 +274,7 @@ func (consensus *Consensus) startViewChange() {
 }
 
 // startNewView stops the current view change
-func (consensus *Consensus) startNewView(viewID uint64, newLeaderPriKey *bls.PrivateKeyWrapper) error {
+func (consensus *Consensus) startNewView(viewID uint64, newLeaderPriKey *bls.PrivateKeyWrapper, reset bool) error {
 	consensus.mutex.Lock()
 	defer consensus.mutex.Unlock()
 
@@ -317,7 +317,9 @@ func (consensus *Consensus) startNewView(viewID uint64, newLeaderPriKey *bls.Pri
 		Msg("[startNewView] viewChange stopped. I am the New Leader")
 
 	// TODO: consider make ResetState unified and only called in one place like finalizeCommit()
-	consensus.ResetState()
+	if reset {
+		consensus.ResetState()
+	}
 	consensus.LeaderPubKey = newLeaderPriKey.Pub
 
 	return nil
@@ -389,7 +391,7 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 		// no previous prepared message, go straight to normal mode
 		// and start proposing new block
 		if consensus.vc.IsM1PayloadEmpty() {
-			if err := consensus.startNewView(recvMsg.ViewID, newLeaderPriKey); err != nil {
+			if err := consensus.startNewView(recvMsg.ViewID, newLeaderPriKey, true); err != nil {
 				consensus.getLogger().Error().Err(err).Msg("[onViewChange] startNewView failed")
 				return
 			}
@@ -405,12 +407,10 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 			consensus.getLogger().Error().Err(err).Msg("[onViewChange] self commit failed")
 			return
 		}
-		if err := consensus.startNewView(recvMsg.ViewID, newLeaderPriKey); err != nil {
+		if err := consensus.startNewView(recvMsg.ViewID, newLeaderPriKey, false); err != nil {
 			consensus.getLogger().Error().Err(err).Msg("[onViewChange] startNewView failed")
 			return
 		}
-		// Have to keep the block hash so the leader can finish the commit phase of prepared block
-		copy(consensus.blockHash[:], payload[:32])
 	}
 }
 

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -316,7 +316,6 @@ func (consensus *Consensus) startNewView(viewID uint64, newLeaderPriKey *bls.Pri
 		Str("myKey", newLeaderPriKey.Pub.Bytes.Hex()).
 		Msg("[startNewView] viewChange stopped. I am the New Leader")
 
-	consensus.ResetState()
 	consensus.LeaderPubKey = newLeaderPriKey.Pub
 
 	return nil

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -316,6 +316,7 @@ func (consensus *Consensus) startNewView(viewID uint64, newLeaderPriKey *bls.Pri
 		Str("myKey", newLeaderPriKey.Pub.Bytes.Hex()).
 		Msg("[startNewView] viewChange stopped. I am the New Leader")
 
+	// TODO: consider make ResetState unified and only called in one place like finalizeCommit()
 	consensus.ResetState()
 	consensus.LeaderPubKey = newLeaderPriKey.Pub
 

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -316,6 +316,7 @@ func (consensus *Consensus) startNewView(viewID uint64, newLeaderPriKey *bls.Pri
 		Str("myKey", newLeaderPriKey.Pub.Bytes.Hex()).
 		Msg("[startNewView] viewChange stopped. I am the New Leader")
 
+	consensus.ResetState()
 	consensus.LeaderPubKey = newLeaderPriKey.Pub
 
 	return nil
@@ -407,6 +408,8 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 			consensus.getLogger().Error().Err(err).Msg("[onViewChange] startNewView failed")
 			return
 		}
+		// Have to keep the block hash so the leader can finish the commit phase of prepared block
+		copy(consensus.blockHash[:], payload[:32])
 	}
 }
 


### PR DESCRIPTION
Fix the issue that view changing id isn't updated as new block committed.

Also should keep the block hash in new view as the leader still need to finalize the block hash if it's a M1 view change.