### PR TITLE
[sync] fix explorer sync

### DIFF
--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -1025,6 +1025,11 @@ func (ss *StateSync) SyncLoop(bc *core.BlockChain, worker *worker.Worker, isBeac
 		if err := ss.addConsensusLastMile(bc, consensus); err != nil {
 			utils.Logger().Error().Err(err).Msg("[SYNC] Add consensus last mile")
 		}
+		if bc.CurrentBlock().IsLastBlockInEpoch() {
+			// Temporary fix for explorer node. This logic is only needed for explorer node.
+			// TODO: refactor this.
+			consensus.UpdateConsensusInformation()
+		}
 	}
 	ss.purgeAllBlocksFromCache()
 }

--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -1025,11 +1025,7 @@ func (ss *StateSync) SyncLoop(bc *core.BlockChain, worker *worker.Worker, isBeac
 		if err := ss.addConsensusLastMile(bc, consensus); err != nil {
 			utils.Logger().Error().Err(err).Msg("[SYNC] Add consensus last mile")
 		}
-		if bc.CurrentBlock().IsLastBlockInEpoch() {
-			// Temporary fix for explorer node. This logic is only needed for explorer node.
-			// TODO: refactor this.
-			consensus.UpdateConsensusInformation()
-		}
+		consensus.UpdateConsensusInformation()
 	}
 	ss.purgeAllBlocksFromCache()
 }

--- a/api/service/syncing/syncing.go
+++ b/api/service/syncing/syncing.go
@@ -1025,6 +1025,8 @@ func (ss *StateSync) SyncLoop(bc *core.BlockChain, worker *worker.Worker, isBeac
 		if err := ss.addConsensusLastMile(bc, consensus); err != nil {
 			utils.Logger().Error().Err(err).Msg("[SYNC] Add consensus last mile")
 		}
+		// This logic is only needed for explorer node.
+		// TODO: refactor this.
 		consensus.UpdateConsensusInformation()
 	}
 	ss.purgeAllBlocksFromCache()

--- a/api/service/syncing/syncing_test.go
+++ b/api/service/syncing/syncing_test.go
@@ -95,7 +95,7 @@ func TestCompareSyncPeerConfigByblockHashes(t *testing.T) {
 }
 
 func TestCreateStateSync(t *testing.T) {
-	stateSync := CreateStateSync("127.0.0.1", "8000", [20]byte{})
+	stateSync := CreateStateSync("127.0.0.1", "8000", [20]byte{}, false)
 
 	if stateSync == nil {
 		t.Error("Unable to create stateSync")

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -64,9 +64,14 @@ func (node *Node) DoSyncWithoutConsensus() {
 // IsSameHeight tells whether node is at same bc height as a peer
 func (node *Node) IsSameHeight() (uint64, bool) {
 	if node.stateSync == nil {
-		node.stateSync = syncing.CreateStateSync(node.SelfPeer.IP, node.SelfPeer.Port, node.GetSyncID())
+		node.stateSync = node.getStateSync()
 	}
 	return node.stateSync.IsSameBlockchainHeight(node.Blockchain())
+}
+
+func (node *Node) getStateSync() *syncing.StateSync {
+	return syncing.CreateStateSync(node.SelfPeer.IP, node.SelfPeer.Port,
+		node.GetSyncID(), node.NodeConfig.Role() == nodeconfig.ExplorerNode)
 }
 
 // SyncingPeerProvider is an interface for getting the peers in the given shard.
@@ -198,7 +203,7 @@ func (node *Node) DoBeaconSyncing() {
 	for {
 		if node.beaconSync == nil {
 			utils.Logger().Info().Msg("initializing beacon sync")
-			node.beaconSync = syncing.CreateStateSync(node.SelfPeer.IP, node.SelfPeer.Port, node.GetSyncID())
+			node.beaconSync = node.getStateSync()
 		}
 		if node.beaconSync.GetActivePeerNumber() == 0 {
 			utils.Logger().Info().Msg("no peers; bootstrapping beacon sync config")
@@ -298,7 +303,7 @@ func (node *Node) SupportSyncing() {
 	}
 
 	if node.stateSync == nil {
-		node.stateSync = syncing.CreateStateSync(node.SelfPeer.IP, node.SelfPeer.Port, node.GetSyncID())
+		node.stateSync = node.getStateSync()
 		utils.Logger().Debug().Msg("[SYNC] initialized state sync")
 	}
 


### PR DESCRIPTION
## Issue

Currently, some of the explorer node is synced every 30 seconds the explorer node block is always lagging behind. This PR aims to address this issue.

## Diagnose

Following error log is found for every committed message in explorer node:

```
{"level":"error","msgBlock":6362649,"caller":"/mnt/jenkins/workspace/harmony-release/harmony/node/node_explorer.go:73","time":"2020-12-09T00:16:48.88101361Z","message":"[Explorer] Failed to verify the multi signature for commit phase"}
```

After digging a little deeper, the explorer node uses `consensus.Decider` to get the signature mask, which can be out of date. 

```
// node/node_explorer.go:43
aggSig, mask, err := node.Consensus.ReadSignatureBitmapPayload(
	recvMsg.Payload, 0,
)
```

This issue is caused by removing `consensus.UpdateConsensusInformation` at the end of sync. So if the epoch change block is inserted from SYNC, the decider is never updated for explorer node and fails block validation. 

Thus, `consensus.UpdateConsensusInformation` is added back for now. Further refactor will take place along with the pub-sub refactor.
