### PR TITLE
Add web3_clientVersion

### DIFF
--- a/node/api.go
+++ b/node/api.go
@@ -118,6 +118,7 @@ func (node *Node) APIs(harmony *hmy.Harmony) []rpc.API {
 			Public:    true,
 		},
 		hmy_rpc.NewPublicNetAPI(node.host, harmony.ChainID, hmy_rpc.Eth),
+		hmy_rpc.NewPublicWeb3API(),
 	}
 }
 

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -38,13 +38,14 @@ const (
 	netNamespace   = "net"
 	netV1Namespace = "netv1"
 	netV2Namespace = "netv2"
+	web3Namespace  = "web3"
 )
 
 var (
 	// HTTPModules ..
-	HTTPModules = []string{"hmy", "hmyv2", "eth", "debug", netNamespace, netV1Namespace, netV2Namespace, "explorer"}
+	HTTPModules = []string{"hmy", "hmyv2", "eth", "debug", netNamespace, netV1Namespace, netV2Namespace, web3Namespace, "explorer"}
 	// WSModules ..
-	WSModules = []string{"hmy", "hmyv2", "eth", "debug", netNamespace, netV1Namespace, netV2Namespace, "web3"}
+	WSModules = []string{"hmy", "hmyv2", "eth", "debug", netNamespace, netV1Namespace, netV2Namespace, web3Namespace, "web3"}
 
 	httpListener     net.Listener
 	httpHandler      *rpc.Server

--- a/rpc/web3.go
+++ b/rpc/web3.go
@@ -1,0 +1,26 @@
+package rpc
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/rpc"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
+)
+
+// PublicWeb3Service offers web3 related RPC methods
+type PublicWeb3Service struct{}
+
+// NewPublicWeb3API creates a new web3 API instance.
+func NewPublicWeb3API() rpc.API {
+	return rpc.API{
+		Namespace: web3Namespace,
+		Version:   APIVersion,
+		Service:   &PublicWeb3Service{},
+		Public:    true,
+	}
+}
+
+// ClientVersion - returns the current client version of the running node
+func (s *PublicWeb3Service) ClientVersion(ctx context.Context) interface{} {
+	return nodeconfig.GetVersion()
+}


### PR DESCRIPTION
This PR adds support for `web3_clientVersion` which is required for Hardhat deployments/interactions.