### PR TITLE
[misc] shut down blockchain at last

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -1173,9 +1173,6 @@ func (node *Node) ServiceManager() *service.Manager {
 
 // ShutDown gracefully shut down the node server and dump the in-memory blockchain state into DB.
 func (node *Node) ShutDown() {
-	node.Blockchain().Stop()
-	node.Beaconchain().Stop()
-
 	if err := node.StopRPC(); err != nil {
 		utils.Logger().Error().Err(err).Msg("failed to stop RPC")
 	}
@@ -1198,6 +1195,9 @@ func (node *Node) ShutDown() {
 	if err := node.host.Close(); err != nil {
 		utils.Logger().Error().Err(err).Msg("failed to stop p2p host")
 	}
+
+	node.Blockchain().Stop()
+	node.Beaconchain().Stop()
 
 	const msg = "Successfully shut down!\n"
 	utils.Logger().Print(msg)


### PR DESCRIPTION
## Issue

When doing tests, hit the following panic error when shutting down:

```
^CGot interrupt signal. Gracefully shutting down...
panic: sync: WaitGroup is reused before previous Wait has returned

goroutine 369215 [running]:
sync.(*WaitGroup).Wait(0xc006a7c390)
        /usr/local/go/src/sync/waitgroup.go:132 +0xad
github.com/harmony-one/harmony/core.(*BlockChain).Stop(0xc006a7c000)
        /home/yx/go/src/github.com/harmony-one/harmony/core/blockchain.go:847 +0x9f
github.com/harmony-one/harmony/node.(*Node).ShutDown(0xc000338580)
        /home/yx/go/src/github.com/harmony-one/harmony/node/node.go:1176 +0x4e
created by main.listenOSSigAndShutDown
        /home/yx/go/src/github.com/harmony-one/harmony/cmd/harmony/main.go:772 +0x220
```

So, Blockchain shall be shutdown after all service stopped.

