### PR TITLE
[bootstrap] do not stop bootstrap timer

### DIFF
--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -174,6 +174,9 @@ func (consensus *Consensus) IsValidatorInCommittee(pubKey bls.SerializedPublicKe
 
 // SetMode sets the mode of consensus
 func (consensus *Consensus) SetMode(m Mode) {
+	consensus.getLogger().Debug().
+		Str("Mode", m.String()).
+		Msg("[SetMode]")
 	consensus.current.SetMode(m)
 }
 


### PR DESCRIPTION
When the node initially rebooted,
it may enter 'Syncing' mode, while it will
stop the bootstrap timer.
When the network is in viewchange mode, itself
can't enter view change mode anymore and will stuck
in syncing mode forever.

This PR is a fix of this long time issue,

https://github.com/harmony-one/harmony/issues/3572

Signed-off-by: Leo Chen <leo@harmony.one>
