### PR TITLE
avoid repeated block verification

### DIFF
--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -696,12 +696,9 @@ func (consensus *Consensus) tryCatchup() error {
 		}
 		blk.SetCurrentCommitSig(msg.Payload)
 
-		if !consensus.FBFTLog.IsBlockVerified(blk) {
-			if err := consensus.BlockVerifier(blk); err != nil {
-				consensus.getLogger().Err(err).Msg("[TryCatchup] failed block verifier")
-				return err
-			}
-			consensus.FBFTLog.MarkBlockVerified(blk)
+		if err := consensus.VerifyBlock(blk); err != nil {
+			consensus.getLogger().Err(err).Msg("[TryCatchup] failed block verifier")
+			return err
 		}
 		consensus.getLogger().Info().Msg("[TryCatchup] Adding block to chain")
 		if err := consensus.commitBlock(blk, msgs[i]); err != nil {

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -173,11 +173,11 @@ func (consensus *Consensus) onPrepared(recvMsg *FBFTMessage) {
 		consensus.getLogger().Debug().Msg("[onPrepared] consensus received message before init. Ignoring")
 		return
 	}
-	if err := consensus.BlockVerifier(&blockObj); err != nil {
+
+	if err := consensus.VerifyBlock(&blockObj); err != nil {
 		consensus.getLogger().Error().Err(err).Msg("[OnPrepared] Block verification failed")
 		return
 	}
-	consensus.FBFTLog.MarkBlockVerified(&blockObj)
 
 	if consensus.checkViewID(recvMsg) != nil {
 		if consensus.current.Mode() == Normal {

--- a/consensus/view_change_msg.go
+++ b/consensus/view_change_msg.go
@@ -45,7 +45,7 @@ func (consensus *Consensus) constructViewChangeMessage(priKey *bls.PrivateKeyWra
 			Interface("preparedMsg", preparedMsg).
 			Msg("[constructViewChangeMessage] found prepared msg")
 		if block != nil {
-			if err := consensus.BlockVerifier(block); err == nil {
+			if err := consensus.VerifyBlock(block); err == nil {
 				tmpEncoded, err := rlp.EncodeToBytes(block)
 				if err != nil {
 					consensus.getLogger().Err(err).Msg("[constructViewChangeMessage] Failed encoding block")


### PR DESCRIPTION
Verified blocks should always be marked to avoid repeated verification on the same block.