### PR TITLE
Return the Ethereum tx hash for Ethereum txs

### DIFF
--- a/rpc/pool.go
+++ b/rpc/pool.go
@@ -51,18 +51,21 @@ func (s *PublicPoolService) SendRawTransaction(
 	}
 
 	var tx *types.Transaction
+	var txHash common.Hash
 
 	if s.version == Eth {
 		ethTx := new(types.EthTransaction)
 		if err := rlp.DecodeBytes(encodedTx, ethTx); err != nil {
 			return common.Hash{}, err
 		}
+		txHash = ethTx.Hash()
 		tx = ethTx.ConvertToHmy()
 	} else {
 		tx = new(types.Transaction)
 		if err := rlp.DecodeBytes(encodedTx, tx); err != nil {
 			return common.Hash{}, err
 		}
+		txHash = tx.Hash()
 	}
 
 	// Verify chainID
@@ -102,7 +105,7 @@ func (s *PublicPoolService) SendRawTransaction(
 	}
 
 	// Response output is the same for all versions
-	return tx.Hash(), nil
+	return txHash, nil
 }
 
 func (s *PublicPoolService) verifyChainID(tx *types.Transaction) error {


### PR DESCRIPTION
In order to be compatible with Ethers.js we need to return the original Ethereum tx hash and not the Harmony tx hash - otherwise Ethers.js will fail with e.g.:

```
Error: Transaction hash mismatch from Provider.sendTransaction. (expectedHash="0x7ab188ea6742b7b646b276b2772ee420bbc624480fcc061f953d4efd0b56026e", returnedHash="0xa2f78d855d6147e269c5635b50fdd6fbb6f07a8ec18e9f7003cddc415adea8f3", code=UNKNOWN_ERROR, version=providers/5.0.19)
```