### PR TITLE
Enable filter API:s for the eth_ namespace

### DIFF
--- a/node/api.go
+++ b/node/api.go
@@ -117,6 +117,12 @@ func (node *Node) APIs(harmony *hmy.Harmony) []rpc.API {
 			Service:   filters.NewPublicFilterAPI(harmony, false),
 			Public:    true,
 		},
+		{
+			Namespace: "eth",
+			Version:   hmy_rpc.APIVersion,
+			Service:   filters.NewPublicFilterAPI(harmony, false),
+			Public:    true,
+		},
 		hmy_rpc.NewPublicNetAPI(node.host, harmony.ChainID, hmy_rpc.Eth),
 		hmy_rpc.NewPublicWeb3API(),
 	}


### PR DESCRIPTION
Filter RPC endpoints are currently only enabled for the `hmy_` namespace, enable them for `eth_` too.