### PR TITLE
[viewchange] shorten the viewchange timeout to 29s

### DIFF
--- a/consensus/config.go
+++ b/consensus/config.go
@@ -4,12 +4,14 @@ import "time"
 
 // timeout constant
 const (
-	// default timeout configuration is shorten to 45 seconds as the consensus is 5s
-	viewChangeTimeout = 45
-	// viewChangeSlot means every 90 seconds, the view change ID will be advanced.
-	// so that the nodes init view change process within the 90 seconds range will
+	// default timeout configuration is shorten to 27 seconds as the consensus is 5s
+	// so each phase of the consensus will timeout every 27 seconds to tirgger a
+	// new view change process
+	viewChangeTimeout = 27
+	// viewChangeSlot means every 45 seconds, the view change ID will be advanced.
+	// so that the nodes init view change process within the 45 seconds range will
 	// be have the same view change ID
-	viewChangeSlot = 90
+	viewChangeSlot = 45
 	// The duration of viewChangeTimeout for each view change
 	viewChangeDuration time.Duration = viewChangeTimeout * time.Second
 

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -132,8 +132,9 @@ func (consensus *Consensus) getNextViewID() (uint64, time.Duration) {
 	if curTimestamp <= blockTimestamp {
 		return consensus.fallbackNextViewID()
 	}
-	// diff only increases
-	diff := uint64((curTimestamp - blockTimestamp) / viewChangeSlot)
+	// diff only increases, since view change timeout is shorter than
+	// view change slot now, we want to make sure diff is always greater than 0
+	diff := uint64((curTimestamp-blockTimestamp)/viewChangeSlot + 1)
 	nextViewID := diff + lastBlockViewID
 
 	consensus.getLogger().Info().


### PR DESCRIPTION
Signed-off-by: Leo Chen <leo@harmony.one>