### PR TITLE
[stream][consensus] resolve stn stuck issue and some fixes to short range sync.

### DIFF
--- a/hmy/downloader/const.go
+++ b/hmy/downloader/const.go
@@ -1,6 +1,8 @@
 package downloader
 
 import (
+	"time"
+
 	"github.com/harmony-one/harmony/core/types"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 )
@@ -19,7 +21,12 @@ const (
 	// no more request will be assigned to workers to wait for InsertChain to finish.
 	softQueueCap int = 100
 
-	defaultConcurrency = 16
+	// defaultConcurrency is the default settings for concurrency
+	defaultConcurrency = 4
+
+	// shortRangeTimeout is the timeout for each short range sync, which allow short range sync
+	// to restart automatically when stuck in `getBlockHashes`
+	shortRangeTimeout = 1 * time.Minute
 )
 
 type (


### PR DESCRIPTION
## Issue

Resolve issue https://github.com/harmony-one/harmony/issues/3601 and some more stream fixes.

1. Added consensus start logic in a corner case of consensus/downloader interface.
2. Added some logs to short range sync.
3. Changed concurrency in short range to avoid the following unexpected error log message.

```
{"level":"debug","module":"request manager","error":"no more available streams","request":"REQUEST [GetBlocksByHashes: 5358c64bc1e8afea2560ec92e402f0885b5a2ebbdec409380eff3f3fc4ec5238]","caller":"/home/yx/go/src/github.com/harmony-one/harmony/p2p/stream/common/requestmanager/requestmanager.go:292","time":"2021-03-22T00:28:25.504096325Z","message":"Pick available streams."}
```