### PR TITLE
correct hmy txn sender in eth_ rpc; add ethHash in hmy txn rpc

### DIFF
--- a/core/types/eth_transaction.go
+++ b/core/types/eth_transaction.go
@@ -21,6 +21,8 @@ import (
 	"math/big"
 	"sync/atomic"
 
+	"github.com/harmony-one/harmony/internal/params"
+
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
@@ -333,7 +335,7 @@ func (tx *EthTransaction) SenderAddress() (common.Address, error) {
 
 // IsEthCompatible returns whether the txn is ethereum compatible
 func (tx *EthTransaction) IsEthCompatible() bool {
-	return true
+	return params.IsEthCompatible(tx.ChainID())
 }
 
 // AsMessage returns the transaction as a core.Message.

--- a/rpc/eth/types.go
+++ b/rpc/eth/types.go
@@ -77,7 +77,13 @@ func NewTransaction(
 	tx *types.EthTransaction, blockHash common.Hash,
 	blockNumber uint64, timestamp uint64, index uint64,
 ) (*Transaction, error) {
-	from, err := tx.SenderAddress()
+	from := common.Address{}
+	var err error
+	if tx.IsEthCompatible() {
+		from, err = tx.SenderAddress()
+	} else {
+		from, err = tx.ConvertToHmy().SenderAddress()
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/v2/types.go
+++ b/rpc/v2/types.go
@@ -38,6 +38,7 @@ type BlockWithTxHash struct {
 	ReceiptsRoot     common.Hash    `json:"receiptsRoot"`
 	Uncles           []common.Hash  `json:"uncles"`
 	Transactions     []common.Hash  `json:"transactions"`
+	EthTransactions  []common.Hash  `json:"EthTransactions"`
 	StakingTxs       []common.Hash  `json:"stakingTransactions"`
 	Signers          []string       `json:"signers,omitempty"`
 }
@@ -78,6 +79,7 @@ type Transaction struct {
 	Gas              uint64        `json:"gas"`
 	GasPrice         *big.Int      `json:"gasPrice"`
 	Hash             common.Hash   `json:"hash"`
+	EthHash          common.Hash   `json:"ethHash"`
 	Input            hexutil.Bytes `json:"input"`
 	Nonce            uint64        `json:"nonce"`
 	To               string        `json:"to"`
@@ -258,6 +260,7 @@ func NewTransaction(
 		Gas:       tx.GasLimit(),
 		GasPrice:  tx.GasPrice(),
 		Hash:      tx.Hash(),
+		EthHash:   tx.ConvertToEth().Hash(),
 		Input:     hexutil.Bytes(tx.Data()),
 		Nonce:     tx.Nonce(),
 		Value:     tx.Value(),
@@ -612,11 +615,13 @@ func NewBlockWithTxHash(
 		ReceiptsRoot:     head.ReceiptHash(),
 		Uncles:           []common.Hash{},
 		Transactions:     []common.Hash{},
+		EthTransactions:  []common.Hash{},
 		StakingTxs:       []common.Hash{},
 	}
 
 	for _, tx := range b.Transactions() {
 		blk.Transactions = append(blk.Transactions, tx.Hash())
+		blk.EthTransactions = append(blk.Transactions, tx.ConvertToEth().Hash())
 	}
 
 	if blockArgs.InclStaking {

--- a/rpc/v2/types.go
+++ b/rpc/v2/types.go
@@ -38,7 +38,7 @@ type BlockWithTxHash struct {
 	ReceiptsRoot     common.Hash    `json:"receiptsRoot"`
 	Uncles           []common.Hash  `json:"uncles"`
 	Transactions     []common.Hash  `json:"transactions"`
-	EthTransactions  []common.Hash  `json:"EthTransactions"`
+	EthTransactions  []common.Hash  `json:"transactionsInEthHash"`
 	StakingTxs       []common.Hash  `json:"stakingTransactions"`
 	Signers          []string       `json:"signers,omitempty"`
 }

--- a/rpc/v2/types.go
+++ b/rpc/v2/types.go
@@ -621,7 +621,7 @@ func NewBlockWithTxHash(
 
 	for _, tx := range b.Transactions() {
 		blk.Transactions = append(blk.Transactions, tx.Hash())
-		blk.EthTransactions = append(blk.Transactions, tx.ConvertToEth().Hash())
+		blk.EthTransactions = append(blk.EthTransactions, tx.ConvertToEth().Hash())
 	}
 
 	if blockArgs.InclStaking {


### PR DESCRIPTION
When a harmony transaction is queried in eth_ rpc, the sender derivation logic should be based on the original harmony txn.

This pr also add eth hash of the txn in hmy_ rpc.