### PR TITLE
update marshal json for blocks to match standard eth output

### DIFF
--- a/block/header.go
+++ b/block/header.go
@@ -2,6 +2,7 @@ package block
 
 import (
 	"encoding/json"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"io"
 	"math/big"
 	"reflect"
@@ -38,17 +39,31 @@ var (
 // MarshalJSON ..
 func (h Header) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
-		S uint32   `json:"shard-id"`
-		H string   `json:"block-header-hash"`
-		N *big.Int `json:"block-number"`
-		V *big.Int `json:"view-id"`
-		E *big.Int `json:"epoch"`
+		N  *big.Int `json:"number"`
+		H  string   `json:"hash"`
+		P  string   `json:"parentHash"`
+		B  string   `json:"logsBloom"`
+		T  string   `json:"transactionsRoot"`
+		S  string   `json:"stateRoot"`
+		R  string   `json:"receiptsRoot"`
+		M  string   `json:"miner"`
+		E  string   `json:"extraData"`
+		GL uint64   `json:"gasLimit"`
+		GU uint64   `json:"gasUsed"`
+		TS *big.Int `json:"timestamp"`
 	}{
-		h.Header.ShardID(),
-		h.Header.Hash().Hex(),
 		h.Header.Number(),
-		h.Header.ViewID(),
-		h.Header.Epoch(),
+		h.Header.Hash().Hex(),
+		h.Header.ParentHash().Hex(),
+		hexutil.Encode(h.Header.Bloom().Bytes()),
+		h.Header.TxHash().Hex(),
+		h.Header.Root().Hex(),
+		h.Header.ReceiptHash().Hex(),
+		h.Header.Coinbase().Hex(),
+		hexutil.Encode(h.Header.Extra()),
+		h.Header.GasLimit(),
+		h.Header.GasUsed(),
+		h.Header.Time(),
 	})
 }
 


### PR DESCRIPTION
## Issue

<!-- link to the issue number or description of the issue -->
https://github.com/harmony-one/harmony/issues/3581

## Test

* Tested the change by running a localnet 
* Ran the script(mentioned in the issue), updating the web socket provider:
```
const Web3 = require("web3");
const web3 = new Web3("ws://localhost:9899");

var subscription = web3.eth
  .subscribe("newBlockHeaders", function (error, result) {
    if (!error) {
      console.log(result);

      return;
    }

    console.error(error);
  })
  .on("connected", function (subscriptionId) {
    console.log(subscriptionId);
  })
  .on("data", function (blockHeader) {
    console.log(blockHeader);
  })
  .on("error", console.error);

// unsubscribes the subscription
subscription.unsubscribe(function (error, success) {
  if (success) {
    console.log("Successfully unsubscribed!");
  }
});
```
* Compared the output with https://web3js.readthedocs.io/en/v1.3.4/web3-eth-subscribe.html?highlight=get%20Headers#subscribe-newblockheaders:
```
{
  number: 2,
  hash: '0xa461f8906e93c17e1f43e7f2f87dcb2cf9b19f5e9c8f9640d4ef7cb5549f3b45',
  parentHash: '0x533a963a9c829b17a7087e1d41d9ef61fd41382f8fe4058be238aca5f4df26fc',
  logsBloom: '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
  transactionsRoot: '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
  stateRoot: '0x509713c0fdfd0843a39c8ed3acaff8424708cff2913dd5704e59879adf6473f0',
  receiptsRoot: '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
  miner: '0x0B585F8DaEfBC68a311FbD4cB20d9174aD174016',
  extraData: '0x',
  gasLimit: 80000000,
  gasUsed: 0,
  timestamp: 1617555522,
  size: undefined
}
```
