### PR TITLE
Use and return the Ethereum tx hash for Ethereum txs

### DIFF
--- a/api/service/explorer/storage.go
+++ b/api/service/explorer/storage.go
@@ -164,7 +164,7 @@ func computeAccountsTransactionsMapForBlock(
 	for _, tx := range block.Transactions() {
 		explorerTransaction, err := GetTransaction(tx, block)
 		if err != nil {
-			utils.Logger().Error().Err(err).Str("txHash", tx.Hash().String()).
+			utils.Logger().Error().Err(err).Str("txHash", tx.HashByType().String()).
 				Msg("[Explorer Storage] Failed to get GetTransaction mapping")
 			continue
 		}

--- a/api/service/explorer/structs.go
+++ b/api/service/explorer/structs.go
@@ -81,8 +81,9 @@ func GetTransaction(tx *types.Transaction, addressBlock *types.Block) (*Transact
 	if from, err = common2.AddressToBech32(msg.From()); err != nil {
 		return nil, err
 	}
+
 	return &Transaction{
-		ID:        tx.Hash().Hex(),
+		ID:        tx.HashByType().Hex(),
 		Timestamp: strconv.Itoa(int(addressBlock.Time().Int64() * 1000)),
 		From:      from,
 		To:        to,

--- a/api/service/explorer/structs_test.go
+++ b/api/service/explorer/structs_test.go
@@ -24,7 +24,7 @@ func TestGetTransaction(t *testing.T) {
 	block := types.NewBlock(blockfactory.NewTestHeader().With().Number(big.NewInt(314)).Header(), txs, types.Receipts{&types.Receipt{}, &types.Receipt{}, &types.Receipt{}}, nil, nil, nil)
 
 	tx, _ := GetTransaction(tx1, block)
-	assert.Equal(t, tx.ID, tx1.Hash().Hex(), "should be equal tx1.Hash()")
+	assert.Equal(t, tx.ID, tx1.HashByType().Hex(), "should be equal tx1.Hash()")
 	assert.Equal(t, tx.To, common2.MustAddressToBech32(common.HexToAddress(tx1.To().Hex())), "should be equal tx1.To()")
 	assert.Equal(t, tx.Bytes, strconv.Itoa(int(tx1.Size())), "should be equal tx1.Size()")
 }

--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -112,7 +112,14 @@ func ReadTransaction(db DatabaseReader, hash common.Hash) (*types.Transaction, c
 		return nil, common.Hash{}, 0, 0
 	}
 	tx := body.TransactionAt(int(txIndex))
-	if tx == nil || !bytes.Equal(hash.Bytes(), tx.Hash().Bytes()) {
+	var hashBytes []byte
+	if tx.IsEthCompatible() {
+		ethTxn := tx.ConvertToEth()
+		hashBytes = ethTxn.Hash().Bytes()
+	} else {
+		hashBytes = tx.Hash().Bytes()
+	}
+	if tx == nil || !bytes.Equal(hash.Bytes(), hashBytes) {
 		utils.Logger().Error().
 			Uint64("number", blockNumber).
 			Str("hash", blockHash.Hex()).

--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -101,6 +101,7 @@ func ReadTransaction(db DatabaseReader, hash common.Hash) (*types.Transaction, c
 	if blockHash == (common.Hash{}) {
 		return nil, common.Hash{}, 0, 0
 	}
+
 	body := ReadBody(db, blockHash, blockNumber)
 	if body == nil {
 		utils.Logger().Error().
@@ -111,9 +112,20 @@ func ReadTransaction(db DatabaseReader, hash common.Hash) (*types.Transaction, c
 		return nil, common.Hash{}, 0, 0
 	}
 	tx := body.TransactionAt(int(txIndex))
-	hmyHash := tx.Hash()
-	ethHash := tx.HashByType()
-	if tx == nil || (!bytes.Equal(hash.Bytes(), hmyHash.Bytes()) && !bytes.Equal(hash.Bytes(), ethHash.Bytes())) {
+	missing := false
+	if tx == nil {
+		missing = true
+	} else {
+		hmyHash := tx.Hash()
+		ethHash := tx.HashByType()
+
+		if !bytes.Equal(hash.Bytes(), hmyHash.Bytes()) && !bytes.Equal(hash.Bytes(), ethHash.Bytes()) {
+			missing = true
+		}
+
+	}
+
+	if missing {
 		utils.Logger().Error().
 			Uint64("number", blockNumber).
 			Str("hash", blockHash.Hex()).

--- a/core/rawdb/accessors_indexes_test.go
+++ b/core/rawdb/accessors_indexes_test.go
@@ -82,10 +82,7 @@ func TestLookupStorage(t *testing.T) {
 	}
 
 	for i, tx := range txs {
-		txnHash := tx.Hash()
-		if tx.IsEthCompatible() {
-			txnHash = tx.ConvertToEth().Hash()
-		}
+		txnHash := tx.HashByType()
 		if txn, hash, number, index := ReadTransaction(db, txnHash); txn == nil {
 			t.Fatalf("tx #%d [%x]: transaction not found", i, tx.Hash())
 		} else {

--- a/core/rawdb/accessors_indexes_test.go
+++ b/core/rawdb/accessors_indexes_test.go
@@ -82,14 +82,18 @@ func TestLookupStorage(t *testing.T) {
 	}
 
 	for i, tx := range txs {
-		if txn, hash, number, index := ReadTransaction(db, tx.Hash()); txn == nil {
+		txnHash := tx.Hash()
+		if tx.IsEthCompatible() {
+			txnHash = tx.ConvertToEth().Hash()
+		}
+		if txn, hash, number, index := ReadTransaction(db, txnHash); txn == nil {
 			t.Fatalf("tx #%d [%x]: transaction not found", i, tx.Hash())
 		} else {
 			if hash != block.Hash() || number != block.NumberU64() || index != uint64(i) {
-				t.Fatalf("tx #%d [%x]: positional metadata mismatch: have %x/%d/%d, want %x/%v/%v", i, tx.Hash(), hash, number, index, block.Hash(), block.NumberU64(), i)
+				t.Fatalf("tx #%d [%x]: positional metadata mismatch: have %x/%d/%d, want %x/%v/%v", i, txnHash, hash, number, index, block.Hash(), block.NumberU64(), i)
 			}
 			if tx.Hash() != txn.Hash() {
-				t.Fatalf("tx #%d [%x]: transaction mismatch: have %v, want %v", i, tx.Hash(), txn, tx)
+				t.Fatalf("tx #%d [%x]: transaction mismatch: have %v, want %v", i, txnHash, txn, tx)
 			}
 		}
 	}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -403,6 +403,15 @@ func (tx *Transaction) Hash() common.Hash {
 	return v
 }
 
+// HashByType hashes the RLP encoding of tx in it's original format (eth or hmy)
+// It uniquely identifies the transaction.
+func (tx *Transaction) HashByType() common.Hash {
+	if tx.IsEthCompatible() {
+		return tx.ConvertToEth().Hash()
+	}
+	return tx.Hash()
+}
+
 // Size returns the true RLP encoded storage size of the transaction, either by
 // encoding and returning it, or returning a previously cached value.
 func (tx *Transaction) Size() common.StorageSize {

--- a/hmy/blockchain.go
+++ b/hmy/blockchain.go
@@ -149,13 +149,14 @@ func (hmy *Harmony) GetPreStakingBlockRewards(
 	}
 	txFees := big.NewInt(0)
 	for _, tx := range blk.Transactions() {
-		dbTx, _, _, receiptIndex := rawdb.ReadTransaction(hmy.ChainDb(), tx.Hash())
+		txnHash := tx.HashByType()
+		dbTx, _, _, receiptIndex := rawdb.ReadTransaction(hmy.ChainDb(), txnHash)
 		if dbTx == nil {
-			return nil, fmt.Errorf("could not find receipt for tx: %v", tx.Hash().String())
+			return nil, fmt.Errorf("could not find receipt for tx: %v", txnHash.String())
 		}
 		if len(receipts) <= int(receiptIndex) {
 			return nil, fmt.Errorf("invalid receipt indext %v (>= num receipts: %v) for tx: %v",
-				receiptIndex, len(receipts), tx.Hash().String())
+				receiptIndex, len(receipts), txnHash.String())
 		}
 		txFee := new(big.Int).Mul(tx.GasPrice(), big.NewInt(int64(receipts[receiptIndex].GasUsed)))
 		txFees = new(big.Int).Add(txFee, txFees)

--- a/node/node.go
+++ b/node/node.go
@@ -278,7 +278,7 @@ func (node *Node) AddPendingTransaction(newTx *types.Transaction) error {
 			}
 		}
 		if err == nil || node.BroadcastInvalidTx {
-			utils.Logger().Info().Str("Hash", newTx.Hash().Hex()).Msg("Broadcasting Tx")
+			utils.Logger().Info().Str("Hash", newTx.Hash().Hex()).Str("HashByType", newTx.HashByType().Hex()).Msg("Broadcasting Tx")
 			node.tryBroadcast(newTx)
 		}
 		return err

--- a/rpc/eth/types.go
+++ b/rpc/eth/types.go
@@ -133,7 +133,7 @@ func NewTransaction(
 	result := &Transaction{
 		Gas:       hexutil.Uint64(tx.GasLimit()),
 		GasPrice:  (*hexutil.Big)(tx.GasPrice()),
-		Hash:      tx.Hash(),
+		Hash:      tx.HashByType(),
 		Input:     hexutil.Bytes(tx.Data()),
 		Nonce:     hexutil.Uint64(tx.Nonce()),
 		Value:     (*hexutil.Big)(tx.Value()),
@@ -187,7 +187,7 @@ func NewTxReceipt(
 	// Declare receipt
 	txReceipt := &TxReceipt{
 		BlockHash:         blockHash,
-		TransactionHash:   tx.Hash(),
+		TransactionHash:   tx.HashByType(),
 		BlockNumber:       hexutil.Uint64(blockNumber),
 		TransactionIndex:  hexutil.Uint64(blockIndex),
 		GasUsed:           hexutil.Uint64(receipt.GasUsed),
@@ -265,7 +265,7 @@ func NewBlockWithTxHash(
 	}
 
 	for _, tx := range b.Transactions() {
-		blk.Transactions = append(blk.Transactions, tx.Hash())
+		blk.Transactions = append(blk.Transactions, tx.HashByType())
 	}
 
 	if blockArgs.WithSigners {

--- a/rpc/filters/filter_system.go
+++ b/rpc/filters/filter_system.go
@@ -346,7 +346,7 @@ func (es *EventSystem) broadcast(filters filterIndex, ev interface{}) {
 	case core.NewTxsEvent:
 		hashes := make([]common.Hash, 0, len(e.Txs))
 		for _, tx := range e.Txs {
-			hashes = append(hashes, tx.Hash())
+			hashes = append(hashes, tx.HashByType())
 		}
 		for _, f := range filters[PendingTransactionsSubscription] {
 			f.hashes <- hashes

--- a/rpc/pool.go
+++ b/rpc/pool.go
@@ -51,18 +51,21 @@ func (s *PublicPoolService) SendRawTransaction(
 	}
 
 	var tx *types.Transaction
+	var txHash common.Hash
 
 	if s.version == Eth {
 		ethTx := new(types.EthTransaction)
 		if err := rlp.DecodeBytes(encodedTx, ethTx); err != nil {
 			return common.Hash{}, err
 		}
+		txHash = ethTx.Hash()
 		tx = ethTx.ConvertToHmy()
 	} else {
 		tx = new(types.Transaction)
 		if err := rlp.DecodeBytes(encodedTx, tx); err != nil {
 			return common.Hash{}, err
 		}
+		txHash = tx.Hash()
 	}
 
 	// Verify chainID
@@ -102,7 +105,7 @@ func (s *PublicPoolService) SendRawTransaction(
 	}
 
 	// Response output is the same for all versions
-	return tx.Hash(), nil
+	return txHash, nil
 }
 
 func (s *PublicPoolService) verifyChainID(tx *types.Transaction) error {

--- a/rpc/pool.go
+++ b/rpc/pool.go
@@ -94,11 +94,13 @@ func (s *PublicPoolService) SendRawTransaction(
 		addr := crypto.CreateAddress(from, tx.Nonce())
 		utils.Logger().Info().
 			Str("fullhash", tx.Hash().Hex()).
+			Str("hashByType", tx.HashByType().Hex()).
 			Str("contract", common2.MustAddressToBech32(addr)).
 			Msg("Submitted contract creation")
 	} else {
 		utils.Logger().Info().
 			Str("fullhash", tx.Hash().Hex()).
+			Str("hashByType", tx.HashByType().Hex()).
 			Str("recipient", tx.To().Hex()).
 			Interface("tx", tx).
 			Msg("Submitted transaction")

--- a/rpc/pool.go
+++ b/rpc/pool.go
@@ -76,7 +76,7 @@ func (s *PublicPoolService) SendRawTransaction(
 	// Submit transaction
 	if err := s.hmy.SendTx(ctx, tx); err != nil {
 		utils.Logger().Warn().Err(err).Msg("Could not submit transaction")
-		return tx.Hash(), err
+		return txHash, err
 	}
 
 	// Log submission


### PR DESCRIPTION
Since we store ethereum txn using the translated format of hmy txn on the chain. The txn hash of the two types of txns are not the same. We need streamline the logic to make sure to the developers/users, when they are sending eth txns, they are always handling the txns by the eth version of the txn hash.

Fix the txn lookup checking where txn hash and the lookup hash doesn't match.

Also update all the txn hash usage to use the appropriate version of the hash.