### PR TITLE
make commit sig timeout longer, also return early for onCommit

### DIFF
--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -32,10 +32,10 @@ var (
 // timeout constant
 const (
 	// CommitSigSenderTimeout is the timeout for sending the commit sig to finish block proposal
-	CommitSigSenderTimeout = 6 * time.Second
+	CommitSigSenderTimeout = 10 * time.Second
 	// CommitSigReceiverTimeout is the timeout for the receiving side of the commit sig
 	// if timeout, the receiver should instead ready directly from db for the commit sig
-	CommitSigReceiverTimeout = 4 * time.Second
+	CommitSigReceiverTimeout = 8 * time.Second
 )
 
 // IsViewChangingMode return true if curernt mode is viewchanging

--- a/internal/chain/reward.go
+++ b/internal/chain/reward.go
@@ -31,7 +31,7 @@ import (
 // timeout constant
 const (
 	// AsyncBlockProposalTimeout is the timeout which will abort the async block proposal.
-	AsyncBlockProposalTimeout = 5 * time.Second
+	AsyncBlockProposalTimeout = 9 * time.Second
 )
 
 func ballotResultBeaconchain(


### PR DESCRIPTION
When the leader is slow, the commit sig timeout is too short and it will just read from the 67% sig for next block. Better make the timeout longer so most of the signers can get into the new block.

Also return early to avoid expensive signature related computation for onCommit.