### PR TITLE
fix cache key issue and viewID check overflow issue

### DIFF
--- a/consensus/checks.go
+++ b/consensus/checks.go
@@ -168,7 +168,7 @@ func (consensus *Consensus) onViewChangeSanityCheck(recvMsg *FBFTMessage) bool {
 			Msg("[onViewChangeSanityCheck] ViewChanging ID Is Low")
 		return false
 	}
-	if recvMsg.ViewID-consensus.GetViewChangingID() > MaxViewIDDiff {
+	if recvMsg.ViewID > consensus.GetViewChangingID() && recvMsg.ViewID-consensus.GetViewChangingID() > MaxViewIDDiff {
 		consensus.getLogger().Debug().
 			Msg("[onViewChangeSanityCheck] Received viewID that is MaxViewIDDiff (249) further from the current viewID!")
 		return false

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1834,7 +1834,7 @@ func (bc *BlockChain) WriteShardStateBytes(db rawdb.DatabaseWriter,
 
 // ReadCommitSig retrieves the commit signature on a block.
 func (bc *BlockChain) ReadCommitSig(blockNum uint64) ([]byte, error) {
-	if cached, ok := bc.lastCommitsCache.Get("commitSig" + string(blockNum)); ok {
+	if cached, ok := bc.lastCommitsCache.Get(blockNum); ok {
 		lastCommits := cached.([]byte)
 		return lastCommits, nil
 	}
@@ -1851,7 +1851,7 @@ func (bc *BlockChain) WriteCommitSig(blockNum uint64, lastCommits []byte) error 
 	if err != nil {
 		return err
 	}
-	bc.lastCommitsCache.Add("commitSig"+string(blockNum), lastCommits)
+	bc.lastCommitsCache.Add(blockNum, lastCommits)
 	return nil
 }
 


### PR DESCRIPTION
string() is converting to a UTF-8-encoded text. It will give a bad output if the uint64 is very large.