### PR TITLE
[Rosetta] Track internal transactions 

### DIFF
--- a/core/vm/gen_structlog.go
+++ b/core/vm/gen_structlog.go
@@ -16,27 +16,27 @@ var _ = (*structLogMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (s StructLog) MarshalJSON() ([]byte, error) {
 	type StructLog struct {
-		Pc            uint64                      `json:"pc"`
-		Op            OpCode                      `json:"op"`
-		CallerAddress common.Address              `json:"callerAddress"`
-		CodeAddress   *common.Address             `json:"codeAddress"`
-		Gas           math.HexOrDecimal64         `json:"gas"`
-		GasCost       math.HexOrDecimal64         `json:"gasCost"`
-		Memory        hexutil.Bytes               `json:"memory"`
-		MemorySize    int                         `json:"memSize"`
-		Stack         []*math.HexOrDecimal256     `json:"stack"`
-		Storage       map[common.Hash]common.Hash `json:"-"`
-		Depth         int                         `json:"depth"`
-		RefundCounter uint64                      `json:"refund"`
-		Err           error                       `json:"-"`
-		OpName        string                      `json:"opName"`
-		ErrorString   string                      `json:"error"`
+		Pc              uint64                      `json:"pc"`
+		Op              OpCode                      `json:"op"`
+		CallerAddress   common.Address              `json:"callerAddress"`
+		ContractAddress common.Address              `json:"contractAddress"`
+		Gas             math.HexOrDecimal64         `json:"gas"`
+		GasCost         math.HexOrDecimal64         `json:"gasCost"`
+		Memory          hexutil.Bytes               `json:"memory"`
+		MemorySize      int                         `json:"memSize"`
+		Stack           []*math.HexOrDecimal256     `json:"stack"`
+		Storage         map[common.Hash]common.Hash `json:"-"`
+		Depth           int                         `json:"depth"`
+		RefundCounter   uint64                      `json:"refund"`
+		Err             error                       `json:"-"`
+		OpName          string                      `json:"opName"`
+		ErrorString     string                      `json:"error"`
 	}
 	var enc StructLog
 	enc.Pc = s.Pc
 	enc.Op = s.Op
 	enc.CallerAddress = s.CallerAddress
-	enc.CodeAddress = s.CodeAddress
+	enc.ContractAddress = s.ContractAddress
 	enc.Gas = math.HexOrDecimal64(s.Gas)
 	enc.GasCost = math.HexOrDecimal64(s.GasCost)
 	enc.Memory = s.Memory
@@ -59,19 +59,19 @@ func (s StructLog) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON unmarshals from JSON.
 func (s *StructLog) UnmarshalJSON(input []byte) error {
 	type StructLog struct {
-		Pc            *uint64                     `json:"pc"`
-		Op            *OpCode                     `json:"op"`
-		CallerAddress *common.Address             `json:"callerAddress"`
-		CodeAddress   *common.Address             `json:"codeAddress"`
-		Gas           *math.HexOrDecimal64        `json:"gas"`
-		GasCost       *math.HexOrDecimal64        `json:"gasCost"`
-		Memory        *hexutil.Bytes              `json:"memory"`
-		MemorySize    *int                        `json:"memSize"`
-		Stack         []*math.HexOrDecimal256     `json:"stack"`
-		Storage       map[common.Hash]common.Hash `json:"-"`
-		Depth         *int                        `json:"depth"`
-		RefundCounter *uint64                     `json:"refund"`
-		Err           error                       `json:"-"`
+		Pc              *uint64                     `json:"pc"`
+		Op              *OpCode                     `json:"op"`
+		CallerAddress   *common.Address             `json:"callerAddress"`
+		ContractAddress *common.Address             `json:"contractAddress"`
+		Gas             *math.HexOrDecimal64        `json:"gas"`
+		GasCost         *math.HexOrDecimal64        `json:"gasCost"`
+		Memory          *hexutil.Bytes              `json:"memory"`
+		MemorySize      *int                        `json:"memSize"`
+		Stack           []*math.HexOrDecimal256     `json:"stack"`
+		Storage         map[common.Hash]common.Hash `json:"-"`
+		Depth           *int                        `json:"depth"`
+		RefundCounter   *uint64                     `json:"refund"`
+		Err             error                       `json:"-"`
 	}
 	var dec StructLog
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -86,8 +86,8 @@ func (s *StructLog) UnmarshalJSON(input []byte) error {
 	if dec.CallerAddress != nil {
 		s.CallerAddress = *dec.CallerAddress
 	}
-	if dec.CodeAddress != nil {
-		s.CodeAddress = dec.CodeAddress
+	if dec.ContractAddress != nil {
+		s.ContractAddress = *dec.ContractAddress
 	}
 	if dec.Gas != nil {
 		s.Gas = uint64(*dec.Gas)

--- a/core/vm/gen_structlog.go
+++ b/core/vm/gen_structlog.go
@@ -18,6 +18,8 @@ func (s StructLog) MarshalJSON() ([]byte, error) {
 	type StructLog struct {
 		Pc            uint64                      `json:"pc"`
 		Op            OpCode                      `json:"op"`
+		CallerAddress common.Address              `json:"callerAddress"`
+		CodeAddress   *common.Address             `json:"codeAddress"`
 		Gas           math.HexOrDecimal64         `json:"gas"`
 		GasCost       math.HexOrDecimal64         `json:"gasCost"`
 		Memory        hexutil.Bytes               `json:"memory"`
@@ -33,6 +35,8 @@ func (s StructLog) MarshalJSON() ([]byte, error) {
 	var enc StructLog
 	enc.Pc = s.Pc
 	enc.Op = s.Op
+	enc.CallerAddress = s.CallerAddress
+	enc.CodeAddress = s.CodeAddress
 	enc.Gas = math.HexOrDecimal64(s.Gas)
 	enc.GasCost = math.HexOrDecimal64(s.GasCost)
 	enc.Memory = s.Memory
@@ -57,6 +61,8 @@ func (s *StructLog) UnmarshalJSON(input []byte) error {
 	type StructLog struct {
 		Pc            *uint64                     `json:"pc"`
 		Op            *OpCode                     `json:"op"`
+		CallerAddress *common.Address             `json:"callerAddress"`
+		CodeAddress   *common.Address             `json:"codeAddress"`
 		Gas           *math.HexOrDecimal64        `json:"gas"`
 		GasCost       *math.HexOrDecimal64        `json:"gasCost"`
 		Memory        *hexutil.Bytes              `json:"memory"`
@@ -76,6 +82,12 @@ func (s *StructLog) UnmarshalJSON(input []byte) error {
 	}
 	if dec.Op != nil {
 		s.Op = *dec.Op
+	}
+	if dec.CallerAddress != nil {
+		s.CallerAddress = *dec.CallerAddress
+	}
+	if dec.CodeAddress != nil {
+		s.CodeAddress = dec.CodeAddress
 	}
 	if dec.Gas != nil {
 		s.Gas = uint64(*dec.Gas)

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -58,6 +58,8 @@ type LogConfig struct {
 type StructLog struct {
 	Pc            uint64                      `json:"pc"`
 	Op            OpCode                      `json:"op"`
+	CallerAddress common.Address              `json:"callerAddress"`
+	CodeAddress   *common.Address             `json:"codeAddress"`
 	Gas           uint64                      `json:"gas"`
 	GasCost       uint64                      `json:"gasCost"`
 	Memory        []byte                      `json:"memory"`
@@ -178,7 +180,7 @@ func (l *StructLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost ui
 		storage = l.changedValues[contract.Address()].Copy()
 	}
 	// create a new snapshot of the EVM.
-	log := StructLog{pc, op, gas, cost, mem, memory.Len(), stck, storage, depth, env.StateDB.GetRefund(), err}
+	log := StructLog{pc, op, contract.CallerAddress, contract.CodeAddr, gas, cost, mem, memory.Len(), stck, storage, depth, env.StateDB.GetRefund(), err}
 
 	l.logs = append(l.logs, log)
 	return nil

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -56,19 +56,19 @@ type LogConfig struct {
 // StructLog is emitted to the EVM each cycle and lists information about the current internal state
 // prior to the execution of the statement.
 type StructLog struct {
-	Pc            uint64                      `json:"pc"`
-	Op            OpCode                      `json:"op"`
-	CallerAddress common.Address              `json:"callerAddress"`
-	CodeAddress   *common.Address             `json:"codeAddress"`
-	Gas           uint64                      `json:"gas"`
-	GasCost       uint64                      `json:"gasCost"`
-	Memory        []byte                      `json:"memory"`
-	MemorySize    int                         `json:"memSize"`
-	Stack         []*big.Int                  `json:"stack"`
-	Storage       map[common.Hash]common.Hash `json:"-"`
-	Depth         int                         `json:"depth"`
-	RefundCounter uint64                      `json:"refund"`
-	Err           error                       `json:"-"`
+	Pc              uint64                      `json:"pc"`
+	Op              OpCode                      `json:"op"`
+	CallerAddress   common.Address              `json:"callerAddress"`
+	ContractAddress common.Address              `json:"contractAddress"`
+	Gas             uint64                      `json:"gas"`
+	GasCost         uint64                      `json:"gasCost"`
+	Memory          []byte                      `json:"memory"`
+	MemorySize      int                         `json:"memSize"`
+	Stack           []*big.Int                  `json:"stack"`
+	Storage         map[common.Hash]common.Hash `json:"-"`
+	Depth           int                         `json:"depth"`
+	RefundCounter   uint64                      `json:"refund"`
+	Err             error                       `json:"-"`
 }
 
 // overrides for gencodec
@@ -180,7 +180,7 @@ func (l *StructLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost ui
 		storage = l.changedValues[contract.Address()].Copy()
 	}
 	// create a new snapshot of the EVM.
-	log := StructLog{pc, op, contract.CallerAddress, contract.CodeAddr, gas, cost, mem, memory.Len(), stck, storage, depth, env.StateDB.GetRefund(), err}
+	log := StructLog{pc, op, contract.CallerAddress, contract.Address(), gas, cost, mem, memory.Len(), stck, storage, depth, env.StateDB.GetRefund(), err}
 
 	l.logs = append(l.logs, log)
 	return nil

--- a/core/vm/logger_json.go
+++ b/core/vm/logger_json.go
@@ -52,6 +52,8 @@ func (l *JSONLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost uint
 	log := StructLog{
 		Pc:            pc,
 		Op:            op,
+		CodeAddress:   contract.CodeAddr,
+		CallerAddress: contract.CallerAddress,
 		Gas:           gas,
 		GasCost:       cost,
 		MemorySize:    memory.Len(),

--- a/core/vm/logger_json.go
+++ b/core/vm/logger_json.go
@@ -50,17 +50,17 @@ func (l *JSONLogger) CaptureStart(from common.Address, to common.Address, create
 // CaptureState outputs state information on the logger.
 func (l *JSONLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost uint64, memory *Memory, stack *Stack, contract *Contract, depth int, err error) error {
 	log := StructLog{
-		Pc:            pc,
-		Op:            op,
-		CodeAddress:   contract.CodeAddr,
-		CallerAddress: contract.CallerAddress,
-		Gas:           gas,
-		GasCost:       cost,
-		MemorySize:    memory.Len(),
-		Storage:       nil,
-		Depth:         depth,
-		RefundCounter: env.StateDB.GetRefund(),
-		Err:           err,
+		Pc:              pc,
+		Op:              op,
+		ContractAddress: contract.Address(),
+		CallerAddress:   contract.CallerAddress,
+		Gas:             gas,
+		GasCost:         cost,
+		MemorySize:      memory.Len(),
+		Storage:         nil,
+		Depth:           depth,
+		RefundCounter:   env.StateDB.GetRefund(),
+		Err:             err,
 	}
 	if !l.cfg.DisableMemory {
 		log.Memory = memory.Data()

--- a/hmy/tracer.go
+++ b/hmy/tracer.go
@@ -719,17 +719,17 @@ type ExecutionResult struct {
 // StructLogRes stores a structured log emitted by the EVM while replaying a
 // transaction in debug mode
 type StructLogRes struct {
-	Pc            uint64             `json:"pc"`
-	Op            string             `json:"op"`
-	CallerAddress common.Address     `json:"callerAddress"`
-	CodeAddress   *common.Address    `json:"codeAddress"`
-	Gas           uint64             `json:"gas"`
-	GasCost       uint64             `json:"gasCost"`
-	Depth         int                `json:"depth"`
-	Error         error              `json:"error,omitempty"`
-	Stack         *[]string          `json:"stack,omitempty"`
-	Memory        *[]string          `json:"memory,omitempty"`
-	Storage       *map[string]string `json:"storage,omitempty"`
+	Pc            uint64            `json:"pc"`
+	Op            string            `json:"op"`
+	CallerAddress common.Address    `json:"callerAddress"`
+	CodeAddress   *common.Address   `json:"codeAddress"`
+	Gas           uint64            `json:"gas"`
+	GasCost       uint64            `json:"gasCost"`
+	Depth         int               `json:"depth"`
+	Error         error             `json:"error,omitempty"`
+	Stack         []string          `json:"stack,omitempty"`
+	Memory        []string          `json:"memory,omitempty"`
+	Storage       map[string]string `json:"storage,omitempty"`
 }
 
 // FormatLogs formats EVM returned structured logs for json output
@@ -751,21 +751,21 @@ func FormatLogs(logs []vm.StructLog) []StructLogRes {
 			for i, stackValue := range trace.Stack {
 				stack[i] = fmt.Sprintf("%x", math.PaddedBigBytes(stackValue, 32))
 			}
-			formatted[index].Stack = &stack
+			formatted[index].Stack = stack
 		}
 		if trace.Memory != nil {
 			memory := make([]string, 0, (len(trace.Memory)+31)/32)
 			for i := 0; i+32 <= len(trace.Memory); i += 32 {
 				memory = append(memory, fmt.Sprintf("%x", trace.Memory[i:i+32]))
 			}
-			formatted[index].Memory = &memory
+			formatted[index].Memory = memory
 		}
 		if trace.Storage != nil {
 			storage := make(map[string]string)
 			for i, storageValue := range trace.Storage {
 				storage[fmt.Sprintf("%x", i)] = fmt.Sprintf("%x", storageValue)
 			}
-			formatted[index].Storage = &storage
+			formatted[index].Storage = storage
 		}
 	}
 	return formatted

--- a/hmy/tracer.go
+++ b/hmy/tracer.go
@@ -719,15 +719,17 @@ type ExecutionResult struct {
 // StructLogRes stores a structured log emitted by the EVM while replaying a
 // transaction in debug mode
 type StructLogRes struct {
-	Pc      uint64             `json:"pc"`
-	Op      string             `json:"op"`
-	Gas     uint64             `json:"gas"`
-	GasCost uint64             `json:"gasCost"`
-	Depth   int                `json:"depth"`
-	Error   error              `json:"error,omitempty"`
-	Stack   *[]string          `json:"stack,omitempty"`
-	Memory  *[]string          `jsogun:"memory,omitempty"`
-	Storage *map[string]string `json:"storage,omitempty"`
+	Pc            uint64             `json:"pc"`
+	Op            string             `json:"op"`
+	CallerAddress common.Address     `json:"callerAddress"`
+	CodeAddress   *common.Address    `json:"codeAddress"`
+	Gas           uint64             `json:"gas"`
+	GasCost       uint64             `json:"gasCost"`
+	Depth         int                `json:"depth"`
+	Error         error              `json:"error,omitempty"`
+	Stack         *[]string          `json:"stack,omitempty"`
+	Memory        *[]string          `json:"memory,omitempty"`
+	Storage       *map[string]string `json:"storage,omitempty"`
 }
 
 // FormatLogs formats EVM returned structured logs for json output
@@ -735,12 +737,14 @@ func FormatLogs(logs []vm.StructLog) []StructLogRes {
 	formatted := make([]StructLogRes, len(logs))
 	for index, trace := range logs {
 		formatted[index] = StructLogRes{
-			Pc:      trace.Pc,
-			Op:      trace.Op.String(),
-			Gas:     trace.Gas,
-			GasCost: trace.GasCost,
-			Depth:   trace.Depth,
-			Error:   trace.Err,
+			Pc:            trace.Pc,
+			Op:            trace.Op.String(),
+			CallerAddress: trace.CallerAddress,
+			CodeAddress:   trace.CodeAddress,
+			Gas:           trace.Gas,
+			GasCost:       trace.GasCost,
+			Depth:         trace.Depth,
+			Error:         trace.Err,
 		}
 		if trace.Stack != nil {
 			stack := make([]string, len(trace.Stack))

--- a/hmy/tracer.go
+++ b/hmy/tracer.go
@@ -719,17 +719,17 @@ type ExecutionResult struct {
 // StructLogRes stores a structured log emitted by the EVM while replaying a
 // transaction in debug mode
 type StructLogRes struct {
-	Pc            uint64            `json:"pc"`
-	Op            string            `json:"op"`
-	CallerAddress common.Address    `json:"callerAddress"`
-	CodeAddress   *common.Address   `json:"codeAddress"`
-	Gas           uint64            `json:"gas"`
-	GasCost       uint64            `json:"gasCost"`
-	Depth         int               `json:"depth"`
-	Error         error             `json:"error,omitempty"`
-	Stack         []string          `json:"stack,omitempty"`
-	Memory        []string          `json:"memory,omitempty"`
-	Storage       map[string]string `json:"storage,omitempty"`
+	Pc              uint64            `json:"pc"`
+	Op              string            `json:"op"`
+	CallerAddress   common.Address    `json:"callerAddress"`
+	ContractAddress common.Address    `json:"contractAddress"`
+	Gas             uint64            `json:"gas"`
+	GasCost         uint64            `json:"gasCost"`
+	Depth           int               `json:"depth"`
+	Error           error             `json:"error,omitempty"`
+	Stack           []string          `json:"stack,omitempty"`
+	Memory          []string          `json:"memory,omitempty"`
+	Storage         map[string]string `json:"storage,omitempty"`
 }
 
 // FormatLogs formats EVM returned structured logs for json output
@@ -737,14 +737,14 @@ func FormatLogs(logs []vm.StructLog) []StructLogRes {
 	formatted := make([]StructLogRes, len(logs))
 	for index, trace := range logs {
 		formatted[index] = StructLogRes{
-			Pc:            trace.Pc,
-			Op:            trace.Op.String(),
-			CallerAddress: trace.CallerAddress,
-			CodeAddress:   trace.CodeAddress,
-			Gas:           trace.Gas,
-			GasCost:       trace.GasCost,
-			Depth:         trace.Depth,
-			Error:         trace.Err,
+			Pc:              trace.Pc,
+			Op:              trace.Op.String(),
+			CallerAddress:   trace.CallerAddress,
+			ContractAddress: trace.ContractAddress,
+			Gas:             trace.Gas,
+			GasCost:         trace.GasCost,
+			Depth:           trace.Depth,
+			Error:           trace.Err,
 		}
 		if trace.Stack != nil {
 			stack := make([]string, len(trace.Stack))

--- a/rosetta/common/operations.go
+++ b/rosetta/common/operations.go
@@ -10,18 +10,19 @@ import (
 	staking "github.com/harmony-one/harmony/staking/types"
 )
 
+// Invariant: A transaction can only contain 1 type of native operation(s) other than gas expenditure & contract creation.
 const (
 	// ExpendGasOperation is an operation that only affects the native currency.
 	ExpendGasOperation = "Gas"
+
+	// ContractCreationOperation is an operation that only affects the native currency.
+	ContractCreationOperation = "ContractCreation"
 
 	// NativeTransferOperation is an operation that only affects the native currency.
 	NativeTransferOperation = "NativeTransfer"
 
 	// NativeCrossShardTransferOperation is an operation that only affects the native currency.
 	NativeCrossShardTransferOperation = "NativeCrossShardTransfer"
-
-	// ContractCreationOperation is an operation that only affects the native currency.
-	ContractCreationOperation = "ContractCreation"
 
 	// GenesisFundsOperation is a side effect operation for genesis block only.
 	// Note that no transaction can be constructed with this operation.

--- a/rosetta/common/operations.go
+++ b/rosetta/common/operations.go
@@ -10,7 +10,6 @@ import (
 	staking "github.com/harmony-one/harmony/staking/types"
 )
 
-// Invariant: A transaction can only contain 1 type of native operation(s) other than gas expenditure & contract creation.
 const (
 	// ExpendGasOperation is an operation that only affects the native currency.
 	ExpendGasOperation = "Gas"
@@ -56,6 +55,12 @@ var (
 		staking.DirectiveDelegate.String(),
 		staking.DirectiveUndelegate.String(),
 		staking.DirectiveCollectRewards.String(),
+	}
+
+	// MutuallyExclusiveOperations for invariant: A transaction can only contain 1 type of 'native' operation.
+	MutuallyExclusiveOperations = map[string]interface{}{
+		NativeTransferOperation:           struct{}{},
+		NativeCrossShardTransferOperation: struct{}{},
 	}
 )
 

--- a/rosetta/common/operations.go
+++ b/rosetta/common/operations.go
@@ -10,7 +10,6 @@ import (
 	staking "github.com/harmony-one/harmony/staking/types"
 )
 
-// Invariant: A transaction can only contain 1 type of native operation(s) other than gas expenditure.
 const (
 	// ExpendGasOperation is an operation that only affects the native currency.
 	ExpendGasOperation = "Gas"

--- a/rosetta/rosetta.go
+++ b/rosetta/rosetta.go
@@ -23,7 +23,7 @@ import (
 var listener net.Listener
 
 // StartServers starts the rosetta http server
-// TODO (dm): optimize rosetta to use single flight to avoid re-processing data
+// TODO (dm): optimize rosetta to use single flight & use extra caching type DB to avoid re-processing data
 func StartServers(hmy *hmy.Harmony, config nodeconfig.RosettaServerConfig) error {
 	if !config.HTTPEnabled {
 		utils.Logger().Info().Msg("Rosetta http server disabled...")

--- a/rosetta/services/block.go
+++ b/rosetta/services/block.go
@@ -173,7 +173,6 @@ func (s *BlockAPI) BlockTransaction(
 				contractInfo.ContractCode = state.GetCode(txInfo.receipt.ContractAddress)
 				contractInfo.ContractAddress = &txInfo.receipt.ContractAddress
 			}
-			// If there is tx data, check contract information for formatter
 			blk, rosettaError := getBlock(
 				ctx, s.hmy, &types.PartialBlockIdentifier{Hash: &request.BlockIdentifier.Hash},
 			)

--- a/rosetta/services/construction_parse.go
+++ b/rosetta/services/construction_parse.go
@@ -53,7 +53,9 @@ func parseUnsignedTransaction(
 	intendedReceipt := &hmyTypes.Receipt{
 		GasUsed: tx.Gas(),
 	}
-	formattedTx, rosettaError := FormatTransaction(tx, intendedReceipt, wrappedTransaction.ContractCode)
+	formattedTx, rosettaError := FormatTransaction(
+		tx, intendedReceipt, &ContractInfo{ContractCode: wrappedTransaction.ContractCode},
+	)
 	if rosettaError != nil {
 		return nil, rosettaError
 	}
@@ -94,7 +96,9 @@ func parseSignedTransaction(
 	intendedReceipt := &hmyTypes.Receipt{
 		GasUsed: tx.Gas(),
 	}
-	formattedTx, rosettaError := FormatTransaction(tx, intendedReceipt, wrappedTransaction.ContractCode)
+	formattedTx, rosettaError := FormatTransaction(
+		tx, intendedReceipt, &ContractInfo{ContractCode: wrappedTransaction.ContractCode},
+	)
 	if rosettaError != nil {
 		return nil, rosettaError
 	}

--- a/rosetta/services/construction_parse_test.go
+++ b/rosetta/services/construction_parse_test.go
@@ -38,7 +38,7 @@ func TestParseUnsignedTransaction(t *testing.T) {
 	refTestReceipt := &hmytypes.Receipt{
 		GasUsed: testTx.Gas(),
 	}
-	refFormattedTx, rosettaError := FormatTransaction(testTx, refTestReceipt, []byte{})
+	refFormattedTx, rosettaError := FormatTransaction(testTx, refTestReceipt, &ContractInfo{})
 	if rosettaError != nil {
 		t.Fatal(rosettaError)
 	}
@@ -101,7 +101,7 @@ func TestParseSignedTransaction(t *testing.T) {
 	refTestReceipt := &hmytypes.Receipt{
 		GasUsed: testTx.Gas(),
 	}
-	refFormattedTx, rosettaError := FormatTransaction(testTx, refTestReceipt, []byte{})
+	refFormattedTx, rosettaError := FormatTransaction(testTx, refTestReceipt, &ContractInfo{})
 	if rosettaError != nil {
 		t.Fatal(rosettaError)
 	}

--- a/rosetta/services/mempool.go
+++ b/rosetta/services/mempool.go
@@ -84,7 +84,7 @@ func (s *MempoolAPI) MempoolTransaction(
 		GasUsed:           poolTx.Gas(),
 	}
 
-	respTx, err := FormatTransaction(poolTx, estReceipt, []byte{})
+	respTx, err := FormatTransaction(poolTx, estReceipt, &ContractInfo{})
 	if err != nil {
 		return nil, err
 	}

--- a/rosetta/services/tx_format.go
+++ b/rosetta/services/tx_format.go
@@ -21,6 +21,9 @@ var (
 
 // ContractInfo contains all relevant data for formatting/inspecting transactions involving contracts
 type ContractInfo struct {
+	// ContractAddress is the address of the primary (or first) contract related to the tx.
+	ContractAddress *ethcommon.Address `json:"contract_hex_address"`
+	// ContractCode is the code of the primary (or first) contract related to the tx.
 	ContractCode    []byte               `json:"contract_code"`
 	ExecutionResult *hmy.ExecutionResult `json:"execution_result"`
 }
@@ -69,7 +72,7 @@ func FormatTransaction(
 			return nil, rosettaError
 		}
 		txMetadata.ContractAccountIdentifier = contractID
-	} else if len(contractInfo.ContractCode) > 0 && tx.To() != nil {
+	} else if contractInfo.ContractAddress != nil && len(contractInfo.ContractCode) > 0 {
 		// Contract code was found, so receiving account must be the contract address
 		contractID, rosettaError := newAccountIdentifier(*tx.To())
 		if rosettaError != nil {

--- a/rosetta/services/tx_format.go
+++ b/rosetta/services/tx_format.go
@@ -9,6 +9,7 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 
 	hmytypes "github.com/harmony-one/harmony/core/types"
+	"github.com/harmony-one/harmony/hmy"
 	"github.com/harmony-one/harmony/rosetta/common"
 	stakingTypes "github.com/harmony-one/harmony/staking/types"
 )
@@ -18,9 +19,15 @@ var (
 	FormatDefaultSenderAddress = ethcommon.HexToAddress("0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE")
 )
 
+// ContractInfo contains all relevant data for formatting/inspecting transactions involving contracts
+type ContractInfo struct {
+	ContractCode    []byte               `json:"contract_code"`
+	ExecutionResult *hmy.ExecutionResult `json:"execution_result"`
+}
+
 // FormatTransaction for staking, cross-shard sender, and plain transactions
 func FormatTransaction(
-	tx hmytypes.PoolTransaction, receipt *hmytypes.Receipt, contractCode []byte,
+	tx hmytypes.PoolTransaction, receipt *hmytypes.Receipt, contractInfo *ContractInfo,
 ) (fmtTx *types.Transaction, rosettaError *types.Error) {
 	var operations []*types.Operation
 	var isCrossShard, isStaking, isContractCreation bool
@@ -39,7 +46,7 @@ func FormatTransaction(
 	case *hmytypes.Transaction:
 		isStaking = false
 		plainTx := tx.(*hmytypes.Transaction)
-		operations, rosettaError = GetNativeOperationsFromTransaction(plainTx, receipt)
+		operations, rosettaError = GetNativeOperationsFromTransaction(plainTx, receipt, contractInfo)
 		if rosettaError != nil {
 			return nil, rosettaError
 		}
@@ -62,7 +69,7 @@ func FormatTransaction(
 			return nil, rosettaError
 		}
 		txMetadata.ContractAccountIdentifier = contractID
-	} else if len(contractCode) > 0 && tx.To() != nil {
+	} else if len(contractInfo.ContractCode) > 0 && tx.To() != nil {
 		// Contract code was found, so receiving account must be the contract address
 		contractID, rosettaError := newAccountIdentifier(*tx.To())
 		if rosettaError != nil {

--- a/rosetta/services/tx_format_test.go
+++ b/rosetta/services/tx_format_test.go
@@ -17,11 +17,10 @@ import (
 	"github.com/harmony-one/harmony/test/helpers"
 )
 
-// Invariant: A transaction can only contain 1 type of native operation(s) other than gas expenditure.
 func assertNativeOperationTypeUniquenessInvariant(operations []*types.Operation) error {
 	foundType := ""
 	for _, op := range operations {
-		if op.Type == common.ExpendGasOperation || op.Type == common.ContractCreationOperation {
+		if _, ok := common.MutuallyExclusiveOperations[op.Type]; !ok {
 			continue
 		}
 		if foundType == "" {

--- a/rosetta/services/tx_format_test.go
+++ b/rosetta/services/tx_format_test.go
@@ -79,7 +79,7 @@ func testFormatStakingTransaction(
 		Status:  hmytypes.ReceiptStatusSuccessful,
 		GasUsed: gasUsed,
 	}
-	rosettaTx, rosettaError := FormatTransaction(tx, receipt, []byte{})
+	rosettaTx, rosettaError := FormatTransaction(tx, receipt, &ContractInfo{})
 	if rosettaError != nil {
 		t.Fatal(rosettaError)
 	}
@@ -134,7 +134,7 @@ func testFormatPlainTransaction(
 		Status:  hmytypes.ReceiptStatusSuccessful,
 		GasUsed: gasUsed,
 	}
-	rosettaTx, rosettaError := FormatTransaction(tx, receipt, []byte{})
+	rosettaTx, rosettaError := FormatTransaction(tx, receipt, &ContractInfo{})
 	if rosettaError != nil {
 		t.Fatal(rosettaError)
 	}
@@ -191,7 +191,7 @@ func testFormatCrossShardSenderTransaction(
 		Status:  hmytypes.ReceiptStatusSuccessful,
 		GasUsed: gasUsed,
 	}
-	rosettaTx, rosettaError := FormatTransaction(tx, receipt, []byte{})
+	rosettaTx, rosettaError := FormatTransaction(tx, receipt, &ContractInfo{})
 	if rosettaError != nil {
 		t.Fatal(rosettaError)
 	}

--- a/rosetta/services/tx_format_test.go
+++ b/rosetta/services/tx_format_test.go
@@ -21,7 +21,7 @@ import (
 func assertNativeOperationTypeUniquenessInvariant(operations []*types.Operation) error {
 	foundType := ""
 	for _, op := range operations {
-		if op.Type == common.ExpendGasOperation {
+		if op.Type == common.ExpendGasOperation || op.Type == common.ContractCreationOperation {
 			continue
 		}
 		if foundType == "" {

--- a/rosetta/services/tx_operation.go
+++ b/rosetta/services/tx_operation.go
@@ -18,7 +18,7 @@ import (
 )
 
 // GetNativeOperationsFromTransaction for one of the following transactions:
-// contract creation, cross-shard sender, same-shard transfer.
+// contract creation, cross-shard sender, same-shard transfer with and without code execution.
 // Native operations only include operations that affect the native currency balance of an account.
 func GetNativeOperationsFromTransaction(
 	tx *hmytypes.Transaction, receipt *hmytypes.Receipt,
@@ -35,20 +35,21 @@ func GetNativeOperationsFromTransaction(
 	// All operations excepts for cross-shard tx payout expend gas
 	gasExpended := new(big.Int).Mul(new(big.Int).SetUint64(receipt.GasUsed), tx.GasPrice())
 	gasOperations := newNativeOperationsWithGas(gasExpended, accountID)
+	startingOpIndex := gasOperations[0].OperationIdentifier.Index + 1
 
-	// Handle different cases of plain transactions
+	// Handle based on tx type & available data.
 	var txOperations []*types.Operation
 	if tx.To() == nil {
-		txOperations, rosettaError = newContractCreationNativeOperations(
-			gasOperations[0].OperationIdentifier, tx, receipt, senderAddress,
+		txOperations, rosettaError = getContractCreationNativeOperations(
+			tx, receipt, senderAddress, &startingOpIndex,
 		)
 	} else if tx.ShardID() != tx.ToShardID() {
-		txOperations, rosettaError = newCrossShardSenderTransferNativeOperations(
-			gasOperations[0].OperationIdentifier, tx, senderAddress,
+		txOperations, rosettaError = getCrossShardSenderTransferNativeOperations(
+			tx, senderAddress, &startingOpIndex,
 		)
 	} else {
-		txOperations, rosettaError = newTransferNativeOperations(
-			gasOperations[0].OperationIdentifier, tx, receipt, senderAddress,
+		txOperations, rosettaError = getBasicSameShardTransferNativeOperations(
+			tx, receipt, senderAddress, tx.To(), &startingOpIndex,
 		)
 	}
 	if rosettaError != nil {
@@ -59,7 +60,7 @@ func GetNativeOperationsFromTransaction(
 }
 
 // GetNativeOperationsFromStakingTransaction for all staking directives
-// Note that only native operations can come from staking transactions.
+// Note that only native token operations can come from staking transactions.
 func GetNativeOperationsFromStakingTransaction(
 	tx *stakingTypes.StakingTransaction, receipt *hmytypes.Receipt,
 ) ([]*types.Operation, *types.Error) {
@@ -116,9 +117,6 @@ func GetNativeOperationsFromStakingTransaction(
 		OperationIdentifier: &types.OperationIdentifier{
 			Index: gasOperations[0].OperationIdentifier.Index + 1,
 		},
-		RelatedOperations: []*types.OperationIdentifier{
-			gasOperations[0].OperationIdentifier,
-		},
 		Type:     tx.StakingType().String(),
 		Status:   common.SuccessOperationStatus.Status,
 		Account:  accountID,
@@ -161,7 +159,109 @@ func GetSideEffectOperationsFromGenesisSpec(
 	)
 }
 
-// getSideEffectOperationsFromValueMap is a helper for side effect operation construction from a value map.
+// getBasicSameShardTransferNativeOperations extracts & formats the basic native operation(s) for plain transaction.
+// Note that this does NOT include any contract related transfers (i.e: internal transactions).
+func getBasicSameShardTransferNativeOperations(
+	tx *hmytypes.Transaction, receipt *hmytypes.Receipt, senderAddress ethcommon.Address, toAddress *ethcommon.Address,
+	startingOperationIndex *int64,
+) ([]*types.Operation, *types.Error) {
+	if toAddress == nil {
+		return nil, common.NewError(common.CatchAllError, nil)
+	}
+
+	// Common operation elements
+	status := common.SuccessOperationStatus.Status
+	if receipt.Status == hmytypes.ReceiptStatusFailed {
+		if len(tx.Data()) > 0 {
+			status = common.ContractFailureOperationStatus.Status
+		} else {
+			// Should never see a failed non-contract related transaction on chain
+			status = common.FailureOperationStatus.Status
+			utils.Logger().Warn().Msgf("Failed transaction on chain: %v", tx.Hash().String())
+		}
+	}
+	from, rosettaError := newAccountIdentifier(senderAddress)
+	if rosettaError != nil {
+		return nil, rosettaError
+	}
+	to, rosettaError := newAccountIdentifier(*toAddress)
+	if rosettaError != nil {
+		return nil, rosettaError
+	}
+
+	return newSameShardTransferNativeOperations(from, to, tx.Value(), status, startingOperationIndex), nil
+}
+
+// getContractCreationNativeOperations extracts & formats the native operation(s) for a contract creation tx
+func getContractCreationNativeOperations(
+	tx *hmytypes.Transaction, txReceipt *hmytypes.Receipt, senderAddress ethcommon.Address,
+	startingOperationIndex *int64,
+) ([]*types.Operation, *types.Error) {
+	operations, rosettaError := getBasicSameShardTransferNativeOperations(
+		tx, txReceipt, senderAddress, &txReceipt.ContractAddress, startingOperationIndex,
+	)
+	if rosettaError != nil {
+		return nil, rosettaError
+	}
+	for _, op := range operations {
+		op.Type = common.ContractCreationOperation
+	}
+
+	return operations, nil
+}
+
+// getCrossShardSenderTransferNativeOperations extracts & formats the native operation(s)
+// for cross-shard-tx on the sender's shard.
+func getCrossShardSenderTransferNativeOperations(
+	tx *hmytypes.Transaction, senderAddress ethcommon.Address,
+	startingOperationIndex *int64,
+) ([]*types.Operation, *types.Error) {
+	if tx.To() == nil {
+		return nil, common.NewError(common.CatchAllError, nil)
+	}
+	senderAccountID, rosettaError := newAccountIdentifier(senderAddress)
+	if rosettaError != nil {
+		return nil, rosettaError
+	}
+	receiverAccountID, rosettaError := newAccountIdentifier(*tx.To())
+	if rosettaError != nil {
+		return nil, rosettaError
+	}
+	metadata, err := types.MarshalMap(common.CrossShardTransactionOperationMetadata{
+		From: senderAccountID,
+		To:   receiverAccountID,
+	})
+	if err != nil {
+		return nil, common.NewError(common.CatchAllError, map[string]interface{}{
+			"message": err.Error(),
+		})
+	}
+
+	var opIndex int64
+	if startingOperationIndex != nil {
+		opIndex = *startingOperationIndex
+	} else {
+		opIndex = 0
+	}
+
+	return []*types.Operation{
+		{
+			OperationIdentifier: &types.OperationIdentifier{
+				Index: opIndex,
+			},
+			Type:    common.NativeCrossShardTransferOperation,
+			Status:  common.SuccessOperationStatus.Status,
+			Account: senderAccountID,
+			Amount: &types.Amount{
+				Value:    negativeBigValue(tx.Value()),
+				Currency: &common.NativeCurrency,
+			},
+			Metadata: metadata,
+		},
+	}, nil
+}
+
+// getSideEffectOperationsFromValueMap is a helper for side effect operation construction from a address to value map.
 func getSideEffectOperationsFromValueMap(
 	valueMap map[ethcommon.Address]*big.Int, opType string, startingOperationIndex *int64,
 ) ([]*types.Operation, *types.Error) {
@@ -263,159 +363,23 @@ func getAmountFromCollectRewards(
 	return amount, nil
 }
 
-// newTransferNativeOperations extracts & formats the native operation(s) for plain transaction,
-// including contract transactions.
-func newTransferNativeOperations(
-	startingOperationID *types.OperationIdentifier,
-	tx *hmytypes.Transaction, receipt *hmytypes.Receipt, senderAddress ethcommon.Address,
-) ([]*types.Operation, *types.Error) {
-	if tx.To() == nil {
-		return nil, common.NewError(common.CatchAllError, nil)
-	}
-	receiverAddress := *tx.To()
-
-	// Common elements
-	opType := common.NativeTransferOperation
-	opStatus := common.SuccessOperationStatus.Status
-	if receipt.Status == hmytypes.ReceiptStatusFailed {
-		if len(tx.Data()) > 0 {
-			opStatus = common.ContractFailureOperationStatus.Status
-		} else {
-			// Should never see a failed non-contract related transaction on chain
-			opStatus = common.FailureOperationStatus.Status
-			utils.Logger().Warn().Msgf("Failed transaction on chain: %v", tx.Hash().String())
-		}
-	}
-
+// newSameShardTransferNativeOperations creates a new slice of operations for a native transfer on the same shard.
+func newSameShardTransferNativeOperations(
+	from, to *types.AccountIdentifier, amount *big.Int, status string,
+	startingOperationIndex *int64,
+) []*types.Operation {
 	// Subtraction operation elements
+	var opIndex int64
+	if startingOperationIndex != nil {
+		opIndex = *startingOperationIndex
+	} else {
+		opIndex = 0
+	}
 	subOperationID := &types.OperationIdentifier{
-		Index: startingOperationID.Index + 1,
-	}
-	subRelatedID := []*types.OperationIdentifier{
-		startingOperationID,
-	}
-	subAccountID, rosettaError := newAccountIdentifier(senderAddress)
-	if rosettaError != nil {
-		return nil, rosettaError
+		Index: opIndex,
 	}
 	subAmount := &types.Amount{
-		Value:    negativeBigValue(tx.Value()),
-		Currency: &common.NativeCurrency,
-	}
-
-	// Addition operation elements
-	addOperationID := &types.OperationIdentifier{
-		Index: subOperationID.Index + 1,
-	}
-	addRelatedID := []*types.OperationIdentifier{
-		subOperationID,
-	}
-	addAccountID, rosettaError := newAccountIdentifier(receiverAddress)
-	if rosettaError != nil {
-		return nil, rosettaError
-	}
-	addAmount := &types.Amount{
-		Value:    tx.Value().String(),
-		Currency: &common.NativeCurrency,
-	}
-
-	return []*types.Operation{
-		{
-			OperationIdentifier: subOperationID,
-			RelatedOperations:   subRelatedID,
-			Type:                opType,
-			Status:              opStatus,
-			Account:             subAccountID,
-			Amount:              subAmount,
-		},
-		{
-			OperationIdentifier: addOperationID,
-			RelatedOperations:   addRelatedID,
-			Type:                opType,
-			Status:              opStatus,
-			Account:             addAccountID,
-			Amount:              addAmount,
-		},
-	}, nil
-}
-
-// newCrossShardSenderTransferNativeOperations extracts & formats the native operation(s)
-// for cross-shard-tx on the sender's shard.
-func newCrossShardSenderTransferNativeOperations(
-	startingOperationID *types.OperationIdentifier,
-	tx *hmytypes.Transaction, senderAddress ethcommon.Address,
-) ([]*types.Operation, *types.Error) {
-	if tx.To() == nil {
-		return nil, common.NewError(common.CatchAllError, nil)
-	}
-	senderAccountID, rosettaError := newAccountIdentifier(senderAddress)
-	if rosettaError != nil {
-		return nil, rosettaError
-	}
-	receiverAccountID, rosettaError := newAccountIdentifier(*tx.To())
-	if rosettaError != nil {
-		return nil, rosettaError
-	}
-	metadata, err := types.MarshalMap(common.CrossShardTransactionOperationMetadata{
-		From: senderAccountID,
-		To:   receiverAccountID,
-	})
-	if err != nil {
-		return nil, common.NewError(common.CatchAllError, map[string]interface{}{
-			"message": err.Error(),
-		})
-	}
-
-	return []*types.Operation{
-		{
-			OperationIdentifier: &types.OperationIdentifier{
-				Index: startingOperationID.Index + 1,
-			},
-			RelatedOperations: []*types.OperationIdentifier{
-				startingOperationID,
-			},
-			Type:    common.NativeCrossShardTransferOperation,
-			Status:  common.SuccessOperationStatus.Status,
-			Account: senderAccountID,
-			Amount: &types.Amount{
-				Value:    negativeBigValue(tx.Value()),
-				Currency: &common.NativeCurrency,
-			},
-			Metadata: metadata,
-		},
-	}, nil
-}
-
-// newContractCreationNativeOperations extracts & formats the native operation(s) for a contract creation tx
-func newContractCreationNativeOperations(
-	startingOperationID *types.OperationIdentifier,
-	tx *hmytypes.Transaction, txReceipt *hmytypes.Receipt, senderAddress ethcommon.Address,
-) ([]*types.Operation, *types.Error) {
-	// TODO: correct the contract creation transaction...
-
-	// Set execution status as necessary
-	status := common.SuccessOperationStatus.Status
-	if txReceipt.Status == hmytypes.ReceiptStatusFailed {
-		status = common.ContractFailureOperationStatus.Status
-	}
-	contractAddressID, rosettaError := newAccountIdentifier(txReceipt.ContractAddress)
-	if rosettaError != nil {
-		return nil, rosettaError
-	}
-
-	// Subtraction operation elements
-	subOperationID := &types.OperationIdentifier{
-		Index: startingOperationID.Index + 1,
-	}
-	subRelatedID := []*types.OperationIdentifier{
-		startingOperationID,
-	}
-	subAccountID, rosettaError := newAccountIdentifier(senderAddress)
-	if rosettaError != nil {
-		return nil, rosettaError
-	}
-	subAmount := &types.Amount{
-		Value:    negativeBigValue(tx.Value()),
+		Value:    negativeBigValue(amount),
 		Currency: &common.NativeCurrency,
 	}
 
@@ -427,28 +391,27 @@ func newContractCreationNativeOperations(
 		subOperationID,
 	}
 	addAmount := &types.Amount{
-		Value:    tx.Value().String(),
+		Value:    amount.String(),
 		Currency: &common.NativeCurrency,
 	}
 
 	return []*types.Operation{
 		{
 			OperationIdentifier: subOperationID,
-			RelatedOperations:   subRelatedID,
-			Type:                common.ContractCreationOperation,
+			Type:                common.NativeTransferOperation,
 			Status:              status,
-			Account:             subAccountID,
+			Account:             from,
 			Amount:              subAmount,
 		},
 		{
 			OperationIdentifier: addOperationID,
 			RelatedOperations:   addRelatedID,
-			Type:                common.ContractCreationOperation,
+			Type:                common.NativeTransferOperation,
 			Status:              status,
-			Account:             contractAddressID,
+			Account:             to,
 			Amount:              addAmount,
 		},
-	}, nil
+	}
 }
 
 // newNativeOperationsWithGas creates a new operation with the gas fee as the first operation.

--- a/rosetta/services/tx_operation.go
+++ b/rosetta/services/tx_operation.go
@@ -289,13 +289,13 @@ func getContractInternalTransferNativeOperations(
 
 	for _, log := range executionResult.StructLogs {
 		if _, ok := internalNativeTransferEvmOps[log.Op]; ok {
-			fromAccId, rosettaError := newAccountIdentifier(log.ContractAddress)
+			fromAccID, rosettaError := newAccountIdentifier(log.ContractAddress)
 			if rosettaError != nil {
 				return nil, rosettaError
 			}
 			// All internalNativeTransferEvmOps have at least 7 elements on the stack.
 			topIndex := len(log.Stack) - 1
-			toAccId, rosettaError := newAccountIdentifier(ethcommon.HexToAddress(log.Stack[topIndex-1]))
+			toAccID, rosettaError := newAccountIdentifier(ethcommon.HexToAddress(log.Stack[topIndex-1]))
 			if rosettaError != nil {
 				return nil, rosettaError
 			}
@@ -307,7 +307,7 @@ func getContractInternalTransferNativeOperations(
 			}
 
 			ops = append(
-				ops, newSameShardTransferNativeOperations(fromAccId, toAccId, value, status, startingOperationIndex)...,
+				ops, newSameShardTransferNativeOperations(fromAccID, toAccID, value, status, startingOperationIndex)...,
 			)
 			nextOpIndex := ops[len(ops)-1].OperationIdentifier.Index + 1
 			startingOperationIndex = &nextOpIndex

--- a/rosetta/services/tx_operation.go
+++ b/rosetta/services/tx_operation.go
@@ -11,7 +11,7 @@ import (
 	hmytypes "github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/core/vm"
 	"github.com/harmony-one/harmony/hmy"
-	"github.com/harmony-one/harmony/internal/utils"
+	"github.com/harmony-one/harmony/internal/params"
 	"github.com/harmony-one/harmony/rosetta/common"
 	rpcV2 "github.com/harmony-one/harmony/rpc/v2"
 	"github.com/harmony-one/harmony/staking"
@@ -169,12 +169,10 @@ func GetTransactionStatus(tx hmytypes.PoolTransaction, receipt *hmytypes.Receipt
 	if _, ok := tx.(*hmytypes.Transaction); ok {
 		status := common.SuccessOperationStatus.Status
 		if receipt.Status == hmytypes.ReceiptStatusFailed {
-			if len(tx.Data()) > 0 {
-				status = common.ContractFailureOperationStatus.Status
-			} else {
-				// Should never see a failed non-contract related transaction on chain
+			if len(tx.Data()) == 0 && receipt.CumulativeGasUsed <= params.TxGas {
 				status = common.FailureOperationStatus.Status
-				utils.Logger().Error().Msgf("Failed non-contract transaction on chain: %v", tx.Hash().String())
+			} else {
+				status = common.ContractFailureOperationStatus.Status
 			}
 		}
 		return status

--- a/rosetta/services/tx_operation.go
+++ b/rosetta/services/tx_operation.go
@@ -48,7 +48,7 @@ func GetNativeOperationsFromTransaction(
 		txOperations, rosettaError = getCrossShardSenderTransferNativeOperations(
 			tx, senderAddress, &startingOpIndex,
 		)
-	} else if contractInfo.ExecutionResult != nil && len(tx.Data()) > 0 {
+	} else if contractInfo.ExecutionResult != nil {
 		txOperations, rosettaError = getContractTransferNativeOperations(
 			tx, receipt, senderAddress, tx.To(), contractInfo, &startingOpIndex,
 		)
@@ -207,19 +207,13 @@ func getBasicTransferNativeOperations(
 	return newSameShardTransferNativeOperations(from, to, tx.Value(), status, startingOperationIndex), nil
 }
 
-// getContractTransferNativeOperations extracts & formats the native operations for any transaction involving a contract.
+// getContractTransferNativeOperations extracts & formats the native operations for any
+// transaction involving a contract.
 // Note that this will include any native tokens that were transferred from the contract (i.e: internal transactions).
-// WARNING: order of execution matters due to operation index.
 func getContractTransferNativeOperations(
 	tx *hmytypes.Transaction, receipt *hmytypes.Receipt, senderAddress ethcommon.Address, toAddress *ethcommon.Address,
 	contractInfo *ContractInfo, startingOperationIndex *int64,
 ) ([]*types.Operation, *types.Error) {
-	if len(tx.Data()) == 0 || contractInfo.ExecutionResult == nil {
-		return nil, common.NewError(common.CatchAllError, map[string]interface{}{
-			"message": "implementation error",
-		})
-	}
-
 	basicOps, rosettaError := getBasicTransferNativeOperations(
 		tx, receipt, senderAddress, toAddress, startingOperationIndex,
 	)

--- a/rosetta/services/tx_operation.go
+++ b/rosetta/services/tx_operation.go
@@ -281,13 +281,12 @@ func getContractInternalTransferNativeOperations(
 	executionResult *hmy.ExecutionResult, status string,
 	startingOperationIndex *int64,
 ) ([]*types.Operation, *types.Error) {
+	ops := []*types.Operation{}
 	if executionResult == nil {
-		return nil, common.NewError(common.CatchAllError, map[string]interface{}{
-			"message": "execution trace result not found",
-		})
+		// No error since nil execution result implies empty StructLogs, which is not an error.
+		return ops, nil
 	}
 
-	ops := []*types.Operation{}
 	for _, log := range executionResult.StructLogs {
 		if _, ok := internalNativeTransferEvmOps[log.Op]; ok {
 			fromAccId, rosettaError := newAccountIdentifier(log.ContractAddress)

--- a/rosetta/services/tx_operation.go
+++ b/rosetta/services/tx_operation.go
@@ -290,6 +290,10 @@ func getContractInternalTransferNativeOperations(
 	ops := []*types.Operation{}
 	for _, log := range executionResult.StructLogs {
 		if _, ok := internalNativeTransferEvmOps[log.Op]; ok {
+			fromAccId, rosettaError := newAccountIdentifier(log.ContractAddress)
+			if rosettaError != nil {
+				return nil, rosettaError
+			}
 			// All internalNativeTransferEvmOps have at least 7 elements on the stack.
 			topIndex := len(log.Stack) - 1
 			toAccId, rosettaError := newAccountIdentifier(ethcommon.HexToAddress(log.Stack[topIndex-1]))
@@ -301,10 +305,6 @@ func getContractInternalTransferNativeOperations(
 				return nil, common.NewError(common.CatchAllError, map[string]interface{}{
 					"message": fmt.Sprintf("unable to set value amount, raw: %v", log.Stack[topIndex-2]),
 				})
-			}
-			fromAccId, rosettaError := newAccountIdentifier(log.CallerAddress)
-			if rosettaError != nil {
-				return nil, rosettaError
 			}
 
 			ops = append(

--- a/rosetta/services/tx_operation_test.go
+++ b/rosetta/services/tx_operation_test.go
@@ -447,7 +447,7 @@ func TestGetBasicTransferOperations(t *testing.T) {
 		Status: hmytypes.ReceiptStatusFailed,
 	}
 	opIndex := startingOpID.Index + 1
-	operations, rosettaError := getBasicSameShardTransferNativeOperations(tx, receipt, senderAddr, tx.To(), &opIndex)
+	operations, rosettaError := getBasicTransferNativeOperations(tx, receipt, senderAddr, tx.To(), &opIndex)
 	if rosettaError != nil {
 		t.Fatal(rosettaError)
 	}
@@ -462,7 +462,7 @@ func TestGetBasicTransferOperations(t *testing.T) {
 	refOperations[0].Status = common.SuccessOperationStatus.Status
 	refOperations[1].Status = common.SuccessOperationStatus.Status
 	receipt.Status = hmytypes.ReceiptStatusSuccessful
-	operations, rosettaError = getBasicSameShardTransferNativeOperations(tx, receipt, senderAddr, tx.To(), &opIndex)
+	operations, rosettaError = getBasicTransferNativeOperations(tx, receipt, senderAddr, tx.To(), &opIndex)
 	if rosettaError != nil {
 		t.Fatal(rosettaError)
 	}

--- a/rosetta/services/tx_operation_test.go
+++ b/rosetta/services/tx_operation_test.go
@@ -123,6 +123,9 @@ func TestGetSideEffectOperationsFromValueMap(t *testing.T) {
 			t.Errorf("operation %v has wrong currency", i)
 		}
 	}
+	if err := assertNativeOperationTypeUniquenessInvariant(ops); err != nil {
+		t.Error(err)
+	}
 
 	testStartingIndex := int64(12)
 	ops, rosettaError = getSideEffectOperationsFromValueMap(testPayouts, testType, &testStartingIndex)
@@ -151,6 +154,9 @@ func TestGetSideEffectOperationsFromValueMap(t *testing.T) {
 		if types.Hash(op.Amount.Currency) != common.NativeCurrencyHash {
 			t.Errorf("operation %v has wrong currency", i)
 		}
+	}
+	if err := assertNativeOperationTypeUniquenessInvariant(ops); err != nil {
+		t.Error(err)
 	}
 }
 

--- a/rosetta/services/tx_operation_test.go
+++ b/rosetta/services/tx_operation_test.go
@@ -63,12 +63,9 @@ func TestGetStakingOperationsFromCreateValidator(t *testing.T) {
 	refOperations := newNativeOperationsWithGas(gasFee, senderAccID)
 	refOperations = append(refOperations, &types.Operation{
 		OperationIdentifier: &types.OperationIdentifier{Index: 1},
-		RelatedOperations: []*types.OperationIdentifier{
-			{Index: 0},
-		},
-		Type:    tx.StakingType().String(),
-		Status:  common.SuccessOperationStatus.Status,
-		Account: senderAccID,
+		Type:                tx.StakingType().String(),
+		Status:              common.SuccessOperationStatus.Status,
+		Account:             senderAccID,
 		Amount: &types.Amount{
 			Value:    negativeBigValue(tenOnes),
 			Currency: &common.NativeCurrency,
@@ -195,12 +192,9 @@ func TestGetStakingOperationsFromDelegate(t *testing.T) {
 	refOperations := newNativeOperationsWithGas(gasFee, senderAccID)
 	refOperations = append(refOperations, &types.Operation{
 		OperationIdentifier: &types.OperationIdentifier{Index: 1},
-		RelatedOperations: []*types.OperationIdentifier{
-			{Index: 0},
-		},
-		Type:    tx.StakingType().String(),
-		Status:  common.SuccessOperationStatus.Status,
-		Account: senderAccID,
+		Type:                tx.StakingType().String(),
+		Status:              common.SuccessOperationStatus.Status,
+		Account:             senderAccID,
 		Amount: &types.Amount{
 			Value:    negativeBigValue(tenOnes),
 			Currency: &common.NativeCurrency,
@@ -259,12 +253,9 @@ func TestGetStakingOperationsFromUndelegate(t *testing.T) {
 	refOperations := newNativeOperationsWithGas(gasFee, senderAccID)
 	refOperations = append(refOperations, &types.Operation{
 		OperationIdentifier: &types.OperationIdentifier{Index: 1},
-		RelatedOperations: []*types.OperationIdentifier{
-			{Index: 0},
-		},
-		Type:    tx.StakingType().String(),
-		Status:  common.SuccessOperationStatus.Status,
-		Account: senderAccID,
+		Type:                tx.StakingType().String(),
+		Status:              common.SuccessOperationStatus.Status,
+		Account:             senderAccID,
 		Amount: &types.Amount{
 			Value:    fmt.Sprintf("0"),
 			Currency: &common.NativeCurrency,
@@ -323,12 +314,9 @@ func TestGetStakingOperationsFromCollectRewards(t *testing.T) {
 	refOperations := newNativeOperationsWithGas(gasFee, senderAccID)
 	refOperations = append(refOperations, &types.Operation{
 		OperationIdentifier: &types.OperationIdentifier{Index: 1},
-		RelatedOperations: []*types.OperationIdentifier{
-			{Index: 0},
-		},
-		Type:    tx.StakingType().String(),
-		Status:  common.SuccessOperationStatus.Status,
-		Account: senderAccID,
+		Type:                tx.StakingType().String(),
+		Status:              common.SuccessOperationStatus.Status,
+		Account:             senderAccID,
 		Amount: &types.Amount{
 			Value:    fmt.Sprintf("%v", tenOnes.Uint64()),
 			Currency: &common.NativeCurrency,
@@ -380,12 +368,9 @@ func TestGetStakingOperationsFromEditValidator(t *testing.T) {
 	refOperations := newNativeOperationsWithGas(gasFee, senderAccID)
 	refOperations = append(refOperations, &types.Operation{
 		OperationIdentifier: &types.OperationIdentifier{Index: 1},
-		RelatedOperations: []*types.OperationIdentifier{
-			{Index: 0},
-		},
-		Type:    tx.StakingType().String(),
-		Status:  common.SuccessOperationStatus.Status,
-		Account: senderAccID,
+		Type:                tx.StakingType().String(),
+		Status:              common.SuccessOperationStatus.Status,
+		Account:             senderAccID,
 		Amount: &types.Amount{
 			Value:    fmt.Sprintf("0"),
 			Currency: &common.NativeCurrency,
@@ -404,7 +389,7 @@ func TestGetStakingOperationsFromEditValidator(t *testing.T) {
 	}
 }
 
-func TestNewTransferNativeOperations(t *testing.T) {
+func TestGetBasicTransferOperations(t *testing.T) {
 	signer := hmytypes.NewEIP155Signer(params.TestChainConfig.ChainID)
 	tx, err := helpers.CreateTestTransaction(
 		signer, 0, 0, 0, 1e18, gasPrice, big.NewInt(1), []byte("test"),
@@ -431,11 +416,6 @@ func TestNewTransferNativeOperations(t *testing.T) {
 		{
 			OperationIdentifier: &types.OperationIdentifier{
 				Index: startingOpID.Index + 1,
-			},
-			RelatedOperations: []*types.OperationIdentifier{
-				{
-					Index: startingOpID.Index,
-				},
 			},
 			Type:    common.NativeTransferOperation,
 			Status:  common.ContractFailureOperationStatus.Status,
@@ -466,7 +446,8 @@ func TestNewTransferNativeOperations(t *testing.T) {
 	receipt := &hmytypes.Receipt{
 		Status: hmytypes.ReceiptStatusFailed,
 	}
-	operations, rosettaError := newTransferNativeOperations(startingOpID, tx, receipt, senderAddr)
+	opIndex := startingOpID.Index + 1
+	operations, rosettaError := getBasicSameShardTransferNativeOperations(tx, receipt, senderAddr, tx.To(), &opIndex)
 	if rosettaError != nil {
 		t.Fatal(rosettaError)
 	}
@@ -481,7 +462,7 @@ func TestNewTransferNativeOperations(t *testing.T) {
 	refOperations[0].Status = common.SuccessOperationStatus.Status
 	refOperations[1].Status = common.SuccessOperationStatus.Status
 	receipt.Status = hmytypes.ReceiptStatusSuccessful
-	operations, rosettaError = newTransferNativeOperations(startingOpID, tx, receipt, senderAddr)
+	operations, rosettaError = getBasicSameShardTransferNativeOperations(tx, receipt, senderAddr, tx.To(), &opIndex)
 	if rosettaError != nil {
 		t.Fatal(rosettaError)
 	}
@@ -493,7 +474,7 @@ func TestNewTransferNativeOperations(t *testing.T) {
 	}
 }
 
-func TestNewCrossShardSenderTransferNativeOperations(t *testing.T) {
+func TestGetCrossShardSenderTransferNativeOperations(t *testing.T) {
 	signer := hmytypes.NewEIP155Signer(params.TestChainConfig.ChainID)
 	tx, err := helpers.CreateTestTransaction(
 		signer, 0, 1, 0, 1e18, gasPrice, big.NewInt(1), []byte("data-does-nothing"),
@@ -527,9 +508,6 @@ func TestNewCrossShardSenderTransferNativeOperations(t *testing.T) {
 			OperationIdentifier: &types.OperationIdentifier{
 				Index: startingOpID.Index + 1,
 			},
-			RelatedOperations: []*types.OperationIdentifier{
-				startingOpID,
-			},
 			Type:    common.NativeCrossShardTransferOperation,
 			Status:  common.SuccessOperationStatus.Status,
 			Account: senderAccID,
@@ -540,7 +518,8 @@ func TestNewCrossShardSenderTransferNativeOperations(t *testing.T) {
 			Metadata: metadata,
 		},
 	}
-	operations, rosettaError := newCrossShardSenderTransferNativeOperations(startingOpID, tx, senderAddr)
+	opIndex := startingOpID.Index + 1
+	operations, rosettaError := getCrossShardSenderTransferNativeOperations(tx, senderAddr, &opIndex)
 	if rosettaError != nil {
 		t.Fatal(rosettaError)
 	}
@@ -552,7 +531,7 @@ func TestNewCrossShardSenderTransferNativeOperations(t *testing.T) {
 	}
 }
 
-func TestNewContractCreationNativeOperations(t *testing.T) {
+func TestGetContractCreationNativeOperations(t *testing.T) {
 	dummyContractKey, err := crypto.GenerateKey()
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -586,9 +565,6 @@ func TestNewContractCreationNativeOperations(t *testing.T) {
 			OperationIdentifier: &types.OperationIdentifier{
 				Index: startingOpID.Index + 1,
 			},
-			RelatedOperations: []*types.OperationIdentifier{
-				startingOpID,
-			},
 			Type:    common.ContractCreationOperation,
 			Status:  common.ContractFailureOperationStatus.Status,
 			Account: senderAccID,
@@ -619,7 +595,8 @@ func TestNewContractCreationNativeOperations(t *testing.T) {
 		Status:          hmytypes.ReceiptStatusFailed,
 		ContractAddress: contractAddr,
 	}
-	operations, rosettaError := newContractCreationNativeOperations(startingOpID, tx, receipt, senderAddr)
+	opIndex := startingOpID.Index + 1
+	operations, rosettaError := getContractCreationNativeOperations(tx, receipt, senderAddr, &opIndex)
 	if rosettaError != nil {
 		t.Fatal(rosettaError)
 	}
@@ -634,7 +611,7 @@ func TestNewContractCreationNativeOperations(t *testing.T) {
 	refOperations[0].Status = common.SuccessOperationStatus.Status
 	refOperations[1].Status = common.SuccessOperationStatus.Status
 	receipt.Status = hmytypes.ReceiptStatusSuccessful // Indicate successful tx
-	operations, rosettaError = newContractCreationNativeOperations(startingOpID, tx, receipt, senderAddr)
+	operations, rosettaError = getContractCreationNativeOperations(tx, receipt, senderAddr, &opIndex)
 	if rosettaError != nil {
 		t.Fatal(rosettaError)
 	}

--- a/rosetta/services/tx_operation_test.go
+++ b/rosetta/services/tx_operation_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 
 	hmytypes "github.com/harmony-one/harmony/core/types"
+	"github.com/harmony-one/harmony/core/vm"
+	"github.com/harmony-one/harmony/hmy"
 	internalCommon "github.com/harmony-one/harmony/internal/common"
 	"github.com/harmony-one/harmony/internal/params"
 	"github.com/harmony-one/harmony/rosetta/common"
@@ -531,6 +533,364 @@ func TestGetCrossShardSenderTransferNativeOperations(t *testing.T) {
 	}
 }
 
+var (
+	testExecResultForInternalTx = &hmy.ExecutionResult{
+		StructLogs: []hmy.StructLogRes{
+			{
+				Pc:              1316,
+				Op:              "DUP9",
+				CallerAddress:   ethcommon.HexToAddress("0x2a44f609f860d4ff8835f9ec1d9b1acdae1fd9cb"),
+				ContractAddress: ethcommon.HexToAddress("0x4c4fde977fbbe722cddf5719d7edd488510be16a"),
+				Gas:             6677398,
+				GasCost:         3,
+				Depth:           1,
+				Stack: []string{
+					"0000000000000000000000000000000000000000000000000000000023024408",
+					"000000000000000000000000000000000000000000000000000000000000019a",
+					"0000000000000000000000007c41e0668b551f4f902cfaec05b5bdca68b124ce",
+					"0000000000000000000000000000000000000000000000000000000000000050",
+					"0000000000000000000000007c41e0668b551f4f902cfaec05b5bdca68b124ce",
+					"0000000000000000000000007c41e0668b551f4f902cfaec05b5bdca68b124ce",
+					"0000000000000000000000000000000000000000000000000000000000000000",
+					"00000000000000000000000000000000000000000000021e19e0c9bab2400000",
+					"0000000000000000000000000000000000000000000000000000000000000080",
+					"0000000000000000000000000000000000000000000000000000000000000000",
+					"0000000000000000000000000000000000000000000000000000000000000080",
+					"0000000000000000000000000000000000000000000000000000000000000000",
+					"0000000000000000000000000000000000000000000000000000000000000080",
+					"00000000000000000000000000000000000000000000021e19e0c9bab2400000",
+					"0000000000000000000000007c41e0668b551f4f902cfaec05b5bdca68b124ce",
+				},
+				Memory: []string{
+					"0000000000000000000000007c41e0668b551f4f902cfaec05b5bdca68b124ce",
+					"0000000000000000000000000000000000000000000000000000000000000003",
+					"0000000000000000000000000000000000000000000000000000000000000080",
+				},
+				Storage: map[string]string{
+					"43a43725d4b041c11b63ea10be0771546465a0c0654fd13c2712f2a8ce3f8b85": "0000000000000000000000000000000000000000000000000000000000000050",
+				},
+			},
+			{
+				Pc:              1317,
+				Op:              vm.CALL.String(),
+				CallerAddress:   ethcommon.HexToAddress("0x2a44f609f860d4ff8835f9ec1d9b1acdae1fd9cb"),
+				ContractAddress: ethcommon.HexToAddress("0x4c4fde977fbbe722cddf5719d7edd488510be16a"),
+				Gas:             6677395,
+				GasCost:         9700,
+				Depth:           1,
+				Stack: []string{
+					"0000000000000000000000000000000000000000000000000000000023024408",
+					"000000000000000000000000000000000000000000000000000000000000019a",
+					"0000000000000000000000007c41e0668b551f4f902cfaec05b5bdca68b124ce",
+					"0000000000000000000000000000000000000000000000000000000000000050",
+					"0000000000000000000000007c41e0668b551f4f902cfaec05b5bdca68b124ce",
+					"0000000000000000000000007c41e0668b551f4f902cfaec05b5bdca68b124ce",
+					"0000000000000000000000000000000000000000000000000000000000000000",
+					"00000000000000000000000000000000000000000000021e19e0c9bab2400000",
+					"0000000000000000000000000000000000000000000000000000000000000080",
+					"0000000000000000000000000000000000000000000000000000000000000000",
+					"0000000000000000000000000000000000000000000000000000000000000080",
+					"0000000000000000000000000000000000000000000000000000000000000000",
+					"0000000000000000000000000000000000000000000000000000000000000080",
+					"0000000000000000000000000000000000000000000000000000000000002710",
+					"0000000000000000000000007c41e0668b551f4f902cfaec05b5bdca68b124ce",
+					"0000000000000000000000000000000000000000000000000000000000000000",
+				},
+				Memory: []string{
+					"0000000000000000000000007c41e0668b551f4f902cfaec05b5bdca68b124ce",
+					"0000000000000000000000000000000000000000000000000000000000000003",
+					"0000000000000000000000000000000000000000000000000000000000000080",
+				},
+				Storage: map[string]string{
+					"43a43725d4b041c11b63ea10be0771546465a0c0654fd13c2712f2a8ce3f8b85": "0000000000000000000000000000000000000000000000000000000000000050",
+				},
+			},
+			{
+				Pc:              1318,
+				Op:              "SWAP4",
+				CallerAddress:   ethcommon.HexToAddress("0x2a44f609f860d4ff8835f9ec1d9b1acdae1fd9cb"),
+				ContractAddress: ethcommon.HexToAddress("0x4c4fde977fbbe722cddf5719d7edd488510be16a"),
+				Gas:             6669995,
+				GasCost:         3,
+				Depth:           1,
+				Stack: []string{
+					"0000000000000000000000000000000000000000000000000000000023024408",
+					"000000000000000000000000000000000000000000000000000000000000019a",
+					"0000000000000000000000007c41e0668b551f4f902cfaec05b5bdca68b124ce",
+					"0000000000000000000000000000000000000000000000000000000000000050",
+					"0000000000000000000000007c41e0668b551f4f902cfaec05b5bdca68b124ce",
+					"0000000000000000000000007c41e0668b551f4f902cfaec05b5bdca68b124ce",
+					"0000000000000000000000000000000000000000000000000000000000000000",
+					"00000000000000000000000000000000000000000000021e19e0c9bab2400000",
+					"0000000000000000000000000000000000000000000000000000000000000080",
+					"0000000000000000000000000000000000000000000000000000000000000001",
+				},
+				Memory: []string{
+					"0000000000000000000000007c41e0668b551f4f902cfaec05b5bdca68b124ce",
+					"0000000000000000000000000000000000000000000000000000000000000003",
+					"0000000000000000000000000000000000000000000000000000000000000080",
+				},
+				Storage: map[string]string{
+					"43a43725d4b041c11b63ea10be0771546465a0c0654fd13c2712f2a8ce3f8b85": "0000000000000000000000000000000000000000000000000000000000000050",
+				},
+			},
+			{
+				Pc:              1319,
+				Op:              vm.CALLCODE.String(),
+				CallerAddress:   ethcommon.HexToAddress("0x2a44f609f860d4ff8835f9ec1d9b1acdae1fd9cb"),
+				ContractAddress: ethcommon.HexToAddress("0x4c4fde977fbbe722cddf5719d7edd488510be16a"),
+				Gas:             6677395,
+				GasCost:         9700,
+				Depth:           1,
+				Stack: []string{
+					"0000000000000000000000000000000000000000000000000000000023024408",
+					"000000000000000000000000000000000000000000000000000000000000019a",
+					"0000000000000000000000007c41e0668b551f4f902cfaec05b5bdca68b124ce",
+					"0000000000000000000000000000000000000000000000000000000000000050",
+					"0000000000000000000000007c41e0668b551f4f902cfaec05b5bdca68b124ce",
+					"0000000000000000000000007c41e0668b551f4f902cfaec05b5bdca68b124ce",
+					"0000000000000000000000000000000000000000000000000000000000000000",
+					"00000000000000000000000000000000000000000000021e19e0c9bab2400000",
+					"0000000000000000000000000000000000000000000000000000000000000080",
+					"0000000000000000000000000000000000000000000000000000000000000000",
+					"0000000000000000000000000000000000000000000000000000000000000080",
+					"0000000000000000000000000000000000000000000000000000000000000000",
+					"0000000000000000000000000000000000000000000000000000000000000080",
+					"0000000000000000000000000000000000000000000000000000000000002710",
+					"0000000000000000000000007c41e0668b551f4f902cfaec05b5bdca68b124ce",
+					"0000000000000000000000000000000000000000000000000000000000000000",
+				},
+				Memory: []string{
+					"0000000000000000000000007c41e0668b551f4f902cfaec05b5bdca68b124ce",
+					"0000000000000000000000000000000000000000000000000000000000000003",
+					"0000000000000000000000000000000000000000000000000000000000000080",
+				},
+				Storage: map[string]string{
+					"43a43725d4b041c11b63ea10be0771546465a0c0654fd13c2712f2a8ce3f8b85": "0000000000000000000000000000000000000000000000000000000000000050",
+				},
+			},
+		},
+	}
+	testExecResultForInternalTxValueSum = uint64(20000)
+)
+
+func TestGetContractInternalTransferNativeOperations(t *testing.T) {
+	refStatus := common.SuccessOperationStatus.Status
+	refStartingIndex := int64(23)
+	baseValidation := func(ops []*types.Operation, expectedValueSum uint64) {
+		prevIndex := int64(-1)
+		valueSum := int64(0)
+		absValueSum := uint64(0)
+		for i, op := range ops {
+			if op.OperationIdentifier.Index <= prevIndex {
+				t.Errorf("expect prev index (%v) < curr index (%v) for op %v",
+					prevIndex, op.OperationIdentifier.Index, i,
+				)
+			}
+			prevIndex = op.OperationIdentifier.Index
+			if op.Status != refStatus {
+				t.Errorf("wrong status for op %v", i)
+			}
+			if op.Type != common.NativeTransferOperation {
+				t.Errorf("wrong operation type for op %v", i)
+			}
+			if types.Hash(op.Amount.Currency) != common.NativeCurrencyHash {
+				t.Errorf("wrong currency for op %v", i)
+			}
+			val, err := types.AmountValue(op.Amount)
+			if err != nil {
+				t.Error(err)
+			}
+			valueSum += val.Int64()
+			absValueSum += val.Abs(val).Uint64()
+		}
+
+		if valueSum != 0 {
+			t.Errorf("expected sum of all non-gas values to be 0")
+		}
+		if expectedValueSum*2 != absValueSum {
+			t.Errorf("sum of all positive values of operations do not match execpted sum of values")
+		}
+	}
+
+	testOps, rosettaError := getContractInternalTransferNativeOperations(
+		testExecResultForInternalTx, refStatus, &refStartingIndex,
+	)
+	if rosettaError != nil {
+		t.Error(rosettaError)
+	}
+	baseValidation(testOps, testExecResultForInternalTxValueSum)
+	if len(testOps) == 0 {
+		t.Errorf("expect atleast 1 operation")
+	}
+	if testOps[0].OperationIdentifier.Index != refStartingIndex {
+		t.Errorf("expected starting index to be %v", refStartingIndex)
+	}
+	if err := assertNativeOperationTypeUniquenessInvariant(testOps); err != nil {
+		t.Error(err)
+	}
+
+	testOps, rosettaError = getContractInternalTransferNativeOperations(
+		testExecResultForInternalTx, refStatus, nil,
+	)
+	if rosettaError != nil {
+		t.Error(rosettaError)
+	}
+	baseValidation(testOps, testExecResultForInternalTxValueSum)
+	if len(testOps) == 0 {
+		t.Errorf("expect atleast 1 operation")
+	}
+	if testOps[0].OperationIdentifier.Index != 0 {
+		t.Errorf("expected starting index to be 0")
+	}
+	if err := assertNativeOperationTypeUniquenessInvariant(testOps); err != nil {
+		t.Error(err)
+	}
+
+	testOps, rosettaError = getContractInternalTransferNativeOperations(
+		nil, refStatus, nil,
+	)
+	if rosettaError != nil {
+		t.Error(rosettaError)
+	}
+	if len(testOps) != 0 {
+		t.Errorf("expected len 0 test operations for nil execution result")
+	}
+	if err := assertNativeOperationTypeUniquenessInvariant(testOps); err != nil {
+		t.Error(err)
+	}
+
+	testOps, rosettaError = getContractInternalTransferNativeOperations(
+		&hmy.ExecutionResult{}, refStatus, nil,
+	)
+	if rosettaError != nil {
+		t.Error(rosettaError)
+	}
+	if len(testOps) != 0 {
+		t.Errorf("expected len 0 test operations for nil struct logs")
+	}
+	if err := assertNativeOperationTypeUniquenessInvariant(testOps); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestGetContractTransferNativeOperations(t *testing.T) {
+	signer := hmytypes.NewEIP155Signer(params.TestChainConfig.ChainID)
+	refTxValue := big.NewInt(1)
+	refTx, err := helpers.CreateTestTransaction(
+		signer, 0, 0, 0, 1e18, gasPrice, refTxValue, []byte("blah-blah-blah"),
+	)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	refSenderAddr, err := refTx.SenderAddress()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	refStatus := common.SuccessOperationStatus.Status
+	refStartingIndex := int64(23)
+	refReceipt := &hmytypes.Receipt{
+		PostState: nil,
+		Status:    1,
+		GasUsed:   params.TxGas * 3, // somme arb number > TxGas
+	}
+	baseValidation := func(ops []*types.Operation, expectedValueSum uint64) {
+		prevIndex := int64(-1)
+		valueSum := int64(0)
+		absValueSum := uint64(0)
+		for i, op := range ops {
+			if op.OperationIdentifier.Index <= prevIndex {
+				t.Errorf("expect prev index (%v) < curr index (%v) for op %v",
+					prevIndex, op.OperationIdentifier.Index, i,
+				)
+			}
+			prevIndex = op.OperationIdentifier.Index
+			if op.Status != refStatus {
+				t.Errorf("wrong status for op %v", i)
+			}
+			if types.Hash(op.Amount.Currency) != common.NativeCurrencyHash {
+				t.Errorf("wrong currency for op %v", i)
+			}
+			if op.Type == common.ExpendGasOperation {
+				continue
+			}
+			if op.Type != common.NativeTransferOperation {
+				t.Errorf("wrong operation type for op %v", i)
+			}
+			val, err := types.AmountValue(op.Amount)
+			if err != nil {
+				t.Error(err)
+			}
+			valueSum += val.Int64()
+			absValueSum += val.Abs(val).Uint64()
+		}
+
+		if valueSum != 0 {
+			t.Errorf("expected sum of all non-gas values to be 0")
+		}
+		if expectedValueSum*2 != absValueSum {
+			t.Errorf("sum of all positive values of operations do not match execpted sum of values")
+		}
+	}
+
+	testOps, rosettaError := getContractTransferNativeOperations(
+		refTx, refReceipt, refSenderAddr, refTx.To(),
+		&ContractInfo{ExecutionResult: testExecResultForInternalTx}, &refStartingIndex,
+	)
+	if rosettaError != nil {
+		t.Error(rosettaError)
+	}
+	baseValidation(testOps, testExecResultForInternalTxValueSum+refTxValue.Uint64())
+	if len(testOps) == 0 {
+		t.Errorf("expect atleast 1 operation")
+	}
+	if testOps[0].OperationIdentifier.Index != refStartingIndex {
+		t.Errorf("expected starting index to be %v", refStartingIndex)
+	}
+	if err := assertNativeOperationTypeUniquenessInvariant(testOps); err != nil {
+		t.Error(err)
+	}
+
+	testOps, rosettaError = getContractTransferNativeOperations(
+		refTx, refReceipt, refSenderAddr, refTx.To(),
+		&ContractInfo{ExecutionResult: testExecResultForInternalTx}, nil,
+	)
+	if rosettaError != nil {
+		t.Error(rosettaError)
+	}
+	baseValidation(testOps, testExecResultForInternalTxValueSum+refTxValue.Uint64())
+	if len(testOps) == 0 {
+		t.Errorf("expect atleast 1 operation")
+	}
+	if testOps[0].OperationIdentifier.Index != 0 {
+		t.Errorf("expected starting index to be 0")
+	}
+	if err := assertNativeOperationTypeUniquenessInvariant(testOps); err != nil {
+		t.Error(err)
+	}
+
+	testOps, rosettaError = getContractTransferNativeOperations(
+		refTx, refReceipt, refSenderAddr, refTx.To(),
+		&ContractInfo{}, nil,
+	)
+	if rosettaError != nil {
+		t.Error(rosettaError)
+	}
+	baseValidation(testOps, refTxValue.Uint64())
+	if len(testOps) == 0 {
+		t.Errorf("expect atleast 1 operation")
+	}
+	if testOps[0].OperationIdentifier.Index != 0 {
+		t.Errorf("expected starting index to be 0")
+	}
+	if len(testOps) > 3 {
+		t.Errorf("expect at most 3 operations for nil ExecutionResult")
+	}
+	if err := assertNativeOperationTypeUniquenessInvariant(testOps); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestGetContractCreationNativeOperations(t *testing.T) {
 	dummyContractKey, err := crypto.GenerateKey()
 	if err != nil {
@@ -621,6 +981,62 @@ func TestGetContractCreationNativeOperations(t *testing.T) {
 	if err := assertNativeOperationTypeUniquenessInvariant(operations); err != nil {
 		t.Error(err)
 	}
+
+	traceValidation := func(ops []*types.Operation, expectedValueSum uint64) {
+		prevIndex := int64(-1)
+		valueSum := int64(0)
+		absValueSum := uint64(0)
+		for i, op := range ops {
+			if op.OperationIdentifier.Index <= prevIndex {
+				t.Errorf("expect prev index (%v) < curr index (%v) for op %v",
+					prevIndex, op.OperationIdentifier.Index, i,
+				)
+			}
+			prevIndex = op.OperationIdentifier.Index
+			if op.Status != refOperations[0].Status {
+				t.Errorf("wrong status for op %v", i)
+			}
+			if types.Hash(op.Amount.Currency) != common.NativeCurrencyHash {
+				t.Errorf("wrong currency for op %v", i)
+			}
+			if op.Type == common.ExpendGasOperation || op.Type == common.ContractCreationOperation {
+				continue
+			}
+			if op.Type != common.NativeTransferOperation {
+				t.Errorf("wrong operation type for op %v", i)
+			}
+			val, err := types.AmountValue(op.Amount)
+			if err != nil {
+				t.Error(err)
+			}
+			valueSum += val.Int64()
+			absValueSum += val.Abs(val).Uint64()
+		}
+
+		if valueSum != 0 {
+			t.Errorf("expected sum of all non-gas values to be 0")
+		}
+		if expectedValueSum*2 != absValueSum {
+			t.Errorf("sum of all positive values of operations do not match execpted sum of values")
+		}
+	}
+	operations, rosettaError = getContractCreationNativeOperations(
+		tx, receipt, senderAddr, &ContractInfo{ExecutionResult: testExecResultForInternalTx}, &opIndex,
+	)
+	if rosettaError != nil {
+		t.Fatal(rosettaError)
+	}
+	traceValidation(operations, testExecResultForInternalTxValueSum)
+	if len(operations) == 0 {
+		t.Errorf("expect atleast 1 operation")
+	}
+	if operations[0].OperationIdentifier.Index != opIndex {
+		t.Errorf("expect first operation to be %v", opIndex)
+	}
+	if err := assertNativeOperationTypeUniquenessInvariant(operations); err != nil {
+		t.Error(err)
+	}
+
 }
 
 func TestNewNativeOperations(t *testing.T) {

--- a/rosetta/services/tx_operation_test.go
+++ b/rosetta/services/tx_operation_test.go
@@ -596,7 +596,7 @@ func TestGetContractCreationNativeOperations(t *testing.T) {
 		ContractAddress: contractAddr,
 	}
 	opIndex := startingOpID.Index + 1
-	operations, rosettaError := getContractCreationNativeOperations(tx, receipt, senderAddr, &opIndex)
+	operations, rosettaError := getContractCreationNativeOperations(tx, receipt, senderAddr, &ContractInfo{}, &opIndex)
 	if rosettaError != nil {
 		t.Fatal(rosettaError)
 	}
@@ -611,7 +611,7 @@ func TestGetContractCreationNativeOperations(t *testing.T) {
 	refOperations[0].Status = common.SuccessOperationStatus.Status
 	refOperations[1].Status = common.SuccessOperationStatus.Status
 	receipt.Status = hmytypes.ReceiptStatusSuccessful // Indicate successful tx
-	operations, rosettaError = getContractCreationNativeOperations(tx, receipt, senderAddr, &opIndex)
+	operations, rosettaError = getContractCreationNativeOperations(tx, receipt, senderAddr, &ContractInfo{}, &opIndex)
 	if rosettaError != nil {
 		t.Fatal(rosettaError)
 	}


### PR DESCRIPTION
This PR closes #3434

## Additional Changes

In order to expose internal transactions, some extra field was added to the trace's `ExecutionResult`. Namely, I added the contract address (to account for nested method calls across different contracts) and opcode caller (for future use and to account for nest method calls across different contracts). 

Note that I correct the output of the trace RPC, this will break any implementation that already consumes this RPC. However, this is necessary for consistency and fixes an oversight during the review process of the initial trace PR. 

Some major refactoring of the operation formatter was done at the same time to make things more consistent. 

## Testing

I've tested this implementation locally using [this payable contract](https://github.com/harmony-one/HRC/blob/751b856c8b205c3d1ff4815dc5a7d1f02236a2e4/examples/node-faucet/contracts/Faucet.sol). 

The output of `/block/transaction` looks something like this:
```json
{
    "transaction": {
        "transaction_identifier": {
            "hash": "0xd2d60e355605cc4ea69e6fda748bda60beef9b2bc9699064311582358f96a91e"
        },
        "operations": [
            {
                "operation_identifier": {
                    "index": 0
                },
                "type": "Gas",
                "status": "success",
                "account": {
                    "address": "one19fz0vz0cvr20lzp4l8kpmxc6ekhplkwtqn9m2v",
                    "metadata": {
                        "hex_address": "0x2a44F609F860D4FF8835F9EC1d9b1AcDAE1FD9cb"
                    }
                },
                "amount": {
                    "value": "-76956000000000",
                    "currency": {
                        "symbol": "ONE",
                        "decimals": 18
                    }
                }
            },
            {
                "operation_identifier": {
                    "index": 1
                },
                "type": "NativeTransfer",
                "status": "success",
                "account": {
                    "address": "one19fz0vz0cvr20lzp4l8kpmxc6ekhplkwtqn9m2v",
                    "metadata": {
                        "hex_address": "0x2a44F609F860D4FF8835F9EC1d9b1AcDAE1FD9cb"
                    }
                },
                "amount": {
                    "value": "0",
                    "currency": {
                        "symbol": "ONE",
                        "decimals": 18
                    }
                }
            },
            {
                "operation_identifier": {
                    "index": 2
                },
                "related_operations": [
                    {
                        "index": 1
                    }
                ],
                "type": "NativeTransfer",
                "status": "success",
                "account": {
                    "address": "one1f38aa9mlh0nj9nwl2uva0mw53pgshct2q20lss",
                    "metadata": {
                        "hex_address": "0x4C4FdE977FBbE722cdDf5719D7EDD488510bE16a"
                    }
                },
                "amount": {
                    "value": "0",
                    "currency": {
                        "symbol": "ONE",
                        "decimals": 18
                    }
                }
            },
            {
                "operation_identifier": {
                    "index": 3
                },
                "type": "NativeTransfer",
                "status": "success",
                "account": {
                    "address": "one1f38aa9mlh0nj9nwl2uva0mw53pgshct2q20lss",
                    "metadata": {
                        "hex_address": "0x4C4FdE977FBbE722cdDf5719D7EDD488510bE16a"
                    }
                },
                "amount": {
                    "value": "-10000000000000000000000",
                    "currency": {
                        "symbol": "ONE",
                        "decimals": 18
                    }
                }
            },
            {
                "operation_identifier": {
                    "index": 4
                },
                "related_operations": [
                    {
                        "index": 3
                    }
                ],
                "type": "NativeTransfer",
                "status": "success",
                "account": {
                    "address": "one13lu674f3jkfk2qhsngfc2vhcf372wprctdjvgu",
                    "metadata": {
                        "hex_address": "0x8fF9aF553195936502f09A138532f84c7CA70478"
                    }
                },
                "amount": {
                    "value": "10000000000000000000000",
                    "currency": {
                        "symbol": "ONE",
                        "decimals": 18
                    }
                }
            }
        ],
        "metadata": {
            "contract_account_identifier": {
                "address": "one1f38aa9mlh0nj9nwl2uva0mw53pgshct2q20lss",
                "metadata": {
                    "hex_address": "0x4C4FdE977FBbE722cdDf5719D7EDD488510bE16a"
                }
            },
            "data": "230244080000000000000000000000008ff9af553195936502f09a138532f84c7ca70478"
        }
    }
}
```

## Documentation

Some changes to the related operations were done for all transactions that consume gas. The example and description in the docs need to be updated for [api.hmny.io](https://api.hmny.io/). Postman PR to the working branch is [here](https://harmony.postman.co/workspace/My-Workspace~04f8dad4-94f8-49a8-8b7f-8e7738f41628/pull-request/05c09ca2-571c-4f58-8499-b61ee501909f?workspace=04f8dad4-94f8-49a8-8b7f-8e7738f41628) (perms needed).
