### PR TITLE
Support for eth hash lookup for hmy txns.

### DIFF
--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -115,12 +115,11 @@ func ReadTransaction(db DatabaseReader, hash common.Hash) (*types.Transaction, c
 		missing = true
 	} else {
 		hmyHash := tx.Hash()
-		ethHash := tx.HashByType()
+		ethHash := tx.ConvertToEth().Hash()
 
 		if !bytes.Equal(hash.Bytes(), hmyHash.Bytes()) && !bytes.Equal(hash.Bytes(), ethHash.Bytes()) {
 			missing = true
 		}
-
 	}
 
 	if missing {

--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -58,12 +58,10 @@ func WriteBlockTxLookUpEntries(db DatabaseWriter, block *types.Block) error {
 		if err := db.Put(key, val); err != nil {
 			return err
 		}
-		if tx.IsEthCompatible() {
-			// Also put a lookup entry for eth transaction's hash
-			key := txLookupKey(tx.HashByType())
-			if err := db.Put(key, val); err != nil {
-				return err
-			}
+		// Also put a lookup entry for eth transaction's hash
+		key = txLookupKey(tx.ConvertToEth().Hash())
+		if err := db.Put(key, val); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/rpc/eth/types.go
+++ b/rpc/eth/types.go
@@ -228,3 +228,14 @@ func NewBlockWithFullTx(b *types.Block, blockArgs *rpc_common.BlockArgs, leader 
 
 	return blkWithTxs, nil
 }
+
+// NewTransactionFromBlockIndex returns a transaction that will serialize to the RPC representation.
+func NewTransactionFromBlockIndex(b *types.Block, index uint64) (*Transaction, error) {
+	txs := b.Transactions()
+	if index >= uint64(len(txs)) {
+		return nil, fmt.Errorf(
+			"tx index %v greater than or equal to number of transactions on block %v", index, b.Hash().String(),
+		)
+	}
+	return NewTransaction(txs[index].ConvertToEth(), b.Hash(), b.NumberU64(), b.Time().Uint64(), index)
+}

--- a/rpc/eth/types.go
+++ b/rpc/eth/types.go
@@ -214,8 +214,8 @@ func NewBlockWithFullTx(b *types.Block, blockArgs *rpc_common.BlockArgs, leader 
 		Transactions: []*Transaction{},
 	}
 
-	for _, tx := range b.Transactions() {
-		fmtTx, err := NewTransactionFromBlockHash(b, tx.Hash())
+	for idx, _ := range b.Transactions() {
+		fmtTx, err := NewTransactionFromBlockIndex(b, uint64(idx))
 		if err != nil {
 			return nil, err
 		}
@@ -227,16 +227,6 @@ func NewBlockWithFullTx(b *types.Block, blockArgs *rpc_common.BlockArgs, leader 
 	}
 
 	return blkWithTxs, nil
-}
-
-// NewTransactionFromBlockHash returns a transaction that will serialize to the RPC representation.
-func NewTransactionFromBlockHash(b *types.Block, hash common.Hash) (*Transaction, error) {
-	for idx, tx := range b.Transactions() {
-		if tx.Hash() == hash {
-			return NewTransactionFromBlockIndex(b, uint64(idx))
-		}
-	}
-	return nil, fmt.Errorf("tx %v not found in block %v", hash, b.Hash().String())
 }
 
 // NewTransactionFromBlockIndex returns a transaction that will serialize to the RPC representation.

--- a/rpc/eth/types.go
+++ b/rpc/eth/types.go
@@ -193,7 +193,7 @@ func NewBlockWithTxHash(b *types.Block, blockArgs *rpc_common.BlockArgs, leader 
 	}
 
 	for _, tx := range b.Transactions() {
-		blkWithTxs.Transactions = append(blkWithTxs.Transactions, tx.Hash())
+		blkWithTxs.Transactions = append(blkWithTxs.Transactions, tx.ConvertToEth().Hash())
 	}
 
 	if blockArgs.WithSigners {
@@ -214,8 +214,8 @@ func NewBlockWithFullTx(b *types.Block, blockArgs *rpc_common.BlockArgs, leader 
 		Transactions: []*Transaction{},
 	}
 
-	for idx, _ := range b.Transactions() {
-		fmtTx, err := NewTransactionFromBlockIndex(b, uint64(idx))
+	for idx, tx := range b.Transactions() {
+		fmtTx, err := NewTransaction(tx.ConvertToEth(), b.Hash(), b.NumberU64(), b.Time().Uint64(), uint64(idx))
 		if err != nil {
 			return nil, err
 		}
@@ -227,15 +227,4 @@ func NewBlockWithFullTx(b *types.Block, blockArgs *rpc_common.BlockArgs, leader 
 	}
 
 	return blkWithTxs, nil
-}
-
-// NewTransactionFromBlockIndex returns a transaction that will serialize to the RPC representation.
-func NewTransactionFromBlockIndex(b *types.Block, index uint64) (*Transaction, error) {
-	txs := b.Transactions()
-	if index >= uint64(len(txs)) {
-		return nil, fmt.Errorf(
-			"tx index %v greater than or equal to number of transactions on block %v", index, b.Hash().String(),
-		)
-	}
-	return NewTransaction(txs[index].ConvertToEth(), b.Hash(), b.NumberU64(), b.Time().Uint64(), index)
 }


### PR DESCRIPTION
Fixing: https://github.com/harmony-one/harmony/issues/3564

1. support harmony txn lookup by its ethereum version of hash.
2. Return ethereum version of hash for txns in eth_getBlockByNumber