### PR TITLE
Fix inconsistent block proposal and verification

### DIFF
--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -353,6 +353,11 @@ func (consensus *Consensus) Start(
 					Uint64("MsgBlockNum", newBlock.NumberU64()).
 					Msg("[ConsensusMainLoop] Received Proposed New Block!")
 
+				if newBlock.NumberU64() < consensus.blockNum {
+					consensus.getLogger().Info().Uint64("newBlockNum", newBlock.NumberU64()).
+						Msg("[ConsensusMainLoop] received old block, abort")
+					continue
+				}
 				// Sleep to wait for the full block time
 				consensus.getLogger().Info().Msg("[ConsensusMainLoop] Waiting for Block Time")
 				<-time.After(time.Until(consensus.NextBlockDue))
@@ -553,6 +558,7 @@ func (consensus *Consensus) preCommitAndPropose(blk *types.Block) error {
 
 		if _, err := consensus.Blockchain.InsertChain([]*types.Block{blk}, true); err != nil {
 			consensus.getLogger().Error().Err(err).Msg("[preCommitAndPropose] Failed to add block to chain")
+			return
 		}
 
 		// if leader successfully finalizes the block, send committed message to validators

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -354,7 +354,7 @@ func (consensus *Consensus) Start(
 					Msg("[ConsensusMainLoop] Received Proposed New Block!")
 
 				if newBlock.NumberU64() < consensus.blockNum {
-					consensus.getLogger().Info().Uint64("newBlockNum", newBlock.NumberU64()).
+					consensus.getLogger().Warn().Uint64("newBlockNum", newBlock.NumberU64()).
 						Msg("[ConsensusMainLoop] received old block, abort")
 					continue
 				}

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -299,6 +299,8 @@ func (consensus *Consensus) onCommitted(recvMsg *FBFTMessage) {
 	// has more signatures and if yes, override the old data.
 	// Otherwise, simply write the commit signature in db.
 	commitSigBitmap, err := consensus.Blockchain.ReadCommitSig(blockObj.NumberU64())
+	// Need to check whether this block actually was committed, because it could be another block
+	// with the same number that's committed and overriding its commit sig is wrong.
 	blk := consensus.Blockchain.GetBlockByHash(blockObj.Hash())
 	if err == nil && len(commitSigBitmap) == len(recvMsg.Payload) && blk != nil {
 		new := mask.CountEnabled()

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -299,7 +299,8 @@ func (consensus *Consensus) onCommitted(recvMsg *FBFTMessage) {
 	// has more signatures and if yes, override the old data.
 	// Otherwise, simply write the commit signature in db.
 	commitSigBitmap, err := consensus.Blockchain.ReadCommitSig(blockObj.NumberU64())
-	if err == nil && len(commitSigBitmap) == len(recvMsg.Payload) {
+	blk := consensus.Blockchain.GetBlockByHash(blockObj.Hash())
+	if err == nil && len(commitSigBitmap) == len(recvMsg.Payload) && blk != nil {
 		new := mask.CountEnabled()
 		mask.SetMask(commitSigBitmap[bls.BLSSignatureSizeInBytes:])
 		cur := mask.CountEnabled()

--- a/node/node.go
+++ b/node/node.go
@@ -117,7 +117,8 @@ type Node struct {
 	// BroadcastInvalidTx flag is considered when adding pending tx to tx-pool
 	BroadcastInvalidTx bool
 	// InSync flag indicates the node is in-sync or not
-	IsInSync *abool.AtomicBool
+	IsInSync      *abool.AtomicBool
+	proposedBlock map[uint64]*types.Block
 
 	deciderCache   *lru.Cache
 	committeeCache *lru.Cache
@@ -944,6 +945,7 @@ func New(
 		}
 
 		node.pendingCXReceipts = map[string]*types.CXReceiptsProof{}
+		node.proposedBlock = map[uint64]*types.Block{}
 		node.Consensus.VerifiedNewBlock = make(chan *types.Block, 1)
 		chain.Engine.SetBeaconchain(beaconChain)
 		// the sequence number is the next block number to be added in consensus protocol, which is

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -250,6 +250,9 @@ func (node *Node) VerifyNewBlock(newBlock *types.Block) error {
 	if newBlock == nil || newBlock.Header() == nil {
 		return errors.New("nil header or block asked to verify")
 	}
+	if newBlock.NumberU64() <= node.Blockchain().CurrentBlock().NumberU64() {
+		return errors.Errorf("block with the same block number is already committed: %d", newBlock.NumberU64())
+	}
 	if err := node.Blockchain().Validator().ValidateHeader(newBlock, true); err != nil {
 		utils.Logger().Error().
 			Str("blockHash", newBlock.Hash().Hex()).

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -84,6 +84,11 @@ func (node *Node) WaitForConsensusReadyV2(readySignal chan consensus.ProposalTyp
 					newBlock, err := node.ProposeNewBlock(newCommitSigsChan)
 
 					if err == nil {
+						if blk, ok := node.proposedBlock[newBlock.NumberU64()]; ok {
+							utils.Logger().Info().Uint64("blockNum", newBlock.NumberU64()).Str("blockHash", blk.Hash().Hex()).
+								Msg("Block with the same number was already proposed, abort.")
+							break
+						}
 						utils.Logger().Info().
 							Uint64("blockNum", newBlock.NumberU64()).
 							Uint64("epoch", newBlock.Epoch().Uint64()).
@@ -94,6 +99,8 @@ func (node *Node) WaitForConsensusReadyV2(readySignal chan consensus.ProposalTyp
 							Msg("=========Successfully Proposed New Block==========")
 
 						// Send the new block to Consensus so it can be confirmed.
+						node.proposedBlock[newBlock.NumberU64()] = newBlock
+						delete(node.proposedBlock, newBlock.NumberU64()-10)
 						node.BlockChannel <- newBlock
 						break
 					} else {


### PR DESCRIPTION
It happened that when a leader is restarted, two part of the code triggered new block proposal and started announce phase, which messed up the consensus states (block content and block hash). This caused the second consensus to fail due to malformed prepared message (containing the second proposed block in last round):

```{"level":"warn","myBlock":1497743,"myViewID":1507399,"phase":"Prepare","mode":"Normal","MsgBlockNum":1497743,"blockNum":1497742,"caller":"/home/lc/go/src/github.com/harmony-one/harmony/consensus/checks.go:129","time":"2020-12-10T05:32:48.149366601Z","message":"[OnPrepared] BlockNum not match"}```

Then view change started with this bad prepared message, but it succeeded because verifyBlock() method doesn't take care of whether the block is at the tip of not. The second proposed block is a valid block itself, it's just it's a old block which should be ignored.

Then view change succeeded with M1 message and all validators signed commit message on this old block. Then the committed message got sent to all validators who override the commit sig for the canonical block, causing all validators to have this bad committed signatures.

This PR fixes this scenario by:

1. avoid proposing duplicate blocks at the same height for leader.
2. add block height check on the VerifyBlock method.
3. add block existence check by hash when overriding commit signature.
4. do not send committed message if failing to commit the block.