### PR TITLE
[sync] remove ticker in syncLoop

### DIFF
--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -917,10 +917,7 @@ func (ss *StateSync) SyncLoop(bc *core.BlockChain, worker *worker.Worker, isBeac
 	if !isBeacon {
 		ss.RegisterNodeInfo()
 	}
-	// remove SyncLoopFrequency
-	ticker := time.NewTicker(SyncLoopFrequency * time.Second)
-	defer ticker.Stop()
-	for range ticker.C {
+	for {
 		otherHeight := ss.getMaxPeerHeight(isBeacon)
 		currentHeight := bc.CurrentBlock().NumberU64()
 		if currentHeight >= otherHeight {


### PR DESCRIPTION
## Issue

Remove an unnecessary ticker in sync logic. Currently what this ticker is doing is simply cause 1s delay for sync loop starts. We can safely remove this.

## Test 

Tested on local node connecting to testnet.
