### PR TITLE
not return early for block proposal

### DIFF
--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -157,7 +157,6 @@ func (consensus *Consensus) finalCommit() {
 		consensus.getLogger().Err(err).
 			Uint64("beforeCatchupBlockNum", beforeCatchupNum).
 			Msg("[finalCommit] Leader failed to commit the confirmed block")
-		return
 	}
 
 	// if leader successfully finalizes the block, send committed message to validators


### PR DESCRIPTION
just in case something weird happened in the leader logic, it should still try propose new blocks. As long as validators still verify the blocks and messages. It doesn't hurt to try move forward optimisitically.