### PR TITLE
shorten leader waiting time

### DIFF
--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -310,7 +310,7 @@ func (consensus *Consensus) onCommit(msg *msg_pb.Message) {
 
 		consensus.getLogger().Info().Msg("[OnCommit] Starting Grace Period")
 		go func(viewID uint64) {
-			time.Sleep(2500 * time.Millisecond)
+			time.Sleep(1000 * time.Millisecond)
 			logger.Info().Msg("[OnCommit] Commit Grace Period Ended")
 			consensus.commitFinishChan <- viewID
 		}(viewID)


### PR DESCRIPTION
right now the commit sig from 67%-100% collection takes less than 1 seconds (if there is no missing sig)