### PR TITLE
[Ethereum RPC] Use BlockNonce type for marshaling nonce fields for blocks

### DIFF
--- a/rpc/eth/types.go
+++ b/rpc/eth/types.go
@@ -8,17 +8,18 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/harmony-one/harmony/core/types"
+	hmytypes "github.com/harmony-one/harmony/core/types"
 	internal_common "github.com/harmony-one/harmony/internal/common"
 	rpc_common "github.com/harmony-one/harmony/rpc/common"
 )
 
 // Block represents a basic block which is further amended by BlockWithTxHash or BlockWithFullTx
 type Block struct {
-	Number     *hexutil.Big `json:"number"`
-	Hash       common.Hash  `json:"hash"`
-	ParentHash common.Hash  `json:"parentHash"`
-	Nonce      uint64       `json:"nonce"`
-	MixHash    common.Hash  `json:"mixHash"`
+	Number     *hexutil.Big        `json:"number"`
+	Hash       common.Hash         `json:"hash"`
+	ParentHash common.Hash         `json:"parentHash"`
+	Nonce      hmytypes.BlockNonce `json:"nonce"`
+	MixHash    common.Hash         `json:"mixHash"`
 	//UncleHash   common.Hash    `json:"sha3Uncles" - used in Ethereum RPC:s
 	LogsBloom        ethtypes.Bloom `json:"logsBloom"`
 	StateRoot        common.Hash    `json:"stateRoot"`
@@ -161,12 +162,12 @@ func newBlock(b *types.Block, leader common.Address) *Block {
 		Number:           (*hexutil.Big)(head.Number()),
 		Hash:             b.Hash(),
 		ParentHash:       head.ParentHash(),
-		Nonce:            0, // Remove this because we don't have it in our header
+		Nonce:            hmytypes.BlockNonce{}, // Legacy comment from hmy -> eth RPC porting: "Remove this because we don't have it in our header"
 		MixHash:          head.MixDigest(),
 		LogsBloom:        head.Bloom(),
 		StateRoot:        head.Root(),
 		Miner:            leader,
-		Difficulty:       (*hexutil.Big)(big.NewInt(0)), // Remove this because we don't have it in our header
+		Difficulty:       (*hexutil.Big)(big.NewInt(0)), // Legacy comment from hmy -> eth RPC porting: "Remove this because we don't have it in our header"
 		ExtraData:        hexutil.Bytes(head.Extra()),
 		Size:             hexutil.Uint64(b.Size()),
 		GasLimit:         hexutil.Uint64(head.GasLimit()),


### PR DESCRIPTION
Our RPC:s (both `hmy_` & `eth_`) are currently returning block nonces as `uint64`.

The `eth_` RPC endpoints need to return these as 0x-prefixed hex strings with a length of 16 characters.

This currently breaks TheGraph node from working properly:
```
Feb 24 23:22:59.188 WARN Trying again after eth_getBlockByNumber(0, false) RPC call failed (attempt #10) with result Err(Decoder error: Error("invalid type: number, expected a 0x-prefixed hex string with length of 16", line: 0, column: 0))
```

The solution is to simply use `BlockNonce` from `github.com/harmony-one/harmony/core/types` that will marshal to the proper format when requested via RPC:

Wrong format (testnet):
```
curl -s https://api.s0.b.hmny.io -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "id": 1, "method": "eth_getBlockByNumber", "params": ["0x0", false]}' | jq '.result.nonce'
-> 0
```

Correct format (localnet):
```
curl -s http://localhost:9500 -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "id": 1, "method": "eth_getBlockByNumber", "params": ["0x0", false]}' | jq '.result.nonce'
-> "0x0000000000000000"
```

Correct format (Infura Mainnet):
```
curl -s https://mainnet.infura.io/v3/ENTER_YOUR_API_KEY_HERE -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "id": 1, "method": "eth_getBlockByNumber", "params": ["0x0", false]}' | jq '.result.nonce'
-> "0x0000000000000042"
```