### PR TITLE
Reuse old shard state if no validator is elected

### DIFF
--- a/shard/committee/assignment.go
+++ b/shard/committee/assignment.go
@@ -350,6 +350,10 @@ func eposStakedCommittee(
 		)
 	}
 
+	if len(completedEPoSRound.AuctionWinners) == 0 {
+		utils.Logger().Warn().Msg("No elected validators in the new epoch!!! Reuse old shard state.")
+		return stakerReader.ReadShardState(big.NewInt(0).Sub(epoch, big.NewInt(1)))
+	}
 	return shardState, nil
 }
 


### PR DESCRIPTION
In the apocalypse/rare case where there is no validator successfully elected, reuse the last committee to move the consensus forward.