### PR TITLE
[consensus] spin sync in onNewView when block number left behind

### DIFF
--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -426,7 +426,10 @@ func (consensus *Consensus) onNewView(msg *msg_pb.Message) {
 		consensus.getLogger().Warn().Err(err).Msg("[onNewView] Unable to Parse NewView Message")
 		return
 	}
-
+	if consensus.blockNum < recvMsg.BlockNum {
+		consensus.getLogger().Info().Msg("[onNewView] block number left behind, spin syncing")
+		consensus.spinUpStateSync()
+	}
 	// change view and leaderKey to keep in sync with network
 	if consensus.blockNum != recvMsg.BlockNum {
 		consensus.getLogger().Warn().


### PR DESCRIPTION
## Issue

It could happen that nodes are out of sync during view change. That could potentially cause consensus stuck since the leader cannot collect enough signature. Note this is a very corner case that could most likely only happens on testnet/stn, since the node will sync on state when new blocks are produced. This issue would be better addressed with minimal code change that does not effect code logic much. 

In this PR, spinning sync logic is added in `onNewView`, thus the node will finally reach consensus.The view change stuck node will go over the following process:

1. Node received NewView message that knows itself is out of sync.
2. Node spin up sync logic to get to latest block. 
3. After sync finished, update current mode to `Normal` and start consensus timeout.
4. After consensus time out, enter `startViewChange` and new leader will be computed with respect to current unix time.
5. The node get to the same view change leader as other nodes and now consensus can process.

## Test

TODO: Get the steps from Leo to reproduce the issue and see whether this PR can be address the problem.
