### PR TITLE
Fix quorum check in localnet staking

### DIFF
--- a/consensus/quorum/one-node-staked-vote.go
+++ b/consensus/quorum/one-node-staked-vote.go
@@ -188,7 +188,7 @@ func (v *stakedVoteWeight) QuorumThreshold() numeric.Dec {
 
 // IsAllSigsCollected ..
 func (v *stakedVoteWeight) IsAllSigsCollected() bool {
-	return v.SignersCount(Commit) == v.ParticipantsCount()
+	return v.voteTally.Commit.tally.Equal(numeric.NewDec(1))
 }
 
 func (v *stakedVoteWeight) SetVoters(


### PR DESCRIPTION
In local net, there could be no external validators, and the signer count == participants even when it's not 100% qourum.