### PR TITLE
[txPool] Further fix in transaction pool

### DIFF
--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -328,7 +328,7 @@ func (l *txList) FilterValid(txPool *TxPool, address common.Address, bn uint64) 
 	var invalids types.PoolTransactions
 
 	removed, errs := l.filterPrice(txPool, address)
-	if bn > l.lastStkCheck+stakingTxCheckThreshold {
+	if bn >= l.lastStkCheck+stakingTxCheckThreshold {
 		l.lastStkCheck = bn
 
 		stkRemoved, errRemoved := l.filterStaking(txPool)

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -22,6 +22,8 @@ import (
 	"math/big"
 	"sort"
 
+	"github.com/pkg/errors"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/internal/utils"
@@ -121,6 +123,36 @@ func (m *txSortedMap) Filter(filter func(types.PoolTransaction) bool) types.Pool
 		m.cache = nil
 	}
 	return removed
+}
+
+// Filter iterates over the list of transactions and removes all of them for which
+// the specified function evaluates to true. Return the filtered transactions and
+// corresponding errors.
+func (m *txSortedMap) FilterWithError(filter func(types.PoolTransaction) error) (types.PoolTransactions, []error) {
+	var (
+		removed types.PoolTransactions
+		errs    []error
+	)
+
+	// Collect all the transactions to filter out
+	for nonce, tx := range m.items {
+		if err := filter(tx); err != nil {
+			removed = append(removed, tx)
+			errs = append(errs, err)
+			delete(m.items, nonce)
+		}
+	}
+	// If transactions were removed, the heap and cache are ruined
+	if len(removed) > 0 {
+		*m.index = make([]uint64, 0, len(m.items))
+		for nonce := range m.items {
+			*m.index = append(*m.index, nonce)
+		}
+		heap.Init(m.index)
+
+		m.cache = nil
+	}
+	return removed, errs
 }
 
 // Cap places a hard limit on the number of items, returning all transactions
@@ -287,26 +319,34 @@ func (l *txList) Forward(threshold uint64) types.PoolTransactions {
 // than the provided thresholds and all staking transactions that can not be validated.
 func (l *txList) FilterValid(
 	txPool *TxPool, address common.Address,
-) (types.PoolTransactions, types.PoolTransactions) {
+) (types.PoolTransactions, types.PoolTransactions, []error) {
 	costLimit := txPool.currentState.GetBalance(address)
 	gasLimit := txPool.currentMaxGas
 	// If all transactions are below the threshold, short circuit
 	if l.costcap.Cmp(costLimit) <= 0 && l.gascap <= gasLimit {
-		return nil, nil
+		return nil, nil, nil
 	}
 	l.costcap = new(big.Int).Set(costLimit) // Lower the caps to the thresholds
 	l.gascap = gasLimit
 
-	return l.Filter(func(tx types.PoolTransaction) bool {
+	return l.Filter(func(tx types.PoolTransaction) error {
 		cost, err := tx.Cost()
 		if err != nil {
-			return true // failure should lead to removal of the tx
+			return err // failure should lead to removal of the tx
+		}
+		if cost.Cmp(costLimit) > 0 {
+			return errors.New("not enough balance")
+		}
+		if tx.GasLimit() > gasLimit {
+			return errors.New("transaction gas limit exceeding block limit")
 		}
 		if _, ok := tx.(*staking.StakingTransaction); ok {
 			err := txPool.validateTx(tx, false)
-			return err != nil
+			if err != nil {
+				return err
+			}
 		}
-		return cost.Cmp(costLimit) == 1 || tx.GasLimit() > gasLimit
+		return nil
 	})
 }
 
@@ -314,13 +354,13 @@ func (l *txList) FilterValid(
 // the specified function evaluates to true. Moreover, it returns all transactions
 // that were invalidated from the filter
 func (l *txList) Filter(
-	filter func(types.PoolTransaction) bool,
-) (types.PoolTransactions, types.PoolTransactions) {
+	filter func(types.PoolTransaction) error,
+) (types.PoolTransactions, types.PoolTransactions, []error) {
 	// If the list was strict, filter anything above the lowest nonce
 	var invalids types.PoolTransactions
 
 	// Filter out all the transactions above the account's funds
-	removed := l.txs.Filter(filter)
+	removed, errs := l.txs.FilterWithError(filter)
 	if l.strict && len(removed) > 0 {
 		lowest := uint64(math.MaxUint64)
 		for _, tx := range removed {
@@ -330,7 +370,7 @@ func (l *txList) Filter(
 		}
 		invalids = l.txs.Filter(func(tx types.PoolTransaction) bool { return tx.Nonce() > lowest })
 	}
-	return removed, invalids
+	return removed, invalids, errs
 }
 
 // Cap places a hard limit on the number of items, returning all transactions

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -511,7 +511,7 @@ func (pool *TxPool) reset(oldHead, newHead *block.Header) {
 	// any transactions that have been included in the block or
 	// have been invalidated because of another transaction (e.g.
 	// higher gas price)
-	pool.demoteUnexecutables()
+	pool.demoteUnexecutables(newHead.Number().Uint64())
 
 	// Update all accounts to the latest known pending nonce
 	for addr, list := range pool.pending {
@@ -1315,14 +1315,15 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 			// Do not report to error sink as old txs are on chain or meaningful error caught elsewhere.
 		}
 		// Drop all transactions that are too costly (low balance or out of gas)
-		drops, _ := list.FilterPrice(pool, addr)
-		for _, tx := range drops {
+		drops, errs, _ := list.FilterValid(pool, addr, 0)
+		for i, tx := range drops {
 			hash := tx.Hash()
 			pool.all.Remove(hash)
 			pool.priced.Removed()
 			queuedNofundsCounter.Inc(1)
-			pool.txErrorSink.Add(tx, fmt.Errorf("removed unpayable queued transaction"))
-			logger.Warn().Str("hash", hash.Hex()).Msg("Removed unpayable queued transaction")
+			pool.txErrorSink.Add(tx, errs[i])
+			logger.Warn().Str("hash", hash.Hex()).Err(errs[i]).
+				Msg("Removed unpayable queued transaction")
 		}
 		// Gather all executable transactions and promote them
 		for _, tx := range list.Ready(pool.pendingState.GetNonce(addr)) {
@@ -1472,7 +1473,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 // demoteUnexecutables removes invalid and processed transactions from the pools
 // executable/pending queue and any subsequent transactions that become unexecutable
 // are moved back into the future queue.
-func (pool *TxPool) demoteUnexecutables() {
+func (pool *TxPool) demoteUnexecutables(bn uint64) {
 	// Iterate over all accounts and demote any non-executable transactions
 	logger := utils.Logger().With().Stack().Logger()
 
@@ -1488,14 +1489,15 @@ func (pool *TxPool) demoteUnexecutables() {
 			// Do not report to error sink as old txs are on chain or meaningful error caught elsewhere.
 		}
 		// Drop all transactions that are too costly (low balance or out of gas), and queue any invalids back for later
-		drops, invalids := list.FilterPrice(pool, addr)
-		for _, tx := range drops {
+		drops, errs, invalids := list.FilterValid(pool, addr, bn)
+		for i, tx := range drops {
 			hash := tx.Hash()
 			pool.all.Remove(hash)
 			pool.priced.Removed()
 			pendingNofundsCounter.Inc(1)
-			pool.txErrorSink.Add(tx, fmt.Errorf("removed unexecutable pending transaction"))
-			logger.Warn().Str("hash", hash.Hex()).Msg("Removed unexecutable pending transaction")
+			pool.txErrorSink.Add(tx, errs[i])
+			logger.Warn().Str("hash", hash.Hex()).Err(errs[i]).
+				Msg("Removed unexecutable pending transaction")
 		}
 		for _, tx := range invalids {
 			hash := tx.Hash()

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1315,14 +1315,14 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 			// Do not report to error sink as old txs are on chain or meaningful error caught elsewhere.
 		}
 		// Drop all transactions that are too costly (low balance or out of gas)
-		drops, _, errs := list.FilterValid(pool, addr)
-		for i, tx := range drops {
+		drops, _ := list.FilterPrice(pool, addr)
+		for _, tx := range drops {
 			hash := tx.Hash()
 			pool.all.Remove(hash)
 			pool.priced.Removed()
 			queuedNofundsCounter.Inc(1)
-			pool.txErrorSink.Add(tx, errs[i])
-			logger.Warn().Str("hash", hash.Hex()).Err(errs[i]).Msg("Removed unpayable queued transaction")
+			pool.txErrorSink.Add(tx, fmt.Errorf("removed unpayable queued transaction"))
+			logger.Warn().Str("hash", hash.Hex()).Msg("Removed unpayable queued transaction")
 		}
 		// Gather all executable transactions and promote them
 		for _, tx := range list.Ready(pool.pendingState.GetNonce(addr)) {
@@ -1488,15 +1488,14 @@ func (pool *TxPool) demoteUnexecutables() {
 			// Do not report to error sink as old txs are on chain or meaningful error caught elsewhere.
 		}
 		// Drop all transactions that are too costly (low balance or out of gas), and queue any invalids back for later
-		drops, invalids, errs := list.FilterValid(pool, addr)
-		for i, tx := range drops {
+		drops, invalids := list.FilterPrice(pool, addr)
+		for _, tx := range drops {
 			hash := tx.Hash()
 			pool.all.Remove(hash)
 			pool.priced.Removed()
 			pendingNofundsCounter.Inc(1)
-			pool.txErrorSink.Add(tx, errs[i])
-			logger.Warn().Str("hash", hash.Hex()).Err(errs[i]).
-				Msg("Removed unexecutable pending transaction")
+			pool.txErrorSink.Add(tx, fmt.Errorf("removed unexecutable pending transaction"))
+			logger.Warn().Str("hash", hash.Hex()).Msg("Removed unexecutable pending transaction")
 		}
 		for _, tx := range invalids {
 			hash := tx.Hash()

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -1532,7 +1532,7 @@ func benchmarkPendingDemotion(b *testing.B, size int) {
 	// Benchmark the speed of pool validation
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		pool.demoteUnexecutables()
+		pool.demoteUnexecutables(0)
 	}
 }
 

--- a/staking/types/transaction.go
+++ b/staking/types/transaction.go
@@ -168,15 +168,10 @@ func (tx *StakingTransaction) Cost() (*big.Int, error) {
 		}
 		total.Add(total, stkMsg.Amount)
 	case DirectiveDelegate:
-		msg, err := RLPDecodeStakeMsg(tx.Data(), DirectiveDelegate)
-		if err != nil {
-			return nil, err
-		}
-		stkMsg, ok := msg.(*Delegate)
-		if !ok {
-			return nil, errStakingTransactionTypeCastErr
-		}
-		total.Add(total, stkMsg.Amount)
+		// Temporary hack: Cost function is not accurate for delegate transaction.
+		// Thus the cost validation is done in `txPool.validateTx`.
+		// TODO: refactor this hack.
+	default:
 	}
 	return total, nil
 }

--- a/staking/types/transaction_test.go
+++ b/staking/types/transaction_test.go
@@ -140,16 +140,22 @@ func TestGasCost(t *testing.T) {
 		t.Errorf("gas price set incorrectly \n")
 	}
 	cost, err := stakingTx.Cost()
-	if err != nil || cost.Int64() != 600100 {
-		t.Errorf("staking transaction cost is incorrect %v\n", err)
+	if err != nil {
+		t.Errorf("unexpected error %v\n", err)
+	}
+	if cost.Int64() != 600100 {
+		t.Errorf("unexpected cost: %v / %v", cost, 600100)
 	}
 	delegateTx, err := createDelegate()
 	if err != nil {
 		t.Errorf("cannot create delegate staking transaction, %v\n", err)
 	}
 	cost, err = delegateTx.Cost()
-	if err != nil || cost.Int64() != 21100 {
-		t.Errorf("staking transaction cost is incorrect %v\n", err)
+	if err != nil {
+		t.Errorf("unexpected error %v\n", err)
+	}
+	if cost.Int64() != 21000 {
+		t.Errorf("unexpected cost: %v / %v", cost, 21000)
 	}
 }
 


### PR DESCRIPTION
## Issue

Another fix for https://github.com/harmony-one/go-sdk/issues/242

Enforce rigid transaction cost check during `txPool.Reset` to remove all invalid transactions. 

## Test

Tested locally.