### PR TITLE
[config] adjust epoch number for testnet/mainet

### DIFF
--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -45,7 +45,7 @@ var (
 		QuickUnlockEpoch:     big.NewInt(191),
 		FiveSecondsEpoch:     big.NewInt(230),
 		TwoSecondsEpoch:      big.NewInt(366), // Around Tuesday Dec 8th 2020, 8AM PST
-		SixtyPercentEpoch:    big.NewInt(432), // Around Wednesday Jan 27 2021, 10PM PST
+		SixtyPercentEpoch:    big.NewInt(434), // Around Friday Jan 29 2021, 10AM PST
 		RedelegationEpoch:    big.NewInt(290),
 		EIP155Epoch:          big.NewInt(28),
 		S3Epoch:              big.NewInt(28),
@@ -64,7 +64,7 @@ var (
 		QuickUnlockEpoch:     big.NewInt(0),
 		FiveSecondsEpoch:     big.NewInt(16500),
 		TwoSecondsEpoch:      big.NewInt(73000),
-		SixtyPercentEpoch:    big.NewInt(73273),
+		SixtyPercentEpoch:    big.NewInt(73280),
 		RedelegationEpoch:    big.NewInt(36500),
 		EIP155Epoch:          big.NewInt(0),
 		S3Epoch:              big.NewInt(0),


### PR DESCRIPTION
To enable 40% external voting power

Signed-off-by: Leo Chen <leo@harmony.one>