### PR TITLE
[sync] make sync rpc compatible with legacy sync

### DIFF
--- a/api/service/explorer/service.go
+++ b/api/service/explorer/service.go
@@ -267,7 +267,7 @@ func (s *Service) GetTotalSupply(w http.ResponseWriter, r *http.Request) {
 // GetNodeSync returns status code 500 if node is not in sync
 func (s *Service) GetNodeSync(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	sync := !s.stateSync.IsOutOfSync(s.blockchain, false)
+	sync, _ := s.stateSync.SyncStatus(s.blockchain)
 	if !sync {
 		w.WriteHeader(http.StatusTeapot)
 	}

--- a/api/service/legacysync/syncing.go
+++ b/api/service/legacysync/syncing.go
@@ -1054,10 +1054,16 @@ func (ss *StateSync) GetMaxPeerHeight() uint64 {
 	return ss.getMaxPeerHeight(false)
 }
 
+// SyncStatus returns inSync and remote height
+func (ss *StateSync) SyncStatus(bc *core.BlockChain) (bool, uint64) {
+	outOfSync, remoteNum := ss.IsOutOfSync(bc, false)
+	return !outOfSync, remoteNum
+}
+
 // IsOutOfSync checks whether the node is out of sync from other peers
-func (ss *StateSync) IsOutOfSync(bc *core.BlockChain, doubleCheck bool) bool {
+func (ss *StateSync) IsOutOfSync(bc *core.BlockChain, doubleCheck bool) (bool, uint64) {
 	if ss.syncConfig == nil {
-		return true // If syncConfig is not instantiated, return not in sync
+		return true, 0 // If syncConfig is not instantiated, return not in sync
 	}
 	otherHeight1 := ss.getMaxPeerHeight(false)
 	lastHeight := bc.CurrentBlock().NumberU64()
@@ -1068,7 +1074,7 @@ func (ss *StateSync) IsOutOfSync(bc *core.BlockChain, doubleCheck bool) bool {
 			Uint64("OtherHeight", otherHeight1).
 			Uint64("lastHeight", lastHeight).
 			Msg("[SYNC] Checking sync status")
-		return wasOutOfSync
+		return wasOutOfSync, otherHeight1
 	}
 	time.Sleep(1 * time.Second)
 	// double check the sync status after 1 second to confirm (avoid false alarm)
@@ -1084,7 +1090,7 @@ func (ss *StateSync) IsOutOfSync(bc *core.BlockChain, doubleCheck bool) bool {
 		Uint64("currentHeight", currentHeight).
 		Msg("[SYNC] Checking sync status")
 	// Only confirm out of sync when the node has lower height and didn't move in heights for 2 consecutive checks
-	return wasOutOfSync && isOutOfSync && lastHeight == currentHeight
+	return wasOutOfSync && isOutOfSync && lastHeight == currentHeight, otherHeight2
 }
 
 // SyncLoop will keep syncing with peers until catches up

--- a/rpc/blockchain.go
+++ b/rpc/blockchain.go
@@ -688,12 +688,14 @@ func (s *PublicBlockchainService) GetStakingNetworkInfo(
 
 // InSync returns if shard chain is syncing
 func (s *PublicBlockchainService) InSync(ctx context.Context) (bool, error) {
-	return !s.hmy.NodeAPI.IsOutOfSync(s.hmy.BlockChain.ShardID()), nil
+	inSync, _ := s.hmy.NodeAPI.SyncStatus(s.hmy.BlockChain.ShardID())
+	return inSync, nil
 }
 
 // BeaconInSync returns if beacon chain is syncing
 func (s *PublicBlockchainService) BeaconInSync(ctx context.Context) (bool, error) {
-	return !s.hmy.NodeAPI.IsOutOfSync(s.hmy.BeaconChain.ShardID()), nil
+	inSync, _ := s.hmy.NodeAPI.SyncStatus(s.hmy.BeaconChain.ShardID())
+	return inSync, nil
 }
 
 func isBlockGreaterThanLatest(hmy *hmy.Harmony, blockNum rpc.BlockNumber) bool {


### PR DESCRIPTION
## Issue

The RPC methods related to sync was updated when adding stream sync protocol. But it did not support DNS sync status update. So this PR is to make these RPCs compatible with DNS sync when downloader is inactive.

## Test

Tested locally

