### PR TITLE
[downloader] fix inSync method

### DIFF
--- a/hmy/downloader/downloader.go
+++ b/hmy/downloader/downloader.go
@@ -84,10 +84,6 @@ func NewDownloader(host p2p.Host, bc *core.BlockChain, config Config) *Downloade
 
 // Start start the downloader
 func (d *Downloader) Start() {
-	if d.config.ServerOnly {
-		return
-	}
-
 	go d.run()
 
 	if d.bh != nil {
@@ -97,10 +93,6 @@ func (d *Downloader) Start() {
 
 // Close close the downloader
 func (d *Downloader) Close() {
-	if d.config.ServerOnly {
-		return
-	}
-
 	close(d.closeC)
 	d.cancel()
 


### PR DESCRIPTION
## Issue

Resolve https://github.com/harmony-one/harmony/issues/3650.

downloaders.active is only set after `config.ServerOnly` check. 