### PR TITLE
Allow validator to update block commit sigs if it has more sigs

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -615,7 +615,7 @@ func setupConsensusAndNode(hc harmonyConfig, nodeConfig *nodeconfig.ConfigType) 
 	}
 
 	// TODO: refactor the creation of blockchain out of node.New()
-	currentConsensus.ChainReader = currentNode.Blockchain()
+	currentConsensus.Blockchain = currentNode.Blockchain()
 	currentNode.NodeConfig.DNSZone = hc.Network.DNSZone
 
 	currentNode.NodeConfig.SetBeaconGroupID(

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -54,8 +54,8 @@ type Consensus struct {
 	multiSigBitmap *bls_cosi.Mask // Bitmap for parsing multisig bitmap from validators
 	multiSigMutex  sync.RWMutex
 
-	// The chain reader for the blockchain this consensus is working on
-	ChainReader *core.BlockChain
+	// The blockchain this consensus is working on
+	Blockchain *core.BlockChain
 	// Minimal number of peers in the shard
 	// If the number of validators is less than minPeers, the consensus won't start
 	MinPeers   int

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -246,7 +246,7 @@ func (consensus *Consensus) ReadSignatureBitmapPayload(
 func (consensus *Consensus) getLeaderPubKeyFromCoinbase(
 	header *block.Header,
 ) (*bls.PublicKeyWrapper, error) {
-	shardState, err := consensus.ChainReader.ReadShardState(header.Epoch())
+	shardState, err := consensus.Blockchain.ReadShardState(header.Epoch())
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot read shard state %v %s",
 			header.Epoch(),
@@ -260,7 +260,7 @@ func (consensus *Consensus) getLeaderPubKeyFromCoinbase(
 	}
 
 	committerKey := new(bls_core.PublicKey)
-	isStaking := consensus.ChainReader.Config().IsStaking(header.Epoch())
+	isStaking := consensus.Blockchain.Config().IsStaking(header.Epoch())
 	for _, member := range committee.Slots {
 		if isStaking {
 			// After staking the coinbase address will be the address of bls public key
@@ -296,7 +296,7 @@ func (consensus *Consensus) getLeaderPubKeyFromCoinbase(
 // (b) node in committed but has any err during processing: Syncing mode
 // (c) node in committed and everything looks good: Normal mode
 func (consensus *Consensus) UpdateConsensusInformation() Mode {
-	curHeader := consensus.ChainReader.CurrentHeader()
+	curHeader := consensus.Blockchain.CurrentHeader()
 	curEpoch := curHeader.Epoch()
 	nextEpoch := new(big.Int).Add(curHeader.Epoch(), common.Big1)
 
@@ -314,15 +314,15 @@ func (consensus *Consensus) UpdateConsensusInformation() Mode {
 	consensus.BlockPeriod = 5 * time.Second
 
 	// Enable aggregate sig at epoch 1000 for mainnet, at epoch 53000 for testnet, and always for other nets.
-	if (consensus.ChainReader.Config().ChainID == params.MainnetChainID && curEpoch.Cmp(big.NewInt(1000)) > 0) ||
-		(consensus.ChainReader.Config().ChainID == params.TestnetChainID && curEpoch.Cmp(big.NewInt(54500)) > 0) ||
-		(consensus.ChainReader.Config().ChainID != params.MainnetChainID && consensus.ChainReader.Config().ChainID != params.TestChainID) {
+	if (consensus.Blockchain.Config().ChainID == params.MainnetChainID && curEpoch.Cmp(big.NewInt(1000)) > 0) ||
+		(consensus.Blockchain.Config().ChainID == params.TestnetChainID && curEpoch.Cmp(big.NewInt(54500)) > 0) ||
+		(consensus.Blockchain.Config().ChainID != params.MainnetChainID && consensus.Blockchain.Config().ChainID != params.TestChainID) {
 		consensus.AggregateSig = true
 	}
 
-	isFirstTimeStaking := consensus.ChainReader.Config().IsStaking(nextEpoch) &&
-		curHeader.IsLastBlockInEpoch() && !consensus.ChainReader.Config().IsStaking(curEpoch)
-	haventUpdatedDecider := consensus.ChainReader.Config().IsStaking(curEpoch) &&
+	isFirstTimeStaking := consensus.Blockchain.Config().IsStaking(nextEpoch) &&
+		curHeader.IsLastBlockInEpoch() && !consensus.Blockchain.Config().IsStaking(curEpoch)
+	haventUpdatedDecider := consensus.Blockchain.Config().IsStaking(curEpoch) &&
 		consensus.Decider.Policy() != quorum.SuperMajorityStake
 
 	// Only happens once, the flip-over to a new Decider policy
@@ -338,7 +338,7 @@ func (consensus *Consensus) UpdateConsensusInformation() Mode {
 	epochToSet := curEpoch
 	hasError := false
 	curShardState, err := committee.WithStakingEnabled.ReadFromDB(
-		curEpoch, consensus.ChainReader,
+		curEpoch, consensus.Blockchain,
 	)
 	if err != nil {
 		utils.Logger().Error().
@@ -354,7 +354,7 @@ func (consensus *Consensus) UpdateConsensusInformation() Mode {
 	if curHeader.IsLastBlockInEpoch() && isNotGenesisBlock {
 
 		nextShardState, err := committee.WithStakingEnabled.ReadFromDB(
-			nextEpoch, consensus.ChainReader,
+			nextEpoch, consensus.Blockchain,
 		)
 		if err != nil {
 			utils.Logger().Error().
@@ -561,7 +561,7 @@ func (consensus *Consensus) selfCommit(payload []byte) error {
 	consensus.switchPhase("selfCommit", FBFTCommit)
 	consensus.aggregatedPrepareSig = aggSig
 	consensus.prepareBitmap = mask
-	commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
+	commitPayload := signature.ConstructCommitPayload(consensus.Blockchain,
 		block.Epoch(), block.Hash(), block.NumberU64(), block.Header().ViewID().Uint64())
 	for i, key := range consensus.priKey {
 		if err := consensus.commitBitmap.SetKey(key.Pub.Bytes, true); err != nil {

--- a/consensus/double_sign.go
+++ b/consensus/double_sign.go
@@ -40,8 +40,8 @@ func (consensus *Consensus) checkDoubleSign(recvMsg *FBFTMessage) bool {
 									return true
 								}
 
-								curHeader := consensus.ChainReader.CurrentHeader()
-								committee, err := consensus.ChainReader.ReadShardState(curHeader.Epoch())
+								curHeader := consensus.Blockchain.CurrentHeader()
+								committee, err := consensus.Blockchain.ReadShardState(curHeader.Epoch())
 								if err != nil {
 									consensus.getLogger().Err(err).
 										Uint32("shard", consensus.ShardID).

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -242,7 +242,7 @@ func (consensus *Consensus) onCommit(msg *msg_pb.Message) {
 			Msg("[OnCommit] Failed finding a matching block for committed message")
 		return
 	}
-	commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
+	commitPayload := signature.ConstructCommitPayload(consensus.Blockchain,
 		blockObj.Epoch(), blockObj.Hash(), blockObj.NumberU64(), blockObj.Header().ViewID().Uint64())
 	logger = logger.With().
 		Uint64("MsgViewID", recvMsg.ViewID).

--- a/consensus/threshold.go
+++ b/consensus/threshold.go
@@ -46,7 +46,7 @@ func (consensus *Consensus) didReachPrepareQuorum() error {
 			Msg("[didReachPrepareQuorum] Unparseable block data")
 		return err
 	}
-	commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
+	commitPayload := signature.ConstructCommitPayload(consensus.Blockchain,
 		blockObj.Epoch(), blockObj.Hash(), blockObj.NumberU64(), blockObj.Header().ViewID().Uint64())
 
 	// so by this point, everyone has committed to the blockhash of this block

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -81,7 +81,7 @@ func (consensus *Consensus) sendCommitMessages(blockObj *types.Block) {
 	priKeys := consensus.getPriKeysInCommittee()
 
 	// Sign commit signature on the received block and construct the p2p messages
-	commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
+	commitPayload := signature.ConstructCommitPayload(consensus.Blockchain,
 		blockObj.Epoch(), blockObj.Hash(), blockObj.NumberU64(), blockObj.Header().ViewID().Uint64())
 
 	p2pMsgs := consensus.constructP2pMessages(msg_pb.MessageType_COMMIT, commitPayload, priKeys)
@@ -256,7 +256,7 @@ func (consensus *Consensus) onCommitted(msg *msg_pb.Message) {
 			Msg("[OnCommitted] Failed finding a matching block for committed message")
 		return
 	}
-	commitPayload := signature.ConstructCommitPayload(consensus.ChainReader,
+	commitPayload := signature.ConstructCommitPayload(consensus.Blockchain,
 		blockObj.Epoch(), blockObj.Hash(), blockObj.NumberU64(), blockObj.Header().ViewID().Uint64())
 	if !aggSig.VerifyHash(mask.AggregatePublic, commitPayload) {
 		consensus.getLogger().Error().

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -117,10 +117,10 @@ func (consensus *Consensus) fallbackNextViewID() (uint64, time.Duration) {
 // viewID is only used as the fallback mechansim to determine the nextViewID
 func (consensus *Consensus) getNextViewID() (uint64, time.Duration) {
 	// handle corner case at first
-	if consensus.ChainReader == nil {
+	if consensus.Blockchain == nil {
 		return consensus.fallbackNextViewID()
 	}
-	curHeader := consensus.ChainReader.CurrentHeader()
+	curHeader := consensus.Blockchain.CurrentHeader()
 	if curHeader == nil {
 		return consensus.fallbackNextViewID()
 	}
@@ -160,11 +160,11 @@ func (consensus *Consensus) getNextLeaderKey(viewID uint64) *bls.PublicKeyWrappe
 	var lastLeaderPubKey *bls.PublicKeyWrapper
 	var err error
 	epoch := big.NewInt(0)
-	if consensus.ChainReader == nil {
-		consensus.getLogger().Error().Msg("[getNextLeaderKey] ChainReader is nil. Use consensus.LeaderPubKey")
+	if consensus.Blockchain == nil {
+		consensus.getLogger().Error().Msg("[getNextLeaderKey] Blockchain is nil. Use consensus.LeaderPubKey")
 		lastLeaderPubKey = consensus.LeaderPubKey
 	} else {
-		curHeader := consensus.ChainReader.CurrentHeader()
+		curHeader := consensus.Blockchain.CurrentHeader()
 		if curHeader == nil {
 			consensus.getLogger().Error().Msg("[getNextLeaderKey] Failed to get current header from blockchain")
 			lastLeaderPubKey = consensus.LeaderPubKey

--- a/internal/chain/sig.go
+++ b/internal/chain/sig.go
@@ -11,15 +11,15 @@ import (
 
 // ReadSignatureBitmapByPublicKeys read the payload of signature and bitmap based on public keys
 func ReadSignatureBitmapByPublicKeys(recvPayload []byte, publicKeys []bls.PublicKeyWrapper) (*bls_core.Sign, *bls.Mask, error) {
-	if len(recvPayload) < 96 {
+	if len(recvPayload) < bls.BLSSignatureSizeInBytes {
 		return nil, nil, errors.New("payload not have enough length")
 	}
 	payload := append(recvPayload[:0:0], recvPayload...)
 	//#### Read payload data
 	// 96 byte of multi-sig
 	offset := 0
-	multiSig := payload[offset : offset+96]
-	offset += 96
+	multiSig := payload[offset : offset+bls.BLSSignatureSizeInBytes]
+	offset += bls.BLSSignatureSizeInBytes
 	// bitmap
 	bitmap := payload[offset:]
 	//#### END Read payload data

--- a/node/node.go
+++ b/node/node.go
@@ -1053,7 +1053,7 @@ func (node *Node) InitConsensusWithValidators() (err error) {
 		Uint64("epoch", epoch.Uint64()).
 		Msg("[InitConsensusWithValidators] Try To Get PublicKeys")
 	shardState, err := committee.WithStakingEnabled.Compute(
-		epoch, node.Consensus.ChainReader,
+		epoch, node.Consensus.Blockchain,
 	)
 	if err != nil {
 		utils.Logger().Err(err).
@@ -1159,7 +1159,7 @@ func (node *Node) populateSelfAddresses(epoch *big.Int) {
 	node.keysToAddrsEpoch = epoch
 
 	shardID := node.Consensus.ShardID
-	shardState, err := node.Consensus.ChainReader.ReadShardState(epoch)
+	shardState, err := node.Consensus.Blockchain.ReadShardState(epoch)
 	if err != nil {
 		utils.Logger().Error().Err(err).
 			Int64("epoch", epoch.Int64()).

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -241,7 +241,7 @@ func (node *Node) BroadcastCrossLink() {
 	node.host.SendMessageToGroups(
 		[]nodeconfig.GroupID{nodeconfig.NewGroupIDByShardID(shard.BeaconChainShardID)},
 		p2p.ConstructMessage(
-			proto_node.ConstructCrossLinkMessage(node.Consensus.ChainReader, headers)),
+			proto_node.ConstructCrossLinkMessage(node.Consensus.Blockchain, headers)),
 	)
 }
 

--- a/shard/committee/assignment.go
+++ b/shard/committee/assignment.go
@@ -227,7 +227,7 @@ func IsEligibleForEPoSAuction(snapshot *staking.ValidatorSnapshot, validator *st
 	}
 }
 
-// ChainReader is a subset of Engine.ChainReader, just enough to do assignment
+// ChainReader is a subset of Engine.Blockchain, just enough to do assignment
 type ChainReader interface {
 	// ReadShardState retrieves sharding state given the epoch number.
 	// This api reads the shard state cached or saved on the chaindb.


### PR DESCRIPTION
Some refactoring +

Add the logic so when validator receives new committed message with more signatures, it can update it's local database with that.