### PR TITLE
Add vrf proposal and verification in block logic

### DIFF
--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -481,15 +481,6 @@ func (consensus *Consensus) IsLeader() bool {
 	return false
 }
 
-// NeedsRandomNumberGeneration returns true if the current epoch needs random number generation
-func (consensus *Consensus) NeedsRandomNumberGeneration(epoch *big.Int) bool {
-	if consensus.ShardID == 0 && epoch.Uint64() >= shard.Schedule.RandomnessStartingEpoch() {
-		return true
-	}
-
-	return false
-}
-
 // SetViewIDs set both current view ID and view changing ID to the height
 // of the blockchain. It is used during client startup to recover the state
 func (consensus *Consensus) SetViewIDs(height uint64) {

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -12,7 +12,6 @@ import (
 	protobuf "github.com/golang/protobuf/proto"
 	bls_core "github.com/harmony-one/bls/ffi/go/bls"
 	msg_pb "github.com/harmony-one/harmony/api/proto/message"
-	"github.com/harmony-one/harmony/block"
 	consensus_engine "github.com/harmony-one/harmony/consensus/engine"
 	"github.com/harmony-one/harmony/consensus/quorum"
 	"github.com/harmony-one/harmony/consensus/signature"
@@ -242,49 +241,6 @@ func (consensus *Consensus) ReadSignatureBitmapPayload(
 	)
 }
 
-// retrieve corresponding blsPublicKey from Coinbase Address
-func (consensus *Consensus) getLeaderPubKeyFromCoinbase(
-	header *block.Header,
-) (*bls.PublicKeyWrapper, error) {
-	shardState, err := consensus.Blockchain.ReadShardState(header.Epoch())
-	if err != nil {
-		return nil, errors.Wrapf(err, "cannot read shard state %v %s",
-			header.Epoch(),
-			header.Coinbase().Hash().Hex(),
-		)
-	}
-
-	committee, err := shardState.FindCommitteeByID(header.ShardID())
-	if err != nil {
-		return nil, err
-	}
-
-	committerKey := new(bls_core.PublicKey)
-	isStaking := consensus.Blockchain.Config().IsStaking(header.Epoch())
-	for _, member := range committee.Slots {
-		if isStaking {
-			// After staking the coinbase address will be the address of bls public key
-			if utils.GetAddressFromBLSPubKeyBytes(member.BLSPublicKey[:]) == header.Coinbase() {
-				if committerKey, err = bls.BytesToBLSPublicKey(member.BLSPublicKey[:]); err != nil {
-					return nil, err
-				}
-				return &bls.PublicKeyWrapper{Object: committerKey, Bytes: member.BLSPublicKey}, nil
-			}
-		} else {
-			if member.EcdsaAddress == header.Coinbase() {
-				if committerKey, err = bls.BytesToBLSPublicKey(member.BLSPublicKey[:]); err != nil {
-					return nil, err
-				}
-				return &bls.PublicKeyWrapper{Object: committerKey, Bytes: member.BLSPublicKey}, nil
-			}
-		}
-	}
-	return nil, errors.Errorf(
-		"cannot find corresponding BLS Public Key coinbase %s",
-		header.Coinbase().Hex(),
-	)
-}
-
 // UpdateConsensusInformation will update shard information (epoch, publicKeys, blockNum, viewID)
 // based on the local blockchain. It is called in two cases for now:
 // 1. consensus object initialization. because of current dependency where chainreader is only available
@@ -424,7 +380,7 @@ func (consensus *Consensus) UpdateConsensusInformation() Mode {
 	// a solution to take care of this case because the coinbase of the latest block doesn't really represent the
 	// the real current leader in case of M1 view change.
 	if !curHeader.IsLastBlockInEpoch() && curHeader.Number().Uint64() != 0 {
-		leaderPubKey, err := consensus.getLeaderPubKeyFromCoinbase(curHeader)
+		leaderPubKey, err := chain.GetLeaderPubKeyFromCoinbase(consensus.Blockchain, curHeader)
 		if err != nil || leaderPubKey == nil {
 			consensus.getLogger().Error().Err(err).
 				Msg("[UpdateConsensusInformation] Unable to get leaderPubKey from coinbase")

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -304,7 +304,6 @@ func (consensus *Consensus) Start(
 		consensus.consensusTimeout[timeoutBootstrap].Start()
 		consensus.getLogger().Info().Msg("[ConsensusMainLoop] Start bootstrap timeout (only once)")
 
-		vdfInProgress := false
 		// Set up next block due time.
 		consensus.NextBlockDue = time.Now().Add(consensus.BlockPeriod)
 		start := false
@@ -401,79 +400,6 @@ func (consensus *Consensus) Start(
 
 				// Update time due for next block
 				consensus.NextBlockDue = time.Now().Add(consensus.BlockPeriod)
-
-				//VRF/VDF is only generated in the beacon chain
-				if consensus.NeedsRandomNumberGeneration(newBlock.Header().Epoch()) {
-					// generate VRF if the current block has a new leader
-					if !consensus.Blockchain.IsSameLeaderAsPreviousBlock(newBlock) {
-						vrfBlockNumbers, err := consensus.Blockchain.ReadEpochVrfBlockNums(newBlock.Header().Epoch())
-						if err != nil {
-							consensus.getLogger().Info().
-								Uint64("MsgBlockNum", newBlock.NumberU64()).
-								Uint64("Epoch", newBlock.Header().Epoch().Uint64()).
-								Msg("[ConsensusMainLoop] no VRF block number from local db")
-						}
-
-						//check if VRF is already generated for the current block
-						vrfAlreadyGenerated := false
-						for _, v := range vrfBlockNumbers {
-							if v == newBlock.NumberU64() {
-								consensus.getLogger().Info().
-									Uint64("MsgBlockNum", newBlock.NumberU64()).
-									Uint64("Epoch", newBlock.Header().Epoch().Uint64()).
-									Msg("[ConsensusMainLoop] VRF is already generated for this block")
-								vrfAlreadyGenerated = true
-								break
-							}
-						}
-
-						if !vrfAlreadyGenerated {
-							//generate a new VRF for the current block
-							vrfBlockNumbers := consensus.GenerateVrfAndProof(newBlock, vrfBlockNumbers)
-
-							//generate a new VDF for the current epoch if there are enough VRFs in the current epoch
-							//note that  >= instead of == is used, because it is possible the current leader
-							//can commit this block, go offline without finishing VDF
-							if (!vdfInProgress) && len(vrfBlockNumbers) >= consensus.VdfSeedSize() {
-								//check local database to see if there's a VDF generated for this epoch
-								//generate a VDF if no blocknum is available
-								_, err := consensus.Blockchain.ReadEpochVdfBlockNum(newBlock.Header().Epoch())
-								if err != nil {
-									consensus.GenerateVdfAndProof(newBlock, vrfBlockNumbers)
-									vdfInProgress = true
-								}
-							}
-						}
-					}
-
-					vdfOutput, seed, err := consensus.GetNextRnd()
-					if err == nil {
-						vdfInProgress = false
-						// Verify the randomness
-						vdfObject := vdf_go.New(shard.Schedule.VdfDifficulty(), seed)
-						if !vdfObject.Verify(vdfOutput) {
-							consensus.getLogger().Warn().
-								Uint64("MsgBlockNum", newBlock.NumberU64()).
-								Uint64("Epoch", newBlock.Header().Epoch().Uint64()).
-								Msg("[ConsensusMainLoop] failed to verify the VDF output")
-						} else {
-							//write the VDF only if VDF has not been generated
-							_, err := consensus.Blockchain.ReadEpochVdfBlockNum(newBlock.Header().Epoch())
-							if err == nil {
-								consensus.getLogger().Info().
-									Uint64("MsgBlockNum", newBlock.NumberU64()).
-									Uint64("Epoch", newBlock.Header().Epoch().Uint64()).
-									Msg("[ConsensusMainLoop] VDF has already been generated previously")
-							} else {
-								consensus.getLogger().Info().
-									Uint64("MsgBlockNum", newBlock.NumberU64()).
-									Uint64("Epoch", newBlock.Header().Epoch().Uint64()).
-									Msg("[ConsensusMainLoop] Generated a new VDF")
-								newBlock.AddVdf(vdfOutput[:])
-							}
-						}
-					}
-				}
 
 				startTime = time.Now()
 				consensus.msgSender.Reset(newBlock.NumberU64())
@@ -774,35 +700,30 @@ func (consensus *Consensus) postCatchup(initBN uint64) {
 }
 
 // GenerateVrfAndProof generates new VRF/Proof from hash of previous block
-func (consensus *Consensus) GenerateVrfAndProof(newBlock *types.Block, vrfBlockNumbers []uint64) []uint64 {
+func (consensus *Consensus) GenerateVrfAndProof(newHeader *block.Header) error {
 	key, err := consensus.GetConsensusLeaderPrivateKey()
 	if err != nil {
-		consensus.getLogger().Error().
-			Err(err).
-			Msg("[GenerateVrfAndProof] VRF generation error")
-		return vrfBlockNumbers
+		return errors.New("[GenerateVrfAndProof] no leader private key provided")
 	}
 	sk := vrf_bls.NewVRFSigner(key.Pri)
-	blockHash := [32]byte{}
 	previousHeader := consensus.Blockchain.GetHeaderByNumber(
-		newBlock.NumberU64() - 1,
+		newHeader.Number().Uint64() - 1,
 	)
 	if previousHeader == nil {
-		return vrfBlockNumbers
+		return errors.New("[GenerateVrfAndProof] no parent header found")
 	}
-	previousHash := previousHeader.Hash()
-	copy(blockHash[:], previousHash[:])
 
-	vrf, proof := sk.Evaluate(blockHash[:])
-	newBlock.AddVrf(append(vrf[:], proof...))
+	previousHash := previousHeader.Hash()
+	vrf, proof := sk.Evaluate(previousHash[:])
+	newHeader.SetVrf(append(vrf[:], proof...))
 
 	consensus.getLogger().Info().
-		Uint64("MsgBlockNum", newBlock.NumberU64()).
-		Uint64("Epoch", newBlock.Header().Epoch().Uint64()).
-		Int("Num of VRF", len(vrfBlockNumbers)).
-		Msg("[ConsensusMainLoop] Leader generated a VRF")
+		Uint64("BlockNum", newHeader.Number().Uint64()).
+		Uint64("Epoch", newHeader.Epoch().Uint64()).
+		Bytes("VRF+Proof", newHeader.Vrf()).
+		Msg("[GenerateVrfAndProof] Leader generated a VRF")
 
-	return vrfBlockNumbers
+	return nil
 }
 
 // ValidateVrfAndProof validates a VRF/Proof from hash of previous block

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -715,6 +715,10 @@ func (consensus *Consensus) GenerateVrfAndProof(newHeader *block.Header) error {
 
 	previousHash := previousHeader.Hash()
 	vrf, proof := sk.Evaluate(previousHash[:])
+	if proof == nil {
+		return errors.New("[GenerateVrfAndProof] failed to generate vrf")
+	}
+
 	newHeader.SetVrf(append(vrf[:], proof...))
 
 	consensus.getLogger().Info().

--- a/consensus/engine/consensus_engine.go
+++ b/consensus/engine/consensus_engine.go
@@ -105,6 +105,9 @@ type Engine interface {
 	// VerifyShardState verifies the shard state during epoch transition is valid
 	VerifyShardState(chain ChainReader, beacon ChainReader, header *block.Header) error
 
+	// VerifyVRF verifies the vrf of the block
+	VerifyVRF(chain ChainReader, header *block.Header) error
+
 	// Beaconchain provides the handle for Beaconchain
 	Beaconchain() ChainReader
 

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/harmony-one/harmony/internal/chain"
+
 	"github.com/harmony-one/harmony/crypto/bls"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -174,7 +176,7 @@ func (consensus *Consensus) getNextLeaderKey(viewID uint64) *bls.PublicKeyWrappe
 			stuckBlockViewID := curHeader.ViewID().Uint64() + 1
 			gap = int(viewID - stuckBlockViewID)
 			// this is the truth of the leader based on blockchain blocks
-			lastLeaderPubKey, err = consensus.getLeaderPubKeyFromCoinbase(curHeader)
+			lastLeaderPubKey, err = chain.GetLeaderPubKeyFromCoinbase(consensus.Blockchain, curHeader)
 			if err != nil || lastLeaderPubKey == nil {
 				consensus.getLogger().Error().Err(err).
 					Msg("[getNextLeaderKey] Unable to get leaderPubKey from coinbase. Set it to consensus.LeaderPubKey")

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2890,6 +2890,7 @@ func (bc *BlockChain) DelegatorsInformation(addr common.Address) []*staking.Dele
 }
 
 // GetECDSAFromCoinbase retrieve corresponding ecdsa address from Coinbase Address
+// TODO: optimize this func by adding cache etc.
 func (bc *BlockChain) GetECDSAFromCoinbase(header *block.Header) (common.Address, error) {
 	// backward compatibility: before isStaking epoch, coinbase address is the ecdsa address
 	coinbase := header.Coinbase()

--- a/crypto/vrf/bls/bls_vrf.go
+++ b/crypto/vrf/bls/bls_vrf.go
@@ -65,6 +65,9 @@ func (k *PrivateKey) Evaluate(alpha []byte) ([32]byte, []byte) {
 	//pi = VRF_prove(SK, alpha)
 	msgHash := sha256.Sum256(alpha)
 	pi := k.SignHash(msgHash[:])
+	if pi == nil {
+		return [32]byte{}, nil
+	}
 
 	//hash the signature and output as VRF beta
 	//beta = VRF_proof2hash(pi)

--- a/hmy/downloader/adapter_test.go
+++ b/hmy/downloader/adapter_test.go
@@ -134,6 +134,9 @@ func (e *dummyEngine) VerifyHeaderSignature(engine.ChainReader, *block.Header, b
 func (e *dummyEngine) VerifyCrossLink(engine.ChainReader, types.CrossLink) error {
 	return nil
 }
+func (e *dummyEngine) VerifyVRF(chain engine.ChainReader, header *block.Header) error {
+	return nil
+}
 func (e *dummyEngine) VerifyHeaders(engine.ChainReader, []*block.Header, []bool) (chan<- struct{}, <-chan error) {
 	return nil, nil
 }

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -156,6 +156,10 @@ func (e *engineImpl) VerifyVRF(
 
 	leaderPubKey, err := GetLeaderPubKeyFromCoinbase(bc, header)
 
+	if leaderPubKey == nil || err != nil {
+		return err
+	}
+
 	vrfPk := blsvrf.NewVRFVerifier(leaderPubKey.Object)
 
 	previousHeader := bc.GetHeaderByNumber(

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -5,6 +5,9 @@ import (
 	"math/big"
 	"sort"
 
+	bls2 "github.com/harmony-one/bls/ffi/go/bls"
+	blsvrf "github.com/harmony-one/harmony/crypto/vrf/bls"
+
 	"github.com/ethereum/go-ethereum/common"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/pkg/errors"
@@ -133,6 +136,92 @@ func (e *engineImpl) VerifyShardState(
 	}
 
 	return nil
+}
+
+// VerifyVRF implements Engine, checking the vrf is valid
+func (e *engineImpl) VerifyVRF(
+	bc engine.ChainReader, header *block.Header,
+) error {
+	if bc.ShardID() != header.ShardID() {
+		return errors.Errorf(
+			"[VerifyVRF] shardID not match %d %d", bc.ShardID(), header.ShardID(),
+		)
+	}
+
+	if bc.Config().IsVRF(header.Epoch()) && len(header.Vrf()) != 128 {
+		return errors.Errorf(
+			"[VerifyVRF] invalid vrf data format or no vrf proposed %x", header.Vrf(),
+		)
+	}
+
+	leaderPubKey, err := GetLeaderPubKeyFromCoinbase(bc, header)
+
+	vrfPk := blsvrf.NewVRFVerifier(leaderPubKey.Object)
+
+	previousHeader := bc.GetHeaderByNumber(
+		header.Number().Uint64() - 1,
+	)
+	if previousHeader == nil {
+		return errors.New("[VerifyVRF] no parent header found")
+	}
+
+	previousHash := previousHeader.Hash()
+	vrfProof := [96]byte{}
+	copy(vrfProof[:], header.Vrf()[32:])
+	hash, err := vrfPk.ProofToHash(previousHash[:], vrfProof[:])
+
+	if err != nil {
+		return errors.New("[VerifyVRF] Failed VRF verification")
+	}
+
+	if !bytes.Equal(hash[:], header.Vrf()[:32]) {
+		return errors.New("[VerifyVRF] VRF proof is not valid")
+	}
+
+	return nil
+}
+
+// retrieve corresponding blsPublicKey from Coinbase Address
+func GetLeaderPubKeyFromCoinbase(
+	blockchain engine.ChainReader, h *block.Header,
+) (*bls.PublicKeyWrapper, error) {
+	shardState, err := blockchain.ReadShardState(h.Epoch())
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot read shard state %v %s",
+			h.Epoch(),
+			h.Coinbase().Hash().Hex(),
+		)
+	}
+
+	committee, err := shardState.FindCommitteeByID(h.ShardID())
+	if err != nil {
+		return nil, err
+	}
+
+	committerKey := new(bls2.PublicKey)
+	isStaking := blockchain.Config().IsStaking(h.Epoch())
+	for _, member := range committee.Slots {
+		if isStaking {
+			// After staking the coinbase address will be the address of bls public key
+			if utils.GetAddressFromBLSPubKeyBytes(member.BLSPublicKey[:]) == h.Coinbase() {
+				if committerKey, err = bls.BytesToBLSPublicKey(member.BLSPublicKey[:]); err != nil {
+					return nil, err
+				}
+				return &bls.PublicKeyWrapper{Object: committerKey, Bytes: member.BLSPublicKey}, nil
+			}
+		} else {
+			if member.EcdsaAddress == h.Coinbase() {
+				if committerKey, err = bls.BytesToBLSPublicKey(member.BLSPublicKey[:]); err != nil {
+					return nil, err
+				}
+				return &bls.PublicKeyWrapper{Object: committerKey, Bytes: member.BLSPublicKey}, nil
+			}
+		}
+	}
+	return nil, errors.Errorf(
+		"cannot find corresponding BLS Public Key coinbase %s",
+		h.Coinbase().Hex(),
+	)
 }
 
 // VerifySeal implements Engine, checking whether the given block's parent block satisfies

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -153,6 +153,14 @@ func (e *engineImpl) VerifyVRF(
 			"[VerifyVRF] invalid vrf data format or no vrf proposed %x", header.Vrf(),
 		)
 	}
+	if !bc.Config().IsVRF(header.Epoch()) {
+		if len(header.Vrf()) != 0 {
+			errors.Errorf(
+				"[VerifyVRF] vrf data present in pre-vrf epoch %x", header.Vrf(),
+			)
+		}
+		return nil
+	}
 
 	leaderPubKey, err := GetLeaderPubKeyFromCoinbase(bc, header)
 

--- a/internal/configs/sharding/fixedschedule.go
+++ b/internal/configs/sharding/fixedschedule.go
@@ -41,12 +41,6 @@ func (s fixedSchedule) VdfDifficulty() int {
 	return mainnetVdfDifficulty
 }
 
-// TODO: remove it after randomness feature turned on mainnet
-//RandonnessStartingEpoch returns starting epoch of randonness generation
-func (s fixedSchedule) RandomnessStartingEpoch() uint64 {
-	return mainnetRandomnessStartingEpoch
-}
-
 func (s fixedSchedule) GetNetworkID() NetworkID {
 	return DevNet
 }

--- a/internal/configs/sharding/localnet.go
+++ b/internal/configs/sharding/localnet.go
@@ -24,8 +24,6 @@ const (
 	localnetBlocksPerEpochV2 = 10
 
 	localnetVdfDifficulty = 5000 // This takes about 10s to finish the vdf
-
-	localnetRandomnessStartingEpoch = 0
 )
 
 func (ls localnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
@@ -114,12 +112,6 @@ func (ls localnetSchedule) EpochLastBlock(epochNum uint64) uint64 {
 
 func (ls localnetSchedule) VdfDifficulty() int {
 	return localnetVdfDifficulty
-}
-
-// TODO: remove it after randomness feature turned on mainnet
-//RandonnessStartingEpoch returns starting epoch of randonness generation
-func (ls localnetSchedule) RandomnessStartingEpoch() uint64 {
-	return localnetRandomnessStartingEpoch
 }
 
 func (ls localnetSchedule) GetNetworkID() NetworkID {

--- a/internal/configs/sharding/mainnet.go
+++ b/internal/configs/sharding/mainnet.go
@@ -17,9 +17,6 @@ const (
 
 	mainnetVdfDifficulty = 50000 // This takes about 100s to finish the vdf
 
-	// TODO: remove it after randomness feature turned on mainnet
-	mainnetRandomnessStartingEpoch = 100000
-
 	mainnetV0_1Epoch = 1
 	mainnetV0_2Epoch = 5
 	mainnetV0_3Epoch = 8
@@ -174,12 +171,6 @@ func (ms mainnetSchedule) EpochLastBlock(epochNum uint64) uint64 {
 
 func (ms mainnetSchedule) VdfDifficulty() int {
 	return mainnetVdfDifficulty
-}
-
-// TODO: remove it after randomness feature turned on mainnet
-//RandonnessStartingEpoch returns starting epoch of randonness generation
-func (ms mainnetSchedule) RandomnessStartingEpoch() uint64 {
-	return mainnetRandomnessStartingEpoch
 }
 
 func (ms mainnetSchedule) GetNetworkID() NetworkID {

--- a/internal/configs/sharding/pangaea.go
+++ b/internal/configs/sharding/pangaea.go
@@ -56,12 +56,6 @@ func (ps pangaeaSchedule) VdfDifficulty() int {
 	return pangaeaVdfDifficulty
 }
 
-// TODO: remove it after randomness feature turned on mainnet
-//RandonnessStartingEpoch returns starting epoch of randonness generation
-func (ps pangaeaSchedule) RandomnessStartingEpoch() uint64 {
-	return mainnetRandomnessStartingEpoch
-}
-
 func (ps pangaeaSchedule) GetNetworkID() NetworkID {
 	return Pangaea
 }

--- a/internal/configs/sharding/partner.go
+++ b/internal/configs/sharding/partner.go
@@ -57,12 +57,6 @@ func (ps partnerSchedule) VdfDifficulty() int {
 	return partnerVdfDifficulty
 }
 
-// TODO: remove it after randomness feature turned on mainnet
-//RandonnessStartingEpoch returns starting epoch of randonness generation
-func (ps partnerSchedule) RandomnessStartingEpoch() uint64 {
-	return mainnetRandomnessStartingEpoch
-}
-
 func (ps partnerSchedule) GetNetworkID() NetworkID {
 	return Partner
 }

--- a/internal/configs/sharding/shardingconfig.go
+++ b/internal/configs/sharding/shardingconfig.go
@@ -30,10 +30,6 @@ type Schedule interface {
 	// VDFDifficulty returns number of iterations for VDF calculation
 	VdfDifficulty() int
 
-	// TODO: remove it after randomness feature turned on mainnet
-	//RandomnessStartingEpoch returns starting epoch of randonness generation
-	RandomnessStartingEpoch() uint64
-
 	// GetNetworkID() return networkID type.
 	GetNetworkID() NetworkID
 

--- a/internal/configs/sharding/stress.go
+++ b/internal/configs/sharding/stress.go
@@ -59,12 +59,6 @@ func (ss stressnetSchedule) VdfDifficulty() int {
 	return stressnetVdfDifficulty
 }
 
-// TODO: remove it after randomness feature turned on mainnet
-//RandonnessStartingEpoch returns starting epoch of randonness generation
-func (ss stressnetSchedule) RandomnessStartingEpoch() uint64 {
-	return mainnetRandomnessStartingEpoch
-}
-
 func (ss stressnetSchedule) GetNetworkID() NetworkID {
 	return StressNet
 }

--- a/internal/configs/sharding/testnet.go
+++ b/internal/configs/sharding/testnet.go
@@ -94,12 +94,6 @@ func (ts testnetSchedule) VdfDifficulty() int {
 	return testnetVdfDifficulty
 }
 
-// TODO: remove it after randomness feature turned on mainnet
-//RandonnessStartingEpoch returns starting epoch of randonness generation
-func (ts testnetSchedule) RandomnessStartingEpoch() uint64 {
-	return mainnetRandomnessStartingEpoch
-}
-
 func (ts testnetSchedule) GetNetworkID() NetworkID {
 	return TestNet
 }

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -50,6 +50,7 @@ var (
 		SixtyPercentEpoch:          big.NewInt(530), // Around Monday Apr 12th 2021, 22:30 UTC
 		RedelegationEpoch:          big.NewInt(290),
 		NoEarlyUnlockEpoch:         big.NewInt(530), // Around Monday Apr 12th 2021, 22:30 UTC
+		VRFEpoch:                   EpochTBD,
 		EIP155Epoch:                big.NewInt(28),
 		S3Epoch:                    big.NewInt(28),
 		IstanbulEpoch:              big.NewInt(314),
@@ -72,6 +73,7 @@ var (
 		SixtyPercentEpoch:          big.NewInt(73282),
 		RedelegationEpoch:          big.NewInt(36500),
 		NoEarlyUnlockEpoch:         big.NewInt(73580),
+		VRFEpoch:                   EpochTBD,
 		EIP155Epoch:                big.NewInt(0),
 		S3Epoch:                    big.NewInt(0),
 		IstanbulEpoch:              big.NewInt(43800),
@@ -95,6 +97,7 @@ var (
 		SixtyPercentEpoch:          big.NewInt(0),
 		RedelegationEpoch:          big.NewInt(0),
 		NoEarlyUnlockEpoch:         big.NewInt(0),
+		VRFEpoch:                   big.NewInt(0),
 		EIP155Epoch:                big.NewInt(0),
 		S3Epoch:                    big.NewInt(0),
 		IstanbulEpoch:              big.NewInt(0),
@@ -118,6 +121,7 @@ var (
 		SixtyPercentEpoch:          big.NewInt(0),
 		RedelegationEpoch:          big.NewInt(0),
 		NoEarlyUnlockEpoch:         big.NewInt(0),
+		VRFEpoch:                   big.NewInt(0),
 		EIP155Epoch:                big.NewInt(0),
 		S3Epoch:                    big.NewInt(0),
 		IstanbulEpoch:              big.NewInt(0),
@@ -141,6 +145,7 @@ var (
 		SixtyPercentEpoch:          big.NewInt(10),
 		RedelegationEpoch:          big.NewInt(0),
 		NoEarlyUnlockEpoch:         big.NewInt(0),
+		VRFEpoch:                   big.NewInt(0),
 		EIP155Epoch:                big.NewInt(0),
 		S3Epoch:                    big.NewInt(0),
 		IstanbulEpoch:              big.NewInt(0),
@@ -163,6 +168,7 @@ var (
 		SixtyPercentEpoch:          EpochTBD, // Never enable it for localnet as localnet has no external validator setup
 		RedelegationEpoch:          big.NewInt(0),
 		NoEarlyUnlockEpoch:         big.NewInt(0),
+		VRFEpoch:                   big.NewInt(0),
 		EIP155Epoch:                big.NewInt(0),
 		S3Epoch:                    big.NewInt(0),
 		IstanbulEpoch:              big.NewInt(0),
@@ -187,6 +193,7 @@ var (
 		big.NewInt(0),                      // SixtyPercentEpoch
 		big.NewInt(0),                      // RedelegationEpoch
 		big.NewInt(0),                      // NoEarlyUnlockEpoch
+		big.NewInt(0),                      // VRFEpoch
 		big.NewInt(0),                      // EIP155Epoch
 		big.NewInt(0),                      // S3Epoch
 		big.NewInt(0),                      // IstanbulEpoch
@@ -211,6 +218,7 @@ var (
 		big.NewInt(0),        // SixtyPercentEpoch
 		big.NewInt(0),        // RedelegationEpoch
 		big.NewInt(0),        // NoEarlyUnlockEpoch
+		big.NewInt(0),        // VRFEpoch
 		big.NewInt(0),        // EIP155Epoch
 		big.NewInt(0),        // S3Epoch
 		big.NewInt(0),        // IstanbulEpoch
@@ -287,6 +295,9 @@ type ChainConfig struct {
 	// NoEarlyUnlockEpoch is the epoch when the early unlock of undelegated token from validators who were elected for
 	// more than 7 epochs is disabled
 	NoEarlyUnlockEpoch *big.Int `json:"no-early-unlock-epoch,omitempty"`
+
+	// VRFEpoch is the epoch when VRF randomness is enabled
+	VRFEpoch *big.Int `json:"vrf-epoch,omitempty"`
 
 	// EIP155 hard fork epoch (include EIP158 too)
 	EIP155Epoch *big.Int `json:"eip155-epoch,omitempty"`
@@ -372,6 +383,11 @@ func (c *ChainConfig) IsRedelegation(epoch *big.Int) bool {
 // IsNoEarlyUnlock determines whether it is the epoch to stop early unlock
 func (c *ChainConfig) IsNoEarlyUnlock(epoch *big.Int) bool {
 	return isForked(c.NoEarlyUnlockEpoch, epoch)
+}
+
+// IsVRF determines whether it is the epoch to enable vrf
+func (c *ChainConfig) IsVRF(epoch *big.Int) bool {
+	return isForked(c.VRFEpoch, epoch)
 }
 
 // IsPreStaking determines whether staking transactions are allowed

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -277,6 +277,18 @@ func (node *Node) VerifyNewBlock(newBlock *types.Block) error {
 		return err
 	}
 
+	if err := node.Blockchain().Engine().VerifyVRF(
+		node.Blockchain(), newBlock.Header(),
+	); err != nil {
+		utils.Logger().Error().
+			Str("blockHash", newBlock.Hash().Hex()).
+			Err(err).
+			Msg("[VerifyNewBlock] Cannot verify vrf for the new block")
+		return errors.New(
+			"[VerifyNewBlock] Cannot verify vrf for the new block",
+		)
+	}
+
 	if err := node.Blockchain().Engine().VerifyShardState(
 		node.Blockchain(), node.Beaconchain(), newBlock.Header(),
 	); err != nil {

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -284,7 +284,7 @@ func (node *Node) VerifyNewBlock(newBlock *types.Block) error {
 			Str("blockHash", newBlock.Hash().Hex()).
 			Err(err).
 			Msg("[VerifyNewBlock] Cannot verify vrf for the new block")
-		return errors.New(
+		return errors.Wrap(err,
 			"[VerifyNewBlock] Cannot verify vrf for the new block",
 		)
 	}
@@ -296,7 +296,7 @@ func (node *Node) VerifyNewBlock(newBlock *types.Block) error {
 			Str("blockHash", newBlock.Hash().Hex()).
 			Err(err).
 			Msg("[VerifyNewBlock] Cannot verify shard state for the new block")
-		return errors.New(
+		return errors.Wrap(err,
 			"[VerifyNewBlock] Cannot verify shard state for the new block",
 		)
 	}

--- a/node/node_handler_test.go
+++ b/node/node_handler_test.go
@@ -172,6 +172,7 @@ func TestVerifyVRF(t *testing.T) {
 	// Write shard state for the new epoch
 	node.Blockchain().WriteShardStateBytes(node.Blockchain().ChainDb(), big.NewInt(1), node.Worker.GetCurrentHeader().ShardState())
 
+	node.Blockchain().Config().VRFEpoch = big.NewInt(0)
 	if err := node.Blockchain().Engine().VerifyVRF(
 		node.Blockchain(), block.Header(),
 	); err != nil {

--- a/node/node_handler_test.go
+++ b/node/node_handler_test.go
@@ -99,6 +99,53 @@ func TestVerifyNewBlock(t *testing.T) {
 	go func() {
 		commitSigs <- []byte{}
 	}()
+	block, _ := node.Worker.FinalizeNewBlock(
+		commitSigs, func() uint64 { return 0 }, common.Address{}, nil, nil,
+	)
+
+	// work around vrf verification as it's tested in another test.
+	node.Blockchain().Config().VRFEpoch = big.NewInt(2)
+	if err := node.VerifyNewBlock(block); err != nil {
+		t.Error("New block is not verified successfully:", err)
+	}
+}
+
+func TestVerifyVRF(t *testing.T) {
+	blsKey := bls.RandPrivateKey()
+	pubKey := blsKey.GetPublicKey()
+	leader := p2p.Peer{IP: "127.0.0.1", Port: "8882", ConsensusPubKey: pubKey}
+	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "9902")
+	host, err := p2p.NewHost(p2p.HostConfig{
+		Self:   &leader,
+		BLSKey: priKey,
+	})
+	if err != nil {
+		t.Fatalf("newhost failure: %v", err)
+	}
+	decider := quorum.NewDecider(
+		quorum.SuperMajorityVote, shard.BeaconChainShardID,
+	)
+	consensus, err := consensus.New(
+		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(blsKey), decider,
+	)
+	if err != nil {
+		t.Fatalf("Cannot craeate consensus: %v", err)
+	}
+	archiveMode := make(map[uint32]bool)
+	archiveMode[0] = true
+	archiveMode[1] = false
+	node := New(host, consensus, testDBFactory, nil, archiveMode)
+
+	consensus.Blockchain = node.Blockchain()
+	txs := make(map[common.Address]types.Transactions)
+	stks := staking.StakingTransactions{}
+	node.Worker.CommitTransactions(
+		txs, stks, common.Address{},
+	)
+	commitSigs := make(chan []byte)
+	go func() {
+		commitSigs <- []byte{}
+	}()
 
 	ecdsaAddr := pubKey.GetAddress()
 
@@ -113,13 +160,21 @@ func TestVerifyNewBlock(t *testing.T) {
 		nil,
 	}
 	com.Slots = append(com.Slots, curNodeID)
-	shardState.Epoch = big.NewInt(0)
+	shardState.Epoch = big.NewInt(1)
 	shardState.Shards = append(shardState.Shards, com)
 
+	node.Consensus.LeaderPubKey = &bls.PublicKeyWrapper{spKey, pubKey}
+	node.Worker.GetCurrentHeader().SetEpoch(big.NewInt(1))
+	node.Consensus.GenerateVrfAndProof(node.Worker.GetCurrentHeader())
 	block, _ := node.Worker.FinalizeNewBlock(
 		commitSigs, func() uint64 { return 0 }, ecdsaAddr, nil, shardState,
 	)
-	if err := node.VerifyNewBlock(block); err != nil {
-		t.Error("New block is not verified successfully:", err)
+	// Write shard state for the new epoch
+	node.Blockchain().WriteShardStateBytes(node.Blockchain().ChainDb(), big.NewInt(1), node.Worker.GetCurrentHeader().ShardState())
+
+	if err := node.Blockchain().Engine().VerifyVRF(
+		node.Blockchain(), block.Header(),
+	); err != nil {
+		t.Error("New vrf is not verified successfully:", err)
 	}
 }

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -164,6 +164,14 @@ func (node *Node) ProposeNewBlock(commitSigs chan []byte) (*types.Block, error) 
 		return nil, err
 	}
 
+	// Add VRF
+	if node.Blockchain().Config().IsVRF(header.Epoch()) {
+		//generate a new VRF for the current block
+		if err := node.Consensus.GenerateVrfAndProof(header); err != nil {
+			return nil, err
+		}
+	}
+
 	// Prepare normal and staking transactions retrieved from transaction pool
 	utils.AnalysisStart("proposeNewBlockChooseFromTxnPool")
 

--- a/test/chain/vrf/main.go
+++ b/test/chain/vrf/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	"github.com/harmony-one/harmony/crypto/bls"
+
+	bls_core "github.com/harmony-one/bls/ffi/go/bls"
+	"github.com/harmony-one/harmony/crypto/hash"
+	vrf_bls "github.com/harmony-one/harmony/crypto/vrf/bls"
+)
+
+func init() {
+	bls_core.Init(bls_core.BLS12_381)
+}
+
+func main() {
+	blsPriKey := bls.RandPrivateKey()
+	pubKeyWrapper := bls.PublicKeyWrapper{Object: blsPriKey.GetPublicKey()}
+	pubKeyWrapper.Bytes.FromLibBLSPublicKey(pubKeyWrapper.Object)
+
+	blockHash := hash.Keccak256([]byte{1, 2, 3, 4, 5})
+
+	sig := &bls_core.Sign{}
+	startTime := time.Now()
+	for i := 0; i < 1000; i++ {
+		sig = blsPriKey.SignHash(blockHash[:])
+	}
+	endTime := time.Now()
+	fmt.Printf("Time required to sign 1000 times: %f seconds\n", endTime.Sub(startTime).Seconds())
+
+	startTime = time.Now()
+	for i := 0; i < 1000; i++ {
+		sig.VerifyHash(pubKeyWrapper.Object, blockHash[:])
+	}
+	endTime = time.Now()
+	fmt.Printf("Time required to verify sig 1000 times: %f seconds\n", endTime.Sub(startTime).Seconds())
+
+	sk := vrf_bls.NewVRFSigner(blsPriKey)
+
+	vrf := [32]byte{}
+	proof := []byte{}
+
+	startTime = time.Now()
+	for i := 0; i < 1000; i++ {
+		vrf, proof = sk.Evaluate(blockHash[:])
+	}
+	endTime = time.Now()
+	fmt.Printf("Time required to generate vrf 1000 times: %f seconds\n", endTime.Sub(startTime).Seconds())
+
+	pk := vrf_bls.NewVRFVerifier(blsPriKey.GetPublicKey())
+
+	resultVrf := [32]byte{}
+	startTime = time.Now()
+	for i := 0; i < 1000; i++ {
+		resultVrf, _ = pk.ProofToHash(blockHash, proof)
+	}
+	endTime = time.Now()
+	fmt.Printf("Time required to verify vrf 1000 times: %f seconds\n", endTime.Sub(startTime).Seconds())
+
+	if bytes.Compare(vrf[:], resultVrf[:]) != 0 {
+		fmt.Printf("Failed to verify VRF")
+
+	}
+
+	// A example result of a single run:
+	//Time required to sign 1000 times: 0.542673 seconds
+	//Time required to verify sig 1000 times: 1.499797 seconds
+	//Time required to generate vrf 1000 times: 0.525362 seconds
+	//Time required to verify vrf 1000 times: 2.076890 seconds
+}


### PR DESCRIPTION
Add vrf epoch and the logic to propose vrf in a new block.

Starting from the VRF epoch, leaders are obligated to propose VRF in every block header.

The VRF is computed using the previous block's hash and the leader's private key.

The resulting vrf and proof are concatenated together and put in the vrf byte[] field of the block header.

Block verification now will verify the vrf data if needed.
