### PR TITLE
[pubsub] change to validation ignore when handling non-consensus topic

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -659,7 +659,7 @@ func (node *Node) Start() error {
 						errChan <- withError{
 							errors.WithStack(errConsensusMessageOnUnexpectedTopic), msg,
 						}
-						return libp2p_pubsub.ValidationReject
+						return libp2p_pubsub.ValidationIgnore
 					}
 					nodeP2PMessageCounterVec.With(prometheus.Labels{"type": "consensus_total"}).Inc()
 


### PR DESCRIPTION
## Issue

When handling non-consensus-bound topic, should use validation ignore instead of validation reject. 