### PR TITLE
remove unnecessary crosslink broadcast in state sync

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -87,6 +87,7 @@ var configFlag = cli.StringFlag{
 }
 
 func init() {
+	rand.Seed(time.Now().UnixNano())
 	cli.SetParseErrorHandle(func(err error) {
 		os.Exit(128) // 128 - invalid command line arguments
 	})
@@ -140,8 +141,6 @@ func prepareRootCmd(cmd *cobra.Command) error {
 	os.Setenv("GODEBUG", "netdns=go")
 	// Don't set higher than num of CPU. It will make go scheduler slower.
 	runtime.GOMAXPROCS(runtime.NumCPU())
-	// Set up randomization seed.
-	rand.Seed(int64(time.Now().Nanosecond()))
 	// Raise fd limits
 	return raiseFdLimits()
 }

--- a/hmy/downloader/beaconhelper.go
+++ b/hmy/downloader/beaconhelper.go
@@ -128,9 +128,12 @@ func (bh *beaconHelper) insertLastMileBlocks() (inserted int, bn uint64, err err
 			return
 		}
 		bh.logger.Info().Uint64("number", b.NumberU64()).Msg("Inserted block from beacon pub-sub")
-		if bh.insertHook != nil {
-			bh.insertHook()
-		}
+		// TODO: clean up insertHook since for beacon chain sync, we shouldn't broadcast crosslinks for all sync nodes.
+		// Crosslink broadcasting is a live operation relative to the beacon consensus, which should only
+		// be triggered when there is a new beacon block produced.
+		//if bh.insertHook != nil {
+		//	bh.insertHook()
+		//}
 		inserted++
 		bn++
 	}

--- a/hmy/downloader/beaconhelper.go
+++ b/hmy/downloader/beaconhelper.go
@@ -128,12 +128,10 @@ func (bh *beaconHelper) insertLastMileBlocks() (inserted int, bn uint64, err err
 			return
 		}
 		bh.logger.Info().Uint64("number", b.NumberU64()).Msg("Inserted block from beacon pub-sub")
-		// TODO: clean up insertHook since for beacon chain sync, we shouldn't broadcast crosslinks for all sync nodes.
-		// Crosslink broadcasting is a live operation related to the beacon consensus, which should only
-		// be triggered when there is a new beacon block produced.
-		//if bh.insertHook != nil {
-		//	bh.insertHook()
-		//}
+
+		if bh.insertHook != nil {
+			bh.insertHook()
+		}
 		inserted++
 		bn++
 	}

--- a/hmy/downloader/beaconhelper.go
+++ b/hmy/downloader/beaconhelper.go
@@ -129,7 +129,7 @@ func (bh *beaconHelper) insertLastMileBlocks() (inserted int, bn uint64, err err
 		}
 		bh.logger.Info().Uint64("number", b.NumberU64()).Msg("Inserted block from beacon pub-sub")
 		// TODO: clean up insertHook since for beacon chain sync, we shouldn't broadcast crosslinks for all sync nodes.
-		// Crosslink broadcasting is a live operation relative to the beacon consensus, which should only
+		// Crosslink broadcasting is a live operation related to the beacon consensus, which should only
 		// be triggered when there is a new beacon block produced.
 		//if bh.insertHook != nil {
 		//	bh.insertHook()

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -337,6 +337,8 @@ func (node *Node) VerifyNewBlock(newBlock *types.Block) error {
 func (node *Node) PostConsensusProcessing(newBlock *types.Block) error {
 	if node.Consensus.IsLeader() {
 		if node.IsRunningBeaconChain() {
+			// TODO: consider removing this and letting other nodes broadcast new blocks.
+			// But need to make sure there is at least 1 node that will do the job.
 			node.BroadcastNewBlock(newBlock)
 		}
 		node.BroadcastCXReceipts(newBlock)
@@ -356,7 +358,6 @@ func (node *Node) PostConsensusProcessing(newBlock *types.Block) error {
 			node.Consensus.UpdateValidatorMetrics(numSig, float64(newBlock.NumberU64()))
 
 			// 1% of the validator also need to do broadcasting
-			rand.Seed(time.Now().UTC().UnixNano())
 			rnd := rand.Intn(100)
 			if rnd < 1 {
 				// Beacon validators also broadcast new blocks to make sure beacon sync is strong.

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -34,14 +34,10 @@ const (
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
 // BeaconSyncHook is the hook function called after inserted beacon in downloader
 // TODO: This is a small misc piece of consensus logic. Better put it to consensus module.
 func (node *Node) BeaconSyncHook() {
-	if node.Consensus.IsLeader() {
+	if node.Consensus.IsLeader() || rand.Intn(100) == 0 {
 		// TODO: Instead of leader, it would better be validator do this broadcast since leader do
 		//       not have much idle resources.
 		node.BroadcastCrossLink()
@@ -208,8 +204,8 @@ func (node *Node) doBeaconSyncing() {
 					)
 					if err != nil {
 						node.beaconSync.AddLastMileBlock(beaconBlock)
-					} else if node.Consensus.IsLeader() {
-						// Only leader broadcast crosslink to avoid spamming p2p
+					} else if node.Consensus.IsLeader() || rand.Intn(100) <= 1 {
+						// Only leader or 2% of validators broadcast crosslink to avoid spamming p2p
 						node.BroadcastCrossLink()
 					}
 				}


### PR DESCRIPTION
1. Let 2% of the validators do crosslink broadcast along with the leader.
2. Cealn up Rand seeding.