### PR TITLE
[consensus] Resolve one consensus log does not makes sense

### DIFF
--- a/consensus/construct.go
+++ b/consensus/construct.go
@@ -62,7 +62,7 @@ func (consensus *Consensus) construct(
 	p msg_pb.MessageType, payloadForSign []byte, priKeys []*bls.PrivateKeyWrapper,
 ) (*NetworkMessage, error) {
 	if len(priKeys) == 0 {
-		return nil, errors.New("No private keys provided")
+		return nil, errors.New("no elected bls keys provided")
 	}
 	message := &msg_pb.Message{
 		ServiceType: msg_pb.ServiceType_CONSENSUS,


### PR DESCRIPTION
## Description

It is reported that a following log is observed when the validator is not elected.

```
{"level":"error","myBlock":10629717,"myViewID":10629979,"phase":"Announce","mode":"Listening","error":"No private keys provided","message-type":"PREPARE","caller":"/mnt/jenkins/workspace/harmony-release/harmony/consensus/validator.go:367","time":"2021-03-17T22:17:03.59564878Z","message":"could not construct message"}
```

This log does not make sense thus added a condition before constructing p2p message.