### PR TITLE
[p2p] reduce min peer for non mainnet bootstrap

### DIFF
--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -130,7 +130,7 @@ func TestPersistConfig(t *testing.T) {
 		},
 		{
 			config: makeTestConfig("mainnet", func(cfg *harmonyConfig) {
-				consensus := getDefaultConsensusConfigCopy()
+				consensus := getConsensusConfigByNetwork("mainnet")
 				cfg.Consensus = &consensus
 
 				devnet := getDefaultDevnetConfigCopy()

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -88,10 +88,6 @@ var defaultLogContext = logContext{
 	Port: 9000,
 }
 
-var defaultConsensusConfig = consensusConfig{
-	MinPeers: 6,
-}
-
 const (
 	defaultBroadcastInvalidTx = true
 )
@@ -127,9 +123,18 @@ func getDefaultLogContextCopy() logContext {
 	return config
 }
 
-func getDefaultConsensusConfigCopy() consensusConfig {
-	config := defaultConsensusConfig
-	return config
+const (
+	mainnetMinPeers = 6
+	otherMinPeers   = 2
+)
+
+func getConsensusConfigByNetwork(networkType string) consensusConfig {
+	if networkType == nodeconfig.Mainnet {
+		return consensusConfig{mainnetMinPeers}
+	}
+	// If network is not mainnet, network scale is expected to be much smaller.
+	// Set the threshold smaller for easier bootstrap.
+	return consensusConfig{otherMinPeers}
 }
 
 const (

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -743,7 +743,7 @@ var (
 	consensusMinPeersFlag = cli.IntFlag{
 		Name:     "consensus.min-peers",
 		Usage:    "minimal number of peers in shard",
-		DefValue: defaultConsensusConfig.MinPeers,
+		DefValue: mainnetMinPeers,
 		Hidden:   true,
 	}
 	legacyDelayCommitFlag = cli.StringFlag{
@@ -760,17 +760,16 @@ var (
 	legacyConsensusMinPeersFlag = cli.IntFlag{
 		Name:     "min_peers",
 		Usage:    "Minimal number of Peers in shard",
-		DefValue: defaultConsensusConfig.MinPeers,
+		DefValue: mainnetMinPeers,
 		Hidden:   true,
 	}
 )
 
 func applyConsensusFlags(cmd *cobra.Command, config *harmonyConfig) {
-	if cli.HasFlagsChanged(cmd, consensusValidFlags) {
-		cfg := getDefaultConsensusConfigCopy()
+	if config.Consensus == nil {
+		cfg := getConsensusConfigByNetwork(config.Network.NetworkType)
 		config.Consensus = &cfg
 	}
-
 	if cli.IsFlagChanged(cmd, consensusMinPeersFlag) {
 		config.Consensus.MinPeers = cli.GetIntFlagValue(cmd, consensusMinPeersFlag)
 	} else if cli.IsFlagChanged(cmd, legacyConsensusMinPeersFlag) {
@@ -930,7 +929,7 @@ var (
 )
 
 func applySysFlags(cmd *cobra.Command, config *harmonyConfig) {
-	if cli.HasFlagsChanged(cmd, sysFlags) || config.Sys == nil {
+	if config.Sys == nil {
 		cfg := getDefaultSysConfigCopy()
 		config.Sys = &cfg
 	}

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -596,8 +596,16 @@ func TestConsensusFlags(t *testing.T) {
 		expErr    error
 	}{
 		{
-			args:      []string{},
-			expConfig: nil,
+			args: []string{},
+			expConfig: &consensusConfig{
+				MinPeers: mainnetMinPeers,
+			},
+		},
+		{
+			args: []string{"--network", "testnet"},
+			expConfig: &consensusConfig{
+				MinPeers: otherMinPeers,
+			},
 		},
 		{
 			args: []string{"--consensus.min-peers", "10"},
@@ -613,7 +621,11 @@ func TestConsensusFlags(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		ts := newFlagTestSuite(t, consensusFlags, applyConsensusFlags)
+		ts := newFlagTestSuite(t, append(networkFlags, consensusFlags...), func(cmd *cobra.Command, cfg *harmonyConfig) {
+			nt := getNetworkType(cmd)
+			cfg.Network = getDefaultNetworkConfig(nt)
+			applyConsensusFlags(cmd, cfg)
+		})
 
 		hc, err := ts.run(test.args)
 

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -574,13 +574,7 @@ func setupConsensusAndNode(hc harmonyConfig, nodeConfig *nodeconfig.ConfigType) 
 	currentConsensus.SetCommitDelay(time.Duration(0))
 
 	// Parse minPeers from harmonyConfig
-	var minPeers int
-	if hc.Consensus != nil {
-		minPeers = hc.Consensus.MinPeers
-	} else {
-		minPeers = defaultConsensusConfig.MinPeers
-	}
-	currentConsensus.MinPeers = minPeers
+	currentConsensus.MinPeers = hc.Consensus.MinPeers
 
 	blacklist, err := setupBlacklist(hc)
 	if err != nil {


### PR DESCRIPTION
## Issue

For new network bootstrap, it could happen that the peers in p2pnetwork is smaller than lower threshold. This PR is to increase the min consensus peer for non-mainnet node during bootstrap.

E.g. During the bootnode migration, the dht data in boot nodes are removed and caused very limited peers when bootstrap.

```
"p2p-connectivity": {
      "connected": 2,
      "not-connected": 1,
      "total-known-peers": 3
},
```

## Test

Tested locally. After the change, the node will not be terminated because of not enough peers.