### PR TITLE
Avoid repeated state creation in validator reading

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2280,18 +2280,29 @@ func (bc *BlockChain) ReadTxLookupEntry(txID common.Hash) (common.Hash, uint64, 
 	return rawdb.ReadTxLookupEntry(bc.db, txID)
 }
 
-// ReadValidatorInformationAt reads staking
+// ReadValidatorInformationAtRoot reads staking
 // information of given validatorWrapper at a specific state root
-func (bc *BlockChain) ReadValidatorInformationAt(
+func (bc *BlockChain) ReadValidatorInformationAtRoot(
 	addr common.Address, root common.Hash,
 ) (*staking.ValidatorWrapper, error) {
 	state, err := bc.StateAt(root)
 	if err != nil || state == nil {
 		return nil, errors.Wrapf(err, "at root: %s", root.Hex())
 	}
+	return bc.ReadValidatorInformationAtState(addr, state)
+}
+
+// ReadValidatorInformationAtState reads staking
+// information of given validatorWrapper at a specific state root
+func (bc *BlockChain) ReadValidatorInformationAtState(
+	addr common.Address, state *state.DB,
+) (*staking.ValidatorWrapper, error) {
+	if state == nil {
+		return nil, errors.New("empty state")
+	}
 	wrapper, err := state.ValidatorWrapper(addr)
 	if err != nil {
-		return nil, errors.Wrapf(err, "at root: %s", root.Hex())
+		return nil, err
 	}
 	return wrapper, nil
 }
@@ -2300,7 +2311,7 @@ func (bc *BlockChain) ReadValidatorInformationAt(
 func (bc *BlockChain) ReadValidatorInformation(
 	addr common.Address,
 ) (*staking.ValidatorWrapper, error) {
-	return bc.ReadValidatorInformationAt(addr, bc.CurrentBlock().Root())
+	return bc.ReadValidatorInformationAtRoot(addr, bc.CurrentBlock().Root())
 }
 
 // ReadValidatorSnapshotAtEpoch reads the snapshot

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -273,6 +273,14 @@ func (cr *fakeChainReader) ReadValidatorInformation(
 ) (*staking.ValidatorWrapper, error) {
 	return nil, nil
 }
+func (cr *fakeChainReader) ReadValidatorInformationAtState(
+	addr common.Address, state *state.DB,
+) (*staking.ValidatorWrapper, error) {
+	return nil, nil
+}
+func (cr *fakeChainReader) StateAt(root common.Hash) (*state.DB, error) {
+	return nil, nil
+}
 func (cr *fakeChainReader) ReadValidatorSnapshot(
 	addr common.Address,
 ) (*staking.ValidatorSnapshot, error) {

--- a/hmy/downloader/adapter_test.go
+++ b/hmy/downloader/adapter_test.go
@@ -99,6 +99,14 @@ func (bc *testBlockChain) ReadCommitSig(blockNum uint64) ([]byte, error)        
 func (bc *testBlockChain) ReadBlockRewardAccumulator(uint64) (*big.Int, error)      { return nil, nil }
 func (bc *testBlockChain) ValidatorCandidates() []common.Address                    { return nil }
 func (bc *testBlockChain) Engine() engine.Engine                                    { return &dummyEngine{} }
+func (cr *testBlockChain) ReadValidatorInformationAtState(
+	addr common.Address, state *state.DB,
+) (*staking.ValidatorWrapper, error) {
+	return nil, nil
+}
+func (cr *testBlockChain) StateAt(root common.Hash) (*state.DB, error) {
+	return nil, nil
+}
 func (bc *testBlockChain) ReadValidatorInformation(addr common.Address) (*staking.ValidatorWrapper, error) {
 	return nil, nil
 }

--- a/hmy/staking.go
+++ b/hmy/staking.go
@@ -282,7 +282,7 @@ func (hmy *Harmony) GetValidatorInformation(
 	addr common.Address, block *types.Block,
 ) (*staking.ValidatorRPCEnhanced, error) {
 	bc := hmy.BlockChain
-	wrapper, err := bc.ReadValidatorInformationAt(addr, block.Root())
+	wrapper, err := bc.ReadValidatorInformationAtRoot(addr, block.Root())
 	if err != nil {
 		s, _ := internalCommon.AddressToBech32(addr)
 		return nil, errors.Wrapf(err, "not found address in current state %s", s)
@@ -469,7 +469,7 @@ func (hmy *Harmony) GetDelegationsByValidator(validator common.Address) []*staki
 func (hmy *Harmony) GetDelegationsByValidatorAtBlock(
 	validator common.Address, block *types.Block,
 ) []*staking.Delegation {
-	wrapper, err := hmy.BlockChain.ReadValidatorInformationAt(validator, block.Root())
+	wrapper, err := hmy.BlockChain.ReadValidatorInformationAtRoot(validator, block.Root())
 	if err != nil || wrapper == nil {
 		return nil
 	}
@@ -501,7 +501,7 @@ func (hmy *Harmony) GetDelegationsByDelegatorByBlock(
 	}
 
 	for i := range delegationIndexes {
-		wrapper, err := hmy.BlockChain.ReadValidatorInformationAt(
+		wrapper, err := hmy.BlockChain.ReadValidatorInformationAtRoot(
 			delegationIndexes[i].ValidatorAddress, block.Root(),
 		)
 		if err != nil || wrapper == nil {
@@ -548,7 +548,7 @@ func (hmy *Harmony) GetUndelegationPayouts(
 
 	lockingPeriod := hmy.GetDelegationLockingPeriodInEpoch(undelegationPayoutBlock.Epoch())
 	for _, validator := range hmy.GetAllValidatorAddresses() {
-		wrapper, err := hmy.BlockChain.ReadValidatorInformationAt(validator, undelegationPayoutBlock.Root())
+		wrapper, err := hmy.BlockChain.ReadValidatorInformationAtRoot(validator, undelegationPayoutBlock.Root())
 		if err != nil || wrapper == nil {
 			continue // Not a validator at this epoch or unable to fetch validator info because of pruned state.
 		}


### PR DESCRIPTION
Refactor the validator reading interface so we don't recreate a new state for each validator reading.

Also optimize undelegation payout logic to avoid repetitive/redundant execution.