### PR TITLE
Fix crashes found during view change

### DIFF
--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -258,14 +258,16 @@ func (consensus *Consensus) startViewChange() {
 	defer consensus.consensusTimeout[timeoutViewChange].Start()
 
 	// update the dictionary key if the viewID is first time received
-	consensus.vc.AddViewIDKeyIfNotExist(nextViewID, consensus.Decider.Participants())
+	members := consensus.Decider.Participants()
+	consensus.vc.AddViewIDKeyIfNotExist(nextViewID, members)
 
 	// init my own payload
 	if err := consensus.vc.InitPayload(
 		consensus.FBFTLog,
 		nextViewID,
 		consensus.blockNum,
-		consensus.priKey); err != nil {
+		consensus.priKey,
+		members); err != nil {
 		consensus.getLogger().Error().Err(err).Msg("[startViewChange] Init Payload Error")
 	}
 
@@ -387,7 +389,8 @@ func (consensus *Consensus) onViewChange(recvMsg *FBFTMessage) {
 	if err := consensus.vc.InitPayload(consensus.FBFTLog,
 		recvMsg.ViewID,
 		recvMsg.BlockNum,
-		consensus.priKey); err != nil {
+		consensus.priKey,
+		members); err != nil {
 		consensus.getLogger().Error().Err(err).Msg("[onViewChange] Init Payload Error")
 		return
 	}

--- a/staking/availability/measure.go
+++ b/staking/availability/measure.go
@@ -206,6 +206,7 @@ func ComputeAndMutateEPOSStatus(
 		utils.Logger().Info().
 			Str("threshold", measure.String()).
 			Interface("computed", computed).
+			Str("validator", snapshot.Validator.Address.String()).
 			Msg("validator failed availability threshold, set to inactive")
 	default:
 		// Default is no-op so validator who wants


### PR DESCRIPTION
This PR fixes the crash found recent test node shard0 down event.

https://github.com/harmony-one/harmony/issues/3570

Added a few more defensive protection to guard un-initialized map.