### PR TITLE
Config 2.0.0

### DIFF
--- a/cmd/harmony/config.go
+++ b/cmd/harmony/config.go
@@ -314,24 +314,35 @@ var updateConfigCmd = &cobra.Command{
 	},
 }
 
+func dumpConfig(cmd *cobra.Command, args []string) {
+	nt := getNetworkType(cmd)
+	config := getDefaultHmyConfigCopy(nt)
+
+	if err := writeHarmonyConfigToFile(config, args[0]); err != nil {
+		fmt.Println(err)
+		os.Exit(128)
+	}
+}
+
 var dumpConfigCmd = &cobra.Command{
 	Use:   "dump [config_file]",
-	Short: "dump default file for harmony binary configurations",
+	Short: "dump default config file for harmony binary configurations",
 	Long:  "dump default config file for harmony binary configurations",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		nt := getNetworkType(cmd)
-		config := getDefaultHmyConfigCopy(nt)
+	Run:   dumpConfig,
+}
 
-		if err := writeHarmonyConfigToFile(config, args[0]); err != nil {
-			fmt.Println(err)
-			os.Exit(128)
-		}
-	},
+var dumpConfigLegacyCmd = &cobra.Command{
+	Use:   "dumpconfig [config_file]",
+	Short: "depricated - use config dump instead",
+	Long:  "depricated - use config dump instead",
+	Args:  cobra.MinimumNArgs(1),
+	Run:   dumpConfig,
 }
 
 func registerDumpConfigFlags() error {
 	return cli.RegisterFlags(dumpConfigCmd, []cli.Flag{networkTypeFlag})
+	return cli.RegisterFlags(dumpConfigLegacyCmd, []cli.Flag{networkTypeFlag})
 }
 
 func promptConfigUpdate() bool {

--- a/cmd/harmony/config.go
+++ b/cmd/harmony/config.go
@@ -44,7 +44,7 @@ type dnsSync struct {
 	Zone          string // replaces: Network.DNSZone
 	LegacySyncing bool   // replaces: Network.LegacySyncing
 	Client        bool   // replaces: Sync.LegacyClient
-	Server        bool   // replaces Sync.LegacyServer
+	Server        bool   // replaces: Sync.LegacyServer
 	ServerPort    int
 }
 

--- a/cmd/harmony/config.go
+++ b/cmd/harmony/config.go
@@ -172,29 +172,6 @@ type syncConfig struct {
 	DiscBatch      int  // size of each discovery
 }
 
-// correctLegacyHarmonyConfig correct values for old config version load
-func correctLegacyHarmonyConfig(config *harmonyConfig) {
-	if config.Sync == (syncConfig{}) {
-		nt := nodeconfig.NetworkType(config.Network.NetworkType)
-		config.Sync = getDefaultSyncConfig(nt)
-	}
-	if config.HTTP.RosettaPort == 0 {
-		config.HTTP.RosettaPort = defaultConfig.HTTP.RosettaPort
-	}
-	if config.P2P.IP == "" {
-		config.P2P.IP = defaultConfig.P2P.IP
-	}
-	if config.Prometheus == nil {
-		config.Prometheus = defaultConfig.Prometheus
-	}
-	if syncPort := config.DNSSync.Port; syncPort == 0 {
-		config.DNSSync.Port = nodeconfig.DefaultDNSPort
-	}
-	if serverPort := config.DNSSync.ServerPort; serverPort == 0 {
-		config.DNSSync.ServerPort = nodeconfig.DefaultDNSPort
-	}
-}
-
 // TODO: use specific type wise validation instead of general string types assertion.
 func validateHarmonyConfig(config harmonyConfig) error {
 	var accepts []string
@@ -390,7 +367,6 @@ func loadHarmonyConfig(file string) (harmonyConfig, string, error) {
 		return harmonyConfig{}, "", err
 	}
 
-	correctLegacyHarmonyConfig(&config)
 	return config, migratedVer, nil
 }
 

--- a/cmd/harmony/config_migrations.go
+++ b/cmd/harmony/config_migrations.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/harmony-one/harmony/api/service/legacysync"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	goversion "github.com/hashicorp/go-version"
 	"github.com/pelletier/go-toml"
@@ -106,6 +107,7 @@ func init() {
 
 		portField := confTree.Get("Network.DNSPort")
 		if p, ok := portField.(int64); ok {
+			p = p - legacysync.SyncingPortDifference
 			confTree.Set("DNSSync.Port", p)
 		} else {
 			confTree.Set("DNSSync.Port", nodeconfig.DefaultDNSPort)

--- a/cmd/harmony/config_migrations.go
+++ b/cmd/harmony/config_migrations.go
@@ -105,13 +105,14 @@ func init() {
 			confTree.Set("DNSSync.Zone", zone)
 		}
 
-		var port = int64(nodeconfig.DefaultDNSPort)
 		portField := confTree.Get("Network.DNSPort")
 		if p, ok := portField.(int64); ok {
 			if p != nodeconfig.DefaultDNSPort {
-				port = p - legacysync.SyncingPortDifference
+				p = p - legacysync.SyncingPortDifference
 			}
-			confTree.Set("DNSSync.Port", port)
+			confTree.Set("DNSSync.Port", p)
+		} else {
+			confTree.Set("DNSSync.Port", nodeconfig.DefaultDNSPort)
 		}
 
 		syncingField := confTree.Get("Network.LegacySyncing")

--- a/cmd/harmony/config_migrations.go
+++ b/cmd/harmony/config_migrations.go
@@ -79,6 +79,26 @@ func init() {
 		nt := parseNetworkType(ntStr)
 
 		defDNSSyncConf := getDefaultDNSSyncConfig(nt)
+		defSyncConfig := getDefaultSyncConfig(nt)
+
+		// Legacy conf missing fields
+		if confTree.Get("Sync") == nil {
+			confTree.Set("Sync", defSyncConfig)
+		}
+
+		if confTree.Get("HTTP.RosettaPort") == nil {
+			confTree.Set("HTTP.RosettaPort", defaultConfig.HTTP.RosettaPort)
+		}
+
+		if confTree.Get("P2P.IP") == nil {
+			confTree.Set("P2P.IP", defaultConfig.P2P.IP)
+		}
+
+		if confTree.Get("Prometheus") == nil {
+			if defaultConfig.Prometheus != nil {
+				confTree.Set("Prometheus", *defaultConfig.Prometheus)
+			}
+		}
 
 		zoneField := confTree.Get("Network.DNSZone")
 		if zone, ok := zoneField.(string); ok {
@@ -119,11 +139,6 @@ func init() {
 			serverPort = int(port)
 		}
 		confTree.Set("DNSSync.ServerPort", serverPort)
-
-		rosettaPort := confTree.Get("HTTP.RosettaPort")
-		if rosettaPort == nil {
-			confTree.Set("HTTP.RosettaPort", defaultConfig.HTTP.RosettaPort)
-		}
 
 		confTree.Set("Version", "2.0.0")
 		return confTree

--- a/cmd/harmony/config_migrations.go
+++ b/cmd/harmony/config_migrations.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/harmony-one/harmony/api/service/legacysync"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	goversion "github.com/hashicorp/go-version"
 	"github.com/pelletier/go-toml"
@@ -107,9 +106,6 @@ func init() {
 
 		portField := confTree.Get("Network.DNSPort")
 		if p, ok := portField.(int64); ok {
-			if p != nodeconfig.DefaultDNSPort {
-				p = p - legacysync.SyncingPortDifference
-			}
 			confTree.Set("DNSSync.Port", p)
 		} else {
 			confTree.Set("DNSSync.Port", nodeconfig.DefaultDNSPort)

--- a/cmd/harmony/config_migrations.go
+++ b/cmd/harmony/config_migrations.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	goversion "github.com/hashicorp/go-version"
+	"github.com/pelletier/go-toml"
+)
+
+const legacyConfigVersion = "1.0.4"
+
+func migrateConf(confBytes []byte) (harmonyConfig, string, error) {
+	var (
+		migratedFrom string
+	)
+	confTree, err := toml.LoadBytes(confBytes)
+	if err != nil {
+		return harmonyConfig{}, "", fmt.Errorf("config file parse error - %s", err.Error())
+	}
+	confVersion, found := confTree.Get("Version").(string)
+	if !found {
+		return harmonyConfig{}, "", errors.New("config file invalid - no version entry found")
+	}
+	migratedFrom = confVersion
+	if confVersion != tomlConfigVersion {
+		Ver, err := goversion.NewVersion(confVersion)
+		if err != nil {
+			return harmonyConfig{}, "", fmt.Errorf("invalid or missing config file version - '%s'", confVersion)
+		}
+		legacyVer, _ := goversion.NewVersion(legacyConfigVersion)
+		migrationKey := confVersion
+		if Ver.LessThan(legacyVer) {
+			migrationKey = legacyConfigVersion
+		}
+
+		migration, found := migrations[migrationKey]
+
+		// Version does not match any of the migration criteria
+		if !found {
+			return harmonyConfig{}, "", fmt.Errorf("unrecognized config version - %s", confVersion)
+		}
+
+		for confVersion != tomlConfigVersion {
+			confTree = migration(confTree)
+			confVersion = confTree.Get("Version").(string)
+			migration = migrations[confVersion]
+		}
+	}
+
+	// At this point we must be at current config version so
+	// we can safely unmarshal it
+	var config harmonyConfig
+	if err := confTree.Unmarshal(&config); err != nil {
+		return harmonyConfig{}, "", err
+	}
+	return config, migratedFrom, nil
+}
+
+var (
+	migrations = make(map[string]configMigrationFunc)
+)
+
+type configMigrationFunc func(*toml.Tree) *toml.Tree
+
+func init() {
+	migrations["1.0.4"] = func(confTree *toml.Tree) *toml.Tree {
+		ntStr := confTree.Get("Network.NetworkType").(string)
+		nt := parseNetworkType(ntStr)
+
+		defDNSSyncConf := getDefaultDNSSyncConfig(nt)
+
+		zoneField := confTree.Get("Network.DNSZone")
+		if zone, ok := zoneField.(string); ok {
+			confTree.Set("DNSSync.Zone", zone)
+		}
+
+		portField := confTree.Get("Network.DNSPort")
+		if port, ok := portField.(int64); ok {
+			confTree.Set("DNSSync.Port", port)
+		}
+
+		syncingField := confTree.Get("Network.LegacySyncing")
+		if syncing, ok := syncingField.(bool); ok {
+			confTree.Set("DNSSync.LegacySyncing", syncing)
+		}
+
+		clientField := confTree.Get("Sync.LegacyClient")
+		if client, ok := clientField.(bool); ok {
+			confTree.Set("DNSSync.Client", client)
+		} else {
+			confTree.Set("DNSSync.Client", defDNSSyncConf.Client)
+		}
+
+		serverField := confTree.Get("Sync.LegacyServer")
+		if server, ok := serverField.(bool); ok {
+			confTree.Set("DNSSync.Server", server)
+		} else {
+			confTree.Set("DNSSync.Server", defDNSSyncConf.Client)
+		}
+
+		serverPort := defDNSSyncConf.ServerPort
+		serverPortField := confTree.Get("Sync.LegacyServerPort")
+		if port, ok := serverPortField.(int64); ok {
+			serverPort = int(port)
+		}
+		confTree.Set("DNSSync.ServerPort", serverPort)
+
+		confTree.Set("Version", "2.0.0")
+		return confTree
+	}
+}

--- a/cmd/harmony/config_migrations_test.go
+++ b/cmd/harmony/config_migrations_test.go
@@ -263,6 +263,7 @@ func Test_migrateConf(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, _, err := migrateConf(tt.args.confBytes)
+			correctLegacyHarmonyConfig(&got)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("migrateConf() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/cmd/harmony/config_migrations_test.go
+++ b/cmd/harmony/config_migrations_test.go
@@ -263,7 +263,6 @@ func Test_migrateConf(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, _, err := migrateConf(tt.args.confBytes)
-			correctLegacyHarmonyConfig(&got)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("migrateConf() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/cmd/harmony/config_migrations_test.go
+++ b/cmd/harmony/config_migrations_test.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
+)
+
+var (
+	V1_0_2ConfigDefault = []byte(`
+Version = "1.0.2"
+
+[BLSKeys]
+  KMSConfigFile = ""
+  KMSConfigSrcType = "shared"
+  KMSEnabled = false
+  KeyDir = "./.hmy/blskeys"
+  KeyFiles = []
+  MaxKeys = 10
+  PassEnabled = true
+  PassFile = ""
+  PassSrcType = "auto"
+  SavePassphrase = false
+
+[General]
+  DataDir = "./"
+  IsArchival = false
+  IsOffline = false
+  NoStaking = false
+  NodeType = "validator"
+  ShardID = -1
+
+[HTTP]
+  Enabled = true
+  IP = "127.0.0.1"
+  Port = 9500
+  RosettaEnabled = false
+  RosettaPort = 9700
+
+[Log]
+  FileName = "harmony.log"
+  Folder = "./latest"
+  RotateSize = 100
+  Verbosity = 3
+
+[Network]
+  BootNodes = ["/ip4/100.26.90.187/tcp/9874/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv","/ip4/54.213.43.194/tcp/9874/p2p/QmZJJx6AdaoEkGLrYG4JeLCKeCKDjnFz2wfHNHxAqFSGA9","/ip4/13.113.101.219/tcp/12019/p2p/QmQayinFSgMMw5cSpDUiD9pQ2WeP6WNmGxpZ6ou3mdVFJX","/ip4/99.81.170.167/tcp/12019/p2p/QmRVbTpEYup8dSaURZfF6ByrMTSKa4UyUzJhSjahFzRqNj"]
+  DNSPort = 9000
+  DNSZone = "t.hmny.io"
+  LegacySyncing = false
+  NetworkType = "mainnet"
+
+[P2P]
+  IP = "0.0.0.0"
+  KeyFile = "./.hmykey"
+  Port = 9000
+
+[Pprof]
+  Enabled = false
+  ListenAddr = "127.0.0.1:6060"
+
+[RPCOpt]
+  DebugEnabled = false
+
+[TxPool]
+  BlacklistFile = "./.hmy/blacklist.txt"
+
+[WS]
+  Enabled = true
+  IP = "127.0.0.1"
+  Port = 9800
+`)
+
+	V1_0_3ConfigDefault = []byte(`
+Version = "1.0.3"
+
+[BLSKeys]
+  KMSConfigFile = ""
+  KMSConfigSrcType = "shared"
+  KMSEnabled = false
+  KeyDir = "./.hmy/blskeys"
+  KeyFiles = []
+  MaxKeys = 10
+  PassEnabled = true
+  PassFile = ""
+  PassSrcType = "auto"
+  SavePassphrase = false
+
+[General]
+  DataDir = "./"
+  IsArchival = false
+  IsBeaconArchival = false
+  IsOffline = false
+  NoStaking = false
+  NodeType = "validator"
+  ShardID = -1
+
+[HTTP]
+  Enabled = true
+  IP = "127.0.0.1"
+  Port = 9500
+  RosettaEnabled = false
+  RosettaPort = 9700
+
+[Log]
+  FileName = "harmony.log"
+  Folder = "./latest"
+  RotateSize = 100
+  Verbosity = 3
+
+[Network]
+  BootNodes = ["/ip4/100.26.90.187/tcp/9874/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv","/ip4/54.213.43.194/tcp/9874/p2p/QmZJJx6AdaoEkGLrYG4JeLCKeCKDjnFz2wfHNHxAqFSGA9","/ip4/13.113.101.219/tcp/12019/p2p/QmQayinFSgMMw5cSpDUiD9pQ2WeP6WNmGxpZ6ou3mdVFJX","/ip4/99.81.170.167/tcp/12019/p2p/QmRVbTpEYup8dSaURZfF6ByrMTSKa4UyUzJhSjahFzRqNj"]
+  DNSPort = 9000
+  DNSZone = "t.hmny.io"
+  LegacySyncing = false
+  NetworkType = "mainnet"
+
+[P2P]
+  IP = "0.0.0.0"
+  KeyFile = "./.hmykey"
+  Port = 9000
+
+[Pprof]
+  Enabled = false
+  ListenAddr = "127.0.0.1:6060"
+
+[RPCOpt]
+  DebugEnabled = false
+
+[TxPool]
+  BlacklistFile = "./.hmy/blacklist.txt"
+
+[WS]
+  Enabled = true
+  IP = "127.0.0.1"
+  Port = 9800
+
+`)
+
+	V1_0_4ConfigDefault = []byte(`
+Version = "1.0.4"
+
+[BLSKeys]
+  KMSConfigFile = ""
+  KMSConfigSrcType = "shared"
+  KMSEnabled = false
+  KeyDir = "./.hmy/blskeys"
+  KeyFiles = []
+  MaxKeys = 10
+  PassEnabled = true
+  PassFile = ""
+  PassSrcType = "auto"
+  SavePassphrase = false
+
+[General]
+  DataDir = "./"
+  IsArchival = false
+  IsBeaconArchival = false
+  IsOffline = false
+  NoStaking = false
+  NodeType = "validator"
+  ShardID = -1
+
+[HTTP]
+  Enabled = true
+  IP = "127.0.0.1"
+  Port = 9500
+  RosettaEnabled = false
+  RosettaPort = 9700
+
+[Log]
+  FileName = "harmony.log"
+  Folder = "./latest"
+  RotateSize = 100
+  Verbosity = 3
+
+[Network]
+  BootNodes = ["/dnsaddr/bootstrap.t.hmny.io"]
+  DNSPort = 9000
+  DNSZone = "t.hmny.io"
+  LegacySyncing = false
+  NetworkType = "mainnet"
+
+[P2P]
+  IP = "0.0.0.0"
+  KeyFile = "./.hmykey"
+  Port = 9000
+
+[Pprof]
+  Enabled = false
+  ListenAddr = "127.0.0.1:6060"
+
+[RPCOpt]
+  DebugEnabled = false
+
+[Sync]
+  Concurrency = 6
+  DiscBatch = 8
+  DiscHardLowCap = 6
+  DiscHighCap = 128
+  DiscSoftLowCap = 8
+  Downloader = false
+  InitStreams = 8
+  LegacyClient = true
+  LegacyServer = true
+  MinPeers = 6
+
+[TxPool]
+  BlacklistFile = "./.hmy/blacklist.txt"
+
+[WS]
+  Enabled = true
+  IP = "127.0.0.1"
+  Port = 9800
+`)
+)
+
+func Test_migrateConf(t *testing.T) {
+	defConf := getDefaultHmyConfigCopy(nodeconfig.Mainnet)
+	legacyDefConf := getDefaultHmyConfigCopy(nodeconfig.Mainnet)
+	// Versions prior to 1.0.3 use different BootNodes
+	legacyDefConf.Network.BootNodes = []string{
+		"/ip4/100.26.90.187/tcp/9874/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv",
+		"/ip4/54.213.43.194/tcp/9874/p2p/QmZJJx6AdaoEkGLrYG4JeLCKeCKDjnFz2wfHNHxAqFSGA9",
+		"/ip4/13.113.101.219/tcp/12019/p2p/QmQayinFSgMMw5cSpDUiD9pQ2WeP6WNmGxpZ6ou3mdVFJX",
+		"/ip4/99.81.170.167/tcp/12019/p2p/QmRVbTpEYup8dSaURZfF6ByrMTSKa4UyUzJhSjahFzRqNj",
+	}
+	type args struct {
+		confBytes []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    harmonyConfig
+		wantErr bool
+	}{
+		{
+			name: "1.0.2 to latest migration",
+			args: args{
+				confBytes: V1_0_2ConfigDefault,
+			},
+			want:    legacyDefConf,
+			wantErr: false,
+		},
+		{
+			name: "1.0.3 to latest migration",
+			args: args{
+				confBytes: V1_0_3ConfigDefault,
+			},
+			want:    legacyDefConf,
+			wantErr: false,
+		},
+		{
+			name: "1.0.4 to latest migration",
+			args: args{
+				confBytes: V1_0_4ConfigDefault,
+			},
+			want:    defConf,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _, err := migrateConf(tt.args.confBytes)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("migrateConf() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("migrateConf() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -30,7 +30,8 @@ func init() {
 }
 
 func TestV1_0_4Config(t *testing.T) {
-	testConfig := `Version = "1.0.4"
+	configs := map[string]string{
+		"default 1.0.4": `Version = "1.0.4"
 
 [BLSKeys]
   KMSConfigFile = ""
@@ -95,35 +96,105 @@ func TestV1_0_4Config(t *testing.T) {
 [WS]
   Enabled = true
   IP = "127.0.0.1"
-  Port = 9800`
-	testDir := filepath.Join(testBaseDir, t.Name())
-	os.RemoveAll(testDir)
-	os.MkdirAll(testDir, 0777)
-	file := filepath.Join(testDir, "test.config")
-	err := ioutil.WriteFile(file, []byte(testConfig), 0644)
-	if err != nil {
-		t.Fatal(err)
+  Port = 9800`,
+
+		"default 1.0.4 with DNSPort=6000": `Version = "1.0.4"
+
+[BLSKeys]
+  KMSConfigFile = ""
+  KMSConfigSrcType = "shared"
+  KMSEnabled = false
+  KeyDir = "./.hmy/blskeys"
+  KeyFiles = []
+  MaxKeys = 10
+  PassEnabled = true
+  PassFile = ""
+  PassSrcType = "auto"
+  SavePassphrase = false
+
+[General]
+  DataDir = "./"
+  IsArchival = false
+  NoStaking = false
+  NodeType = "validator"
+  ShardID = -1
+
+[HTTP]
+  Enabled = true
+  IP = "127.0.0.1"
+  Port = 9500
+
+[Log]
+  FileName = "harmony.log"
+  Folder = "./latest"
+  RotateSize = 100
+  Verbosity = 3
+
+[Network]
+  BootNodes = ["/dnsaddr/bootstrap.t.hmny.io"]
+  DNSPort = 6000
+  DNSZone = "t.hmny.io"
+  LegacySyncing = false
+  NetworkType = "mainnet"
+
+[P2P]
+  KeyFile = "./.hmykey"
+  Port = 9000
+
+[Pprof]
+  Enabled = false
+  ListenAddr = "127.0.0.1:6060"
+
+[TxPool]
+  BlacklistFile = "./.hmy/blacklist.txt"
+
+[Sync]
+  Downloader = false
+  Concurrency = 6
+  DiscBatch = 8
+  DiscHardLowCap = 6
+  DiscHighCap = 128
+  DiscSoftLowCap = 8
+  InitStreams = 8
+  LegacyClient = true
+  LegacyServer = true
+  MinPeers = 6
+
+[WS]
+  Enabled = true
+  IP = "127.0.0.1"
+  Port = 9800`,
 	}
-	config, migratedFrom, err := loadHarmonyConfig(file)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defConf := getDefaultHmyConfigCopy(nodeconfig.Mainnet)
-	if config.HTTP.RosettaEnabled {
-		t.Errorf("Expected rosetta http server to be disabled when loading old config")
-	}
-	if config.General.IsOffline {
-		t.Errorf("Expect node to de online when loading old config")
-	}
-	if config.P2P.IP != defConf.P2P.IP {
-		t.Errorf("Expect default p2p IP if old config is provided")
-	}
-	if migratedFrom != "1.0.4" {
-		t.Errorf("Expected config version: 1.0.4, not %v", config.Version)
-	}
-	config.Version = defConf.Version // Shortcut for testing, value checked above
-	if !reflect.DeepEqual(config, defConf) {
-		t.Errorf("Unexpected config \n\t%+v \n\t%+v", config, defaultConfig)
+	for testname, testConfig := range configs {
+		testDir := filepath.Join(testBaseDir, t.Name())
+		os.RemoveAll(testDir)
+		os.MkdirAll(testDir, 0777)
+		file := filepath.Join(testDir, "test.config")
+		err := ioutil.WriteFile(file, []byte(testConfig), 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+		config, migratedFrom, err := loadHarmonyConfig(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defConf := getDefaultHmyConfigCopy(nodeconfig.Mainnet)
+		if config.HTTP.RosettaEnabled {
+			t.Errorf("Expected rosetta http server to be disabled when loading old config")
+		}
+		if config.General.IsOffline {
+			t.Errorf("Expect node to de online when loading old config")
+		}
+		if config.P2P.IP != defConf.P2P.IP {
+			t.Errorf("Expect default p2p IP if old config is provided")
+		}
+		if migratedFrom != "1.0.4" {
+			t.Errorf("Expected config version: 1.0.4, not %v", config.Version)
+		}
+		config.Version = defConf.Version // Shortcut for testing, value checked above
+		if !reflect.DeepEqual(config, defConf) {
+			t.Errorf("Unexpected config(%s) \n\t%+v \n\t%+v", testname, config, defaultConfig)
+		}
 	}
 }
 

--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -30,9 +30,8 @@ func init() {
 }
 
 func TestV1_0_4Config(t *testing.T) {
-	configs := map[string]string{
-		"default 1.0.4": `Version = "1.0.4"
-
+	testConfig := `
+Version = "1.0.4"
 [BLSKeys]
   KMSConfigFile = ""
   KMSConfigSrcType = "shared"
@@ -96,105 +95,35 @@ func TestV1_0_4Config(t *testing.T) {
 [WS]
   Enabled = true
   IP = "127.0.0.1"
-  Port = 9800`,
-
-		"default 1.0.4 with DNSPort=6000": `Version = "1.0.4"
-
-[BLSKeys]
-  KMSConfigFile = ""
-  KMSConfigSrcType = "shared"
-  KMSEnabled = false
-  KeyDir = "./.hmy/blskeys"
-  KeyFiles = []
-  MaxKeys = 10
-  PassEnabled = true
-  PassFile = ""
-  PassSrcType = "auto"
-  SavePassphrase = false
-
-[General]
-  DataDir = "./"
-  IsArchival = false
-  NoStaking = false
-  NodeType = "validator"
-  ShardID = -1
-
-[HTTP]
-  Enabled = true
-  IP = "127.0.0.1"
-  Port = 9500
-
-[Log]
-  FileName = "harmony.log"
-  Folder = "./latest"
-  RotateSize = 100
-  Verbosity = 3
-
-[Network]
-  BootNodes = ["/dnsaddr/bootstrap.t.hmny.io"]
-  DNSPort = 6000
-  DNSZone = "t.hmny.io"
-  LegacySyncing = false
-  NetworkType = "mainnet"
-
-[P2P]
-  KeyFile = "./.hmykey"
-  Port = 9000
-
-[Pprof]
-  Enabled = false
-  ListenAddr = "127.0.0.1:6060"
-
-[TxPool]
-  BlacklistFile = "./.hmy/blacklist.txt"
-
-[Sync]
-  Downloader = false
-  Concurrency = 6
-  DiscBatch = 8
-  DiscHardLowCap = 6
-  DiscHighCap = 128
-  DiscSoftLowCap = 8
-  InitStreams = 8
-  LegacyClient = true
-  LegacyServer = true
-  MinPeers = 6
-
-[WS]
-  Enabled = true
-  IP = "127.0.0.1"
-  Port = 9800`,
+  Port = 9800`
+	testDir := filepath.Join(testBaseDir, t.Name())
+	os.RemoveAll(testDir)
+	os.MkdirAll(testDir, 0777)
+	file := filepath.Join(testDir, "test.config")
+	err := ioutil.WriteFile(file, []byte(testConfig), 0644)
+	if err != nil {
+		t.Fatal(err)
 	}
-	for testname, testConfig := range configs {
-		testDir := filepath.Join(testBaseDir, t.Name())
-		os.RemoveAll(testDir)
-		os.MkdirAll(testDir, 0777)
-		file := filepath.Join(testDir, "test.config")
-		err := ioutil.WriteFile(file, []byte(testConfig), 0644)
-		if err != nil {
-			t.Fatal(err)
-		}
-		config, migratedFrom, err := loadHarmonyConfig(file)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defConf := getDefaultHmyConfigCopy(nodeconfig.Mainnet)
-		if config.HTTP.RosettaEnabled {
-			t.Errorf("Expected rosetta http server to be disabled when loading old config")
-		}
-		if config.General.IsOffline {
-			t.Errorf("Expect node to de online when loading old config")
-		}
-		if config.P2P.IP != defConf.P2P.IP {
-			t.Errorf("Expect default p2p IP if old config is provided")
-		}
-		if migratedFrom != "1.0.4" {
-			t.Errorf("Expected config version: 1.0.4, not %v", config.Version)
-		}
-		config.Version = defConf.Version // Shortcut for testing, value checked above
-		if !reflect.DeepEqual(config, defConf) {
-			t.Errorf("Unexpected config(%s) \n\t%+v \n\t%+v", testname, config, defaultConfig)
-		}
+	config, migratedFrom, err := loadHarmonyConfig(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defConf := getDefaultHmyConfigCopy(nodeconfig.Mainnet)
+	if config.HTTP.RosettaEnabled {
+		t.Errorf("Expected rosetta http server to be disabled when loading old config")
+	}
+	if config.General.IsOffline {
+		t.Errorf("Expect node to de online when loading old config")
+	}
+	if config.P2P.IP != defConf.P2P.IP {
+		t.Errorf("Expect default p2p IP if old config is provided")
+	}
+	if migratedFrom != "1.0.4" {
+		t.Errorf("Expected config version: 1.0.4, not %v", config.Version)
+	}
+	config.Version = defConf.Version // Shortcut for testing, value checked above
+	if !reflect.DeepEqual(config, defConf) {
+		t.Errorf("Unexpected config \n\t%+v \n\t%+v", config, defaultConfig)
 	}
 }
 

--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -104,7 +104,7 @@ func TestV1_0_4Config(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	config, err := loadHarmonyConfig(file)
+	config, migratedFrom, err := loadHarmonyConfig(file)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +118,7 @@ func TestV1_0_4Config(t *testing.T) {
 	if config.P2P.IP != defConf.P2P.IP {
 		t.Errorf("Expect default p2p IP if old config is provided")
 	}
-	if config.Version != "1.0.4" {
+	if migratedFrom != "1.0.4" {
 		t.Errorf("Expected config version: 1.0.4, not %v", config.Version)
 	}
 	config.Version = defConf.Version // Shortcut for testing, value checked above
@@ -169,7 +169,7 @@ func TestPersistConfig(t *testing.T) {
 		if err := writeHarmonyConfigToFile(test.config, file); err != nil {
 			t.Fatal(err)
 		}
-		config, err := loadHarmonyConfig(file)
+		config, _, err := loadHarmonyConfig(file)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -2,7 +2,7 @@ package main
 
 import nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 
-const tomlConfigVersion = "1.0.5"
+const tomlConfigVersion = "2.0.0"
 
 const (
 	defNetworkType = nodeconfig.Mainnet
@@ -67,6 +67,7 @@ var defaultConfig = harmonyConfig{
 		RotateSize: 100,
 		Verbosity:  3,
 	},
+	DNSSync: getDefaultDNSSyncConfig(defNetworkType),
 }
 
 var defaultSysConfig = sysConfig{
@@ -105,59 +106,47 @@ var defaultPrometheusConfig = prometheusConfig{
 
 var (
 	defaultMainnetSyncConfig = syncConfig{
-		Downloader:       false,
-		LegacyServer:     true,
-		LegacyServerPort: nodeconfig.DefaultDNSPort,
-		LegacyClient:     true,
-		Concurrency:      6,
-		MinPeers:         6,
-		InitStreams:      8,
-		DiscSoftLowCap:   8,
-		DiscHardLowCap:   6,
-		DiscHighCap:      128,
-		DiscBatch:        8,
+		Downloader:     false,
+		Concurrency:    6,
+		MinPeers:       6,
+		InitStreams:    8,
+		DiscSoftLowCap: 8,
+		DiscHardLowCap: 6,
+		DiscHighCap:    128,
+		DiscBatch:      8,
 	}
 
 	defaultTestNetSyncConfig = syncConfig{
-		Downloader:       false,
-		LegacyServer:     true,
-		LegacyServerPort: nodeconfig.DefaultDNSPort,
-		LegacyClient:     true,
-		Concurrency:      4,
-		MinPeers:         4,
-		InitStreams:      4,
-		DiscSoftLowCap:   4,
-		DiscHardLowCap:   4,
-		DiscHighCap:      1024,
-		DiscBatch:        8,
+		Downloader:     false,
+		Concurrency:    4,
+		MinPeers:       4,
+		InitStreams:    4,
+		DiscSoftLowCap: 4,
+		DiscHardLowCap: 4,
+		DiscHighCap:    1024,
+		DiscBatch:      8,
 	}
 
 	defaultLocalNetSyncConfig = syncConfig{
-		Downloader:       false,
-		LegacyServer:     true,
-		LegacyServerPort: nodeconfig.DefaultDNSPort,
-		LegacyClient:     true,
-		Concurrency:      4,
-		MinPeers:         4,
-		InitStreams:      4,
-		DiscSoftLowCap:   4,
-		DiscHardLowCap:   4,
-		DiscHighCap:      1024,
-		DiscBatch:        8,
+		Downloader:     false,
+		Concurrency:    4,
+		MinPeers:       4,
+		InitStreams:    4,
+		DiscSoftLowCap: 4,
+		DiscHardLowCap: 4,
+		DiscHighCap:    1024,
+		DiscBatch:      8,
 	}
 
 	defaultElseSyncConfig = syncConfig{
-		Downloader:       true,
-		LegacyServer:     true,
-		LegacyServerPort: nodeconfig.DefaultDNSPort,
-		LegacyClient:     false,
-		Concurrency:      4,
-		MinPeers:         4,
-		InitStreams:      4,
-		DiscSoftLowCap:   4,
-		DiscHardLowCap:   4,
-		DiscHighCap:      1024,
-		DiscBatch:        8,
+		Downloader:     true,
+		Concurrency:    4,
+		MinPeers:       4,
+		InitStreams:    4,
+		DiscSoftLowCap: 4,
+		DiscHardLowCap: 4,
+		DiscHighCap:    1024,
+		DiscBatch:      8,
 	}
 )
 
@@ -174,6 +163,7 @@ func getDefaultHmyConfigCopy(nt nodeconfig.NetworkType) harmonyConfig {
 		config.Devnet = &devnet
 	}
 	config.Sync = getDefaultSyncConfig(nt)
+	config.DNSSync = getDefaultDNSSyncConfig(nt)
 
 	return config
 }

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -368,11 +368,12 @@ var (
 	legacyDNSPortFlag = cli.IntFlag{
 		Name:       "dns_port",
 		Usage:      "port of dns node",
-		Deprecated: "use --dns.zone",
+		Deprecated: "use --dns.port",
 	}
 	legacyDNSFlag = cli.BoolFlag{
 		Name:       "dns",
 		DefValue:   true,
+		Hidden:     true,
 		Usage:      "use dns for syncing",
 		Deprecated: "only set to false to use self discovered peers for syncing",
 	}

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -32,6 +32,7 @@ var (
 	dnsSyncFlags = []cli.Flag{
 		dnsZoneFlag,
 		dnsPortFlag,
+		dnsServerPortFlag,
 		dnsClientFlag,
 		dnsServerFlag,
 
@@ -382,7 +383,12 @@ var (
 	dnsPortFlag = cli.IntFlag{
 		Name:     "dns.port",
 		DefValue: nodeconfig.DefaultDNSPort,
-		Usage:    "port of customized dns node",
+		Usage:    "dns sync remote server port",
+	}
+	dnsServerPortFlag = cli.IntFlag{
+		Name:     "dns.server-port",
+		DefValue: nodeconfig.DefaultDNSPort,
+		Usage:    "dns sync local server port",
 	}
 	syncLegacyClientFlag = cli.BoolFlag{
 		Name:       "sync.legacy.client",
@@ -453,6 +459,10 @@ func applyDNSSyncFlags(cmd *cobra.Command, cfg *harmonyConfig) {
 		cfg.DNSSync.Client = cli.GetBoolFlagValue(cmd, syncLegacyClientFlag)
 	} else if cli.IsFlagChanged(cmd, dnsClientFlag) {
 		cfg.DNSSync.Client = cli.GetBoolFlagValue(cmd, dnsClientFlag)
+	}
+
+	if cli.IsFlagChanged(cmd, dnsServerPortFlag) {
+		cfg.DNSSync.ServerPort = cli.GetIntFlagValue(cmd, dnsServerPortFlag)
 	}
 
 }

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -248,7 +248,7 @@ func TestNetworkFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--network", "stk", "--bootnodes", "1,2,3,4", "--dns.zone", "8.8.8.8",
-				"--dns.port", "9001"},
+				"--dns.port", "9001", "--dns.server-port", "9002"},
 			expConfig: harmonyConfig{
 				Network: networkConfig{
 					NetworkType: "pangaea",
@@ -259,7 +259,7 @@ func TestNetworkFlags(t *testing.T) {
 					Zone:          "8.8.8.8",
 					LegacySyncing: false,
 					Server:        true,
-					ServerPort:    nodeconfig.GetDefaultDNSPort(nodeconfig.Pangaea),
+					ServerPort:    9002,
 				},
 			},
 		},

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -48,10 +48,11 @@ func TestHarmonyFlags(t *testing.T) {
 					},
 				},
 				DNSSync: dnsSync{
-					Port:   9000,
-					Zone:   "t.hmny.io",
-					Server: true,
-					Client: true,
+					Port:       6000,
+					Zone:       "t.hmny.io",
+					Server:     true,
+					Client:     true,
+					ServerPort: nodeconfig.DefaultDNSPort,
 				},
 				P2P: p2pConfig{
 					Port:    9000,
@@ -258,6 +259,7 @@ func TestNetworkFlags(t *testing.T) {
 					Zone:          "8.8.8.8",
 					LegacySyncing: false,
 					Server:        true,
+					ServerPort:    nodeconfig.GetDefaultDNSPort(nodeconfig.Pangaea),
 				},
 			},
 		},
@@ -274,6 +276,7 @@ func TestNetworkFlags(t *testing.T) {
 					Zone:          "8.8.8.8",
 					LegacySyncing: false,
 					Server:        true,
+					ServerPort:    nodeconfig.GetDefaultDNSPort(nodeconfig.Pangaea),
 				},
 			},
 		},
@@ -290,6 +293,7 @@ func TestNetworkFlags(t *testing.T) {
 					LegacySyncing: true,
 					Client:        true,
 					Server:        true,
+					ServerPort:    nodeconfig.GetDefaultDNSPort(nodeconfig.Pangaea),
 				},
 			},
 		},
@@ -316,10 +320,10 @@ func TestNetworkFlags(t *testing.T) {
 			continue
 		}
 		if !reflect.DeepEqual(got.Network, test.expConfig.Network) {
-			t.Errorf("Test %v: unexpected network config: \n\t%+v\n\t%+v", i, got.Network, test.expConfig)
+			t.Errorf("Test %v: unexpected network config: \n\t%+v\n\t%+v", i, got.Network, test.expConfig.Network)
 		}
 		if !reflect.DeepEqual(got.DNSSync, test.expConfig.DNSSync) {
-			t.Errorf("Test %v: unexpected dnssync config: \n\t%+v\n\t%+v", i, got.Network, test.expConfig)
+			t.Errorf("Test %v: unexpected dnssync config: \n\t%+v\n\t%+v", i, got.DNSSync, test.expConfig.DNSSync)
 		}
 		ts.tearDown()
 	}

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -23,7 +23,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/harmony-one/harmony/api/service"
-	"github.com/harmony-one/harmony/api/service/legacysync"
 	"github.com/harmony-one/harmony/api/service/prometheus"
 	"github.com/harmony-one/harmony/api/service/synchronize"
 	"github.com/harmony-one/harmony/common/fdlimit"
@@ -662,7 +661,7 @@ func setupConsensusAndNode(hc harmonyConfig, nodeConfig *nodeconfig.ConfigType) 
 	} else if hc.DNSSync.LegacySyncing {
 		currentNode.SyncingPeerProvider = node.NewLegacySyncingPeerProvider(currentNode)
 	} else {
-		currentNode.SyncingPeerProvider = node.NewDNSSyncingPeerProvider(hc.DNSSync.Zone, legacysync.GetSyncingPort(strconv.Itoa(hc.DNSSync.Port)))
+		currentNode.SyncingPeerProvider = node.NewDNSSyncingPeerProvider(hc.DNSSync.Zone, strconv.Itoa(hc.DNSSync.Port))
 	}
 
 	// TODO: refactor the creation of blockchain out of node.New()

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -162,10 +162,11 @@ func raiseFdLimits() error {
 
 func getHarmonyConfig(cmd *cobra.Command) (harmonyConfig, error) {
 	var (
-		config       harmonyConfig
-		err          error
-		migratedFrom string
-		configFile   string
+		config         harmonyConfig
+		err            error
+		migratedFrom   string
+		configFile     string
+		isUsingDefault bool
 	)
 	if cli.IsFlagChanged(cmd, configFlag) {
 		configFile = cli.GetStringFlagValue(cmd, configFlag)
@@ -173,11 +174,12 @@ func getHarmonyConfig(cmd *cobra.Command) (harmonyConfig, error) {
 	} else {
 		nt := getNetworkType(cmd)
 		config = getDefaultHmyConfigCopy(nt)
+		isUsingDefault = true
 	}
 	if err != nil {
 		return harmonyConfig{}, err
 	}
-	if migratedFrom != defaultConfig.Version {
+	if migratedFrom != defaultConfig.Version && !isUsingDefault {
 		fmt.Printf("Old config version detected %s\n",
 			migratedFrom)
 		stat, _ := os.Stdin.Stat()

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -94,6 +94,7 @@ func init() {
 	configCmd.AddCommand(updateConfigCmd)
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(dumpConfigLegacyCmd)
 
 	if err := registerRootCmdFlags(); err != nil {
 		os.Exit(2)


### PR DESCRIPTION
## Issue

https://github.com/harmony-one/bounties/issues/34

## Test

### Unit Test Coverage

Before:

```
PASS
coverage: 46.0% of statements
ok      github.com/harmony-one/harmony/cmd/harmony      0.043s
```

After:

```
PASS
coverage: 47.1% of statements
ok      github.com/harmony-one/harmony/cmd/harmony      0.072s
```

### Test/Run Logs
When running and stdin is terminal
```
Loaded config version 1.0.4 which is not latest (2.0.0).
Do you want to update config to latest version: (Y/n)

Config updated from 1.0.4 to 2.0.0
```
When stdin is piped
```
echo Y |./harmony -c config.toml
Loaded config version 1.0.4 which is not latest (2.0.0).
Update saved config with `./harmony config update [config_file]`
```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

