### PR TITLE
Add Accounts endpoint

### DIFF
--- a/rpc/blockchain.go
+++ b/rpc/blockchain.go
@@ -56,6 +56,14 @@ func (s *PublicBlockchainService) ChainId(ctx context.Context) (interface{}, err
 	}
 }
 
+// Accounts returns the collection of accounts this node manages
+// While this JSON-RPC method is supported, it will not return any accounts.
+// Similar to e.g. Infura "unlocking" accounts isn't supported.
+// Instead, users should send already signed raw transactions using hmy_sendRawTransaction or eth_sendRawTransaction
+func (s *PublicBlockchainService) Accounts() []common.Address {
+	return []common.Address{}
+}
+
 // getBlockOptions is a helper to get block args given an interface option from RPC params.
 func (s *PublicBlockchainService) getBlockOptions(opts interface{}) (*rpc_common.BlockArgs, error) {
 	switch s.version {


### PR DESCRIPTION
Adds support for `hmy_accounts` and `eth_accounts`:

```
$ curl http://localhost:9500/ -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"hmy_accounts","params": [],"id":1}'
{"jsonrpc":"2.0","id":1,"result":[]}
```

```
$ curl http://localhost:9500/ -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_accounts","params": [],"id":1}'
{"jsonrpc":"2.0","id":1,"result":[]}
```

The endpoint will always return an empty array similar to how e.g. Infura (https://infura.io/docs/ethereum/json-rpc/eth-accounts) handles it:

> NOTE: While this JSON-RPC method is supported by Infura, it will not return any accounts. Infura does not support "unlocking" accounts. Instead, users should send already signed raw transactions using eth_sendRawTransaction.

The endpoint is solely implemented to support various Ethereum-related tools that rely on `eth_accounts` being a valid RPC endpoint.