### PR TITLE
Make finalCommit in the same thread as consensus

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -50,8 +50,6 @@ type Consensus struct {
 	current State
 	// How long to delay sending commit messages.
 	delayCommit time.Duration
-	// Consensus rounds whose commit phase finished
-	commitFinishChan chan uint64
 	// 2 types of timeouts: normal and viewchange
 	consensusTimeout map[TimeoutType]*utils.Timeout
 	// Commits collected from validators.
@@ -216,7 +214,6 @@ func New(
 	consensus.syncReadyChan = make(chan struct{})
 	consensus.syncNotReadyChan = make(chan struct{})
 	consensus.SlashChan = make(chan slash.Record)
-	consensus.commitFinishChan = make(chan uint64)
 	consensus.ReadySignal = make(chan ProposalType)
 	consensus.CommitSigChannel = make(chan []byte)
 	// channel for receiving newly generated VDF

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -165,11 +165,6 @@ func (consensus *Consensus) ResetState() {
 	consensus.aggregatedCommitSig = nil
 }
 
-// ToggleConsensusCheck flip the flag of whether ignore viewID check during consensus process
-func (consensus *Consensus) ToggleConsensusCheck() {
-	consensus.IgnoreViewIDCheck.Toggle()
-}
-
 // IsValidatorInCommittee returns whether the given validator BLS address is part of my committee
 func (consensus *Consensus) IsValidatorInCommittee(pubKey bls.SerializedPublicKey) bool {
 	return consensus.Decider.IndexOf(pubKey) != -1

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -69,9 +69,6 @@ func TestConsensusInitialization(t *testing.T) {
 	assert.IsType(t, make(chan slash.Record), consensus.SlashChan)
 	assert.NotNil(t, consensus.SlashChan)
 
-	assert.IsType(t, make(chan uint64), consensus.commitFinishChan)
-	assert.NotNil(t, consensus.commitFinishChan)
-
 	assert.IsType(t, make(chan ProposalType), consensus.ReadySignal)
 	assert.NotNil(t, consensus.ReadySignal)
 

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -432,19 +432,6 @@ func (consensus *Consensus) Start(
 					Int64("publicKeys", consensus.Decider.ParticipantsCount()).
 					Msg("[ConsensusMainLoop] STARTING CONSENSUS")
 				consensus.announce(newBlock)
-
-			case viewID := <-consensus.commitFinishChan:
-				consensus.getLogger().Info().Uint64("viewID", viewID).Msg("[ConsensusMainLoop] commitFinishChan")
-
-				// Only Leader execute this condition
-				func() {
-					consensus.mutex.Lock()
-					defer consensus.mutex.Unlock()
-					if viewID == consensus.GetCurBlockViewID() {
-						consensus.finalCommit()
-					}
-				}()
-
 			case <-stopChan:
 				consensus.getLogger().Info().Msg("[ConsensusMainLoop] stopChan")
 				return

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -325,6 +325,7 @@ func (consensus *Consensus) Start(
 					consensus.SetViewIDs(consensus.Blockchain.CurrentHeader().ViewID().Uint64() + 1)
 					mode := consensus.UpdateConsensusInformation()
 					consensus.current.SetMode(mode)
+					consensus.consensusTimeout[timeoutConsensus].Start()
 					consensus.getLogger().Info().Str("Mode", mode.String()).Msg("Node is IN SYNC")
 				}
 				consensus.mutex.Unlock()

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -285,11 +285,8 @@ func (consensus *Consensus) onCommit(msg *msg_pb.Message) {
 	viewID := consensus.GetCurBlockViewID()
 
 	if consensus.Decider.IsAllSigsCollected() {
-		go func(viewID uint64) {
-			logger.Info().Msg("[OnCommit] 100% Enough commits received")
-
-			consensus.finalCommit()
-		}(viewID)
+		logger.Info().Msg("[OnCommit] 100% Enough commits received")
+		consensus.finalCommit()
 
 		consensus.msgSender.StopRetry(msg_pb.MessageType_PREPARED)
 		return
@@ -311,7 +308,9 @@ func (consensus *Consensus) onCommit(msg *msg_pb.Message) {
 			time.Sleep(1000 * time.Millisecond)
 			logger.Info().Msg("[OnCommit] Commit Grace Period Ended")
 
-			consensus.finalCommit()
+			if viewID == consensus.GetCurBlockViewID() {
+				consensus.finalCommit()
+			}
 		}(viewID)
 
 		consensus.msgSender.StopRetry(msg_pb.MessageType_PREPARED)

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -308,6 +308,8 @@ func (consensus *Consensus) onCommit(msg *msg_pb.Message) {
 			time.Sleep(1000 * time.Millisecond)
 			logger.Info().Msg("[OnCommit] Commit Grace Period Ended")
 
+			consensus.mutex.Lock()
+			defer consensus.mutex.Unlock()
 			if viewID == consensus.GetCurBlockViewID() {
 				consensus.finalCommit()
 			}


### PR DESCRIPTION
Previously, the finalCommit is executed from a channel as a signal. there is a risk that if the commit Sig is reset before the finalCommit is called, then finalCommit will send out empty committed messages.

This PR make finalCommit in the same thread as consensus. so the data inconsistency will never happen