### PR TITLE
[stream] make travis test dns sync logic

### DIFF
--- a/api/service/legacysync/syncing.go
+++ b/api/service/legacysync/syncing.go
@@ -812,7 +812,7 @@ func (ss *StateSync) UpdateBlockAndStatus(block *types.Block, bc *core.BlockChai
 	if block.NumberU64() > 1 {
 		// Verify signature every 100 blocks
 		verifySeal := block.NumberU64()%verifyHeaderBatchSize == 0 || verifyAllSig
-		verifyCurrentSig := verifyAllSig && verifySeal
+		verifyCurrentSig := verifyAllSig && haveCurrentSig
 		if verifyCurrentSig {
 			sig, bitmap, err := chain.ParseCommitSigAndBitmap(block.GetCurrentCommitSig())
 			if err != nil {

--- a/cmd/harmony/config.go
+++ b/cmd/harmony/config.go
@@ -261,6 +261,8 @@ func getDefaultSyncConfig(nt nodeconfig.NetworkType) syncConfig {
 		return defaultMainnetSyncConfig
 	case nodeconfig.Testnet:
 		return defaultTestNetSyncConfig
+	case nodeconfig.Localnet:
+		return defaultLocalNetSyncConfig
 	default:
 		return defaultElseSyncConfig
 	}

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -129,6 +129,19 @@ var (
 		DiscBatch:      8,
 	}
 
+	defaultLocalNetSyncConfig = syncConfig{
+		Downloader:     false,
+		LegacyServer:   true,
+		LegacyClient:   true,
+		Concurrency:    4,
+		MinPeers:       4,
+		InitStreams:    4,
+		DiscSoftLowCap: 4,
+		DiscHardLowCap: 4,
+		DiscHighCap:    1024,
+		DiscBatch:      8,
+	}
+
 	defaultElseSyncConfig = syncConfig{
 		Downloader:     true,
 		LegacyServer:   true,


### PR DESCRIPTION
## Description

Currently, travis test (local rpc test and rosetta test) is actually testing the downloader logic with stream sync. However, downloader module will not be enabled in production environment in the near future. So in this PR, add a new default config for local net, to instruct travis to test DNS sync logic instead of downloader logic. 