### PR TITLE
[viewchange] protect view change struct during reset

### DIFF
--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -101,7 +101,10 @@ func (consensus *Consensus) UpdatePublicKeys(pubKeys []bls_cosi.PublicKeyWrapper
 	consensus.UpdateBitmaps()
 	consensus.ResetState()
 
-	consensus.ResetViewChangeState()
+	// do not reset view change state if it is in view changing mode
+	if !consensus.IsViewChangingMode() {
+		consensus.ResetViewChangeState()
+	}
 	return consensus.Decider.ParticipantsCount()
 }
 


### PR DESCRIPTION
This is a further fix of the following issue.
https://github.com/harmony-one/harmony/issues/3557

Signed-off-by: Leo Chen <leo@harmony.one>
