### PR TITLE
[TxPool] Broadcasting stuck transaction

### DIFF
--- a/core/metric.go
+++ b/core/metric.go
@@ -1,0 +1,84 @@
+package core
+
+import (
+	prom "github.com/harmony-one/harmony/api/service/prometheus"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func init() {
+	prom.PromRegistry().MustRegister(
+		receivedTxsCounter,
+		stuckTxsCounter,
+		invalidTxsCounterVec,
+		knownTxsCounter,
+		lowNonceTxCounter,
+		pendingTxGauge,
+		queuedTxGauge,
+	)
+}
+
+var (
+	receivedTxsCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "hmy",
+			Subsystem: "txPool",
+			Name:      "received",
+			Help:      "number of transactions received",
+		},
+	)
+
+	stuckTxsCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "hmy",
+			Subsystem: "txPool",
+			Name:      "stuck",
+			Help:      "number of transactions observed to be stuck and broadcast again",
+		},
+	)
+
+	invalidTxsCounterVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "hmy",
+			Subsystem: "txPool",
+			Name:      "invalid",
+			Help:      "transactions failed validation",
+		},
+		[]string{"err"},
+	)
+
+	knownTxsCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "hmy",
+			Subsystem: "txPool",
+			Name:      "known",
+			Help:      "number of known transaction received",
+		},
+	)
+
+	lowNonceTxCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "hmy",
+			Subsystem: "txPool",
+			Name:      "low_nonce",
+			Help:      "number of transactions removed because of low nonce (including processed transactions)",
+		},
+	)
+
+	pendingTxGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "hmy",
+			Subsystem: "txPool",
+			Name:      "pending",
+			Help:      "number of executable transactions",
+		},
+	)
+
+	queuedTxGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "hmy",
+			Subsystem: "txPool",
+			Name:      "queued",
+			Help:      "number of queued non-executable transactions",
+		},
+	)
+)

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -235,7 +235,7 @@ func (m *txSortedMap) Len() int {
 // it's requested again before any modifications are made to the contents.
 func (m *txSortedMap) Flatten() types.PoolTransactions {
 	// If the sorting was not cached yet, create and cache it
-	if m.cache != nil {
+	if m.cache == nil {
 		m.cache = m.sortedTxs()
 	}
 	// Copy the cache to prevent accidental modifications
@@ -246,7 +246,7 @@ func (m *txSortedMap) Flatten() types.PoolTransactions {
 
 // Peek return the transaction with the lowest nonce.
 func (m *txSortedMap) Peek() types.PoolTransaction {
-	if m.cache != nil {
+	if m.cache == nil {
 		m.cache = m.sortedTxs()
 	}
 	if len(m.cache) == 0 {

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -258,7 +258,7 @@ func (m *txSortedMap) Peek() types.PoolTransaction {
 func (m *txSortedMap) sortedTxs() types.PoolTransactions {
 	cache := make(types.PoolTransactions, 0, len(m.items))
 	for _, tx := range m.items {
-		cache = append(m.cache, tx)
+		cache = append(cache, tx)
 	}
 	sort.Sort(types.PoolTxByNonce(cache))
 	return cache

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1638,17 +1638,6 @@ func (pool *TxPool) stuckExecutables() types.PoolTransactions {
 	return stuckTxs
 }
 
-// lockedStats return the statistics for prometheus metrics.
-func (pool *TxPool) stats() (pending, queued int) {
-	for _, txList := range pool.pending {
-		pending += txList.Len()
-	}
-	for _, txList := range pool.queue {
-		queued += txList.Len()
-	}
-	return
-}
-
 // addressByHeartbeat is an account address tagged with its last activity timestamp.
 type addressByHeartbeat struct {
 	address   common.Address

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -180,7 +180,7 @@ type TxPoolConfig struct {
 	AccountQueue uint64 // Maximum number of non-executable transaction slots permitted per account
 	GlobalQueue  uint64 // Maximum number of non-executable transaction slots for all accounts
 
-	broadcast func(types.PoolTransactions) // broadcast invalid transaction
+	Broadcast func(types.PoolTransactions) // broadcast invalid transaction
 	Lifetime  time.Duration                // Maximum amount of time non-executable transaction are queued
 
 	Blacklist map[common.Address]struct{} // Set of accounts that cannot be a part of any transaction
@@ -234,7 +234,7 @@ func (config *TxPoolConfig) sanitize() TxPoolConfig {
 		utils.Logger().Warn().Msg("Sanitizing nil blacklist set")
 		conf.Blacklist = DefaultTxPoolConfig.Blacklist
 	}
-	if conf.broadcast == nil {
+	if conf.Broadcast == nil {
 		utils.Logger().Warn().Msg("broadcast function is nil, unable to broadcast stuck transaction")
 	}
 
@@ -302,7 +302,7 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig,
 		chainHeadCh: make(chan ChainHeadEvent, chainHeadChanSize),
 		gasPrice:    new(big.Int).SetUint64(config.PriceLimit),
 		txErrorSink: txErrorSink,
-		broadcast:   config.broadcast,
+		broadcast:   config.Broadcast,
 	}
 	pool.locals = newAccountSet(chainconfig.ChainID)
 	for _, addr := range config.Locals {

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -436,10 +436,9 @@ func (pool *TxPool) loop() {
 			}
 			pool.mu.Unlock()
 
-			utils.Logger().Info().Int("Count", len(stuckTxs)).
-				Msg("Broadcasting stuck transaction")
-
-			if pool.broadcast != nil {
+			if pool.broadcast != nil && len(stuckTxs) != 0 {
+				utils.Logger().Info().Int("Count", len(stuckTxs)).
+					Msg("Broadcasting stuck transaction")
 				go pool.broadcast(stuckTxs)
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/deckarep/golang-set v1.7.1
 	github.com/ethereum/go-ethereum v1.9.23
 	github.com/fjl/memsize v0.0.0-20180929194037-2a09253e352a // indirect
-	github.com/fwojciec/clock v0.0.0-20201211142135-a6f233dec376 // indirect
+	github.com/fwojciec/clock v0.0.0-20201211142135-a6f233dec376
 	github.com/garslo/gogen v0.0.0-20170307003452-d6ebae628c7c // indirect
 	github.com/golang/mock v1.4.0
 	github.com/golang/protobuf v1.4.3

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/deckarep/golang-set v1.7.1
 	github.com/ethereum/go-ethereum v1.9.23
 	github.com/fjl/memsize v0.0.0-20180929194037-2a09253e352a // indirect
+	github.com/fwojciec/clock v0.0.0-20201211142135-a6f233dec376 // indirect
 	github.com/garslo/gogen v0.0.0-20170307003452-d6ebae628c7c // indirect
 	github.com/golang/mock v1.4.0
 	github.com/golang/protobuf v1.4.3

--- a/node/node.go
+++ b/node/node.go
@@ -159,7 +159,7 @@ func (node *Node) broadcastTransactions(txs types.PoolTransactions) {
 	for _, tx := range txs {
 		switch t := tx.(type) {
 		case *types.Transaction:
-			node.broadcastTx(t)
+			node.broadcastPlainTx(t)
 
 		case *staking.StakingTransaction:
 			node.broadcastStakingTx(t)
@@ -172,14 +172,14 @@ func (node *Node) broadcastTransactions(txs types.PoolTransactions) {
 }
 
 // TODO: make this batch more transactions
-func (node *Node) broadcastTx(tx *types.Transaction) {
+func (node *Node) broadcastPlainTx(tx *types.Transaction) {
 	shardGroupID := nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(tx.ShardID()))
 	groups := []nodeconfig.GroupID{shardGroupID}
 
 	msg := proto_node.ConstructTransactionListMessageAccount(types.Transactions{tx})
 	finalMsg := p2p.ConstructMessage(msg)
 
-	utils.Logger().Info().Str("shardGroupID", string(shardGroupID)).Msg("broadcastTx")
+	utils.Logger().Info().Str("shardGroupID", string(shardGroupID)).Msg("broadcastPlainTx")
 
 	if err := node.host.SendMessageToGroups(groups, finalMsg); err != nil {
 		utils.Logger().Error().Err(err).Msg("Error when trying to broadcast tx")
@@ -297,7 +297,7 @@ func (node *Node) AddPendingTransaction(newTx *types.Transaction) error {
 		}
 		if err == nil || node.BroadcastInvalidTx {
 			utils.Logger().Info().Str("Hash", newTx.Hash().Hex()).Str("HashByType", newTx.HashByType().Hex()).Msg("Broadcasting Tx")
-			node.broadcastTx(newTx)
+			node.broadcastPlainTx(newTx)
 		}
 		return err
 	}


### PR DESCRIPTION
## Issue

Further fix to harmony-one/go-sdk#242

Observed some transactions are missing during broadcasting in pub-sub. This fix is to broadcast "stuck" executable transactions periodically to the network. 

## Test

Tested locally with code: https://github.com/JackyWYX/harmony/tree/txpool_staking_check_test.

Broadcasting print message is observed when transaction get stuck. 