### PR TITLE
Add eth txn hash lookup entry

### DIFF
--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -58,6 +58,14 @@ func WriteBlockTxLookUpEntries(db DatabaseWriter, block *types.Block) error {
 		if err := db.Put(key, val); err != nil {
 			return err
 		}
+		if tx.IsEthCompatible() {
+			// Also put a lookup entry for eth transaction's hash
+			ethTxn := tx.ConvertToEth()
+			key := txLookupKey(ethTxn.Hash())
+			if err := db.Put(key, val); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Ethereum toolings such as Metamask will lookup txns based on the hash/iD of txn in the original ethereum format. So we need to also index the eth txns by their "ethereum" hash in our node.

Tested with Metamask in localnet. I was able to use the txn hash in MetaMask to look it up in hmy rpc