### PR TITLE
[travis] Cache docker imgs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language: go
 go:
   - 1.14
 go_import_path: github.com/harmony-one/harmony
+cache:
+  directories:
+    - docker_images
 env:
   - TEST="make"
   - TEST="bash ./scripts/travis_go_checker.sh"

--- a/scripts/travis_rosetta_checker.sh
+++ b/scripts/travis_rosetta_checker.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+CACHE_DIR="docker_images"
+docker load -i $CACHE_DIR/images.tar || true
 docker pull harmonyone/localnet-test
+docker save -o $CACHE_DIR/images.tar harmonyone/localnet-test
 docker run -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test -r

--- a/scripts/travis_rosetta_checker.sh
+++ b/scripts/travis_rosetta_checker.sh
@@ -2,7 +2,10 @@
 set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 CACHE_DIR="docker_images"
+mkdir -p $CACHE_DIR
+echo "pulling cached docker img"
 docker load -i $CACHE_DIR/images.tar || true
 docker pull harmonyone/localnet-test
+echo "saving cached docker img"
 docker save -o $CACHE_DIR/images.tar harmonyone/localnet-test
 docker run -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test -r

--- a/scripts/travis_rpc_checker.sh
+++ b/scripts/travis_rpc_checker.sh
@@ -2,7 +2,10 @@
 set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 CACHE_DIR="docker_images"
+mkdir -p $CACHE_DIR
+echo "pulling cached docker img"
 docker load -i $CACHE_DIR/images.tar || true
 docker pull harmonyone/localnet-test
+echo "saving cached docker img"
 docker save -o $CACHE_DIR/images.tar harmonyone/localnet-test
 docker run -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test -n

--- a/scripts/travis_rpc_checker.sh
+++ b/scripts/travis_rpc_checker.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+CACHE_DIR="docker_images"
+docker load -i $CACHE_DIR/images.tar || true
 docker pull harmonyone/localnet-test
+docker save -o $CACHE_DIR/images.tar harmonyone/localnet-test
 docker run -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test -n


### PR DESCRIPTION
Cache the docker img to make ux better with the new docker-hub rate limit.

This is the only option that we have since we CANNOT use private env vars (via Travis) to auth a docker account as they DO NOT work on forks (for security reasons). 