### PR TITLE
Avoid reset state that's resetting committed content.

### DIFF
--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -1025,7 +1025,6 @@ func (ss *StateSync) SyncLoop(bc *core.BlockChain, worker *worker.Worker, isBeac
 		if err := ss.addConsensusLastMile(bc, consensus); err != nil {
 			utils.Logger().Error().Err(err).Msg("[SYNC] Add consensus last mile")
 		}
-		consensus.SetMode(consensus.UpdateConsensusInformation())
 	}
 	ss.purgeAllBlocksFromCache()
 }

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -343,6 +343,8 @@ func (consensus *Consensus) Start(
 				// Sleep to wait for the full block time
 				consensus.getLogger().Info().Msg("[ConsensusMainLoop] Waiting for Block Time")
 				<-time.After(time.Until(consensus.NextBlockDue))
+				consensus.StartFinalityCount()
+
 				// Update time due for next block
 				consensus.NextBlockDue = time.Now().Add(consensus.BlockPeriod)
 

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -302,10 +302,10 @@ func (consensus *Consensus) onCommit(msg *msg_pb.Message) {
 
 		if !blockObj.IsLastBlockInEpoch() {
 			// only do early commit if it's not epoch block to avoid problems
-			go func() {
-				// TODO: make it synchronized with commitFinishChan
-				consensus.preCommitAndPropose(blockObj)
-			}()
+
+			// TODO: make it synchronized with commitFinishChan
+			consensus.preCommitAndPropose(blockObj)
+
 		}
 
 		consensus.getLogger().Info().Msg("[OnCommit] Starting Grace Period")

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -80,7 +80,6 @@ func (node *Node) WaitForConsensusReadyV2(readySignal chan consensus.ProposalTyp
 							}
 						}
 					}()
-					node.Consensus.StartFinalityCount()
 					newBlock, err := node.ProposeNewBlock(newCommitSigsChan)
 
 					if err == nil {


### PR DESCRIPTION
make precommit's committed message construction in the same thread as the main consensus thread, so that no other thread can clear the state in between.