### PR TITLE
[sync] fix nil pointer when querying /node-sync

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -1043,6 +1043,9 @@ func New(
 
 	node.serviceManager = service.NewManager()
 
+	node.stateSync = node.getStateSync()
+	node.beaconSync = node.getStateSync()
+
 	return &node
 }
 


### PR DESCRIPTION
Hit runtime nil pointer when I was running query of /node-sync

Apr 12 09:04:06 ip-172-31-50-182.us-west-2.compute.internal harmony[9866]: 2021/04/12 09:04:06 http: panic serving 54.153.42.130:51206: runtime error: invalid memory address or nil poin

Signed-off-by: Leo Chen <leo@harmony.one>
