### PR TITLE
Viewchange fix out of sync

### DIFF
--- a/consensus/config.go
+++ b/consensus/config.go
@@ -6,6 +6,10 @@ import "time"
 const (
 	// default timeout configuration is shorten to 45 seconds as the consensus is 5s
 	viewChangeTimeout = 45
+	// viewChangeSlot means every 90 seconds, the view change ID will be advanced.
+	// so that the nodes init view change process within the 90 seconds range will
+	// be have the same view change ID
+	viewChangeSlot = 90
 	// The duration of viewChangeTimeout for each view change
 	viewChangeDuration time.Duration = viewChangeTimeout * time.Second
 

--- a/consensus/quorum/one-node-staked-vote.go
+++ b/consensus/quorum/one-node-staked-vote.go
@@ -146,6 +146,9 @@ func (v *stakedVoteWeight) IsQuorumAchieved(p Phase) bool {
 // IsQuorumAchivedByMask ..
 func (v *stakedVoteWeight) IsQuorumAchievedByMask(mask *bls_cosi.Mask) bool {
 	threshold := v.QuorumThreshold()
+	if mask == nil {
+		return false
+	}
 	currentTotalPower := v.computeTotalPowerByMask(mask)
 	if currentTotalPower == nil {
 		return false

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -169,6 +169,8 @@ func (consensus *Consensus) getNextLeaderKey(viewID uint64) *bls.PublicKeyWrappe
 			consensus.getLogger().Error().Msg("[getNextLeaderKey] Failed to get current header from blockchain")
 			lastLeaderPubKey = consensus.LeaderPubKey
 		} else {
+			lastBlockViewID := curHeader.ViewID().Uint64()
+			gap = int(viewID - lastBlockViewID)
 			// this is the truth of the leader based on blockchain blocks
 			lastLeaderPubKey, err = consensus.getLeaderPubKeyFromCoinbase(curHeader)
 			if err != nil || lastLeaderPubKey == nil {

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -133,7 +133,7 @@ func (consensus *Consensus) getNextViewID() (uint64, time.Duration) {
 		return consensus.fallbackNextViewID()
 	}
 	// diff only increases
-	diff := uint64((curTimestamp - blockTimestamp) / viewChangeTimeout)
+	diff := uint64((curTimestamp - blockTimestamp) / viewChangeSlot)
 	nextViewID := diff + lastBlockViewID
 
 	consensus.getLogger().Info().

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -351,7 +351,7 @@ func (consensus *Consensus) onViewChange(msg *msg_pb.Message) {
 		return
 	}
 
-	if consensus.Decider.IsQuorumAchieved(quorum.ViewChange) {
+	if consensus.Decider.IsQuorumAchievedByMask(consensus.vc.GetViewIDBitmap(recvMsg.ViewID)) {
 		consensus.getLogger().Info().
 			Int64("have", consensus.Decider.SignersCount(quorum.ViewChange)).
 			Int64("need", consensus.Decider.TwoThirdsSignersCount()).

--- a/consensus/view_change_construct.go
+++ b/consensus/view_change_construct.go
@@ -202,6 +202,10 @@ func (vc *viewChange) VerifyNewViewMsg(recvMsg *FBFTMessage) (*types.Block, erro
 	binary.LittleEndian.PutUint64(viewIDBytes, recvMsg.ViewID)
 
 	if !m3Sig.VerifyHash(m3Mask.AggregatePublic, viewIDBytes) {
+		vc.getLogger().Warn().
+			Bytes("viewIDBytes", viewIDBytes).
+			Interface("AggregatePublic", m3Mask.AggregatePublic).
+			Msg("m3Sig.VerifyHash Failed")
 		return nil, errors.New("[VerifyNewViewMsg] Unable to Verify Aggregated Signature of M3 (ViewID) payload")
 	}
 
@@ -209,6 +213,10 @@ func (vc *viewChange) VerifyNewViewMsg(recvMsg *FBFTMessage) (*types.Block, erro
 	if recvMsg.M2AggSig != nil {
 		m2Sig := recvMsg.M2AggSig
 		if !m2Sig.VerifyHash(m2Mask.AggregatePublic, NIL) {
+			vc.getLogger().Warn().
+				Bytes("NIL", NIL).
+				Interface("AggregatePublic", m2Mask.AggregatePublic).
+				Msg("m2Sig.VerifyHash Failed")
 			return nil, errors.New("[VerifyNewViewMsg] Unable to Verify Aggregated Signature of M2 (NIL) payload")
 		}
 	}


### PR DESCRIPTION
This PR fixed the gap calculation in getNextLeader.

It also increase the period when calculating the nextView ID to avoid view ID out of sync when nodes start view change at different time.  If the view ID period is the same as the view change timeout, the nodes will always have different view ID.  I have found this issue during another stress test on STN.

Tested on STN, shutdown 2/10 nodes and can still recover consensus after view change.