### PR TITLE
[Ethereum RPC] Add sha3Uncles for block RPC endpoints

### DIFF
--- a/rpc/eth/rpc.go
+++ b/rpc/eth/rpc.go
@@ -1,4 +1,4 @@
-package v1
+package eth
 
 import (
 	"context"

--- a/rpc/eth/types.go
+++ b/rpc/eth/types.go
@@ -1,4 +1,4 @@
-package v1
+package eth
 
 import (
 	"fmt"
@@ -15,24 +15,24 @@ import (
 
 // Block represents a basic block which is further amended by BlockWithTxHash or BlockWithFullTx
 type Block struct {
-	Number     *hexutil.Big        `json:"number"`
-	Hash       common.Hash         `json:"hash"`
-	ParentHash common.Hash         `json:"parentHash"`
-	Nonce      hmytypes.BlockNonce `json:"nonce"`
-	MixHash    common.Hash         `json:"mixHash"`
-	//UncleHash   common.Hash    `json:"sha3Uncles" - used in Ethereum RPC:s
-	LogsBloom        ethtypes.Bloom `json:"logsBloom"`
-	StateRoot        common.Hash    `json:"stateRoot"`
-	Miner            common.Address `json:"miner"`
-	Difficulty       *hexutil.Big   `json:"difficulty"`
-	ExtraData        hexutil.Bytes  `json:"extraData"`
-	Size             hexutil.Uint64 `json:"size"`
-	GasLimit         hexutil.Uint64 `json:"gasLimit"`
-	GasUsed          hexutil.Uint64 `json:"gasUsed"`
-	Timestamp        hexutil.Uint64 `json:"timestamp"`
-	TransactionsRoot common.Hash    `json:"transactionsRoot"`
-	ReceiptsRoot     common.Hash    `json:"receiptsRoot"`
-	Uncles           []common.Hash  `json:"uncles"`
+	Number           *hexutil.Big        `json:"number"`
+	Hash             common.Hash         `json:"hash"`
+	ParentHash       common.Hash         `json:"parentHash"`
+	Nonce            hmytypes.BlockNonce `json:"nonce"`
+	MixHash          common.Hash         `json:"mixHash"`
+	UncleHash        common.Hash         `json:"sha3Uncles"`
+	LogsBloom        ethtypes.Bloom      `json:"logsBloom"`
+	StateRoot        common.Hash         `json:"stateRoot"`
+	Miner            common.Address      `json:"miner"`
+	Difficulty       *hexutil.Big        `json:"difficulty"`
+	ExtraData        hexutil.Bytes       `json:"extraData"`
+	Size             hexutil.Uint64      `json:"size"`
+	GasLimit         hexutil.Uint64      `json:"gasLimit"`
+	GasUsed          hexutil.Uint64      `json:"gasUsed"`
+	Timestamp        hexutil.Uint64      `json:"timestamp"`
+	TransactionsRoot common.Hash         `json:"transactionsRoot"`
+	ReceiptsRoot     common.Hash         `json:"receiptsRoot"`
+	Uncles           []common.Hash       `json:"uncles"`
 }
 
 // BlockWithTxHash represents a block that will serialize to the RPC representation of a block
@@ -164,6 +164,7 @@ func newBlock(b *types.Block, leader common.Address) *Block {
 		ParentHash:       head.ParentHash(),
 		Nonce:            hmytypes.BlockNonce{}, // Legacy comment from hmy -> eth RPC porting: "Remove this because we don't have it in our header"
 		MixHash:          head.MixDigest(),
+		UncleHash:        hmytypes.CalcUncleHash(b.Uncles()),
 		LogsBloom:        head.Bloom(),
 		StateRoot:        head.Root(),
 		Miner:            leader,


### PR DESCRIPTION
`sha3Uncles` was missing from our Ethereum block related RPC calls (e.g. `eth_getBlockByNumber`), this results in e.g. TheGraph not being able to properly traverse blocks.

This PR adds a `sha3Uncles` response field that represents a hashed value of a block's uncles using `types.CalcUncleHash(block.Uncles())`.

E.g:
```
$ curl -s http://localhost:9500 -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "id": 1, "method": "eth_getBlockByNumber", "params": ["0x0", false]}' | jq '.result.sha3Uncles'
-> "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
```

