### PR TITLE
[node.sh] return ipv4 address only

### DIFF
--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -56,7 +56,7 @@ function valid_ip()
 
 function myip() {
 # get ipv4 address only, right now only support ipv4 addresses
-   PUB_IP=$(dig TXT +short o-o.myaddr.l.google.com @ns1.google.com | awk -F'"' '{ print $2}')
+   PUB_IP=$(dig -4 TXT +short o-o.myaddr.l.google.com @ns1.google.com | awk -F'"' '{ print $2}')
    if valid_ip $PUB_IP; then
       msg "public IP address autodetected: $PUB_IP"
    else


### PR DESCRIPTION
As reported by node runner, in case the host has an ipv6 address and the ipv6 address will failure the script checking.

Signed-off-by: Leo Chen <leo@harmony.one>
