### PR TITLE
Make eth_getTransactionReceipt compatible with EIP-658

### DIFF
--- a/rpc/pool.go
+++ b/rpc/pool.go
@@ -207,7 +207,7 @@ func (s *PublicPoolService) PendingTransactions(
 					continue // Legacy behavior is to not return error here
 				}
 			case Eth:
-				tx, err = eth.NewTransaction(plainTx, common.Hash{}, 0, 0, 0)
+				tx, err = eth.NewTransaction(plainTx.ConvertToEth(), common.Hash{}, 0, 0, 0)
 				if err != nil {
 					utils.Logger().Debug().
 						Err(err).

--- a/rpc/transaction.go
+++ b/rpc/transaction.go
@@ -187,7 +187,7 @@ func (s *PublicTransactionService) GetTransactionByHash(
 		}
 		return NewStructuredResponse(tx)
 	case Eth:
-		tx, err := eth.NewTransaction(tx, blockHash, blockNumber, block.Time().Uint64(), index)
+		tx, err := eth.NewTransaction(tx.ConvertToEth(), blockHash, blockNumber, block.Time().Uint64(), index)
 		if err != nil {
 			return nil, err
 		}
@@ -648,10 +648,8 @@ func (s *PublicTransactionService) GetTransactionReceipt(
 		}
 		return NewStructuredResponse(RPCReceipt)
 	case Eth:
-		if tx == nil {
-			RPCReceipt, err = eth.NewReceipt(stx, blockHash, blockNumber, index, receipt)
-		} else {
-			RPCReceipt, err = eth.NewReceipt(tx, blockHash, blockNumber, index, receipt)
+		if tx != nil {
+			RPCReceipt, err = eth.NewReceipt(tx.ConvertToEth(), blockHash, blockNumber, index, receipt)
 		}
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR fixes an issue where `eth_getTransactionReceipt` was returning both a pre-Byzantium `root` field as well as a post-Byzantium `status` field - you're supposed to return one of them, not both.

Related EIP: https://eips.ethereum.org/EIPS/eip-658