### PR TITLE
[consensus] add remove fbft log in commitBlock on leader node.

### DIFF
--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -1044,7 +1044,6 @@ func (ss *StateSync) addConsensusLastMile(bc *core.BlockChain, consensus *consen
 			return errors.Wrap(err, "failed to InsertChain")
 		}
 	}
-	consensus.FBFTLog.PruneCacheBeforeBlock(bc.CurrentBlock().NumberU64())
 	return nil
 }
 

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -157,6 +157,8 @@ func (consensus *Consensus) finalCommit() {
 		return
 	}
 
+	consensus.FBFTLog.PruneCacheBeforeBlock(block.NumberU64())
+
 	// if leader successfully finalizes the block, send committed message to validators
 	// Note: leader already sent 67% commit in preCommit. The 100% commit won't be sent immediately
 	// to save network traffic. It will only be sent in retry if consensus doesn't move forward.

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -660,7 +660,6 @@ func (consensus *Consensus) postCatchup(initBN uint64) {
 		consensus.current.SetMode(Normal)
 		consensus.consensusTimeout[timeoutViewChange].Stop()
 	}
-	// clean up old log
 }
 
 // GenerateVrfAndProof generates new VRF/Proof from hash of previous block

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -157,8 +157,6 @@ func (consensus *Consensus) finalCommit() {
 		return
 	}
 
-	consensus.FBFTLog.PruneCacheBeforeBlock(block.NumberU64())
-
 	// if leader successfully finalizes the block, send committed message to validators
 	// Note: leader already sent 67% commit in preCommit. The 100% commit won't be sent immediately
 	// to save network traffic. It will only be sent in retry if consensus doesn't move forward.
@@ -645,6 +643,7 @@ func (consensus *Consensus) SetupForNewConsensus(blk *types.Block, committedMsg 
 	if blk.IsLastBlockInEpoch() {
 		consensus.SetMode(consensus.UpdateConsensusInformation())
 	}
+	consensus.FBFTLog.PruneCacheBeforeBlock(blk.NumberU64())
 	consensus.ResetState()
 }
 
@@ -662,7 +661,6 @@ func (consensus *Consensus) postCatchup(initBN uint64) {
 		consensus.consensusTimeout[timeoutViewChange].Stop()
 	}
 	// clean up old log
-	consensus.FBFTLog.PruneCacheBeforeBlock(consensus.blockNum)
 }
 
 // GenerateVrfAndProof generates new VRF/Proof from hash of previous block


### PR DESCRIPTION
## Issue

Currently, FBFTLog method might take extensive CPU resource:

![Screen Shot 2020-11-15 at 9 36 42 PM](https://user-images.githubusercontent.com/40162696/99216495-a90b6b00-278a-11eb-88d8-0e6f50cbdbf4.png)

The reason why this happens is that the look up mechanism is actually iterating over the FBFT log entries. And for leader nodes, currently there is no logic taking care of removing fbft log messages after commit. This PR add removing FBFT message logic after successfully committed for leader node.