### PR TITLE
Add SignEthTx()

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -237,6 +237,23 @@ func (ks *KeyStore) SignTx(a accounts.Account, tx *types.Transaction, chainID *b
 	return types.SignTx(tx, types.HomesteadSigner{}, unlockedKey.PrivateKey)
 }
 
+// SignEthTx signs the given transaction with the requested account.
+func (ks *KeyStore) SignEthTx(a accounts.Account, tx *types.EthTransaction, chainID *big.Int) (*types.EthTransaction, error) {
+	// Look up the key to sign with and abort if it cannot be found
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+
+	unlockedKey, found := ks.unlocked[a.Address]
+	if !found {
+		return nil, ErrLocked
+	}
+	// Depending on the presence of the chain ID, sign with EIP155 or homestead
+	if chainID != nil {
+		return types.SignEthTx(tx, types.NewEIP155Signer(chainID), unlockedKey.PrivateKey)
+	}
+	return types.SignEthTx(tx, types.HomesteadSigner{}, unlockedKey.PrivateKey)
+}
+
 // SignHashWithPassphrase signs hash if the private key matching the given address
 // can be decrypted with the given passphrase. The produced signature is in the
 // [R || S || V] format where V is 0 or 1.
@@ -277,6 +294,22 @@ func (ks *KeyStore) SignTxWithPassphrase(a accounts.Account, passphrase string, 
 		return types.SignTx(tx, types.NewEIP155Signer(chainID), key.PrivateKey)
 	}
 	return types.SignTx(tx, types.HomesteadSigner{}, key.PrivateKey)
+}
+
+// SignEthTxWithPassphrase signs the transaction if the private key matching the
+// given address can be decrypted with the given passphrase.
+func (ks *KeyStore) SignEthTxWithPassphrase(a accounts.Account, passphrase string, tx *types.EthTransaction, chainID *big.Int) (*types.EthTransaction, error) {
+	_, key, err := ks.GetDecryptedKey(a, passphrase)
+	if err != nil {
+		return nil, err
+	}
+	defer zeroKey(key.PrivateKey)
+
+	// Depending on the presence of the chain ID, sign with EIP155 or homestead
+	if chainID != nil {
+		return types.SignEthTx(tx, types.NewEIP155Signer(chainID), key.PrivateKey)
+	}
+	return types.SignEthTx(tx, types.HomesteadSigner{}, key.PrivateKey)
 }
 
 // Unlock unlocks the given account indefinitely.

--- a/core/types/eth_transaction.go
+++ b/core/types/eth_transaction.go
@@ -359,7 +359,7 @@ func (tx *EthTransaction) AsMessage(s Signer) (Message, error) {
 
 // WithSignature returns a new transaction with the given signature.
 // This signature needs to be in the [R || S || V] format where V is 0 or 1.
-func (tx *EthTransaction) WithSignature(signer Signer, sig []byte) (InternalTransaction, error) {
+func (tx *EthTransaction) WithSignature(signer Signer, sig []byte) (*EthTransaction, error) {
 	r, s, v, err := signer.SignatureValues(tx, sig)
 	if err != nil {
 		return nil, err

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -64,6 +64,16 @@ func SignTx(tx *Transaction, s Signer, prv *ecdsa.PrivateKey) (*Transaction, err
 	return tx.WithSignature(s, sig)
 }
 
+// SignEthTx signs the eth transaction using the given signer and private key
+func SignEthTx(tx *EthTransaction, s Signer, prv *ecdsa.PrivateKey) (*EthTransaction, error) {
+	h := s.Hash(tx)
+	sig, err := crypto.Sign(h[:], prv)
+	if err != nil {
+		return nil, err
+	}
+	return tx.WithSignature(s, sig)
+}
+
 // Sender returns the address derived from the signature (V, R, S) using secp256k1
 // elliptic curve and an error if it failed deriving or upon an incorrect
 // signature.


### PR DESCRIPTION
Adds support for `SignEthTx` to enable signing EthTransactions in go-sdk, go-lib etc.

`(tx *EthTransaction) WithSignature` was changed to return a `*EthTransaction` instead of `InternalTransaction` to follow the same pattern as `(tx *Transaction) WithSignature`.

(Changing `(tx *Transaction) WithSignature` to return a `InternalTransaction` results in a lot of failing tests due to failing type assertions - hence why `tx *Transaction` and `tx *EthTransaction` are returned respectively.)