### PR TITLE
[sync] fix a panic issue found in stream tests

### DIFF
--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -87,8 +87,15 @@ func (node *Node) createStateSync() *legacysync.StateSync {
 	// Thus for compatibility, we are doing the arithmetics here, and not to change the
 	// protocol itself. This is just the temporary hack and will not be a concern after
 	// state sync.
-	syncPort := node.downloaderServer.Port
-	mutatedPort := strconv.Itoa(syncPort + legacysync.SyncingPortDifference)
+	var mySyncPort int
+	if node.downloaderServer != nil {
+		mySyncPort = node.downloaderServer.Port
+	} else {
+		// If local sync server is not started, the port field in protocol is actually not
+		// functional, simply set it to default value.
+		mySyncPort = nodeconfig.DefaultDNSPort
+	}
+	mutatedPort := strconv.Itoa(mySyncPort + legacysync.SyncingPortDifference)
 	return legacysync.CreateStateSync(node.SelfPeer.IP, mutatedPort,
 		node.GetSyncID(), node.NodeConfig.Role() == nodeconfig.ExplorerNode)
 }


### PR DESCRIPTION
## Issue

Fix https://github.com/harmony-one/harmony/issues/3685 of panic issue.

When user start node with dns server as false, node will panic and exit. The error is introduced in sync port fix.

## Test:

Tested locally