### PR TITLE
Update beacon chain config

### DIFF
--- a/internal/shardchain/shardchains.go
+++ b/internal/shardchain/shardchains.go
@@ -106,7 +106,7 @@ func (sc *CollectionImpl) ShardChain(shardID uint32) (*core.BlockChain, error) {
 		chainConfig.EthCompatibleChainID = big.NewInt(chainConfig.EthCompatibleShard0ChainID.Int64())
 	}
 	bc, err := core.NewBlockChain(
-		db, cacheConfig, sc.chainConfig, sc.engine, vm.Config{}, nil,
+		db, cacheConfig, &chainConfig, sc.engine, vm.Config{}, nil,
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot create blockchain")


### PR DESCRIPTION
Should use the updated chain config for beacon blockchain initialization.

Otherwise, beacon chain in non-beacon shards will recognize the eth-compatible txns and will report error:

```
{"level":"error","caller":"/mnt/jenkins/workspace/harmony-release/harmony/core/blockchain.go:1645","time":"2021-01-25T22:01:28.59753681+01:00","message":"\n########## BAD BLOCK #########\nChain config: {ChainID: 2 EthCompatibleChainID: 1666700001 EIP155: 0 CrossTx: 0 Staking: 2 CrossLink: 2 ReceiptLog: 0}\n\nNumber: 5150267\nEpoch: 73290\nNumTxn: 1\nNumStkTxn: 0\nHash: 0x95aba0e885317a89b7ee9d81fba42c2d7d5092ed3ae1981cb4c22c88f06eb638\n\n\nError: invalid chain id for signer\n##############################\n"}
```