### PR TITLE
Separate archival configuration for beacon chain and shard chain

### DIFF
--- a/cmd/harmony/config.go
+++ b/cmd/harmony/config.go
@@ -52,12 +52,13 @@ type p2pConfig struct {
 }
 
 type generalConfig struct {
-	NodeType   string
-	NoStaking  bool
-	ShardID    int
-	IsArchival bool
-	IsOffline  bool
-	DataDir    string
+	NodeType         string
+	NoStaking        bool
+	ShardID          int
+	IsArchival       bool
+	IsBeaconArchival bool
+	IsOffline        bool
+	DataDir          string
 }
 
 type consensusConfig struct {

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -11,12 +11,13 @@ const (
 var defaultConfig = harmonyConfig{
 	Version: tomlConfigVersion,
 	General: generalConfig{
-		NodeType:   "validator",
-		NoStaking:  false,
-		ShardID:    -1,
-		IsArchival: false,
-		IsOffline:  false,
-		DataDir:    "./",
+		NodeType:         "validator",
+		NoStaking:        false,
+		ShardID:          -1,
+		IsArchival:       false,
+		IsBeaconArchival: false,
+		IsOffline:        false,
+		DataDir:          "./",
 	},
 	Network: getDefaultNetworkConfig(defNetworkType),
 	P2P: p2pConfig{

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -15,6 +15,7 @@ var (
 		noStakingFlag,
 		shardIDFlag,
 		isArchiveFlag,
+		isBeaconArchiveFlag,
 		isOfflineFlag,
 		dataDirFlag,
 
@@ -197,6 +198,11 @@ var (
 		Usage:    "run node in archive mode",
 		DefValue: defaultConfig.General.IsArchival,
 	}
+	isBeaconArchiveFlag = cli.BoolFlag{
+		Name:     "run.beacon-archive",
+		Usage:    "beacon chain also in archival mode",
+		DefValue: defaultConfig.General.IsBeaconArchival,
+	}
 	isOfflineFlag = cli.BoolFlag{
 		Name:     "run.offline",
 		Usage:    "run node in offline mode",
@@ -291,6 +297,10 @@ func applyGeneralFlags(cmd *cobra.Command, config *harmonyConfig) {
 		config.General.IsArchival = cli.GetBoolFlagValue(cmd, isArchiveFlag)
 	} else if cli.IsFlagChanged(cmd, legacyIsArchiveFlag) {
 		config.General.IsArchival = cli.GetBoolFlagValue(cmd, legacyIsArchiveFlag)
+	}
+
+	if cli.IsFlagChanged(cmd, isBeaconArchiveFlag) {
+		config.General.IsBeaconArchival = cli.GetBoolFlagValue(cmd, isBeaconArchiveFlag)
 	}
 
 	if cli.IsFlagChanged(cmd, dataDirFlag) {

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -195,12 +195,12 @@ var (
 	}
 	isArchiveFlag = cli.BoolFlag{
 		Name:     "run.archive",
-		Usage:    "run node in archive mode",
+		Usage:    "run shard chain in archive mode",
 		DefValue: defaultConfig.General.IsArchival,
 	}
 	isBeaconArchiveFlag = cli.BoolFlag{
 		Name:     "run.beacon-archive",
-		Usage:    "beacon chain also in archival mode",
+		Usage:    "run beacon chain in archive mode",
 		DefValue: defaultConfig.General.IsBeaconArchival,
 	}
 	isOfflineFlag = cli.BoolFlag{

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -616,7 +616,7 @@ func setupConsensusAndNode(hc harmonyConfig, nodeConfig *nodeconfig.ConfigType) 
 	// Current node.
 	chainDBFactory := &shardchain.LDBFactory{RootDir: nodeConfig.DBDir}
 
-	currentNode := node.New(myHost, currentConsensus, chainDBFactory, blacklist, nodeConfig.IsArchival())
+	currentNode := node.New(myHost, currentConsensus, chainDBFactory, blacklist, nodeConfig.ArchiveModes())
 
 	if hc.Legacy != nil && hc.Legacy.TPBroadcastInvalidTxn != nil {
 		currentNode.BroadcastInvalidTx = *hc.Legacy.TPBroadcastInvalidTxn

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -534,8 +534,9 @@ func createGlobalConfig(hc harmonyConfig) (*nodeconfig.ConfigType, error) {
 
 	// Set network type
 	netType := nodeconfig.NetworkType(hc.Network.NetworkType)
-	nodeconfig.SetNetworkType(netType) // sets for both global and shard configs
-	nodeConfig.SetArchival(hc.General.IsArchival)
+	nodeconfig.SetNetworkType(netType)                // sets for both global and shard configs
+	nodeConfig.SetShardID(initialAccounts[0].ShardID) // sets shard ID
+	nodeConfig.SetArchival(hc.General.IsBeaconArchival, hc.General.IsArchival)
 	nodeConfig.IsOffline = hc.General.IsOffline
 
 	// P2P private key is used for secure message transfer between p2p nodes.
@@ -615,7 +616,7 @@ func setupConsensusAndNode(hc harmonyConfig, nodeConfig *nodeconfig.ConfigType) 
 	// Current node.
 	chainDBFactory := &shardchain.LDBFactory{RootDir: nodeConfig.DBDir}
 
-	currentNode := node.New(myHost, currentConsensus, chainDBFactory, blacklist, hc.General.IsArchival)
+	currentNode := node.New(myHost, currentConsensus, chainDBFactory, blacklist, nodeConfig.IsArchival())
 
 	if hc.Legacy != nil && hc.Legacy.TPBroadcastInvalidTxn != nil {
 		currentNode.BroadcastInvalidTx = *hc.Legacy.TPBroadcastInvalidTxn

--- a/hmy/hmy.go
+++ b/hmy/hmy.go
@@ -164,8 +164,8 @@ func (hmy *Harmony) IsLeader() bool {
 
 // GetNodeMetadata ..
 func (hmy *Harmony) GetNodeMetadata() commonRPC.NodeMetadata {
-	cfg := nodeconfig.GetDefaultConfig()
 	header := hmy.CurrentBlock().Header()
+	cfg := nodeconfig.GetShardConfig(header.ShardID())
 	var blockEpoch *uint64
 
 	if header.ShardID() == shard.BeaconChainShardID {

--- a/internal/configs/node/config.go
+++ b/internal/configs/node/config.go
@@ -229,8 +229,8 @@ func (conf *ConfigType) SetArchival(bcArchival, archival bool) {
 	conf.isArchival[conf.ShardID] = archival
 }
 
-// IsArchival return the isArchival map
-func (conf *ConfigType) IsArchival() map[uint32]bool {
+// ArchiveModes return the map of the archive setting
+func (conf *ConfigType) ArchiveModes() map[uint32]bool {
 	return conf.isArchival
 }
 

--- a/internal/shardchain/shardchains.go
+++ b/internal/shardchain/shardchains.go
@@ -50,11 +50,12 @@ func NewCollection(
 	chainConfig *params.ChainConfig,
 ) *CollectionImpl {
 	return &CollectionImpl{
-		dbFactory:   dbFactory,
-		dbInit:      dbInit,
-		engine:      engine,
-		pool:        make(map[uint32]*core.BlockChain),
-		chainConfig: chainConfig,
+		dbFactory:    dbFactory,
+		dbInit:       dbInit,
+		engine:       engine,
+		pool:         make(map[uint32]*core.BlockChain),
+		disableCache: make(map[uint32]bool),
+		chainConfig:  chainConfig,
 	}
 }
 

--- a/internal/shardchain/shardchains.go
+++ b/internal/shardchain/shardchains.go
@@ -35,7 +35,7 @@ type CollectionImpl struct {
 	engine       engine.Engine
 	mtx          sync.Mutex
 	pool         map[uint32]*core.BlockChain
-	disableCache bool
+	disableCache map[uint32]bool
 	chainConfig  *params.ChainConfig
 }
 
@@ -88,8 +88,11 @@ func (sc *CollectionImpl) ShardChain(shardID uint32) (*core.BlockChain, error) {
 		}
 	}
 	var cacheConfig *core.CacheConfig
-	if sc.disableCache {
+	if sc.disableCache[shardID] {
 		cacheConfig = &core.CacheConfig{Disabled: true}
+		utils.Logger().Info().
+			Uint32("shardID", shardID).
+			Msg("disable cache, running in archival mode")
 	}
 
 	bc, err := core.NewBlockChain(
@@ -106,8 +109,11 @@ func (sc *CollectionImpl) ShardChain(shardID uint32) (*core.BlockChain, error) {
 // DisableCache disables caching mode for newly opened chains.
 // It does not affect already open chains.  For best effect,
 // use this immediately after creating collection.
-func (sc *CollectionImpl) DisableCache() {
-	sc.disableCache = true
+func (sc *CollectionImpl) DisableCache(shardID uint32) {
+	if sc.disableCache == nil {
+		sc.disableCache = make(map[uint32]bool)
+	}
+	sc.disableCache[shardID] = true
 }
 
 // CloseShardChain closes the given shard chain.

--- a/node/node.go
+++ b/node/node.go
@@ -870,7 +870,7 @@ func New(
 	consensusObj *consensus.Consensus,
 	chainDBFactory shardchain.DBFactory,
 	blacklist map[common.Address]struct{},
-	isArchival bool,
+	isArchival map[uint32]bool,
 ) *Node {
 	node := Node{}
 	node.unixTimeAtNodeStart = time.Now().Unix()
@@ -895,8 +895,11 @@ func New(
 	collection := shardchain.NewCollection(
 		chainDBFactory, &genesisInitializer{&node}, chain.Engine, &chainConfig,
 	)
-	if isArchival {
-		collection.DisableCache()
+
+	for shardID, archival := range isArchival {
+		if archival {
+			collection.DisableCache(shardID)
+		}
 	}
 	node.shardChains = collection
 	node.IsInSync = abool.NewBool(false)

--- a/node/node_handler_test.go
+++ b/node/node_handler_test.go
@@ -35,7 +35,7 @@ func TestAddNewBlock(t *testing.T) {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
 	nodeconfig.SetNetworkType(nodeconfig.Devnet)
-	node := New(host, consensus, testDBFactory, nil, false)
+	node := New(host, consensus, testDBFactory, nil, nil)
 
 	txs := make(map[common.Address]types.Transactions)
 	stks := staking.StakingTransactions{}
@@ -78,7 +78,10 @@ func TestVerifyNewBlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
-	node := New(host, consensus, testDBFactory, nil, false)
+	archiveMode := make(map[uint32]bool)
+	archiveMode[0] = true
+	archiveMode[1] = false
+	node := New(host, consensus, testDBFactory, nil, archiveMode)
 
 	txs := make(map[common.Address]types.Transactions)
 	stks := staking.StakingTransactions{}

--- a/node/node_newblock_test.go
+++ b/node/node_newblock_test.go
@@ -37,7 +37,7 @@ func TestFinalizeNewBlockAsync(t *testing.T) {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
 	var testDBFactory = &shardchain.MemDBFactory{}
-	node := New(host, consensus, testDBFactory, nil, false)
+	node := New(host, consensus, testDBFactory, nil, nil)
 
 	node.Worker.UpdateCurrent()
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -36,7 +36,7 @@ func TestNewNode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
-	node := New(host, consensus, testDBFactory, nil, false)
+	node := New(host, consensus, testDBFactory, nil, nil)
 	if node.Consensus == nil {
 		t.Error("Consensus is not initialized for the node")
 	}
@@ -207,7 +207,10 @@ func TestAddBeaconPeer(t *testing.T) {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
 
-	node := New(host, consensus, testDBFactory, nil, false)
+	archiveMode := make(map[uint32]bool)
+	archiveMode[0] = true
+	archiveMode[1] = false
+	node := New(host, consensus, testDBFactory, nil, archiveMode)
 	for _, p := range peers1 {
 		ret := node.AddBeaconPeer(p)
 		if ret {

--- a/rosetta/rosetta.go
+++ b/rosetta/rosetta.go
@@ -36,7 +36,7 @@ func StartServers(hmy *hmy.Harmony, config nodeconfig.RosettaServerConfig) error
 	}
 	serverAsserter, err := asserter.NewServer(
 		append(common.PlainOperationTypes, common.StakingOperationTypes...),
-		nodeconfig.GetDefaultConfig().Role() == nodeconfig.ExplorerNode,
+		nodeconfig.GetShardConfig(hmy.ShardID).Role() == nodeconfig.ExplorerNode,
 		[]*types.NetworkIdentifier{network},
 	)
 	if err != nil {

--- a/rosetta/services/network.go
+++ b/rosetta/services/network.go
@@ -98,7 +98,7 @@ func (s *NetworkAPI) NetworkStatus(
 
 	// Only applicable to non-archival nodes
 	var oldestBlockIdentifier *types.BlockIdentifier
-	if !nodeconfig.GetDefaultConfig().GetArchival() {
+	if !nodeconfig.GetShardConfig(s.hmy.ShardID).GetArchival() {
 		maxGarbCollectedBlockNum := s.hmy.BlockChain.GetMaxGarbageCollectedBlockNumber()
 		if maxGarbCollectedBlockNum == -1 || maxGarbCollectedBlockNum >= currentHeader.Number().Int64() {
 			oldestBlockIdentifier = currentBlockIdentifier
@@ -143,7 +143,7 @@ func (s *NetworkAPI) NetworkOptions(
 
 	// Fetch allows based on current network option
 	var allow *types.Allow
-	isArchival := nodeconfig.GetDefaultConfig().GetArchival()
+	isArchival := nodeconfig.GetShardConfig(s.hmy.ShardID).GetArchival()
 	if s.hmy.ShardID == shard.BeaconChainShardID {
 		allow = getBeaconAllow(isArchival)
 	} else {


### PR DESCRIPTION
We used to use one `run.archive` flag to represent the archival mode for both beacon chain and shard chain.

This PR separates the archival configuration for beacon chain and shard chain.
By default, the beacon chain is not in archival mode, which is not necessary even for explorer node on shard chain.

This change can save a lot of disk space on the explorer node for shard chain.