### PR TITLE
design and implement redundant validator setup

### DIFF
--- a/cmd/harmony/config.go
+++ b/cmd/harmony/config.go
@@ -62,6 +62,7 @@ type generalConfig struct {
 	NoStaking        bool
 	ShardID          int
 	IsArchival       bool
+	IsBackup         bool
 	IsBeaconArchival bool
 	IsOffline        bool
 	DataDir          string

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -227,6 +227,11 @@ var (
 		Usage:    "run node in offline mode",
 		DefValue: defaultConfig.General.IsOffline,
 	}
+	isBackupFlag = cli.BoolFlag{
+		Name:     "run.backup",
+		Usage:    "run node in backup mode",
+		DefValue: defaultConfig.General.IsBackup,
+	}
 	dataDirFlag = cli.StringFlag{
 		Name:     "datadir",
 		Usage:    "directory of chain database",
@@ -331,6 +336,10 @@ func applyGeneralFlags(cmd *cobra.Command, config *harmonyConfig) {
 
 	if cli.IsFlagChanged(cmd, isOfflineFlag) {
 		config.General.IsOffline = cli.GetBoolFlagValue(cmd, isOfflineFlag)
+	}
+
+	if cli.IsFlagChanged(cmd, isBackupFlag) {
+		config.General.IsBackup = cli.GetBoolFlagValue(cmd, isBackupFlag)
 	}
 }
 

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -661,6 +661,10 @@ func setupConsensusAndNode(hc harmonyConfig, nodeConfig *nodeconfig.ConfigType) 
 	case nodeTypeValidator:
 		nodeconfig.SetDefaultRole(nodeconfig.Validator)
 		currentNode.NodeConfig.SetRole(nodeconfig.Validator)
+
+		if hc.General.IsBackup {
+			currentConsensus.SetIsBackup(true)
+		}
 	}
 	currentNode.NodeConfig.SetShardGroupID(nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(nodeConfig.ShardID)))
 	currentNode.NodeConfig.SetClientGroupID(nodeconfig.NewClientGroupIDByShardID(shard.BeaconChainShardID))

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -653,19 +653,7 @@ func setupConsensusAndNode(hc harmonyConfig, nodeConfig *nodeconfig.ConfigType) 
 	)
 
 	nodeconfig.GetDefaultConfig().DBDir = nodeConfig.DBDir
-	switch hc.General.NodeType {
-	case nodeTypeExplorer:
-		nodeconfig.SetDefaultRole(nodeconfig.ExplorerNode)
-		currentNode.NodeConfig.SetRole(nodeconfig.ExplorerNode)
-
-	case nodeTypeValidator:
-		nodeconfig.SetDefaultRole(nodeconfig.Validator)
-		currentNode.NodeConfig.SetRole(nodeconfig.Validator)
-
-		if hc.General.IsBackup {
-			currentConsensus.SetIsBackup(true)
-		}
-	}
+	processNodeType(hc, currentNode, currentConsensus)
 	currentNode.NodeConfig.SetShardGroupID(nodeconfig.NewGroupIDByShardID(nodeconfig.ShardID(nodeConfig.ShardID)))
 	currentNode.NodeConfig.SetClientGroupID(nodeconfig.NewClientGroupIDByShardID(shard.BeaconChainShardID))
 	currentNode.NodeConfig.ConsensusPriKey = nodeConfig.ConsensusPriKey
@@ -692,6 +680,22 @@ func setupConsensusAndNode(hc harmonyConfig, nodeConfig *nodeconfig.ConfigType) 
 	currentConsensus.SetMode(currentConsensus.UpdateConsensusInformation())
 	currentConsensus.NextBlockDue = time.Now()
 	return currentNode
