### PR TITLE
[explorer] Instruct explorer.InSync RPC uses NodeAPI as backend.

### DIFF
--- a/api/service/explorer/service.go
+++ b/api/service/explorer/service.go
@@ -14,8 +14,8 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/gorilla/mux"
 	msg_pb "github.com/harmony-one/harmony/api/proto/message"
-	"github.com/harmony-one/harmony/api/service/legacysync"
 	"github.com/harmony-one/harmony/core"
+	"github.com/harmony-one/harmony/hmy"
 	"github.com/harmony-one/harmony/internal/chain"
 	"github.com/harmony-one/harmony/internal/common"
 	"github.com/harmony-one/harmony/internal/utils"
@@ -45,13 +45,18 @@ type Service struct {
 	Storage     *Storage
 	server      *http.Server
 	messageChan chan *msg_pb.Message
-	stateSync   *legacysync.StateSync
 	blockchain  *core.BlockChain
+	backend     hmy.NodeAPI
 }
 
 // New returns explorer service.
-func New(selfPeer *p2p.Peer, ss *legacysync.StateSync, bc *core.BlockChain) *Service {
-	return &Service{IP: selfPeer.IP, Port: selfPeer.Port, stateSync: ss, blockchain: bc}
+func New(selfPeer *p2p.Peer, bc *core.BlockChain, backend hmy.NodeAPI) *Service {
+	return &Service{
+		IP:         selfPeer.IP,
+		Port:       selfPeer.Port,
+		blockchain: bc,
+		backend:    backend,
+	}
 }
 
 // Start starts explorer service.
@@ -267,7 +272,7 @@ func (s *Service) GetTotalSupply(w http.ResponseWriter, r *http.Request) {
 // GetNodeSync returns status code 500 if node is not in sync
 func (s *Service) GetNodeSync(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	sync, _ := s.stateSync.SyncStatus(s.blockchain)
+	sync, _ := s.backend.SyncStatus(s.blockchain.ShardID())
 	if !sync {
 		w.WriteHeader(http.StatusTeapot)
 	}

--- a/node/service_setup.go
+++ b/node/service_setup.go
@@ -27,7 +27,7 @@ func (node *Node) RegisterValidatorServices() {
 func (node *Node) RegisterExplorerServices() {
 	// Register explorer service.
 	node.serviceManager.Register(
-		service.SupportExplorer, explorer.New(&node.SelfPeer, node.stateSync, node.Blockchain()),
+		service.SupportExplorer, explorer.New(&node.SelfPeer, node.Blockchain(), node),
 	)
 }
 


### PR DESCRIPTION
## Issue

A further fix based on https://github.com/harmony-one/harmony/pull/3653.

Instruct explorer node to use `NodeAPI.InSync` interface for compatibility with stream sync.

## Test

Tested locally, RPC returns true as expected.
