### PR TITLE
[Stream] Enable downloader module and updated main.go flags.

### DIFF
--- a/api/service/manager.go
+++ b/api/service/manager.go
@@ -21,6 +21,7 @@ const (
 	BlockProposal
 	NetworkInfo
 	Prometheus
+	Synchronize
 )
 
 func (t Type) String() string {
@@ -37,6 +38,8 @@ func (t Type) String() string {
 		return "NetworkInfo"
 	case Prometheus:
 		return "Prometheus"
+	case Synchronize:
+		return "Synchronize"
 	default:
 		return "Unknown"
 	}

--- a/api/service/manager.go
+++ b/api/service/manager.go
@@ -82,6 +82,11 @@ func (m *Manager) GetServices() []Service {
 	return m.services
 }
 
+// GetService get the specified service
+func (m *Manager) GetService(t Type) Service {
+	return m.serviceMap[t]
+}
+
 // StartServices run all registered services. If one of the starting service returns
 // an error, closing all started services.
 func (m *Manager) StartServices() (err error) {

--- a/api/service/synchronize/service.go
+++ b/api/service/synchronize/service.go
@@ -1,0 +1,37 @@
+package synchronize
+
+import (
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/harmony-one/harmony/core"
+	"github.com/harmony-one/harmony/hmy/downloader"
+	"github.com/harmony-one/harmony/p2p"
+)
+
+// Service is simply a adapter of Downloaders, which support block synchronization
+type Service struct {
+	Downloaders *downloader.Downloaders
+}
+
+// NewService creates the a new downloader service
+func NewService(host p2p.Host, bcs []*core.BlockChain, config downloader.Config) *Service {
+	return &Service{
+		Downloaders: downloader.NewDownloaders(host, bcs, config),
+	}
+}
+
+// Start start the service
+func (s *Service) Start() error {
+	s.Downloaders.Start()
+	return nil
+}
+
+// Stop stop the service
+func (s *Service) Stop() error {
+	s.Downloaders.Close()
+	return nil
+}
+
+// APIs return all APIs of the service
+func (s *Service) APIs() []rpc.API {
+	return nil
+}

--- a/cmd/harmony/config.go
+++ b/cmd/harmony/config.go
@@ -28,6 +28,7 @@ type harmonyConfig struct {
 	TxPool     txPoolConfig
 	Pprof      pprofConfig
 	Log        logConfig
+	Sync       syncConfig
 	Sys        *sysConfig        `toml:",omitempty"`
 	Consensus  *consensusConfig  `toml:",omitempty"`
 	Devnet     *devnetConfig     `toml:",omitempty"`
@@ -152,6 +153,18 @@ type prometheusConfig struct {
 	Gateway    string
 }
 
+type syncConfig struct {
+	LegacyServer   bool // provide the gRPC sync protocol server
+	LegacyClient   bool // aside from stream sync protocol, also run gRPC client to get blocks
+	Concurrency    int  // concurrency used for stream sync protocol
+	MinPeers       int  // minimum streams to start a sync task.
+	InitStreams    int  // minimum streams in bootstrap to start sync loop.
+	DiscSoftLowCap int  // when number of streams is below this value, spin discover during check
+	DiscHardLowCap int  // when removing stream, num is below this value, spin discovery immediately
+	DiscHighCap    int  // upper limit of streams in one sync protocol
+	DiscBatch      int  // size of each discovery
+}
+
 // TODO: use specific type wise validation instead of general string types assertion.
 func validateHarmonyConfig(config harmonyConfig) error {
 	var accepts []string
@@ -232,6 +245,17 @@ func parseNetworkType(nt string) nodeconfig.NetworkType {
 		return nodeconfig.Devnet
 	default:
 		return ""
+	}
+}
+
+func getDefaultSyncConfig(nt nodeconfig.NetworkType) syncConfig {
+	switch nt {
+	case nodeconfig.Mainnet:
+		return defaultMainnetSyncConfig
+	case nodeconfig.Testnet:
+		return defaultTestNetSyncConfig
+	default:
+		return defaultElseSyncConfig
 	}
 }
 

--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -30,7 +30,7 @@ func init() {
 }
 
 func TestV1_0_0Config(t *testing.T) {
-	testConfig := `Version = "1.0.3"
+	testConfig := `Version = "1.0.4"
 
 [BLSKeys]
   KMSConfigFile = ""
@@ -80,6 +80,17 @@ func TestV1_0_0Config(t *testing.T) {
 [TxPool]
   BlacklistFile = "./.hmy/blacklist.txt"
 
+[Sync]
+  Concurrency = 6
+  DiscBatch = 8
+  DiscHardLowCap = 6
+  DiscHighCap = 128
+  DiscSoftLowCap = 8
+  InitStreams = 8
+  LegacyClient = false
+  LegacyServer = true
+  MinPeers = 6
+
 [WS]
   Enabled = true
   IP = "127.0.0.1"
@@ -96,20 +107,21 @@ func TestV1_0_0Config(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defConf := getDefaultHmyConfigCopy(nodeconfig.Mainnet)
 	if config.HTTP.RosettaEnabled {
 		t.Errorf("Expected rosetta http server to be disabled when loading old config")
 	}
 	if config.General.IsOffline {
 		t.Errorf("Expect node to de online when loading old config")
 	}
-	if config.P2P.IP != defaultConfig.P2P.IP {
+	if config.P2P.IP != defConf.P2P.IP {
 		t.Errorf("Expect default p2p IP if old config is provided")
 	}
-	if config.Version != "1.0.3" {
-		t.Errorf("Expected config version: 1.0.3, not %v", config.Version)
+	if config.Version != "1.0.4" {
+		t.Errorf("Expected config version: 1.0.4, not %v", config.Version)
 	}
-	config.Version = defaultConfig.Version // Shortcut for testing, value checked above
-	if !reflect.DeepEqual(config, defaultConfig) {
+	config.Version = defConf.Version // Shortcut for testing, value checked above
+	if !reflect.DeepEqual(config, defConf) {
 		t.Errorf("Unexpected config \n\t%+v \n\t%+v", config, defaultConfig)
 	}
 }

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -102,6 +102,44 @@ var defaultPrometheusConfig = prometheusConfig{
 	Gateway:    "https://gateway.harmony.one",
 }
 
+var (
+	defaultMainnetSyncConfig = syncConfig{
+		LegacyServer:   true,
+		LegacyClient:   false,
+		Concurrency:    16,
+		MinPeers:       16,
+		InitStreams:    32,
+		DiscSoftLowCap: 16,
+		DiscHardLowCap: 32,
+		DiscHighCap:    128,
+		DiscBatch:      16,
+	}
+
+	defaultTestNetSyncConfig = syncConfig{
+		LegacyServer:   true,
+		LegacyClient:   false,
+		Concurrency:    4,
+		MinPeers:       4,
+		InitStreams:    4,
+		DiscSoftLowCap: 4,
+		DiscHardLowCap: 4,
+		DiscHighCap:    1024,
+		DiscBatch:      8,
+	}
+
+	defaultElseSyncConfig = syncConfig{
+		LegacyServer:   true,
+		LegacyClient:   false,
+		Concurrency:    4,
+		MinPeers:       4,
+		InitStreams:    4,
+		DiscSoftLowCap: 4,
+		DiscHardLowCap: 4,
+		DiscHighCap:    1024,
+		DiscBatch:      8,
+	}
+)
+
 const (
 	defaultBroadcastInvalidTx = true
 )

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -2,7 +2,7 @@ package main
 
 import nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 
-const tomlConfigVersion = "1.0.3"
+const tomlConfigVersion = "1.0.4"
 
 const (
 	defNetworkType = nodeconfig.Mainnet
@@ -106,13 +106,13 @@ var (
 	defaultMainnetSyncConfig = syncConfig{
 		LegacyServer:   true,
 		LegacyClient:   false,
-		Concurrency:    16,
-		MinPeers:       16,
-		InitStreams:    32,
-		DiscSoftLowCap: 16,
-		DiscHardLowCap: 32,
+		Concurrency:    6,
+		MinPeers:       6,
+		InitStreams:    8,
+		DiscSoftLowCap: 8,
+		DiscHardLowCap: 6,
 		DiscHighCap:    128,
-		DiscBatch:      16,
+		DiscBatch:      8,
 	}
 
 	defaultTestNetSyncConfig = syncConfig{
@@ -152,6 +152,8 @@ func getDefaultHmyConfigCopy(nt nodeconfig.NetworkType) harmonyConfig {
 		devnet := getDefaultDevnetConfigCopy()
 		config.Devnet = &devnet
 	}
+	config.Sync = getDefaultSyncConfig(nt)
+
 	return config
 }
 

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -175,6 +175,18 @@ var (
 		prometheusGatewayFlag,
 		prometheusEnablePushFlag,
 	}
+
+	syncFlags = []cli.Flag{
+		syncLegacyClientFlag,
+		syncLegacyServerFlag,
+		syncConcurrencyFlag,
+		syncMinPeersFlag,
+		syncInitStreamsFlag,
+		syncDiscSoftLowFlag,
+		syncDiscHardLowFlag,
+		syncDiscHighFlag,
+		syncDiscBatchFlag,
+	}
 )
 
 var (
@@ -267,6 +279,7 @@ func getRootFlags() []cli.Flag {
 	flags = append(flags, revertFlags...)
 	flags = append(flags, legacyMiscFlags...)
 	flags = append(flags, prometheusFlags...)
+	flags = append(flags, syncFlags...)
 
 	return flags
 }
@@ -1267,5 +1280,99 @@ func applyPrometheusFlags(cmd *cobra.Command, config *harmonyConfig) {
 	}
 	if cli.IsFlagChanged(cmd, prometheusEnablePushFlag) {
 		config.Prometheus.EnablePush = cli.GetBoolFlagValue(cmd, prometheusEnablePushFlag)
+	}
+}
+
+var (
+	syncLegacyServerFlag = cli.BoolFlag{
+		Name:     "sync.legacy.server",
+		Usage:    "Enable the gRPC sync server for backward compatibility",
+		Hidden:   true,
+		DefValue: true,
+	}
+	syncLegacyClientFlag = cli.BoolFlag{
+		Name:     "sync.legacy.client",
+		Usage:    "Enable the legacy centralized sync service for block synchronization",
+		Hidden:   true,
+		DefValue: false,
+	}
+	syncConcurrencyFlag = cli.IntFlag{
+		Name:   "sync.concurrency",
+		Usage:  "Concurrency when doing p2p sync requests",
+		Hidden: true,
+	}
+	syncMinPeersFlag = cli.IntFlag{
+		Name:   "sync.min-peers",
+		Usage:  "Minimum peers check for each shard-wise sync loop",
+		Hidden: true,
+	}
+	syncInitStreamsFlag = cli.IntFlag{
+		Name:   "sync.init-peers",
+		Usage:  "Initial shard-wise number of peers to start syncing",
+		Hidden: true,
+	}
+	syncDiscSoftLowFlag = cli.IntFlag{
+		Name:   "sync.disc.soft-low-cap",
+		Usage:  "Soft low cap for sync stream management",
+		Hidden: true,
+	}
+	syncDiscHardLowFlag = cli.IntFlag{
+		Name:   "sync.disc.hard-low-cap",
+		Usage:  "Hard low cap for sync stream management",
+		Hidden: true,
+	}
+	syncDiscHighFlag = cli.IntFlag{
+		Name:   "sync.disc.hi-cap",
+		Usage:  "High cap for sync stream management",
+		Hidden: true,
+	}
+	syncDiscBatchFlag = cli.IntFlag{
+		Name:   "sync.disc.batch",
+		Usage:  "batch size of the sync discovery",
+		Hidden: true,
+	}
+)
+
+// applySyncFlags apply the sync flags.
+func applySyncFlags(cmd *cobra.Command, config *harmonyConfig) {
+	if config.Sync == (syncConfig{}) {
+		nt := nodeconfig.NetworkType(config.Network.NetworkType)
+		config.Sync = getDefaultSyncConfig(nt)
+	}
+
+	if cli.IsFlagChanged(cmd, syncLegacyServerFlag) {
+		config.Sync.LegacyServer = cli.GetBoolFlagValue(cmd, syncLegacyServerFlag)
+	}
+
+	if cli.IsFlagChanged(cmd, syncLegacyClientFlag) {
+		config.Sync.LegacyClient = cli.GetBoolFlagValue(cmd, syncLegacyClientFlag)
+	}
+
+	if cli.IsFlagChanged(cmd, syncConcurrencyFlag) {
+		config.Sync.Concurrency = cli.GetIntFlagValue(cmd, syncConcurrencyFlag)
+	}
+
+	if cli.IsFlagChanged(cmd, syncMinPeersFlag) {
+		config.Sync.MinPeers = cli.GetIntFlagValue(cmd, syncMinPeersFlag)
+	}
+
+	if cli.IsFlagChanged(cmd, syncInitStreamsFlag) {
+		config.Sync.InitStreams = cli.GetIntFlagValue(cmd, syncInitStreamsFlag)
+	}
+
+	if cli.IsFlagChanged(cmd, syncDiscSoftLowFlag) {
+		config.Sync.DiscSoftLowCap = cli.GetIntFlagValue(cmd, syncDiscSoftLowFlag)
+	}
+
+	if cli.IsFlagChanged(cmd, syncDiscHardLowFlag) {
+		config.Sync.DiscHardLowCap = cli.GetIntFlagValue(cmd, syncDiscHardLowFlag)
+	}
+
+	if cli.IsFlagChanged(cmd, syncDiscHighFlag) {
+		config.Sync.DiscHighCap = cli.GetIntFlagValue(cmd, syncDiscHighFlag)
+	}
+
+	if cli.IsFlagChanged(cmd, syncDiscBatchFlag) {
+		config.Sync.DiscBatch = cli.GetIntFlagValue(cmd, syncDiscBatchFlag)
 	}
 }

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -16,6 +16,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/harmony-one/harmony/api/service/synchronize"
+	"github.com/harmony-one/harmony/hmy/downloader"
+
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/harmony-one/bls/ffi/go/bls"
@@ -204,6 +207,7 @@ func applyRootFlags(cmd *cobra.Command, config *harmonyConfig) {
 	applyDevnetFlags(cmd, config)
 	applyRevertFlags(cmd, config)
 	applyPrometheusFlags(cmd, config)
+	applySyncFlags(cmd, config)
 }
 
 func setupNodeLog(config harmonyConfig) {
@@ -304,12 +308,6 @@ func setupNodeAndRun(hc harmonyConfig) {
 		WSPort:       hc.WS.Port,
 		DebugEnabled: hc.RPCOpt.DebugEnabled,
 	}
-	if nodeConfig.ShardID != shard.BeaconChainShardID {
-		utils.Logger().Info().
-			Uint32("shardID", currentNode.Blockchain().ShardID()).
-			Uint32("shardID", nodeConfig.ShardID).Msg("SupportBeaconSyncing")
-		currentNode.SupportBeaconSyncing()
-	}
 
 	// Parse rosetta config
 	nodeConfig.RosettaServer = nodeconfig.RosettaServerConfig{
@@ -360,6 +358,9 @@ func setupNodeAndRun(hc harmonyConfig) {
 
 	nodeconfig.SetPeerID(myHost.GetID())
 
+	// Setup services
+	setupSyncService(currentNode, myHost, hc)
+
 	if currentNode.NodeConfig.Role() == nodeconfig.Validator {
 		currentNode.RegisterValidatorServices()
 	} else if currentNode.NodeConfig.Role() == nodeconfig.ExplorerNode {
@@ -369,8 +370,14 @@ func setupNodeAndRun(hc harmonyConfig) {
 		setupPrometheusService(currentNode, hc, nodeConfig.ShardID)
 	}
 
-	// TODO: replace this legacy syncing
-	currentNode.SupportSyncing()
+	if hc.Sync.LegacyServer && !hc.General.IsOffline {
+		utils.Logger().Info().Msg("support gRPC sync server")
+		currentNode.SupportGRPCSyncServer()
+	}
+	if hc.Sync.LegacyClient && !hc.General.IsOffline {
+		utils.Logger().Info().Msg("go with gRPC sync client")
+		currentNode.StartGRPCSyncClient()
+	}
 
 	if err := currentNode.StartServices(); err != nil {
 		fmt.Fprint(os.Stderr, err.Error())
@@ -391,22 +398,24 @@ func setupNodeAndRun(hc harmonyConfig) {
 
 	go listenOSSigAndShutDown(currentNode)
 
-	if err := myHost.Start(); err != nil {
-		utils.Logger().Fatal().
-			Err(err).
-			Msg("Start p2p host failed")
-	}
+	if !hc.General.IsOffline {
+		if err := myHost.Start(); err != nil {
+			utils.Logger().Fatal().
+				Err(err).
+				Msg("Start p2p host failed")
+		}
 
-	if err := currentNode.BootstrapConsensus(); err != nil {
-		fmt.Fprint(os.Stderr, "could not bootstrap consensus", err.Error())
-		if !currentNode.NodeConfig.IsOffline {
+		if err := currentNode.BootstrapConsensus(); err != nil {
+			fmt.Fprint(os.Stderr, "could not bootstrap consensus", err.Error())
+			if !currentNode.NodeConfig.IsOffline {
+				os.Exit(-1)
+			}
+		}
+
+		if err := currentNode.StartPubSub(); err != nil {
+			fmt.Fprint(os.Stderr, "could not begin network message handling for node", err.Error())
 			os.Exit(-1)
 		}
-	}
-
-	if err := currentNode.StartPubSub(); err != nil {
-		fmt.Fprint(os.Stderr, "could not begin network message handling for node", err.Error())
-		os.Exit(-1)
 	}
 
 	select {}
@@ -697,6 +706,37 @@ func setupPrometheusService(node *node.Node, hc harmonyConfig, sid uint32) {
 	}
 	p := prometheus.NewService(prometheusConfig)
 	node.RegisterService(service.Prometheus, p)
+}
+
+func setupSyncService(node *node.Node, host p2p.Host, hc harmonyConfig) {
+	blockchains := []*core.BlockChain{
+		node.Blockchain(),
+		node.Beaconchain(),
+	} // The duplicate blockchain will be skipped in config parsing
+	dConfig := downloader.Config{
+		Network:      nodeconfig.NetworkType(hc.Network.NetworkType),
+		Concurrency:  hc.Sync.Concurrency,
+		MinStreams:   hc.Sync.MinPeers,
+		InitStreams:  hc.Sync.InitStreams,
+		SmSoftLowCap: hc.Sync.DiscSoftLowCap,
+		SmHardLowCap: hc.Sync.DiscHardLowCap,
+		SmHiCap:      hc.Sync.DiscHighCap,
+		SmDiscBatch:  hc.Sync.DiscBatch,
+	}
+	// If we are running side chain, we will need to do some extra works for beacon
+	// sync
+	if node.NodeConfig.ShardID != 0 {
+		dConfig.BHConfig = &downloader.BeaconHelperConfig{
+			BlockC:     node.BeaconBlockChannel,
+			InsertHook: node.BeaconSyncHook,
+		}
+	}
+	s := synchronize.NewService(host, blockchains, dConfig)
+
+	node.RegisterService(service.Synchronize, s)
+
+	d := s.Downloaders.GetShardDownloader(node.Blockchain().ShardID())
+	node.Consensus.SetDownloader(d)
 }
 
 func setupBlacklist(hc harmonyConfig) (map[ethCommon.Address]struct{}, error) {

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -709,10 +709,11 @@ func setupPrometheusService(node *node.Node, hc harmonyConfig, sid uint32) {
 }
 
 func setupSyncService(node *node.Node, host p2p.Host, hc harmonyConfig) {
-	blockchains := []*core.BlockChain{
-		node.Blockchain(),
-		node.Beaconchain(),
-	} // The duplicate blockchain will be skipped in config parsing
+	blockchains := []*core.BlockChain{node.Blockchain()}
+	if node.NodeConfig.ShardID != 0 {
+		blockchains = append(blockchains, node.Beaconchain())
+	}
+
 	dConfig := downloader.Config{
 		Network:      nodeconfig.NetworkType(hc.Network.NetworkType),
 		Concurrency:  hc.Sync.Concurrency,

--- a/hmy/downloader/beaconhelper.go
+++ b/hmy/downloader/beaconhelper.go
@@ -120,7 +120,9 @@ func (bh *beaconHelper) insertLastMileBlocks() (inserted int, bn uint64, err err
 			bn--
 			return
 		}
-		if err = bh.ih.verifyAndInsertBlock(b); err != nil {
+		// TODO: Instruct the beacon helper to verify signatures. This may require some forks
+		//       in pub-sub message (add commit sigs in node.block.sync messages)
+		if _, err = bh.bc.InsertChain(types.Blocks{b}, true); err != nil {
 			bn--
 			return
 		}

--- a/hmy/downloader/shortrange.go
+++ b/hmy/downloader/shortrange.go
@@ -15,6 +15,8 @@ import (
 	"github.com/rs/zerolog"
 )
 
+var emptySigVerifyError *sigVerifyError
+
 // doShortRangeSync does the short range sync.
 // Compared with long range sync, short range sync is more focused on syncing to the latest block.
 // It consist of 3 steps:
@@ -56,7 +58,7 @@ func (d *Downloader) doShortRangeSync() (int, error) {
 	}
 	n, err := d.ih.verifyAndInsertBlocks(blocks)
 	if err != nil {
-		if !errors.As(err, &sigVerifyError{}) {
+		if !errors.As(err, &emptySigVerifyError) {
 			sh.removeStreams(whitelist) // Data provided by remote nodes is corrupted
 		}
 		return n, errors.Wrap(err, "InsertChain")

--- a/hmy/hmy.go
+++ b/hmy/hmy.go
@@ -87,8 +87,9 @@ type NodeAPI interface {
 	GetTransactionsCount(address, txType string) (uint64, error)
 	GetStakingTransactionsCount(address, txType string) (uint64, error)
 	IsCurrentlyLeader() bool
-	IsOutOfSync(*core.BlockChain) bool
-	GetMaxPeerHeight() uint64
+	IsOutOfSync(shardID uint32) bool
+	SyncStatus(shardID uint32) (bool, uint64)
+	SyncPeers() map[string]int
 	ReportStakingErrorSink() types.TransactionErrorReports
 	ReportPlainErrorSink() types.TransactionErrorReports
 	PendingCXReceipts() []*types.CXReceiptsProof
@@ -186,6 +187,7 @@ func (hmy *Harmony) GetNodeMetadata() commonRPC.NodeMetadata {
 	c := commonRPC.C{}
 	c.TotalKnownPeers, c.Connected, c.NotConnected = hmy.NodeAPI.PeerConnectivity()
 
+	syncPeers := hmy.NodeAPI.SyncPeers()
 	consensusInternal := hmy.NodeAPI.GetConsensusInternal()
 
 	return commonRPC.NodeMetadata{
@@ -204,6 +206,7 @@ func (hmy *Harmony) GetNodeMetadata() commonRPC.NodeMetadata {
 		PeerID:         nodeconfig.GetPeerID(),
 		Consensus:      consensusInternal,
 		C:              c,
+		SyncPeers:      syncPeers,
 	}
 }
 

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -7,21 +7,24 @@ import (
 	"sync"
 	"time"
 
-	"github.com/harmony-one/harmony/shard"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/pkg/errors"
+
+	"github.com/harmony-one/harmony/api/service"
 	"github.com/harmony-one/harmony/api/service/legacysync"
-	"github.com/harmony-one/harmony/api/service/legacysync/downloader"
+	legdownloader "github.com/harmony-one/harmony/api/service/legacysync/downloader"
 	downloader_pb "github.com/harmony-one/harmony/api/service/legacysync/downloader/proto"
+	"github.com/harmony-one/harmony/api/service/synchronize"
 	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/core/types"
+	"github.com/harmony-one/harmony/hmy/downloader"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/node/worker"
 	"github.com/harmony-one/harmony/p2p"
-	lru "github.com/hashicorp/golang-lru"
-	"github.com/pkg/errors"
+	"github.com/harmony-one/harmony/shard"
 )
 
 // Constants related to doing syncing.
@@ -315,7 +318,7 @@ func (node *Node) supportSyncing() {
 // InitSyncingServer starts downloader server.
 func (node *Node) InitSyncingServer() {
 	if node.downloaderServer == nil {
-		node.downloaderServer = downloader.NewServer(node)
+		node.downloaderServer = legdownloader.NewServer(node)
 	}
 }
 
@@ -468,7 +471,7 @@ func (node *Node) CalculateResponse(request *downloader_pb.DownloaderRequest, in
 		} else {
 			response.Type = downloader_pb.DownloaderResponse_FAIL
 			syncPort := legacysync.GetSyncingPort(port)
-			client := downloader.ClientSetup(ip, syncPort)
+			client := legdownloader.ClientSetup(ip, syncPort)
 			if client == nil {
 				utils.Logger().Warn().
 					Str("ip", ip).
@@ -542,12 +545,49 @@ func (node *Node) getEncodedBlockByHash(hash common.Hash) ([]byte, error) {
 	return b, nil
 }
 
-// GetMaxPeerHeight ...
-func (node *Node) GetMaxPeerHeight() uint64 {
-	return node.stateSync.GetMaxPeerHeight()
+// SyncStatus return the syncing status, including whether node is syncing
+// and the target block number.
+func (node *Node) SyncStatus(shardID uint32) (bool, uint64) {
+	ds := node.getDownloaders()
+	if ds == nil {
+		return false, 0
+	}
+	return ds.SyncStatus(shardID)
 }
 
-// IsOutOfSync ...
-func (node *Node) IsOutOfSync(bc *core.BlockChain) bool {
-	return node.stateSync.IsOutOfSync(bc, false)
+// IsOutOfSync return whether the node is out of sync of the given hsardID
+func (node *Node) IsOutOfSync(shardID uint32) bool {
+	ds := node.getDownloaders()
+	if ds == nil {
+		return false
+	}
+	isSyncing, _ := ds.SyncStatus(shardID)
+	return !isSyncing
+}
+
+// SyncPeers return connected sync peers for each shard
+func (node *Node) SyncPeers() map[string]int {
+	ds := node.getDownloaders()
+	if ds == nil {
+		return nil
+	}
+	nums := ds.NumPeers()
+	res := make(map[string]int)
+	for sid, num := range nums {
+		s := fmt.Sprintf("shard-%v", sid)
+		res[s] = num
+	}
+	return res
+}
+
+func (node *Node) getDownloaders() *downloader.Downloaders {
+	syncService := node.serviceManager.GetService(service.Synchronize)
+	if syncService == nil {
+		return nil
+	}
+	dsService, ok := syncService.(*synchronize.Service)
+	if !ok {
+		return nil
+	}
+	return dsService.Downloaders
 }

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/libp2p/go-libp2p-core/protocol"
+
 	"github.com/harmony-one/bls/ffi/go/bls"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
@@ -230,8 +232,9 @@ func (host *HostV2) C() (int, int, int) {
 // AddStreamProtocol adds the stream protocols to the host to be started and closed
 // when the host starts or close
 func (host *HostV2) AddStreamProtocol(protocols ...sttypes.Protocol) {
-	for _, protocol := range protocols {
-		host.streamProtos = append(host.streamProtos, protocol)
+	for _, proto := range protocols {
+		host.streamProtos = append(host.streamProtos, proto)
+		host.h.SetStreamHandlerMatch(protocol.ID(proto.ProtoID()), proto.Match, proto.HandleStream)
 	}
 }
 

--- a/rosetta/services/network.go
+++ b/rosetta/services/network.go
@@ -82,12 +82,12 @@ func (s *NetworkAPI) NetworkStatus(
 	if rosettaError != nil {
 		return nil, rosettaError
 	}
-	targetHeight := int64(s.hmy.NodeAPI.GetMaxPeerHeight())
+	isSyncing, targetHeight := s.hmy.NodeAPI.SyncStatus(s.hmy.BlockChain.ShardID())
 	syncStatus := common.SyncingFinish
-	if s.hmy.NodeAPI.IsOutOfSync(s.hmy.BlockChain) {
-		syncStatus = common.SyncingNewBlock
-	} else if targetHeight == 0 {
+	if targetHeight == 0 {
 		syncStatus = common.SyncingUnknown
+	} else if isSyncing {
+		syncStatus = common.SyncingNewBlock
 	}
 	stage := syncStatus.String()
 
@@ -116,6 +116,13 @@ func (s *NetworkAPI) NetworkStatus(
 		}
 	}
 
+	targetInt := int64(targetHeight)
+	ss := &types.SyncStatus{
+		CurrentIndex: currentHeader.Number().Int64(),
+		TargetIndex:  &targetInt,
+		Stage:        &stage,
+	}
+
 	return &types.NetworkStatusResponse{
 		CurrentBlockIdentifier: currentBlockIdentifier,
 		OldestBlockIdentifier:  oldestBlockIdentifier,
@@ -124,12 +131,8 @@ func (s *NetworkAPI) NetworkStatus(
 			Index: genesisHeader.Number().Int64(),
 			Hash:  genesisHeader.Hash().String(),
 		},
-		Peers: peers,
-		SyncStatus: &types.SyncStatus{
-			CurrentIndex: currentHeader.Number().Int64(),
-			TargetIndex:  &targetHeight,
-			Stage:        &stage,
-		},
+		Peers:      peers,
+		SyncStatus: ss,
 	}, nil
 }
 

--- a/rpc/blockchain.go
+++ b/rpc/blockchain.go
@@ -685,12 +685,12 @@ func (s *PublicBlockchainService) GetStakingNetworkInfo(
 
 // InSync returns if shard chain is syncing
 func (s *PublicBlockchainService) InSync(ctx context.Context) (bool, error) {
-	return !s.hmy.NodeAPI.IsOutOfSync(s.hmy.BlockChain), nil
+	return !s.hmy.NodeAPI.IsOutOfSync(s.hmy.BlockChain.ShardID()), nil
 }
 
 // BeaconInSync returns if beacon chain is syncing
 func (s *PublicBlockchainService) BeaconInSync(ctx context.Context) (bool, error) {
-	return !s.hmy.NodeAPI.IsOutOfSync(s.hmy.BeaconChain), nil
+	return !s.hmy.NodeAPI.IsOutOfSync(s.hmy.BeaconChain.ShardID()), nil
 }
 
 func isBlockGreaterThanLatest(hmy *hmy.Harmony, blockNum rpc.BlockNumber) bool {

--- a/rpc/common/types.go
+++ b/rpc/common/types.go
@@ -64,6 +64,7 @@ type NodeMetadata struct {
 	PeerID         peer.ID            `json:"peerid"`
 	Consensus      ConsensusInternal  `json:"consensus"`
 	C              C                  `json:"p2p-connectivity"`
+	SyncPeers      map[string]int     `json:"sync-peers",omitempty`
 }
 
 // P captures the connected peers per topic


### PR DESCRIPTION
## Description

This is another break down of https://github.com/harmony-one/harmony/pull/3535, and is rebased on https://github.com/harmony-one/harmony/pull/3586.

NOTE: This PR will turn the stream sync protocol on and disable the legacy DNS sync client by default, and will require some extensive tests.

1. Added sync related flags.
2. Register sync service (downloader) to service manager.
3. Added RPC and Rosetta supports.

## Tests

1. Local test passed.
2. Testing with fault injected code on stn. (ON-GOING, code base https://github.com/JackyWYX/harmony/tree/stn_stream_main)