### PR TITLE
[txPool] added gas balance check when validating delegate transaction

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -846,7 +846,7 @@ func (pool *TxPool) validateStakingTx(tx *staking.StakingTransaction) error {
 		}
 		// We need to deduct gas price and verify balance since txn.Cost() is not accurate for delegate
 		// staking transaction because of re-delegation.
-		gasAmt := new(big.Int).Mul(tx.GasPrice(), new(big.Int).SetUint64(tx.GasLimit())))
+		gasAmt := new(big.Int).Mul(tx.GasPrice(), new(big.Int).SetUint64(tx.GasLimit()))
 		totalAmt := new(big.Int).Add(delegateAmt, gasAmt)
 		if bal := pool.currentState.GetBalance(from); bal.Cmp(totalAmt) < 0 {
 			return fmt.Errorf("not enough balance for delegation: %v < %v", bal, delegateAmt)


### PR DESCRIPTION
## Issue

https://github.com/harmony-one/go-sdk/issues/242 (3.1.1 temporary fix)

Added balance check with gas price for delegation staking transaction. 

Some delegation transaction will pass `txPool.validateTx` with amount set equal to balance (not aware of the additional gas fee). This PR is to fix the validation for delegation transaction.

## Tests

Tested locally and resolve the issue.