### PR TITLE
[blockchain] added cache in ReadValidatorSnapshot

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2332,7 +2332,12 @@ func (bc *BlockChain) ReadValidatorSnapshot(
 	if cached, ok := bc.validatorSnapshotCache.Get(key); ok {
 		return cached.(*staking.ValidatorSnapshot), nil
 	}
-	return rawdb.ReadValidatorSnapshot(bc.db, addr, epoch)
+	vs, err := rawdb.ReadValidatorSnapshot(bc.db, addr, epoch)
+	if err != nil {
+		return nil, err
+	}
+	bc.validatorSnapshotCache.Add(key, vs)
+	return vs, nil
 }
 
 // WriteValidatorSnapshot writes the snapshot of provided validator


### PR DESCRIPTION
## Description

Added cache to `Blockchain.ReadValidatorSnapshot` according to pprof results in https://github.com/harmony-one/harmony/issues/3635, and expect to reduce 30% CPU usage for newly started leader node. 

Previously, `validatorSnapshotCache` is only added when the node goes through epoch block. For a newly started node, it will read from db and decode `ValidatorWrapper` (a super nested structure poor in rlp performance) every time when accumulating rewards. So previously, it is expected that newly started node will have bad performance compared to nodes come through an epoch block.

This PR added cache to the `ReadValidatorSnapshot` method and shall resolve the high CPU usage for newly started machine.