### PR TITLE
[engine] Engine cache for `VerifyCrossLink`

### DIFF
--- a/consensus/engine/consensus_engine.go
+++ b/consensus/engine/consensus_engine.go
@@ -87,6 +87,9 @@ type Engine interface {
 		chain ChainReader, header *block.Header, commitSig bls.SerializedSignature, commitBitmap []byte,
 	) error
 
+	// VerifyCrossLink verify cross link
+	VerifyCrossLink(ChainReader, types.CrossLink) error
+
 	// VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers
 	// concurrently. The method returns a quit channel to abort the operations and
 	// a results channel to retrieve the async verifications (the order is that of

--- a/hmy/downloader/adapter_test.go
+++ b/hmy/downloader/adapter_test.go
@@ -131,6 +131,9 @@ func (e *dummyEngine) VerifyHeader(engine.ChainReader, *block.Header, bool) erro
 func (e *dummyEngine) VerifyHeaderSignature(engine.ChainReader, *block.Header, bls.SerializedSignature, []byte) error {
 	return nil
 }
+func (e *dummyEngine) VerifyCrossLink(engine.ChainReader, types.CrossLink) error {
+	return nil
+}
 func (e *dummyEngine) VerifyHeaders(engine.ChainReader, []*block.Header, []bool) (chan<- struct{}, <-chan error) {
 	return nil, nil
 }

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -472,13 +472,11 @@ func (e *engineImpl) getEpochCtxCached(chain engine.ChainReader, shardID uint32,
 	}
 	cached, ok := e.epochCtxCache.Get(ecKey)
 	if ok && cached != nil {
-		if ec := cached.(epochCtx); ec.qrVerifier != nil {
-			return ec, nil
-		}
+		return cached.(epochCtx), nil
 	}
 	ec, err := readEpochCtxFromChain(chain, ecKey)
 	if err != nil {
-		return epochCtx{}, nil
+		return epochCtx{}, err
 	}
 	e.epochCtxCache.Add(ecKey, ec)
 	return ec, nil

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	verifiedSigCache = 50
+	verifiedSigCache = 100
 	epochCtxCache    = 20
 )
 

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -472,7 +472,9 @@ func (e *engineImpl) getEpochCtxCached(chain engine.ChainReader, shardID uint32,
 	}
 	cached, ok := e.epochCtxCache.Get(ecKey)
 	if ok && cached != nil {
-		return cached.(epochCtx), nil
+		if ec := cached.(epochCtx); ec.qrVerifier != nil {
+			return ec, nil
+		}
 	}
 	ec, err := readEpochCtxFromChain(chain, ecKey)
 	if err != nil {

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -409,11 +409,7 @@ func (e *engineImpl) VerifyHeaderSignature(chain engine.ChainReader, header *blo
 	pas := payloadArgsFromHeader(header)
 	sas := sigArgs{commitSig, commitBitmap}
 
-	err := e.verifySignatureCached(chain, pas, sas)
-	if err != nil {
-		return err
-	}
-	return nil
+	return e.verifySignatureCached(chain, pas, sas)
 }
 
 // VerifyCrossLink verifies the signature of the given CrossLink.

--- a/node/node_cross_link.go
+++ b/node/node_cross_link.go
@@ -1,8 +1,6 @@
 package node
 
 import (
-	"fmt"
-
 	common2 "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/harmony-one/harmony/core/types"
@@ -127,7 +125,6 @@ func (node *Node) VerifyCrossLink(cl types.CrossLink) error {
 	engine := node.Blockchain().Engine()
 
 	if err := engine.VerifyCrossLink(node.Blockchain(), cl); err != nil {
-		fmt.Println("verify crosslink failed", err)
 		return errors.Wrap(err, "[VerifyCrossLink]")
 	}
 	return nil


### PR DESCRIPTION
## Description

1. Added a new method `VerifyCrossLink` to engine interface.
2. Refactored some code of`engineImpl` to use the same cache for crosslink and headers.
3. Basically, `VerifyCrossLink` `VerifySeal` `VerifyHeaderSignature` will share the same cache to reduce duplicate signature verification.

## Test

tested locally.