### PR TITLE
enable eth txn for testnet at epoch 73290

### DIFF
--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -60,7 +60,7 @@ var (
 		ChainID:                    TestnetChainID,
 		EthCompatibleChainID:       EthTestnetShard0ChainID,
 		EthCompatibleShard0ChainID: EthTestnetShard0ChainID,
-		EthCompatibleEpoch:         EpochTBD,
+		EthCompatibleEpoch:         big.NewInt(73290),
 		CrossTxEpoch:               big.NewInt(0),
 		CrossLinkEpoch:             big.NewInt(2),
 		StakingEpoch:               big.NewInt(2),


### PR DESCRIPTION
which happens closely before noon Monday 1/25/2021 PST