### PR TITLE
Bootnode dnsaddr support

### DIFF
--- a/api/service/networkinfo/service.go
+++ b/api/service/networkinfo/service.go
@@ -18,6 +18,7 @@ import (
 	libp2pdis "github.com/libp2p/go-libp2p-discovery"
 	libp2pdht "github.com/libp2p/go-libp2p-kad-dht"
 	libp2pdhtopts "github.com/libp2p/go-libp2p-kad-dht/opts"
+	madns "github.com/multiformats/go-multiaddr-dns"
 	manet "github.com/multiformats/go-multiaddr-net"
 	"github.com/pkg/errors"
 )
@@ -139,7 +140,21 @@ func (s *Service) Init() error {
 	}
 
 	connected := false
-	for _, peerAddr := range s.bootnodes {
+	var bnList p2p.AddrList
+	for _, maddr := range s.bootnodes {
+		if madns.Matches(maddr) {
+			mas, err := madns.Resolve(context.Background(), maddr)
+			if err != nil {
+				utils.Logger().Error().Err(err).Msg("Resolve bootnode")
+				continue
+			}
+			bnList = append(bnList, mas...)
+		} else {
+			bnList = append(bnList, maddr)
+		}
+	}
+
+	for _, peerAddr := range bnList {
 		peerinfo, _ := libp2p_peer.AddrInfoFromP2pAddr(peerAddr)
 		wg.Add(1)
 		go func() {

--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -63,7 +63,7 @@ func TestV1_0_0Config(t *testing.T) {
   Verbosity = 3
 
 [Network]
-  BootNodes = ["/ip4/100.26.90.187/tcp/9874/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv","/ip4/54.213.43.194/tcp/9874/p2p/QmZJJx6AdaoEkGLrYG4JeLCKeCKDjnFz2wfHNHxAqFSGA9","/ip4/13.113.101.219/tcp/12019/p2p/QmQayinFSgMMw5cSpDUiD9pQ2WeP6WNmGxpZ6ou3mdVFJX","/ip4/99.81.170.167/tcp/12019/p2p/QmRVbTpEYup8dSaURZfF6ByrMTSKa4UyUzJhSjahFzRqNj"]
+  BootNodes = ["/dnsaddr/bootstrap.t.hmny.io"]
   DNSPort = 9000
   DNSZone = "t.hmny.io"
   LegacySyncing = false

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/libp2p/go-libp2p-kad-dht v0.8.3
 	github.com/libp2p/go-libp2p-pubsub v0.3.3
 	github.com/multiformats/go-multiaddr v0.2.2
+	github.com/multiformats/go-multiaddr-dns v0.2.0
 	github.com/multiformats/go-multiaddr-net v0.1.5
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/pborman/uuid v1.2.0

--- a/internal/configs/node/network.go
+++ b/internal/configs/node/network.go
@@ -6,8 +6,7 @@ var (
 	}
 
 	testnetBootNodes = []string{
-		"/ip4/54.86.126.90/tcp/9867/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv",
-		"/ip4/52.40.84.2/tcp/9867/p2p/QmbPVwrqWsTYXq1RxGWcxx9SWaTUCfoo1wA6wmdbduWe29",
+		"/dnsaddr/bootstrap.b.hmny.io",
 	}
 
 	pangaeaBootNodes = []string{

--- a/internal/configs/node/network.go
+++ b/internal/configs/node/network.go
@@ -24,7 +24,7 @@ var (
 	}
 
 	stressBootNodes = []string{
-		"/ip4/52.40.84.2/tcp/9842/p2p/QmbPVwrqWsTYXq1RxGWcxx9SWaTUCfoo1wA6wmdbduWe29",
+		"/dnsaddr/bootstrap.stn.hmny.io",
 	}
 
 	devnetBootNodes = []string{}

--- a/internal/configs/node/network.go
+++ b/internal/configs/node/network.go
@@ -2,10 +2,7 @@ package nodeconfig
 
 var (
 	mainnetBootNodes = []string{
-		"/ip4/100.26.90.187/tcp/9874/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv",
-		"/ip4/54.213.43.194/tcp/9874/p2p/QmZJJx6AdaoEkGLrYG4JeLCKeCKDjnFz2wfHNHxAqFSGA9",
-		"/ip4/13.113.101.219/tcp/12019/p2p/QmQayinFSgMMw5cSpDUiD9pQ2WeP6WNmGxpZ6ou3mdVFJX",
-		"/ip4/99.81.170.167/tcp/12019/p2p/QmRVbTpEYup8dSaURZfF6ByrMTSKa4UyUzJhSjahFzRqNj",
+		"/dnsaddr/bootstrap.t.hmny.io",
 	}
 
 	testnetBootNodes = []string{


### PR DESCRIPTION
This PR enabled /dnsaddr/ format support of the bootnode.
So that we don't have to change the hardcoded IP addresses in the code binary if bootnode is migrated or updated.

To support dns based bootnode address, just need to add TXT record in DNS.

The following official document depicts the details.
https://github.com/multiformats/go-multiaddr-dns