+}
+
+func processNodeType(hc harmonyConfig, currentNode *node.Node, currentConsensus *consensus.Consensus) {
+	switch hc.General.NodeType {
+	case nodeTypeExplorer:
+		nodeconfig.SetDefaultRole(nodeconfig.ExplorerNode)
+		currentNode.NodeConfig.SetRole(nodeconfig.ExplorerNode)
+
+	case nodeTypeValidator:
+		nodeconfig.SetDefaultRole(nodeconfig.Validator)
+		currentNode.NodeConfig.SetRole(nodeconfig.Validator)
+
+		if hc.General.IsBackup {
+			currentConsensus.SetIsBackup(true)
+		}
+	}
 }
 
 func setupPrometheusService(node *node.Node, hc harmonyConfig, sid uint32) {

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -48,6 +48,8 @@ type Consensus struct {
 	phase FBFTPhase
 	// current indicates what state a node is in
 	current State
+	// isBackup declarative the node is in backup mode
+	isBackup bool
 	// 2 types of timeouts: normal and viewchange
 	consensusTimeout map[TimeoutType]*utils.Timeout
 	// Commits collected from validators.
@@ -183,6 +185,10 @@ func (consensus *Consensus) GetConsensusLeaderPrivateKey() (*bls.PrivateKeyWrapp
 func (consensus *Consensus) SetBlockVerifier(verifier VerifyBlockFunc) {
 	consensus.BlockVerifier = verifier
 	consensus.vc.SetVerifyBlock(consensus.VerifyBlock)
+}
+
+func (consensus *Consensus) IsBackup() bool {
+	return consensus.isBackup
 }
 
 // New create a new Consensus record

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -174,10 +174,23 @@ func (consensus *Consensus) IsValidatorInCommittee(pubKey bls.SerializedPublicKe
 
 // SetMode sets the mode of consensus
 func (consensus *Consensus) SetMode(m Mode) {
+	if m == Normal && consensus.isBackup {
+		m = NormalBackup
+	}
+
 	consensus.getLogger().Debug().
 		Str("Mode", m.String()).
 		Msg("[SetMode]")
 	consensus.current.SetMode(m)
+}
+
+// SetIsBackup sets the mode of consensus
+func (consensus *Consensus) SetIsBackup(isBackup bool) {
+	consensus.getLogger().Debug().
+		Bool("IsBackup", isBackup).
+		Msg("[SetIsBackup]")
+	consensus.isBackup = isBackup
+	consensus.current.SetIsBackup(isBackup)
 }
 
 // Mode returns the mode of consensus
@@ -201,7 +214,7 @@ func (consensus *Consensus) checkViewID(msg *FBFTMessage) error {
 	if consensus.IgnoreViewIDCheck.IsSet() {
 		//in syncing mode, node accepts incoming messages without viewID/leaderKey checking
 		//so only set mode to normal when new node enters consensus and need checking viewID
-		consensus.current.SetMode(Normal)
+		consensus.SetMode(Normal)
 		consensus.SetViewIDs(msg.ViewID)
 		if !msg.HasSingleSender() {
 			return errors.New("Leader message can not have multiple sender keys")

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -45,7 +45,7 @@ const (
 
 // IsViewChangingMode return true if curernt mode is viewchanging
 func (consensus *Consensus) IsViewChangingMode() bool {
-	return consensus.current.Mode() == ViewChanging
+	return consensus.current.Mode() == ViewChanging || (consensus.current.Mode() == Normal && consensus.IsBackup())
 }
 
 // HandleMessageUpdate will update the consensus state according to received message

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -45,7 +45,7 @@ const (
 
 // IsViewChangingMode return true if curernt mode is viewchanging
 func (consensus *Consensus) IsViewChangingMode() bool {
-	return consensus.current.Mode() == ViewChanging || (consensus.current.Mode() == Normal && consensus.IsBackup())
+	return consensus.current.Mode() == ViewChanging
 }
 
 // HandleMessageUpdate will update the consensus state according to received message
@@ -92,9 +92,16 @@ func (consensus *Consensus) HandleMessageUpdate(ctx context.Context, msg *msg_pb
 		return errors.Wrapf(err, "unable to parse consensus msg with type: %s", msg.Type)
 	}
 
+	canHandleViewChange := true
 	intendedForValidator, intendedForLeader :=
 		!consensus.IsLeader(),
 		consensus.IsLeader()
+
+	// if in backup normal mode, force ignore view change event and leader event.
+	if consensus.current.Mode() == NormalBackup {
+		canHandleViewChange = false
+		intendedForLeader = false
+	}
 
 	// Route message to handler
 	switch t := msg.Type; true {
@@ -113,9 +120,9 @@ func (consensus *Consensus) HandleMessageUpdate(ctx context.Context, msg *msg_pb
 		consensus.onCommit(fbftMsg)
 
 	// Handle view change messages
-	case t == msg_pb.MessageType_VIEWCHANGE:
+	case t == msg_pb.MessageType_VIEWCHANGE && canHandleViewChange:
 		consensus.onViewChange(fbftMsg)
-	case t == msg_pb.MessageType_NEWVIEW:
+	case t == msg_pb.MessageType_NEWVIEW && canHandleViewChange:
 		consensus.onNewView(fbftMsg)
 	}
 

--- a/consensus/enums.go
+++ b/consensus/enums.go
@@ -34,6 +34,7 @@ var (
 		ViewChanging: "ViewChanging",
 		Syncing:      "Syncing",
 		Listening:    "Listening",
+		NormalBackup: "NormalBackup",
 	}
 	phaseNames = map[FBFTPhase]string{
 		FBFTAnnounce: "Announce",

--- a/consensus/enums.go
+++ b/consensus/enums.go
@@ -14,6 +14,8 @@ const (
 	Syncing
 	// Listening ..
 	Listening
+	// NormalBackup Backup Node ..
+	NormalBackup
 )
 
 // FBFTPhase : different phases of consensus

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -57,9 +57,14 @@ func (consensus *Consensus) onAnnounce(msg *msg_pb.Message) {
 		return
 	}
 	consensus.prepare()
+	consensus.switchPhase("Announce", FBFTPrepare)
 }
 
 func (consensus *Consensus) prepare() {
+	if consensus.IsBackup() {
+		return
+	}
+
 	priKeys := consensus.getPriKeysInCommittee()
 
 	p2pMsgs := consensus.constructP2pMessages(msg_pb.MessageType_PREPARE, nil, priKeys)
@@ -71,12 +76,14 @@ func (consensus *Consensus) prepare() {
 			Str("blockHash", hex.EncodeToString(consensus.blockHash[:])).
 			Msg("[OnAnnounce] Sent Prepare Message!!")
 	}
-
-	consensus.switchPhase("Announce", FBFTPrepare)
 }
 
 // sendCommitMessages send out commit messages to leader
 func (consensus *Consensus) sendCommitMessages(blockObj *types.Block) {
+	if consensus.IsBackup() {
+		return
+	}
+
 	priKeys := consensus.getPriKeysInCommittee()
 
 	// Sign commit signature on the received block and construct the p2p messages

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -35,7 +35,8 @@ type State struct {
 	// it is the next view id
 	viewChangingID uint64
 
-	viewMux sync.RWMutex
+	viewMux  sync.RWMutex
+	isBackup bool
 }
 
 // Mode return the current node mode
@@ -47,6 +48,10 @@ func (pm *State) Mode() Mode {
 
 // SetMode set the node mode as required
 func (pm *State) SetMode(s Mode) {
+	if s == Normal && pm.isBackup {
+		s = NormalBackup
+	}
+
 	pm.modeMux.Lock()
 	defer pm.modeMux.Unlock()
 	pm.mode = s
@@ -91,6 +96,10 @@ func (pm *State) GetViewChangeDuraion() time.Duration {
 	defer pm.cViewMux.RUnlock()
 	diff := int64(pm.viewChangingID - pm.blockViewID)
 	return time.Duration(diff * diff * int64(viewChangeDuration))
+}
+
+func (pm *State) SetIsBackup(isBackup bool) {
+	pm.isBackup = isBackup
 }
 
 // fallbackNextViewID return the next view ID and duration when there is an exception

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -236,7 +236,7 @@ func createTimeout() map[TimeoutType]*utils.Timeout {
 
 // startViewChange start the view change process
 func (consensus *Consensus) startViewChange() {
-	if consensus.disableViewChange {
+	if consensus.disableViewChange || consensus.IsBackup() {
 		return
 	}
 	consensus.mutex.Lock()

--- a/hmy/hmy.go
+++ b/hmy/hmy.go
@@ -100,6 +100,8 @@ type NodeAPI interface {
 	ListBlockedPeer() []peer.ID
 
 	GetConsensusInternal() commonRPC.ConsensusInternal
+	IsBackup() bool
+	SetNodeBackupMode(isBackup bool) bool
 
 	// debug API
 	GetConsensusMode() string

--- a/node/api.go
+++ b/node/api.go
@@ -142,3 +142,19 @@ func (node *Node) GetConsensusInternal() rpc_common.ConsensusInternal {
 		ConsensusTime: node.Consensus.GetFinality(),
 	}
 }
+
+// IsBackup returns the node is in backup mode
+func (node *Node) IsBackup() bool {
+	return node.Consensus.IsBackup()
+}
+
+// SetNodeBackupMode change node backup mode
+func (node *Node) SetNodeBackupMode(isBackup bool) bool {
+	if node.Consensus.IsBackup() == isBackup {
+		return false
+	}
+
+	node.Consensus.SetIsBackup(isBackup)
+	node.Consensus.ResetViewChangeState()
+	return true
+}

--- a/rpc/blockchain.go
+++ b/rpc/blockchain.go
@@ -708,3 +708,11 @@ func isBlockGreaterThanLatest(hmy *hmy.Harmony, blockNum rpc.BlockNumber) bool {
 	}
 	return uint64(blockNum) > hmy.CurrentBlock().NumberU64()
 }
+
+func (s *PublicBlockchainService) GetCurrentNodeBackupState(ctx context.Context) (bool, error) {
+	return s.hmy.NodeAPI.IsBackup(), nil
+}
+
+func (s *PublicBlockchainService) SetNodeToBackupMode(ctx context.Context, isBackup bool) (bool, error) {
+	return s.hmy.NodeAPI.SetNodeBackupMode(isBackup), nil
+}


### PR DESCRIPTION
## Issue

harmony-one/harmony#3670 and https://github.com/harmony-one/bounties/issues/36

## Test

### Unit Test Coverage

Before:

![image](https://user-images.githubusercontent.com/14296262/117163998-c7c3f380-adf6-11eb-8d84-6dce73db1318.png)


After:

![image](https://user-images.githubusercontent.com/14296262/117163790-96e3be80-adf6-11eb-94ce-8c5068296c5b.png)

### Test/Run Logs

```
=== RUN   TestMessageSenderInitialization
--- PASS: TestMessageSenderInitialization (0.13s)
=== RUN   TestMessageSenderReset
--- PASS: TestMessageSenderReset (0.10s)
=== RUN   TestSignAndMarshalConsensusMessage
--- PASS: TestSignAndMarshalConsensusMessage (0.16s)
=== RUN   TestSetViewID
--- PASS: TestSetViewID (0.13s)
=== RUN   TestConsensusInitialization
--- PASS: TestConsensusInitialization (0.23s)
=== RUN   TestConstructAnnounceMessage
--- PASS: TestConstructAnnounceMessage (0.16s)
=== RUN   TestConstructPreparedMessage
    construct_test.go:100: vote is already submitted 7639ab784fc61cdd702809de5275c73f1c5fb0842878a8b0c53a5a311711d2d112db23f80b5e3d2d68f638cc2bfb8686
    construct_test.go:105: prepareBitmap.SetKey
    construct_test.go:108: prepareBitmap.SetKey
--- PASS: TestConstructPreparedMessage (0.13s)
=== RUN   TestConstructPrepareMessage
--- PASS: TestConstructPrepareMessage (0.16s)
=== RUN   TestConstructCommitMessage
--- PASS: TestConstructCommitMessage (0.16s)
=== RUN   TestPopulateMessageFields
--- PASS: TestPopulateMessageFields (0.16s)
=== RUN   TestModeStrings
--- PASS: TestModeStrings (0.00s)
=== RUN   TestPhaseStrings
--- PASS: TestPhaseStrings (0.00s)
=== RUN   TestFBFTLog_id
--- PASS: TestFBFTLog_id (0.00s)
=== RUN   TestGetMessagesByTypeSeqViewHash
--- PASS: TestGetMessagesByTypeSeqViewHash (0.00s)
=== RUN   TestHasMatchingAnnounce
--- PASS: TestHasMatchingAnnounce (0.00s)
=== RUN   TestBasicViewChanging
--- PASS: TestBasicViewChanging (0.08s)
=== RUN   TestPhaseSwitching
--- PASS: TestPhaseSwitching (0.21s)
=== RUN   TestGetNextLeaderKeyShouldFailForStandardGeneratedConsensus
--- PASS: TestGetNextLeaderKeyShouldFailForStandardGeneratedConsensus (0.11s)
=== RUN   TestGetNextLeaderKeyShouldSucceed
--- PASS: TestGetNextLeaderKeyShouldSucceed (0.10s)
PASS
```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

   NO

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    NO

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**
   NO
