### PR TITLE
[SYNC] Dynamic DNS peer discovery

### DIFF
--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -501,7 +501,7 @@ func (ss *StateSync) downloadBlocks(bc *core.BlockChain) {
 				}
 				payload, err := peerConfig.GetBlocks(tasks.blockHashes())
 				if err != nil {
-					utils.Logger().Error().Err(err).
+					utils.Logger().Warn().Err(err).
 						Str("peerID", peerConfig.ip).
 						Str("port", peerConfig.port).
 						Msg("[SYNC] downloadBlocks: GetBlocks failed")

--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -134,6 +134,7 @@ func (sc *SyncConfig) RemovePeer(peer *SyncPeerConfig) {
 	for i, p := range sc.peers {
 		if p == peer {
 			sc.peers = append(sc.peers[:i], sc.peers[i+1:]...)
+			break
 		}
 	}
 	utils.Logger().Info().Str("peerIP", peer.ip).Str("peerPortMsg", peer.port).


### PR DESCRIPTION
## Issue

To address pagerduty issue: https://harmonyone.pagerduty.com/incidents/P4U6NZ0/timeline.

Before this change, node dns peers are static: not changed after initialization. Thus if some node ips are removed from sync domain, the syncing peers are still not updated. Thus, this PR is proposed to dynamically update the DNS nodes according to the domain name.

## Test

Tested with local machine with customized code connecting to mainnet.

## Appendix: diagnose

The root cause of the node stuck is:
1. Some of the DNS nodes IPs are reset. Old IPs are no longer available.
2. DNS syncing peers are not updated dynamically. DNS peers are actually static after initialization.

From the node logs we can see that the node is connected to 4 sync peers and all of them are not available, thus causing sync to be permanently stuck:

```
{"level":"warn","error":"rpc error: code = DeadlineExceeded desc = latest connection error: connection error: desc = \"transport: Error while dialing dial tcp 35.196.104.173:6000: i/o timeout\"","peerIP":"35.196.104.173","peerPort":"6000","caller":"/mnt/jenkins/workspace/harmony-release/harmony/api/service/syncing/syncing.go:873","time":"2020-10-31T20:24:26.542036653Z","message":"[Sync]GetBlockChainHeight failed"}
{"level":"warn","error":"rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 35.198.203.4:6000: connect: connection timed out\"","peerIP":"35.198.203.4","peerPort":"6000","caller":"/mnt/jenkins/workspace/harmony-release/harmony/api/service/syncing/syncing.go:873","time":"2020-10-31T20:25:21.561774267Z","message":"[Sync]GetBlockChainHeight failed"}
{"level":"warn","error":"rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 35.196.104.173:6000: connect: connection timed out\"","peerIP":"35.196.104.173","peerPort":"6000","caller":"/mnt/jenkins/workspace/harmony-release/harmony/api/service/syncing/syncing.go:873","time":"2020-10-31T20:25:21.562065628Z","message":"[Sync]GetBlockChainHeight failed"}
{"level":"warn","error":"rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 34.91.70.107:6000: i/o timeout\"","peerIP":"34.91.70.107","peerPort":"6000","caller":"/mnt/jenkins/workspace/harmony-release/harmony/api/service/syncing/syncing.go:873","time":"2020-10-31T20:25:21.56216913Z","message":"[Sync]GetBlockChainHeight failed"}
{"level":"warn","error":"rpc error: code = DeadlineExceeded desc = latest connection error: connection error: desc = \"transport: Error while dialing dial tcp 34.91.249.175:6000: i/o timeout\"","peerIP":"34.91.249.175","peerPort":"6000","caller":"/mnt/jenkins/workspace/harmony-release/harmony/api/service/syncing/syncing.go:873","time":"2020-10-31T20:25:26.560284736Z","message":"[Sync]GetBlockChainHeight failed"}
```