### PR TITLE
[viewchange] always use first participant as base of leader pubkey

### DIFF
--- a/consensus/config.go
+++ b/consensus/config.go
@@ -33,6 +33,18 @@ const (
 	timeoutBootstrap
 )
 
+func (t TimeoutType) String() string {
+	switch t {
+	case timeoutConsensus:
+		return "timeoutConsensus"
+	case timeoutViewChange:
+		return "timeoutViewChange"
+	case timeoutBootstrap:
+		return "timeoutBootstrap"
+	}
+	return "unknown"
+}
+
 var (
 	// NIL is the m2 type message, which suppose to be nil/empty, however
 	// we cannot sign on empty message, instead we sign on some default "nil" message

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -298,6 +298,10 @@ func (consensus *Consensus) UpdateConsensusInformation() Mode {
 	if curHeader.IsLastBlockInEpoch() {
 		nextShardState, err := curHeader.GetShardState()
 		if err != nil {
+			consensus.getLogger().Error().
+				Err(err).
+				Uint32("shard", consensus.ShardID).
+				Msg("[UpdateConsensusInformation] Error retrieving current shard state in the first block")
 			return Syncing
 		}
 		if nextShardState.Epoch != nil {
@@ -439,6 +443,10 @@ func (consensus *Consensus) UpdateConsensusInformation() Mode {
 		myPubKeys := consensus.GetPublicKeys()
 		if myPubKeys.Contains(key.Object) {
 			if hasError {
+				consensus.getLogger().Error().
+					Str("myKey", myPubKeys.SerializeToHexStr()).
+					Msg("[UpdateConsensusInformation] hasError")
+
 				return Syncing
 			}
 
@@ -455,6 +463,9 @@ func (consensus *Consensus) UpdateConsensusInformation() Mode {
 			return Normal
 		}
 	}
+	consensus.getLogger().Info().
+		Msg("[UpdateConsensusInformation] not in committee, Listening")
+
 	// not in committee
 	return Listening
 }

--- a/consensus/quorum/quorum.go
+++ b/consensus/quorum/quorum.go
@@ -75,6 +75,7 @@ type ParticipantTracker interface {
 	ParticipantsCount() int64
 	NthNext(*bls.PublicKeyWrapper, int) (bool, *bls.PublicKeyWrapper)
 	NthNextHmy(shardingconfig.Instance, *bls.PublicKeyWrapper, int) (bool, *bls.PublicKeyWrapper)
+	FirstParticipant(shardingconfig.Instance) *bls.PublicKeyWrapper
 	UpdateParticipants(pubKeys []bls.PublicKeyWrapper)
 }
 
@@ -241,6 +242,11 @@ func (s *cIdentities) NthNextHmy(instance shardingconfig.Instance, pubKey *bls.P
 	}
 	idx = (idx + next) % numNodes
 	return found, &s.publicKeys[idx]
+}
+
+// FirstParticipant returns the first participant of the shard
+func (s *cIdentities) FirstParticipant(instance shardingconfig.Instance) *bls.PublicKeyWrapper {
+	return &s.publicKeys[0]
 }
 
 func (s *cIdentities) Participants() multibls.PublicKeys {

--- a/node/node.go
+++ b/node/node.go
@@ -1050,6 +1050,9 @@ func (node *Node) InitConsensusWithValidators() (err error) {
 	}
 	subComm, err := shardState.FindCommitteeByID(shardID)
 	if err != nil {
+		utils.Logger().Err(err).
+			Interface("shardState", shardState).
+			Msg("[InitConsensusWithValidators] Find CommitteeByID")
 		return err
 	}
 	pubKeys, err := subComm.BLSPublicKeys()
@@ -1069,6 +1072,7 @@ func (node *Node) InitConsensusWithValidators() (err error) {
 			utils.Logger().Info().
 				Uint64("blockNum", blockNum).
 				Int("numPubKeys", len(pubKeys)).
+				Str("mode", node.Consensus.Mode().String()).
 				Msg("[InitConsensusWithValidators] Successfully updated public keys")
 			node.Consensus.UpdatePublicKeys(pubKeys)
 			node.Consensus.SetMode(consensus.Normal)


### PR DESCRIPTION
when view change happended at the first block of the new epoch

Signed-off-by: Leo Chen <leo@harmony.one>