### PR TITLE
make sure consensus always work in testnet

### DIFF
--- a/consensus/votepower/roster.go
+++ b/consensus/votepower/roster.go
@@ -187,7 +187,7 @@ func Compute(subComm *shard.Committee, epoch *big.Int) (*Roster, error) {
 	if nodeconfig.GetDefaultConfig().GetNetworkType() == nodeconfig.Testnet && epoch.Cmp(big.NewInt(73305)) >= 0 &&
 		epoch.Cmp(big.NewInt(73330)) <= 0 {
 		harmonyPercent = numeric.MustNewDecFromStr("0.70")
-		externalPercent = numeric.MustNewDecFromStr("0.30")
+		externalPercent = numeric.MustNewDecFromStr("0.40") // Make sure consensus is always good.
 	}
 
 	for i := range staked {


### PR DESCRIPTION
shard 0 having a case where 1 external validator with 40% voting power signed previously. Thus, the new 70-30 assignment made the previous block's signature invalid because that 40% voting power become 30%.

This should always make testnet work during these stuck epochs.