### PR TITLE
QOL Fixes for Rosetta

### DIFF
--- a/rosetta/common/operations.go
+++ b/rosetta/common/operations.go
@@ -15,11 +15,11 @@ const (
 	// ExpendGasOperation is an operation that only affects the native currency.
 	ExpendGasOperation = "Gas"
 
-	// TransferNativeOperation is an operation that only affects the native currency.
-	TransferNativeOperation = "NativeTransfer"
+	// NativeTransferOperation is an operation that only affects the native currency.
+	NativeTransferOperation = "NativeTransfer"
 
-	// CrossShardTransferNativeOperation is an operation that only affects the native currency.
-	CrossShardTransferNativeOperation = "NativeCrossShardTransfer"
+	// NativeCrossShardTransferOperation is an operation that only affects the native currency.
+	NativeCrossShardTransferOperation = "NativeCrossShardTransfer"
 
 	// ContractCreationOperation is an operation that only affects the native currency.
 	ContractCreationOperation = "ContractCreation"
@@ -41,8 +41,8 @@ var (
 	// PlainOperationTypes ..
 	PlainOperationTypes = []string{
 		ExpendGasOperation,
-		TransferNativeOperation,
-		CrossShardTransferNativeOperation,
+		NativeTransferOperation,
+		NativeCrossShardTransferOperation,
 		ContractCreationOperation,
 		GenesisFundsOperation,
 		PreStakingBlockRewardOperation,

--- a/rosetta/common/operations_test.go
+++ b/rosetta/common/operations_test.go
@@ -50,8 +50,8 @@ func TestPlainOperationTypes(t *testing.T) {
 	plainOperationTypes := PlainOperationTypes
 	referenceOperationTypes := []string{
 		ExpendGasOperation,
-		TransferNativeOperation,
-		CrossShardTransferNativeOperation,
+		NativeTransferOperation,
+		NativeCrossShardTransferOperation,
 		ContractCreationOperation,
 		GenesisFundsOperation,
 		PreStakingBlockRewardOperation,

--- a/rosetta/services/construction_check.go
+++ b/rosetta/services/construction_check.go
@@ -76,6 +76,17 @@ func (s *ConstructAPI) ConstructionPreprocess(
 			"message": "sender address is not found for given operations",
 		})
 	}
+	if txMetadata.ToShardID != nil && txMetadata.FromShardID != nil &&
+		components.Type != common.CrossShardTransferNativeOperation && *txMetadata.ToShardID != *txMetadata.FromShardID {
+		return nil, common.NewError(common.InvalidTransactionConstructionError, map[string]interface{}{
+			"message": "given from & to shard are different for a native same shard transfer",
+		})
+	}
+	if request.SuggestedFeeMultiplier != nil && *request.SuggestedFeeMultiplier < 1 {
+		return nil, common.NewError(common.InvalidTransactionConstructionError, map[string]interface{}{
+			"message": "given gas price multiplier must be at least 1",
+		})
+	}
 
 	options, err := types.MarshalMap(ConstructMetadataOptions{
 		TransactionMetadata: txMetadata,
@@ -84,6 +95,11 @@ func (s *ConstructAPI) ConstructionPreprocess(
 	})
 	if err != nil {
 		return nil, common.NewError(common.CatchAllError, map[string]interface{}{
+			"message": err.Error(),
+		})
+	}
+	if _, err := getAddress(components.From); err != nil {
+		return nil, common.NewError(common.InvalidTransactionConstructionError, map[string]interface{}{
 			"message": err.Error(),
 		})
 	}

--- a/rosetta/services/construction_check.go
+++ b/rosetta/services/construction_check.go
@@ -77,7 +77,7 @@ func (s *ConstructAPI) ConstructionPreprocess(
 		})
 	}
 	if txMetadata.ToShardID != nil && txMetadata.FromShardID != nil &&
-		components.Type != common.CrossShardTransferNativeOperation && *txMetadata.ToShardID != *txMetadata.FromShardID {
+		components.Type != common.NativeCrossShardTransferOperation && *txMetadata.ToShardID != *txMetadata.FromShardID {
 		return nil, common.NewError(common.InvalidTransactionConstructionError, map[string]interface{}{
 			"message": "given from & to shard are different for a native same shard transfer",
 		})

--- a/rosetta/services/construction_check_test.go
+++ b/rosetta/services/construction_check_test.go
@@ -28,7 +28,7 @@ func TestConstructMetadataOptions(t *testing.T) {
 		{
 			Metadata: ConstructMetadataOptions{
 				TransactionMetadata: refTxMedata,
-				OperationType:       common.TransferNativeOperation,
+				OperationType:       common.NativeTransferOperation,
 				GasPriceMultiplier:  nil,
 			},
 			ExpectError: false,
@@ -36,7 +36,7 @@ func TestConstructMetadataOptions(t *testing.T) {
 		{
 			Metadata: ConstructMetadataOptions{
 				TransactionMetadata: refTxMedata,
-				OperationType:       common.TransferNativeOperation,
+				OperationType:       common.NativeTransferOperation,
 				GasPriceMultiplier:  &refGasPrice,
 			},
 			ExpectError: false,
@@ -44,7 +44,7 @@ func TestConstructMetadataOptions(t *testing.T) {
 		{
 			Metadata: ConstructMetadataOptions{
 				TransactionMetadata: nil,
-				OperationType:       common.TransferNativeOperation,
+				OperationType:       common.NativeTransferOperation,
 				GasPriceMultiplier:  &refGasPrice,
 			},
 			ExpectError: true,
@@ -52,7 +52,7 @@ func TestConstructMetadataOptions(t *testing.T) {
 		{
 			Metadata: ConstructMetadataOptions{
 				TransactionMetadata: nil,
-				OperationType:       common.TransferNativeOperation,
+				OperationType:       common.NativeTransferOperation,
 				GasPriceMultiplier:  nil,
 			},
 			ExpectError: true,

--- a/rosetta/services/construction_create.go
+++ b/rosetta/services/construction_create.go
@@ -242,7 +242,7 @@ func (s *ConstructAPI) ConstructionCombine(
 	senderAddress, err := signedTx.SenderAddress()
 	if err != nil {
 		return nil, common.NewError(common.InvalidTransactionConstructionError, map[string]interface{}{
-			"message": errors.WithMessage(err, "unable to get sender address with signed transaction").Error(),
+			"message": errors.WithMessage(err, "bad signature payload").Error(),
 		})
 	}
 	if *sigAddress != senderAddress {

--- a/rosetta/services/construction_create.go
+++ b/rosetta/services/construction_create.go
@@ -196,7 +196,7 @@ func (s *ConstructAPI) ConstructionCombine(
 	sig := request.Signatures[0]
 	if sig.SignatureType != common.SignatureType {
 		return nil, common.NewError(common.InvalidTransactionConstructionError, map[string]interface{}{
-			"message": fmt.Sprintf("invalid transaction type, currently only support %v", common.SignatureType),
+			"message": fmt.Sprintf("invalid signature type, currently only support %v", common.SignatureType),
 		})
 	}
 	sigAddress, rosettaError := getAddressFromPublicKey(sig.PublicKey)

--- a/rosetta/services/construction_create.go
+++ b/rosetta/services/construction_create.go
@@ -118,6 +118,13 @@ func (s *ConstructAPI) ConstructionPayloads(
 			"message": "sender account identifier from operations does not match account identifier from public key",
 		})
 	}
+	if metadata.Transaction.FromShardID != nil && *metadata.Transaction.FromShardID != s.hmy.ShardID {
+		return nil, common.NewError(common.InvalidTransactionConstructionError, map[string]interface{}{
+			"message": fmt.Sprintf("transaction is for shard %v != shard %v",
+				*metadata.Transaction.FromShardID, s.hmy.ShardID,
+			),
+		})
+	}
 
 	unsignedTx, rosettaError := ConstructTransaction(components, metadata, s.hmy.ShardID)
 	if rosettaError != nil {

--- a/rosetta/services/construction_create.go
+++ b/rosetta/services/construction_create.go
@@ -113,7 +113,7 @@ func (s *ConstructAPI) ConstructionPayloads(
 			"message": "sender address is not found for given operations",
 		})
 	}
-	if types.Hash(senderID) != types.Hash(components.From) {
+	if senderID.Address != components.From.Address {
 		return nil, common.NewError(common.InvalidTransactionConstructionError, map[string]interface{}{
 			"message": "sender account identifier from operations does not match account identifier from public key",
 		})
@@ -202,7 +202,7 @@ func (s *ConstructAPI) ConstructionCombine(
 	if rosettaError != nil {
 		return nil, rosettaError
 	}
-	if wrappedTransaction.From == nil || types.Hash(wrappedTransaction.From) != types.Hash(sigAccountID) {
+	if wrappedTransaction.From == nil || wrappedTransaction.From.Address != sigAccountID.Address {
 		return nil, common.NewError(common.InvalidTransactionConstructionError, map[string]interface{}{
 			"message": "signer public key does not match unsigned transaction's sender",
 		})

--- a/rosetta/services/construction_create.go
+++ b/rosetta/services/construction_create.go
@@ -187,6 +187,11 @@ func (s *ConstructAPI) ConstructionCombine(
 			"message": "require exactly 1 signature",
 		})
 	}
+	if tx.ShardID() != s.hmy.ShardID {
+		return nil, common.NewError(common.InvalidTransactionConstructionError, map[string]interface{}{
+			"message": fmt.Sprintf("transaction is for shard %v != shard %v", tx.ShardID(), s.hmy.ShardID),
+		})
+	}
 
 	sig := request.Signatures[0]
 	if sig.SignatureType != common.SignatureType {

--- a/rosetta/services/construction_parse.go
+++ b/rosetta/services/construction_parse.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/pkg/errors"
@@ -20,6 +21,11 @@ func (s *ConstructAPI) ConstructionParse(
 	wrappedTransaction, tx, rosettaError := unpackWrappedTransactionFromString(request.Transaction)
 	if rosettaError != nil {
 		return nil, rosettaError
+	}
+	if tx.ShardID() != s.hmy.ShardID {
+		return nil, common.NewError(common.InvalidTransactionConstructionError, map[string]interface{}{
+			"message": fmt.Sprintf("transaction is for shard %v != shard %v", tx.ShardID(), s.hmy.ShardID),
+		})
 	}
 	if request.Signed {
 		return parseSignedTransaction(ctx, wrappedTransaction, tx)

--- a/rosetta/services/construction_parse.go
+++ b/rosetta/services/construction_parse.go
@@ -52,7 +52,7 @@ func parseUnsignedTransaction(
 	foundSender := false
 	operations := formattedTx.Operations
 	for _, op := range operations {
-		if types.Hash(op.Account) == types.Hash(tempAccID) {
+		if op.Account.Address == tempAccID.Address {
 			foundSender = true
 			op.Account = wrappedTransaction.From
 		}
@@ -96,7 +96,7 @@ func parseSignedTransaction(
 	if rosettaError != nil {
 		return nil, rosettaError
 	}
-	if types.Hash(senderID) != types.Hash(wrappedTransaction.From) {
+	if senderID.Address != wrappedTransaction.From.Address {
 		return nil, common.NewError(common.InvalidTransactionConstructionError, map[string]interface{}{
 			"message": "wrapped transaction sender/from does not match transaction signer",
 		})

--- a/rosetta/services/construction_parse.go
+++ b/rosetta/services/construction_parse.go
@@ -37,6 +37,12 @@ func parseUnsignedTransaction(
 		})
 	}
 
+	if _, err := getAddress(wrappedTransaction.From); err != nil {
+		return nil, common.NewError(common.InvalidTransactionConstructionError, map[string]interface{}{
+			"message": err.Error(),
+		})
+	}
+
 	// TODO (dm): implement intended receipt for staking transactions
 	intendedReceipt := &hmyTypes.Receipt{
 		GasUsed: tx.Gas(),
@@ -89,7 +95,7 @@ func parseSignedTransaction(
 	sender, err := tx.SenderAddress()
 	if err != nil {
 		return nil, common.NewError(common.InvalidTransactionConstructionError, map[string]interface{}{
-			"message": errors.WithMessage(err, "unable to get sender address, invalid signed transaction"),
+			"message": errors.WithMessage(err, "unable to get sender address for signed transaction").Error(),
 		})
 	}
 	senderID, rosettaError := newAccountIdentifier(sender)

--- a/rosetta/services/construction_submit.go
+++ b/rosetta/services/construction_submit.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/pkg/errors"
@@ -27,6 +28,11 @@ func (s *ConstructAPI) ConstructionHash(
 			"message": "nil transaction",
 		})
 	}
+	if tx.ShardID() != s.hmy.ShardID {
+		return nil, common.NewError(common.InvalidTransactionConstructionError, map[string]interface{}{
+			"message": fmt.Sprintf("transaction is for shard %v != shard %v", tx.ShardID(), s.hmy.ShardID),
+		})
+	}
 	return &types.TransactionIdentifierResponse{
 		TransactionIdentifier: &types.TransactionIdentifier{Hash: tx.Hash().String()},
 	}, nil
@@ -46,6 +52,11 @@ func (s *ConstructAPI) ConstructionSubmit(
 	if wrappedTransaction == nil || tx == nil {
 		return nil, common.NewError(common.CatchAllError, map[string]interface{}{
 			"message": "nil wrapped transaction or nil unwrapped transaction",
+		})
+	}
+	if tx.ShardID() != s.hmy.ShardID {
+		return nil, common.NewError(common.InvalidTransactionConstructionError, map[string]interface{}{
+			"message": fmt.Sprintf("transaction is for shard %v != shard %v", tx.ShardID(), s.hmy.ShardID),
 		})
 	}
 

--- a/rosetta/services/tx_construction.go
+++ b/rosetta/services/tx_construction.go
@@ -57,7 +57,7 @@ func ConstructTransaction(
 
 	var tx hmyTypes.PoolTransaction
 	switch components.Type {
-	case common.CrossShardTransferNativeOperation:
+	case common.NativeCrossShardTransferOperation:
 		if tx, rosettaError = constructCrossShardTransaction(components, metadata, sourceShardID); rosettaError != nil {
 			return nil, rosettaError
 		}
@@ -65,7 +65,7 @@ func ConstructTransaction(
 		if tx, rosettaError = constructContractCreationTransaction(components, metadata, sourceShardID); rosettaError != nil {
 			return nil, rosettaError
 		}
-	case common.TransferNativeOperation:
+	case common.NativeTransferOperation:
 		if tx, rosettaError = constructPlainTransaction(components, metadata, sourceShardID); rosettaError != nil {
 			return nil, rosettaError
 		}

--- a/rosetta/services/tx_construction_test.go
+++ b/rosetta/services/tx_construction_test.go
@@ -27,7 +27,7 @@ func TestConstructPlainTransaction(t *testing.T) {
 	refDataBytes := []byte{0xEE, 0xEE, 0xEE}
 	refData := hexutil.Encode(refDataBytes)
 	refComponents := &OperationComponents{
-		Type:           common.TransferNativeOperation,
+		Type:           common.NativeTransferOperation,
 		From:           refFrom,
 		To:             refTo,
 		Amount:         big.NewInt(12000),
@@ -116,7 +116,7 @@ func TestConstructPlainTransaction(t *testing.T) {
 
 	// test invalid receiver
 	_, rosettaError = constructPlainTransaction(&OperationComponents{
-		Type:           common.TransferNativeOperation,
+		Type:           common.NativeTransferOperation,
 		From:           refFrom,
 		To:             nil,
 		Amount:         big.NewInt(12000),
@@ -126,7 +126,7 @@ func TestConstructPlainTransaction(t *testing.T) {
 		t.Error("expected error")
 	}
 	_, rosettaError = constructPlainTransaction(&OperationComponents{
-		Type: common.TransferNativeOperation,
+		Type: common.NativeTransferOperation,
 		From: refFrom,
 		To: &types.AccountIdentifier{
 			Address: "",
@@ -140,7 +140,7 @@ func TestConstructPlainTransaction(t *testing.T) {
 
 	// test valid nil sender
 	_, rosettaError = constructPlainTransaction(&OperationComponents{
-		Type:           common.TransferNativeOperation,
+		Type:           common.NativeTransferOperation,
 		From:           nil,
 		To:             refTo,
 		Amount:         big.NewInt(12000),
@@ -179,7 +179,7 @@ func TestConstructCrossShardTransaction(t *testing.T) {
 	refDataBytes := []byte{0xEE, 0xEE, 0xEE}
 	refData := hexutil.Encode(refDataBytes)
 	refComponents := &OperationComponents{
-		Type:           common.CrossShardTransferNativeOperation,
+		Type:           common.NativeCrossShardTransferOperation,
 		From:           refFrom,
 		To:             refTo,
 		Amount:         big.NewInt(12000),
@@ -238,7 +238,7 @@ func TestConstructCrossShardTransaction(t *testing.T) {
 
 	// test invalid receiver
 	_, rosettaError = constructCrossShardTransaction(&OperationComponents{
-		Type:           common.CrossShardTransferNativeOperation,
+		Type:           common.NativeCrossShardTransferOperation,
 		From:           refFrom,
 		To:             nil,
 		Amount:         big.NewInt(12000),
@@ -248,7 +248,7 @@ func TestConstructCrossShardTransaction(t *testing.T) {
 		t.Error("expected error")
 	}
 	_, rosettaError = constructCrossShardTransaction(&OperationComponents{
-		Type: common.CrossShardTransferNativeOperation,
+		Type: common.NativeCrossShardTransferOperation,
 		From: refFrom,
 		To: &types.AccountIdentifier{
 			Address: "",
@@ -262,7 +262,7 @@ func TestConstructCrossShardTransaction(t *testing.T) {
 
 	// test valid nil sender
 	_, rosettaError = constructCrossShardTransaction(&OperationComponents{
-		Type:           common.CrossShardTransferNativeOperation,
+		Type:           common.NativeCrossShardTransferOperation,
 		From:           nil,
 		To:             refTo,
 		Amount:         big.NewInt(12000),
@@ -432,7 +432,7 @@ func TestConstructTransaction(t *testing.T) {
 
 	// test valid cross-shard transfer (negative test cases are in TestConstructCrossShardTransaction)
 	generalTx, rosettaError := ConstructTransaction(&OperationComponents{
-		Type:           common.CrossShardTransferNativeOperation,
+		Type:           common.NativeCrossShardTransferOperation,
 		From:           refFrom,
 		To:             refTo,
 		Amount:         big.NewInt(12000),
@@ -485,7 +485,7 @@ func TestConstructTransaction(t *testing.T) {
 
 	// test valid transfer (negative test cases are in TestConstructPlainTransaction)
 	generalTx, rosettaError = ConstructTransaction(&OperationComponents{
-		Type:           common.TransferNativeOperation,
+		Type:           common.NativeTransferOperation,
 		From:           refFrom,
 		To:             refTo,
 		Amount:         big.NewInt(12000),
@@ -512,7 +512,7 @@ func TestConstructTransaction(t *testing.T) {
 	// test invalid sender shard
 	badShard := refShard + refToShard + 1
 	_, rosettaError = ConstructTransaction(&OperationComponents{
-		Type:           common.TransferNativeOperation,
+		Type:           common.NativeTransferOperation,
 		From:           refFrom,
 		To:             refTo,
 		Amount:         big.NewInt(12000),

--- a/rosetta/services/tx_format.go
+++ b/rosetta/services/tx_format.go
@@ -137,7 +137,7 @@ func FormatCrossShardReceiverTransaction(
 				OperationIdentifier: &types.OperationIdentifier{
 					Index: 0, // There is no gas expenditure for cross-shard transaction payout
 				},
-				Type:    common.CrossShardTransferNativeOperation,
+				Type:    common.NativeCrossShardTransferOperation,
 				Status:  common.SuccessOperationStatus.Status,
 				Account: receiverAccountID,
 				Amount: &types.Amount{

--- a/rosetta/services/tx_format_test.go
+++ b/rosetta/services/tx_format_test.go
@@ -152,7 +152,7 @@ func testFormatPlainTransaction(
 	if rosettaTx.Operations[0].Type != common.ExpendGasOperation {
 		t.Error("Expected 1st operation to be gas")
 	}
-	if rosettaTx.Operations[1].Type != common.TransferNativeOperation {
+	if rosettaTx.Operations[1].Type != common.NativeTransferOperation {
 		t.Error("Expected 2nd operation to transfer related")
 	}
 	if rosettaTx.Operations[1].Metadata != nil {
@@ -340,7 +340,7 @@ func testFormatCrossShardSenderTransaction(
 	if rosettaTx.Operations[0].Type != common.ExpendGasOperation {
 		t.Error("Expected 1st operation to be gas")
 	}
-	if rosettaTx.Operations[1].Type != common.CrossShardTransferNativeOperation {
+	if rosettaTx.Operations[1].Type != common.NativeCrossShardTransferOperation {
 		t.Error("Expected 2nd operation to cross-shard transfer related")
 	}
 	if reflect.DeepEqual(rosettaTx.Operations[1].Metadata, map[string]interface{}{}) {
@@ -396,7 +396,7 @@ func TestFormatCrossShardReceiverTransaction(t *testing.T) {
 			OperationIdentifier: &types.OperationIdentifier{
 				Index: 0, // There is no gas expenditure for cross-shard payout
 			},
-			Type:    common.CrossShardTransferNativeOperation,
+			Type:    common.NativeCrossShardTransferOperation,
 			Status:  common.SuccessOperationStatus.Status,
 			Account: receiverAccID,
 			Amount: &types.Amount{

--- a/rosetta/services/tx_operation.go
+++ b/rosetta/services/tx_operation.go
@@ -210,7 +210,7 @@ func newTransferNativeOperations(
 	receiverAddress := *tx.To()
 
 	// Common elements
-	opType := common.TransferNativeOperation
+	opType := common.NativeTransferOperation
 	opStatus := common.SuccessOperationStatus.Status
 	if receipt.Status == hmytypes.ReceiptStatusFailed {
 		if len(tx.Data()) > 0 {
@@ -309,7 +309,7 @@ func newCrossShardSenderTransferNativeOperations(
 			RelatedOperations: []*types.OperationIdentifier{
 				startingOperationID,
 			},
-			Type:    common.CrossShardTransferNativeOperation,
+			Type:    common.NativeCrossShardTransferOperation,
 			Status:  common.SuccessOperationStatus.Status,
 			Account: senderAccountID,
 			Amount: &types.Amount{

--- a/rosetta/services/tx_operation_components.go
+++ b/rosetta/services/tx_operation_components.go
@@ -187,7 +187,7 @@ func getCrossShardOperationComponents(
 			"message": "operation must have account sender/from & receiver/to identifiers for cross shard transfer",
 		})
 	}
-	if types.Hash(operation.Account) != types.Hash(components.From) {
+	if operation.Account.Address != components.From.Address {
 		return nil, common.NewError(common.InvalidTransactionConstructionError, map[string]interface{}{
 			"message": "operation account identifier does not match sender/from identifiers for cross shard transfer",
 		})

--- a/rosetta/services/tx_operation_components.go
+++ b/rosetta/services/tx_operation_components.go
@@ -57,7 +57,7 @@ func GetOperationComponents(
 		return getTransferOperationComponents(operations)
 	}
 	switch operations[0].Type {
-	case common.CrossShardTransferNativeOperation:
+	case common.NativeCrossShardTransferOperation:
 		return getCrossShardOperationComponents(operations[0])
 	case common.ContractCreationOperation:
 		return getContractCreationOperationComponents(operations[0])
@@ -78,7 +78,7 @@ func getTransferOperationComponents(
 		})
 	}
 	op0, op1 := operations[0], operations[1]
-	if op0.Type != common.TransferNativeOperation || op1.Type != common.TransferNativeOperation {
+	if op0.Type != common.NativeTransferOperation || op1.Type != common.NativeTransferOperation {
 		return nil, common.NewError(common.InvalidTransactionConstructionError, map[string]interface{}{
 			"message": "invalid operation type(s) for same shard transfer",
 		})

--- a/rosetta/services/tx_operation_components_test.go
+++ b/rosetta/services/tx_operation_components_test.go
@@ -124,7 +124,7 @@ func TestGetCrossShardOperationComponents(t *testing.T) {
 
 	// test valid operations
 	refOperation := &types.Operation{
-		Type:     common.CrossShardTransferNativeOperation,
+		Type:     common.NativeCrossShardTransferOperation,
 		Amount:   refAmount,
 		Account:  refFrom,
 		Metadata: refMetadataMap,
@@ -148,7 +148,7 @@ func TestGetCrossShardOperationComponents(t *testing.T) {
 
 	// test nil amount
 	_, rosettaError = getCrossShardOperationComponents(&types.Operation{
-		Type:     common.CrossShardTransferNativeOperation,
+		Type:     common.NativeCrossShardTransferOperation,
 		Amount:   nil,
 		Account:  refFrom,
 		Metadata: refMetadataMap,
@@ -159,7 +159,7 @@ func TestGetCrossShardOperationComponents(t *testing.T) {
 
 	// test positive amount
 	_, rosettaError = getCrossShardOperationComponents(&types.Operation{
-		Type: common.CrossShardTransferNativeOperation,
+		Type: common.NativeCrossShardTransferOperation,
 		Amount: &types.Amount{
 			Value:    "12000",
 			Currency: &common.NativeCurrency,
@@ -173,7 +173,7 @@ func TestGetCrossShardOperationComponents(t *testing.T) {
 
 	// test different/unsupported currency
 	_, rosettaError = getCrossShardOperationComponents(&types.Operation{
-		Type: common.CrossShardTransferNativeOperation,
+		Type: common.NativeCrossShardTransferOperation,
 		Amount: &types.Amount{
 			Value: "-12000",
 			Currency: &types.Currency{
@@ -190,7 +190,7 @@ func TestGetCrossShardOperationComponents(t *testing.T) {
 
 	// test nil account
 	_, rosettaError = getCrossShardOperationComponents(&types.Operation{
-		Type:     common.CrossShardTransferNativeOperation,
+		Type:     common.NativeCrossShardTransferOperation,
 		Amount:   refAmount,
 		Account:  nil,
 		Metadata: refMetadataMap,
@@ -201,7 +201,7 @@ func TestGetCrossShardOperationComponents(t *testing.T) {
 
 	// test no metadata
 	_, rosettaError = getCrossShardOperationComponents(&types.Operation{
-		Type:    common.CrossShardTransferNativeOperation,
+		Type:    common.NativeCrossShardTransferOperation,
 		Amount:  refAmount,
 		Account: refFrom,
 	})
@@ -224,7 +224,7 @@ func TestGetCrossShardOperationComponents(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, rosettaError = getCrossShardOperationComponents(&types.Operation{
-		Type:     common.CrossShardTransferNativeOperation,
+		Type:     common.NativeCrossShardTransferOperation,
 		Amount:   refAmount,
 		Account:  refFrom,
 		Metadata: badMetadataMap,
@@ -266,7 +266,7 @@ func TestGetTransferOperationComponents(t *testing.T) {
 			OperationIdentifier: &types.OperationIdentifier{
 				Index: 0,
 			},
-			Type:    common.TransferNativeOperation,
+			Type:    common.NativeTransferOperation,
 			Amount:  refFromAmount,
 			Account: refFrom,
 		},
@@ -279,7 +279,7 @@ func TestGetTransferOperationComponents(t *testing.T) {
 					Index: 0,
 				},
 			},
-			Type:    common.TransferNativeOperation,
+			Type:    common.NativeTransferOperation,
 			Amount:  refToAmount,
 			Account: refTo,
 		},
@@ -345,20 +345,20 @@ func TestGetTransferOperationComponents(t *testing.T) {
 
 	// test invalid operation
 	refOperations[0].Type = common.ExpendGasOperation
-	refOperations[1].Type = common.TransferNativeOperation
+	refOperations[1].Type = common.NativeTransferOperation
 	_, rosettaError = getTransferOperationComponents(refOperations)
 	if rosettaError == nil {
 		t.Error("expected error")
 	}
 
 	// test invalid operation sender
-	refOperations[0].Type = common.TransferNativeOperation
+	refOperations[0].Type = common.NativeTransferOperation
 	refOperations[1].Type = common.ExpendGasOperation
 	_, rosettaError = getTransferOperationComponents(refOperations)
 	if rosettaError == nil {
 		t.Error("expected error")
 	}
-	refOperations[1].Type = common.TransferNativeOperation
+	refOperations[1].Type = common.NativeTransferOperation
 
 	// test nil amount
 	refOperations[0].Amount = nil
@@ -517,7 +517,7 @@ func TestGetOperationComponents(t *testing.T) {
 			OperationIdentifier: &types.OperationIdentifier{
 				Index: 0,
 			},
-			Type:    common.TransferNativeOperation,
+			Type:    common.NativeTransferOperation,
 			Amount:  refFromAmount,
 			Account: refFrom,
 		},
@@ -530,7 +530,7 @@ func TestGetOperationComponents(t *testing.T) {
 					Index: 0,
 				},
 			},
-			Type:    common.TransferNativeOperation,
+			Type:    common.NativeTransferOperation,
 			Amount:  refToAmount,
 			Account: refTo,
 		},
@@ -551,7 +551,7 @@ func TestGetOperationComponents(t *testing.T) {
 	}
 	_, rosettaError = GetOperationComponents([]*types.Operation{
 		{
-			Type:     common.CrossShardTransferNativeOperation,
+			Type:     common.NativeCrossShardTransferOperation,
 			Amount:   refFromAmount,
 			Account:  refFrom,
 			Metadata: refMetadataMap,

--- a/rosetta/services/tx_operation_test.go
+++ b/rosetta/services/tx_operation_test.go
@@ -368,7 +368,7 @@ func TestNewTransferNativeOperations(t *testing.T) {
 					Index: startingOpID.Index,
 				},
 			},
-			Type:    common.TransferNativeOperation,
+			Type:    common.NativeTransferOperation,
 			Status:  common.ContractFailureOperationStatus.Status,
 			Account: senderAccID,
 			Amount: &types.Amount{
@@ -385,7 +385,7 @@ func TestNewTransferNativeOperations(t *testing.T) {
 					Index: startingOpID.Index + 1,
 				},
 			},
-			Type:    common.TransferNativeOperation,
+			Type:    common.NativeTransferOperation,
 			Status:  common.ContractFailureOperationStatus.Status,
 			Account: receiverAccID,
 			Amount: &types.Amount{
@@ -461,7 +461,7 @@ func TestNewCrossShardSenderTransferNativeOperations(t *testing.T) {
 			RelatedOperations: []*types.OperationIdentifier{
 				startingOpID,
 			},
-			Type:    common.CrossShardTransferNativeOperation,
+			Type:    common.NativeCrossShardTransferOperation,
 			Status:  common.SuccessOperationStatus.Status,
 			Account: senderAccID,
 			Amount: &types.Amount{


### PR DESCRIPTION
It is possible to preprocess a transaction's construction with some weird options. For example, it was possible to specify a native same shard transfer in the operations, but then have it go cross-shard in the options. This PR adds errors to such inconsistency when preprocessing a transaction.

I also took this time to change the native token operation constant names for consistency's sake. 

Lastly, I added in some extra checks that should return errors with more context to help developers debug.