### PR TITLE
Revert "remove beacon sync for explorer node"

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -315,7 +315,7 @@ func setupNodeAndRun(hc harmonyConfig) {
 		WSPort:       hc.WS.Port,
 		DebugEnabled: hc.RPCOpt.DebugEnabled,
 	}
-	if nodeConfig.ShardID != shard.BeaconChainShardID && hc.General.NodeType != nodeTypeExplorer {
+	if nodeConfig.ShardID != shard.BeaconChainShardID {
 		utils.Logger().Info().
 			Uint32("shardID", currentNode.Blockchain().ShardID()).
 			Uint32("shardID", nodeConfig.ShardID).Msg("SupportBeaconSyncing")


### PR DESCRIPTION
Reverts harmony-one/harmony#3420

instead should make beacon chain non-archival.