### PR TITLE
make block header subscription output format complaint with ethereum

### DIFF
--- a/block/header.go
+++ b/block/header.go
@@ -6,7 +6,9 @@ import (
 	"math/big"
 	"reflect"
 
-	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
 	blockif "github.com/harmony-one/harmony/block/interface"
 	v0 "github.com/harmony-one/harmony/block/v0"
@@ -38,17 +40,40 @@ var (
 // MarshalJSON ..
 func (h Header) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
-		S uint32   `json:"shard-id"`
-		H string   `json:"block-header-hash"`
-		N *big.Int `json:"block-number"`
-		V *big.Int `json:"view-id"`
-		E *big.Int `json:"epoch"`
+		ParentHash  common.Hash    `json:"parentHash"       gencodec:"required"`
+		Coinbase    common.Address `json:"miner"            gencodec:"required"`
+		Root        common.Hash    `json:"stateRoot"        gencodec:"required"`
+		TxHash      common.Hash    `json:"transactionsRoot" gencodec:"required"`
+		ReceiptHash common.Hash    `json:"receiptsRoot"     gencodec:"required"`
+		Bloom       types.Bloom    `json:"logsBloom"        gencodec:"required"`
+		Number      *hexutil.Big   `json:"number"           gencodec:"required"`
+		GasLimit    hexutil.Uint64 `json:"gasLimit"         gencodec:"required"`
+		GasUsed     hexutil.Uint64 `json:"gasUsed"          gencodec:"required"`
+		Time        *hexutil.Big   `json:"timestamp"        gencodec:"required"`
+		Extra       hexutil.Bytes  `json:"extraData"        gencodec:"required"`
+		MixDigest   common.Hash    `json:"mixHash"          gencodec:"required"`
+		Hash        common.Hash    `json:"hash"`
+		// Additional Fields
+		ViewID  *big.Int `json:"viewID"           gencodec:"required"`
+		Epoch   *big.Int `json:"epoch"            gencodec:"required"`
+		ShardID uint32   `json:"shardID"          gencodec:"required"`
 	}{
-		h.Header.ShardID(),
-		h.Header.Hash().Hex(),
-		h.Header.Number(),
+		h.ParentHash(),
+		h.Coinbase(),
+		h.Root(),
+		h.TxHash(),
+		h.ReceiptHash(),
+		h.Bloom(),
+		(*hexutil.Big)(h.Number()),
+		hexutil.Uint64(h.GasLimit()),
+		hexutil.Uint64(h.GasUsed()),
+		(*hexutil.Big)(h.Time()),
+		h.Extra(),
+		h.MixDigest(),
+		h.Hash(),
 		h.Header.ViewID(),
 		h.Header.Epoch(),
+		h.Header.ShardID(),
 	})
 }
 
@@ -87,7 +112,7 @@ func (h *Header) DecodeRLP(s *rlp.Stream) error {
 
 // Hash returns the block hash of the header.  This uses HeaderRegistry to
 // choose and return the right tagged RLP form of the header.
-func (h *Header) Hash() ethcommon.Hash {
+func (h *Header) Hash() common.Hash {
 	return hash.FromRLP(h)
 }
 


### PR DESCRIPTION
Fixes https://github.com/harmony-one/harmony/issues/3581

NewBlockHeader subscription using eth ws should return standard eth response. The previous format was just dummy, I don't think anyone was using it, so it can assumed safe to standardize this format.

new output response:
```
{ parentHash:
   '0xcbdeba1dbb882837bdad0f40cfbf478dc139b888644582bd7e9bef264fe7ef1f',
  miner: '0x6911B75B2560be9a8F71164a33086be4511fC99A',
  stateRoot:
   '0x4d0b5b168bd3214e32f95718ef591e04c54f060f89e4304c8d4ff2745ebad3a9',
  transactionsRoot:
   '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
  receiptsRoot:
   '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
  logsBloom:
   '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
  number: 231,
  gasLimit: 80000000,
  gasUsed: 0,
  timestamp: 1618276118,
  extraData: '0x',
  mixHash:
   '0x0000000000000000000000000000000000000000000000000000000000000000',
  hash:
   '0x9a8cab6710cf8e3c0baba1c1b93c200f375bf40c7cb4280cde8c8d0192f38c3b',
  viewID: 231,
  epoch: 24,
  shardID: 0
}
```