### PR TITLE
[stream] change time.Tick to Ticker

### DIFF
--- a/hmy/downloader/beaconhelper.go
+++ b/hmy/downloader/beaconhelper.go
@@ -57,9 +57,10 @@ func (bh *beaconHelper) close() {
 }
 
 func (bh *beaconHelper) loop() {
+	t := time.NewTicker(10 * time.Second)
 	for {
 		select {
-		case <-time.Tick(10 * time.Second):
+		case <-t.C:
 			bh.insertAsync()
 
 		case b, ok := <-bh.blockC:


### PR DESCRIPTION
## Description

A potential fix to https://github.com/harmony-one/harmony/issues/3618. 

`time.Tick` is creating a Ticker object every time when called and might potentially cause CPU and memory leak (Hard to discover in pprof). Replace `time.Tick` with `time.NewTicker`.