### PR TITLE
enable 40% external voting power on stressnet

### DIFF
--- a/consensus/quorum/one-node-staked-vote.go
+++ b/consensus/quorum/one-node-staked-vote.go
@@ -216,7 +216,7 @@ func (v *stakedVoteWeight) SetVoters(
 	// Hold onto this calculation
 	v.roster = *roster
 
-	utils.Logger().Info().
+	utils.Logger().Debug().
 		Uint64("curEpoch", epoch.Uint64()).
 		Uint32("shard-id", subCommittee.ShardID).
 		Str("committee", roster.String()).

--- a/internal/configs/sharding/stress.go
+++ b/internal/configs/sharding/stress.go
@@ -16,8 +16,8 @@ var StressNetSchedule stressnetSchedule
 type stressnetSchedule struct{}
 
 const (
-	// ~304 sec epochs for P2 of open staking
-	stressnetBlocksPerEpoch = 38
+	// ~0.5 hour per epoch
+	stressnetBlocksPerEpoch = 1024
 
 	stressnetVdfDifficulty = 10000 // This takes about 20s to finish the vdf
 
@@ -29,6 +29,8 @@ const (
 
 func (ss stressnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	switch {
+	case params.StressnetChainConfig.IsSixtyPercent(epoch):
+		return stressnetV2
 	case epoch.Cmp(params.StressnetChainConfig.StakingEpoch) >= 0:
 		return stressnetV1
 	default: // genesis
@@ -84,3 +86,4 @@ var stressnetReshardingEpoch = []*big.Int{
 
 var stressnetV0 = MustNewInstance(2, 10, 10, numeric.OneDec(), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, stressnetReshardingEpoch, StressNetSchedule.BlocksPerEpoch())
 var stressnetV1 = MustNewInstance(2, 30, 10, numeric.MustNewDecFromStr("0.9"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, stressnetReshardingEpoch, StressNetSchedule.BlocksPerEpoch())
+var stressnetV2 = MustNewInstance(2, 30, 10, numeric.MustNewDecFromStr("0.6"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, stressnetReshardingEpoch, StressNetSchedule.BlocksPerEpoch())

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -134,7 +134,7 @@ var (
 		QuickUnlockEpoch:           big.NewInt(0),
 		FiveSecondsEpoch:           big.NewInt(0),
 		TwoSecondsEpoch:            big.NewInt(0),
-		SixtyPercentEpoch:          EpochTBD, // Never enable it for STN as STN has no external validator setup
+		SixtyPercentEpoch:          big.NewInt(10),
 		RedelegationEpoch:          big.NewInt(0),
 		EIP155Epoch:                big.NewInt(0),
 		S3Epoch:                    big.NewInt(0),


### PR DESCRIPTION
This PR enables 40% external voting power on stressnet. It is used to test the voting power change w/o interruption of testnet.