### PR TITLE
[rosetta] Support EVM pre-process for contract creation txs

### DIFF
--- a/rosetta/services/construction_check.go
+++ b/rosetta/services/construction_check.go
@@ -240,15 +240,16 @@ func (s *ConstructAPI) ConstructionMetadata(
 
 	evmErrorMsg := ""
 	evmReturn := hexutil.Bytes{}
-	if !isStakingOperation(options.OperationType) &&
-		options.OperationType != common.ContractCreationOperation &&
-		len(data) > 0 {
+	if len(data) > 0 && (options.OperationType == common.ContractCreationOperation ||
+		options.OperationType == common.NativeTransferOperation) {
 		gas := hexutil.Uint64(estGasUsed)
 		callArgs := rpc.CallArgs{
 			From: senderAddr,
-			To:   &contractAddress,
 			Data: &data,
 			Gas:  &gas,
+		}
+		if options.OperationType == common.NativeTransferOperation {
+			callArgs.To = &contractAddress
 		}
 		evmExe, err := rpc.DoEVMCall(
 			ctx, s.hmy, callArgs, ethRpc.LatestBlockNumber, vm.Config{}, rpc.CallTimeout, s.hmy.RPCGasCap,


### PR DESCRIPTION
Previously, the EVM data & error message was only returned for transactions calling an existing contract. However, it may be useful to get the data/error message of a contract creation transaction that one is in the process of constructing. This PR exposes such functionality.