### PR TITLE
[consensus] fix the rare consensus/sync race condition

### DIFF
--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -346,6 +346,9 @@ func (consensus *Consensus) Start(
 					consensus.consensusTimeout[timeoutConsensus].Start()
 					consensus.getLogger().Info().Str("Mode", mode.String()).Msg("Node is IN SYNC")
 					consensusSyncCounterVec.With(prometheus.Labels{"consensus": "in_sync"}).Inc()
+				} else if consensus.Mode() == Syncing {
+					mode := consensus.UpdateConsensusInformation()
+					consensus.SetMode(mode)
 				}
 				consensus.mutex.Unlock()
 


### PR DESCRIPTION
## Issue

Fix https://github.com/harmony-one/harmony/issues/3538. 

Added logic that when consensus and sync races on insert block, the node is forever stuck in syncing mode.
