### PR TITLE
[rpc] Add Rate Limiter for RPCs

### DIFF
--- a/cmd/harmony/config.go
+++ b/cmd/harmony/config.go
@@ -6,8 +6,8 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 
-	"github.com/harmony-one/harmony/api/service/legacysync"
 	"github.com/harmony-one/harmony/internal/cli"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/pelletier/go-toml"
@@ -36,18 +36,21 @@ type harmonyConfig struct {
 	Revert     *revertConfig     `toml:",omitempty"`
 	Legacy     *legacyConfig     `toml:",omitempty"`
 	Prometheus *prometheusConfig `toml:",omitempty"`
+	DNSSync    dnsSync
+}
+
+type dnsSync struct {
+	Port          int    // replaces: Network.DNSSyncPort
+	Zone          string // replaces: Network.DNSZone
+	LegacySyncing bool   // replaces: Network.LegacySyncing
+	Client        bool   // replaces: Sync.LegacyClient
+	Server        bool   // replaces: Sync.LegacyServer
+	ServerPort    int
 }
 
 type networkConfig struct {
 	NetworkType string
 	BootNodes   []string
-
-	LegacySyncing bool // if true, use LegacySyncingPeerProvider
-	DNSZone       string
-	DNSSyncPort   int
-
-	// Legacy field
-	LegacyDNSPort *int `toml:"DNSPort,omitempty"`
 }
 
 type p2pConfig struct {
@@ -128,7 +131,9 @@ type wsConfig struct {
 }
 
 type rpcOptConfig struct {
-	DebugEnabled bool // Enables PrivateDebugService APIs, including the EVM tracer
+	DebugEnabled      bool // Enables PrivateDebugService APIs, including the EVM tracer
+	RateLimterEnabled bool // Enable Rate limiter for RPC
+	RequestsPerSecond int  // for RPC rate limiter
 }
 
 type devnetConfig struct {
@@ -159,45 +164,14 @@ type prometheusConfig struct {
 
 type syncConfig struct {
 	// TODO: Remove this bool after stream sync is fully up.
-	Downloader       bool // start the sync downloader client
-	LegacyServer     bool // provide the gRPC sync protocol server
-	LegacyServerPort int  // sync server port
-	LegacyClient     bool // aside from stream sync protocol, also run gRPC client to get blocks
-
-	Concurrency    int // concurrency used for stream sync protocol
-	MinPeers       int // minimum streams to start a sync task.
-	InitStreams    int // minimum streams in bootstrap to start sync loop.
-	DiscSoftLowCap int // when number of streams is below this value, spin discover during check
-	DiscHardLowCap int // when removing stream, num is below this value, spin discovery immediately
-	DiscHighCap    int // upper limit of streams in one sync protocol
-	DiscBatch      int // size of each discovery
-}
-
-// sanityFixHarmonyConfig correct values for old config version load
-func correctLegacyHarmonyConfig(config *harmonyConfig) {
-	if config.Sync == (syncConfig{}) {
-		nt := nodeconfig.NetworkType(config.Network.NetworkType)
-		config.Sync = getDefaultSyncConfig(nt)
-	}
-	if config.HTTP.RosettaPort == 0 {
-		config.HTTP.RosettaPort = defaultConfig.HTTP.RosettaPort
-	}
-	if config.P2P.IP == "" {
-		config.P2P.IP = defaultConfig.P2P.IP
-	}
-	if config.Prometheus == nil {
-		config.Prometheus = defaultConfig.Prometheus
-	}
-	if syncPort := config.Network.DNSSyncPort; syncPort == 0 {
-		config.Network.DNSSyncPort = nodeconfig.DefaultDNSPort
-	}
-	if serverPort := config.Sync.LegacyServerPort; serverPort == 0 {
-		config.Sync.LegacyServerPort = nodeconfig.DefaultDNSPort
-	}
-	if legSyncPort := config.Network.LegacyDNSPort; legSyncPort != nil && *legSyncPort != nodeconfig.DefaultLegacyDNSPort {
-		config.Network.DNSSyncPort = *legSyncPort - legacysync.SyncingPortDifference
-	}
-	config.Network.LegacyDNSPort = nil // Change to nil after applied legacy value
+	Downloader     bool // start the sync downloader client
+	Concurrency    int  // concurrency used for stream sync protocol
+	MinPeers       int  // minimum streams to start a sync task.
+	InitStreams    int  // minimum streams in bootstrap to start sync loop.
+	DiscSoftLowCap int  // when number of streams is below this value, spin discover during check
+	DiscHardLowCap int  // when removing stream, num is below this value, spin discovery immediately
+	DiscHighCap    int  // upper limit of streams in one sync protocol
+	DiscBatch      int  // size of each discovery
 }
 
 // TODO: use specific type wise validation instead of general string types assertion.
@@ -236,7 +210,7 @@ func validateHarmonyConfig(config harmonyConfig) error {
 		return fmt.Errorf("flag --run.offline must have p2p IP be %v", nodeconfig.DefaultLocalListenIP)
 	}
 
-	if !config.Sync.Downloader && !config.Sync.LegacyClient {
+	if !config.Sync.Downloader && !config.DNSSync.Client {
 		// There is no module up for sync
 		return errors.New("either --sync.downloader or --sync.legacy.client shall be enabled")
 	}
@@ -254,16 +228,37 @@ func checkStringAccepted(flag string, val string, accepts []string) error {
 	return fmt.Errorf("unknown arg for %s: %s (%v)", flag, val, acceptsStr)
 }
 
-func getDefaultNetworkConfig(nt nodeconfig.NetworkType) networkConfig {
-	bn := nodeconfig.GetDefaultBootNodes(nt)
+func getDefaultDNSSyncConfig(nt nodeconfig.NetworkType) dnsSync {
 	zone := nodeconfig.GetDefaultDNSZone(nt)
 	port := nodeconfig.GetDefaultDNSPort(nt)
-	return networkConfig{
-		NetworkType:   string(nt),
-		BootNodes:     bn,
+	dnsSync := dnsSync{
+		Port:          port,
+		Zone:          zone,
 		LegacySyncing: false,
-		DNSZone:       zone,
-		DNSSyncPort:   port,
+		ServerPort:    nodeconfig.DefaultDNSPort,
+	}
+	switch nt {
+	case nodeconfig.Mainnet:
+		dnsSync.Server = true
+		dnsSync.Client = true
+	case nodeconfig.Testnet:
+		dnsSync.Server = true
+		dnsSync.Client = true
+	case nodeconfig.Localnet:
+		dnsSync.Server = true
+		dnsSync.Client = true
+	default:
+		dnsSync.Server = true
+		dnsSync.Client = false
+	}
+	return dnsSync
+}
+
+func getDefaultNetworkConfig(nt nodeconfig.NetworkType) networkConfig {
+	bn := nodeconfig.GetDefaultBootNodes(nt)
+	return networkConfig{
+		NetworkType: string(nt),
+		BootNodes:   bn,
 	}
 }
 
@@ -301,39 +296,112 @@ func getDefaultSyncConfig(nt nodeconfig.NetworkType) syncConfig {
 	}
 }
 
-var dumpConfigCmd = &cobra.Command{
-	Use:   "dumpconfig [config_file]",
-	Short: "dump the config file for harmony binary configurations",
-	Long:  "dump the config file for harmony binary configurations",
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "dump or update config",
+	Long:  "",
+}
+
+var updateConfigCmd = &cobra.Command{
+	Use:   "update [config_file]",
+	Short: "update config to latest version",
+	Long:  "updates config file to latest version, preserving values",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		nt := getNetworkType(cmd)
-		config := getDefaultHmyConfigCopy(nt)
-
-		if err := writeHarmonyConfigToFile(config, args[0]); err != nil {
+		err := updateConfigFile(args[0])
+		if err != nil {
 			fmt.Println(err)
 			os.Exit(128)
 		}
 	},
 }
 
-func registerDumpConfigFlags() error {
-	return cli.RegisterFlags(dumpConfigCmd, []cli.Flag{networkTypeFlag})
+func dumpConfig(cmd *cobra.Command, args []string) {
+	nt := getNetworkType(cmd)
+	config := getDefaultHmyConfigCopy(nt)
+
+	if err := writeHarmonyConfigToFile(config, args[0]); err != nil {
+		fmt.Println(err)
+		os.Exit(128)
+	}
 }
 
-func loadHarmonyConfig(file string) (harmonyConfig, error) {
+var dumpConfigCmd = &cobra.Command{
+	Use:   "dump [config_file]",
+	Short: "dump default config file for harmony binary configurations",
+	Long:  "dump default config file for harmony binary configurations",
+	Args:  cobra.MinimumNArgs(1),
+	Run:   dumpConfig,
+}
+
+var dumpConfigLegacyCmd = &cobra.Command{
+	Use:   "dumpconfig [config_file]",
+	Short: "depricated - use config dump instead",
+	Long:  "depricated - use config dump instead",
+	Args:  cobra.MinimumNArgs(1),
+	Run:   dumpConfig,
+}
+
+func registerDumpConfigFlags() error {
+	return cli.RegisterFlags(dumpConfigCmd, []cli.Flag{networkTypeFlag})
+	return cli.RegisterFlags(dumpConfigLegacyCmd, []cli.Flag{networkTypeFlag})
+}
+
+func promptConfigUpdate() bool {
+	var readStr string
+	fmt.Println("Do you want to update config to the latest version: [y/N]")
+	timeoutTimer := time.NewTimer(time.Second * 15)
+	read := make(chan string)
+	go func() {
+		fmt.Scanf("%s", &readStr)
+		read <- readStr
+	}()
+	select {
+	case <-timeoutTimer.C:
+		fmt.Println("Timed out - update manually with ./harmony config update [config_file]")
+		return false
+	case <-read:
+		readStr = strings.TrimSpace(readStr)
+		if len(readStr) > 1 {
+			readStr = readStr[0:1]
+		}
+		readStr = strings.ToLower(readStr)
+		return readStr == "y"
+	}
+}
+
+func loadHarmonyConfig(file string) (harmonyConfig, string, error) {
 	b, err := ioutil.ReadFile(file)
 	if err != nil {
-		return harmonyConfig{}, err
+		return harmonyConfig{}, "", err
+	}
+	config, migratedVer, err := migrateConf(b)
+	if err != nil {
+		return harmonyConfig{}, "", err
 	}
 
-	var config harmonyConfig
-	if err := toml.Unmarshal(b, &config); err != nil {
-		return harmonyConfig{}, err
-	}
+	return config, migratedVer, nil
+}
 
-	correctLegacyHarmonyConfig(&config)
-	return config, nil
+func updateConfigFile(file string) error {
+	configBytes, err := ioutil.ReadFile(file)
+	if err != nil {
+		return err
+	}
+	backup := fmt.Sprintf("%s.backup", file)
+	if err := ioutil.WriteFile(backup, configBytes, 0664); err != nil {
+		return err
+	}
+	fmt.Printf("Original config backed up to %s\n", fmt.Sprintf("%s.backup", file))
+	config, migratedFromVer, err := migrateConf(configBytes)
+	if err != nil {
+		return err
+	}
+	if err := writeHarmonyConfigToFile(config, file); err != nil {
+		return err
+	}
+	fmt.Printf("Successfully migrated %s from %s to %s \n", file, migratedFromVer, config.Version)
+	return nil
 }
 
 func writeHarmonyConfigToFile(config harmonyConfig, file string) error {

--- a/cmd/harmony/config_migrations.go
+++ b/cmd/harmony/config_migrations.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/harmony-one/harmony/api/service/legacysync"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
+	goversion "github.com/hashicorp/go-version"
+	"github.com/pelletier/go-toml"
+)
+
+const legacyConfigVersion = "1.0.4"
+
+func doMigrations(confVersion string, confTree *toml.Tree) error {
+	Ver, err := goversion.NewVersion(confVersion)
+	if err != nil {
+		return fmt.Errorf("invalid or missing config file version - '%s'", confVersion)
+	}
+	legacyVer, _ := goversion.NewVersion(legacyConfigVersion)
+	migrationKey := confVersion
+	if Ver.LessThan(legacyVer) {
+		migrationKey = legacyConfigVersion
+	}
+
+	migration, found := migrations[migrationKey]
+
+	// Version does not match any of the migration criteria
+	if !found {
+		return fmt.Errorf("unrecognized config version - %s", confVersion)
+	}
+
+	for confVersion != tomlConfigVersion {
+		confTree = migration(confTree)
+		confVersion = confTree.Get("Version").(string)
+		migration = migrations[confVersion]
+	}
+	return nil
+}
+
+func migrateConf(confBytes []byte) (harmonyConfig, string, error) {
+	var (
+		migratedFrom string
+	)
+	confTree, err := toml.LoadBytes(confBytes)
+	if err != nil {
+		return harmonyConfig{}, "", fmt.Errorf("config file parse error - %s", err.Error())
+	}
+	confVersion, found := confTree.Get("Version").(string)
+	if !found {
+		return harmonyConfig{}, "", errors.New("config file invalid - no version entry found")
+	}
+	migratedFrom = confVersion
+	if confVersion != tomlConfigVersion {
+		err = doMigrations(confVersion, confTree)
+		if err != nil {
+			return harmonyConfig{}, "", err
+		}
+	}
+
+	// At this point we must be at current config version so
+	// we can safely unmarshal it
+	var config harmonyConfig
+	if err := confTree.Unmarshal(&config); err != nil {
+		return harmonyConfig{}, "", err
+	}
+	return config, migratedFrom, nil
+}
+
+var (
+	migrations = make(map[string]configMigrationFunc)
+)
+
+type configMigrationFunc func(*toml.Tree) *toml.Tree
+
+func init() {
+	migrations["1.0.4"] = func(confTree *toml.Tree) *toml.Tree {
+		ntStr := confTree.Get("Network.NetworkType").(string)
+		nt := parseNetworkType(ntStr)
+
+		defDNSSyncConf := getDefaultDNSSyncConfig(nt)
+		defSyncConfig := getDefaultSyncConfig(nt)
+
+		// Legacy conf missing fields
+		if confTree.Get("Sync") == nil {
+			confTree.Set("Sync", defSyncConfig)
+		}
+
+		if confTree.Get("HTTP.RosettaPort") == nil {
+			confTree.Set("HTTP.RosettaPort", defaultConfig.HTTP.RosettaPort)
+		}
+
+		if confTree.Get("P2P.IP") == nil {
+			confTree.Set("P2P.IP", defaultConfig.P2P.IP)
+		}
+
+		if confTree.Get("Prometheus") == nil {
+			if defaultConfig.Prometheus != nil {
+				confTree.Set("Prometheus", *defaultConfig.Prometheus)
+			}
+		}
+
+		zoneField := confTree.Get("Network.DNSZone")
+		if zone, ok := zoneField.(string); ok {
+			confTree.Set("DNSSync.Zone", zone)
+		}
+
+		portField := confTree.Get("Network.DNSPort")
+		if p, ok := portField.(int64); ok {
+			p = p - legacysync.SyncingPortDifference
+			confTree.Set("DNSSync.Port", p)
+		} else {
+			confTree.Set("DNSSync.Port", nodeconfig.DefaultDNSPort)
+		}
+
+		syncingField := confTree.Get("Network.LegacySyncing")
+		if syncing, ok := syncingField.(bool); ok {
+			confTree.Set("DNSSync.LegacySyncing", syncing)
+		}
+
+		clientField := confTree.Get("Sync.LegacyClient")
+		if client, ok := clientField.(bool); ok {
+			confTree.Set("DNSSync.Client", client)
+		} else {
+			confTree.Set("DNSSync.Client", defDNSSyncConf.Client)
+		}
+
+		serverField := confTree.Get("Sync.LegacyServer")
+		if server, ok := serverField.(bool); ok {
+			confTree.Set("DNSSync.Server", server)
+		} else {
+			confTree.Set("DNSSync.Server", defDNSSyncConf.Client)
+		}
+
+		serverPort := defDNSSyncConf.ServerPort
+		serverPortField := confTree.Get("Sync.LegacyServerPort")
+		if port, ok := serverPortField.(int64); ok {
+			serverPort = int(port)
+		}
+		confTree.Set("DNSSync.ServerPort", serverPort)
+
+		confTree.Set("Version", "2.0.0")
+		return confTree
+	}
+}

--- a/cmd/harmony/config_migrations_test.go
+++ b/cmd/harmony/config_migrations_test.go
@@ -1,0 +1,280 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
+)
+
+var (
+	V1_0_2ConfigDefault = []byte(`
+Version = "1.0.2"
+
+[BLSKeys]
+  KMSConfigFile = ""
+  KMSConfigSrcType = "shared"
+  KMSEnabled = false
+  KeyDir = "./.hmy/blskeys"
+  KeyFiles = []
+  MaxKeys = 10
+  PassEnabled = true
+  PassFile = ""
+  PassSrcType = "auto"
+  SavePassphrase = false
+
+[General]
+  DataDir = "./"
+  IsArchival = false
+  IsOffline = false
+  NoStaking = false
+  NodeType = "validator"
+  ShardID = -1
+
+[HTTP]
+  Enabled = true
+  IP = "127.0.0.1"
+  Port = 9500
+  RosettaEnabled = false
+  RosettaPort = 9700
+
+[Log]
+  FileName = "harmony.log"
+  Folder = "./latest"
+  RotateSize = 100
+  Verbosity = 3
+
+[Network]
+  BootNodes = ["/ip4/100.26.90.187/tcp/9874/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv","/ip4/54.213.43.194/tcp/9874/p2p/QmZJJx6AdaoEkGLrYG4JeLCKeCKDjnFz2wfHNHxAqFSGA9","/ip4/13.113.101.219/tcp/12019/p2p/QmQayinFSgMMw5cSpDUiD9pQ2WeP6WNmGxpZ6ou3mdVFJX","/ip4/99.81.170.167/tcp/12019/p2p/QmRVbTpEYup8dSaURZfF6ByrMTSKa4UyUzJhSjahFzRqNj"]
+  DNSPort = 9000
+  DNSZone = "t.hmny.io"
+  LegacySyncing = false
+  NetworkType = "mainnet"
+
+[P2P]
+  IP = "0.0.0.0"
+  KeyFile = "./.hmykey"
+  Port = 9000
+
+[Pprof]
+  Enabled = false
+  ListenAddr = "127.0.0.1:6060"
+
+[RPCOpt]
+  DebugEnabled = false
+  RateLimterEnabled = true
+  RequestsPerSecond = 300
+
+[TxPool]
+  BlacklistFile = "./.hmy/blacklist.txt"
+
+[WS]
+  Enabled = true
+  IP = "127.0.0.1"
+  Port = 9800
+`)
+
+	V1_0_3ConfigDefault = []byte(`
+Version = "1.0.3"
+
+[BLSKeys]
+  KMSConfigFile = ""
+  KMSConfigSrcType = "shared"
+  KMSEnabled = false
+  KeyDir = "./.hmy/blskeys"
+  KeyFiles = []
+  MaxKeys = 10
+  PassEnabled = true
+  PassFile = ""
+  PassSrcType = "auto"
+  SavePassphrase = false
+
+[General]
+  DataDir = "./"
+  IsArchival = false
+  IsBeaconArchival = false
+  IsOffline = false
+  NoStaking = false
+  NodeType = "validator"
+  ShardID = -1
+
+[HTTP]
+  Enabled = true
+  IP = "127.0.0.1"
+  Port = 9500
+  RosettaEnabled = false
+  RosettaPort = 9700
+
+[Log]
+  FileName = "harmony.log"
+  Folder = "./latest"
+  RotateSize = 100
+  Verbosity = 3
+
+[Network]
+  BootNodes = ["/ip4/100.26.90.187/tcp/9874/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv","/ip4/54.213.43.194/tcp/9874/p2p/QmZJJx6AdaoEkGLrYG4JeLCKeCKDjnFz2wfHNHxAqFSGA9","/ip4/13.113.101.219/tcp/12019/p2p/QmQayinFSgMMw5cSpDUiD9pQ2WeP6WNmGxpZ6ou3mdVFJX","/ip4/99.81.170.167/tcp/12019/p2p/QmRVbTpEYup8dSaURZfF6ByrMTSKa4UyUzJhSjahFzRqNj"]
+  DNSPort = 9000
+  DNSZone = "t.hmny.io"
+  LegacySyncing = false
+  NetworkType = "mainnet"
+
+[P2P]
+  IP = "0.0.0.0"
+  KeyFile = "./.hmykey"
+  Port = 9000
+
+[Pprof]
+  Enabled = false
+  ListenAddr = "127.0.0.1:6060"
+
+[RPCOpt]
+  DebugEnabled = false
+  RateLimterEnabled = true
+  RequestsPerSecond = 300
+
+[TxPool]
+  BlacklistFile = "./.hmy/blacklist.txt"
+
+[WS]
+  Enabled = true
+  IP = "127.0.0.1"
+  Port = 9800
+`)
+
+	V1_0_4ConfigDefault = []byte(`
+Version = "1.0.4"
+
+[BLSKeys]
+  KMSConfigFile = ""
+  KMSConfigSrcType = "shared"
+  KMSEnabled = false
+  KeyDir = "./.hmy/blskeys"
+  KeyFiles = []
+  MaxKeys = 10
+  PassEnabled = true
+  PassFile = ""
+  PassSrcType = "auto"
+  SavePassphrase = false
+
+[General]
+  DataDir = "./"
+  IsArchival = false
+  IsBeaconArchival = false
+  IsOffline = false
+  NoStaking = false
+  NodeType = "validator"
+  ShardID = -1
+
+[HTTP]
+  Enabled = true
+  IP = "127.0.0.1"
+  Port = 9500
+  RosettaEnabled = false
+  RosettaPort = 9700
+
+[Log]
+  FileName = "harmony.log"
+  Folder = "./latest"
+  RotateSize = 100
+  Verbosity = 3
+
+[Network]
+  BootNodes = ["/dnsaddr/bootstrap.t.hmny.io"]
+  DNSPort = 9000
+  DNSZone = "t.hmny.io"
+  LegacySyncing = false
+  NetworkType = "mainnet"
+
+[P2P]
+  IP = "0.0.0.0"
+  KeyFile = "./.hmykey"
+  Port = 9000
+
+[Pprof]
+  Enabled = false
+  ListenAddr = "127.0.0.1:6060"
+
+[RPCOpt]
+  DebugEnabled = false
+  RateLimterEnabled = true
+  RequestsPerSecond = 300
+
+[Sync]
+  Concurrency = 6
+  DiscBatch = 8
+  DiscHardLowCap = 6
+  DiscHighCap = 128
+  DiscSoftLowCap = 8
+  Downloader = false
+  InitStreams = 8
+  LegacyClient = true
+  LegacyServer = true
+  MinPeers = 6
+
+[TxPool]
+  BlacklistFile = "./.hmy/blacklist.txt"
+
+[WS]
+  Enabled = true
+  IP = "127.0.0.1"
+  Port = 9800
+`)
+)
+
+func Test_migrateConf(t *testing.T) {
+	defConf := getDefaultHmyConfigCopy(nodeconfig.Mainnet)
+	legacyDefConf := getDefaultHmyConfigCopy(nodeconfig.Mainnet)
+	// Versions prior to 1.0.3 use different BootNodes
+	legacyDefConf.Network.BootNodes = []string{
+		"/ip4/100.26.90.187/tcp/9874/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv",
+		"/ip4/54.213.43.194/tcp/9874/p2p/QmZJJx6AdaoEkGLrYG4JeLCKeCKDjnFz2wfHNHxAqFSGA9",
+		"/ip4/13.113.101.219/tcp/12019/p2p/QmQayinFSgMMw5cSpDUiD9pQ2WeP6WNmGxpZ6ou3mdVFJX",
+		"/ip4/99.81.170.167/tcp/12019/p2p/QmRVbTpEYup8dSaURZfF6ByrMTSKa4UyUzJhSjahFzRqNj",
+	}
+	type args struct {
+		confBytes []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    harmonyConfig
+		wantErr bool
+	}{
+		{
+			name: "1.0.2 to latest migration",
+			args: args{
+				confBytes: V1_0_2ConfigDefault,
+			},
+			want:    legacyDefConf,
+			wantErr: false,
+		},
+		{
+			name: "1.0.3 to latest migration",
+			args: args{
+				confBytes: V1_0_3ConfigDefault,
+			},
+			want:    legacyDefConf,
+			wantErr: false,
+		},
+		{
+			name: "1.0.4 to latest migration",
+			args: args{
+				confBytes: V1_0_4ConfigDefault,
+			},
+			want:    defConf,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _, err := migrateConf(tt.args.confBytes)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("migrateConf() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("migrateConf() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -30,8 +30,8 @@ func init() {
 }
 
 func TestV1_0_4Config(t *testing.T) {
-	testConfig := `Version = "1.0.4"
-
+	testConfig := `
+Version = "1.0.4"
 [BLSKeys]
   KMSConfigFile = ""
   KMSConfigSrcType = "shared"
@@ -104,7 +104,7 @@ func TestV1_0_4Config(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	config, err := loadHarmonyConfig(file)
+	config, migratedFrom, err := loadHarmonyConfig(file)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +118,7 @@ func TestV1_0_4Config(t *testing.T) {
 	if config.P2P.IP != defConf.P2P.IP {
 		t.Errorf("Expect default p2p IP if old config is provided")
 	}
-	if config.Version != "1.0.4" {
+	if migratedFrom != "1.0.4" {
 		t.Errorf("Expected config version: 1.0.4, not %v", config.Version)
 	}
 	config.Version = defConf.Version // Shortcut for testing, value checked above
@@ -169,7 +169,7 @@ func TestPersistConfig(t *testing.T) {
 		if err := writeHarmonyConfigToFile(test.config, file); err != nil {
 			t.Fatal(err)
 		}
-		config, err := loadHarmonyConfig(file)
+		config, _, err := loadHarmonyConfig(file)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -95,7 +95,11 @@ Version = "1.0.4"
 [WS]
   Enabled = true
   IP = "127.0.0.1"
-  Port = 9800`
+  Port = 9800
+ 
+[RPCOpt]
+  RateLimterEnabled = true
+  RequestsPerSecond = 300`
 	testDir := filepath.Join(testBaseDir, t.Name())
 	os.RemoveAll(testDir)
 	os.MkdirAll(testDir, 0777)

--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -96,7 +96,7 @@ Version = "1.0.4"
   Enabled = true
   IP = "127.0.0.1"
   Port = 9800
- 
+  
 [RPCOpt]
   RateLimterEnabled = true
   RequestsPerSecond = 300`

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -2,7 +2,7 @@ package main
 
 import nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 
-const tomlConfigVersion = "1.0.5"
+const tomlConfigVersion = "2.0.0"
 
 const (
 	defNetworkType = nodeconfig.Mainnet
@@ -38,7 +38,9 @@ var defaultConfig = harmonyConfig{
 		Port:    nodeconfig.DefaultWSPort,
 	},
 	RPCOpt: rpcOptConfig{
-		DebugEnabled: false,
+		DebugEnabled:      false,
+		RateLimterEnabled: true,
+		RequestsPerSecond: nodeconfig.DefaultRPCRateLimit,
 	},
 	BLSKeys: blsConfig{
 		KeyDir:   "./.hmy/blskeys",
@@ -67,6 +69,7 @@ var defaultConfig = harmonyConfig{
 		RotateSize: 100,
 		Verbosity:  3,
 	},
+	DNSSync: getDefaultDNSSyncConfig(defNetworkType),
 }
 
 var defaultSysConfig = sysConfig{
@@ -105,59 +108,47 @@ var defaultPrometheusConfig = prometheusConfig{
 
 var (
 	defaultMainnetSyncConfig = syncConfig{
-		Downloader:       false,
-		LegacyServer:     true,
-		LegacyServerPort: nodeconfig.DefaultDNSPort,
-		LegacyClient:     true,
-		Concurrency:      6,
-		MinPeers:         6,
-		InitStreams:      8,
-		DiscSoftLowCap:   8,
-		DiscHardLowCap:   6,
-		DiscHighCap:      128,
-		DiscBatch:        8,
+		Downloader:     false,
+		Concurrency:    6,
+		MinPeers:       6,
+		InitStreams:    8,
+		DiscSoftLowCap: 8,
+		DiscHardLowCap: 6,
+		DiscHighCap:    128,
+		DiscBatch:      8,
 	}
 
 	defaultTestNetSyncConfig = syncConfig{
-		Downloader:       false,
-		LegacyServer:     true,
-		LegacyServerPort: nodeconfig.DefaultDNSPort,
-		LegacyClient:     true,
-		Concurrency:      4,
-		MinPeers:         4,
-		InitStreams:      4,
-		DiscSoftLowCap:   4,
-		DiscHardLowCap:   4,
-		DiscHighCap:      1024,
-		DiscBatch:        8,
+		Downloader:     false,
+		Concurrency:    4,
+		MinPeers:       4,
+		InitStreams:    4,
+		DiscSoftLowCap: 4,
+		DiscHardLowCap: 4,
+		DiscHighCap:    1024,
+		DiscBatch:      8,
 	}
 
 	defaultLocalNetSyncConfig = syncConfig{
-		Downloader:       false,
-		LegacyServer:     true,
-		LegacyServerPort: nodeconfig.DefaultDNSPort,
-		LegacyClient:     true,
-		Concurrency:      4,
-		MinPeers:         4,
-		InitStreams:      4,
-		DiscSoftLowCap:   4,
-		DiscHardLowCap:   4,
-		DiscHighCap:      1024,
-		DiscBatch:        8,
+		Downloader:     false,
+		Concurrency:    4,
+		MinPeers:       4,
+		InitStreams:    4,
+		DiscSoftLowCap: 4,
+		DiscHardLowCap: 4,
+		DiscHighCap:    1024,
+		DiscBatch:      8,
 	}
 
 	defaultElseSyncConfig = syncConfig{
-		Downloader:       true,
-		LegacyServer:     true,
-		LegacyServerPort: nodeconfig.DefaultDNSPort,
-		LegacyClient:     false,
-		Concurrency:      4,
-		MinPeers:         4,
-		InitStreams:      4,
-		DiscSoftLowCap:   4,
-		DiscHardLowCap:   4,
-		DiscHighCap:      1024,
-		DiscBatch:        8,
+		Downloader:     true,
+		Concurrency:    4,
+		MinPeers:       4,
+		InitStreams:    4,
+		DiscSoftLowCap: 4,
+		DiscHardLowCap: 4,
+		DiscHighCap:    1024,
+		DiscBatch:      8,
 	}
 )
 
@@ -174,6 +165,7 @@ func getDefaultHmyConfigCopy(nt nodeconfig.NetworkType) harmonyConfig {
 		config.Devnet = &devnet
 	}
 	config.Sync = getDefaultSyncConfig(nt)
+	config.DNSSync = getDefaultDNSSyncConfig(nt)
 
 	return config
 }

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -29,15 +29,23 @@ var (
 		legacyDataDirFlag,
 	}
 
-	networkFlags = []cli.Flag{
-		networkTypeFlag,
-		bootNodeFlag,
+	dnsSyncFlags = []cli.Flag{
 		dnsZoneFlag,
 		dnsPortFlag,
+		dnsServerPortFlag,
+		dnsClientFlag,
+		dnsServerFlag,
 
+		syncLegacyClientFlag,
+		syncLegacyServerFlag,
 		legacyDNSZoneFlag,
 		legacyDNSPortFlag,
 		legacyDNSFlag,
+	}
+
+	networkFlags = []cli.Flag{
+		networkTypeFlag,
+		bootNodeFlag,
 		legacyNetworkTypeFlag,
 	}
 
@@ -66,6 +74,8 @@ var (
 
 	rpcOptFlags = []cli.Flag{
 		rpcDebugEnabledFlag,
+		rpcRateLimiterEnabledFlag,
+		rpcRateLimitFlag,
 	}
 
 	blsFlags = append(newBLSFlags, legacyBLSFlags...)
@@ -181,10 +191,6 @@ var (
 
 	syncFlags = []cli.Flag{
 		syncDownloaderFlag,
-		syncLegacyClientFlag,
-		syncLegacyServerFlag,
-		syncLegacyServerPortFlag,
-
 		syncConcurrencyFlag,
 		syncMinPeersFlag,
 		syncInitStreamsFlag,
@@ -271,6 +277,7 @@ func getRootFlags() []cli.Flag {
 	flags = append(flags, configFlag)
 	flags = append(flags, generalFlags...)
 	flags = append(flags, networkFlags...)
+	flags = append(flags, dnsSyncFlags...)
 	flags = append(flags, p2pFlags...)
 	flags = append(flags, httpFlags...)
 	flags = append(flags, wsFlags...)
@@ -346,6 +353,32 @@ var (
 		Name:  "bootnodes",
 		Usage: "a list of bootnode multiaddress (delimited by ,)",
 	}
+	legacyDNSZoneFlag = cli.StringFlag{
+		Name:       "dns_zone",
+		Usage:      "use peers from the zone for state syncing",
+		Deprecated: "use --dns.zone",
+	}
+	legacyNetworkTypeFlag = cli.StringFlag{
+		Name:       "network_type",
+		Usage:      "network to join (mainnet, testnet, pangaea, localnet, partner, stressnet, devnet)",
+		Deprecated: "use --network",
+	}
+)
+
+// DNSSync flags
+var (
+	legacyDNSPortFlag = cli.IntFlag{
+		Name:       "dns_port",
+		Usage:      "port of dns node",
+		Deprecated: "use --dns.port",
+	}
+	legacyDNSFlag = cli.BoolFlag{
+		Name:       "dns",
+		DefValue:   true,
+		Hidden:     true,
+		Usage:      "use dns for syncing",
+		Deprecated: "only set to false to use self discovered peers for syncing",
+	}
 	dnsZoneFlag = cli.StringFlag{
 		Name:  "dns.zone",
 		Usage: "use customized peers from the zone for state syncing",
@@ -353,28 +386,38 @@ var (
 	dnsPortFlag = cli.IntFlag{
 		Name:     "dns.port",
 		DefValue: nodeconfig.DefaultDNSPort,
-		Usage:    "data port of the remote DNS service provider",
+		Usage:    "dns sync remote server port",
 	}
-	legacyDNSZoneFlag = cli.StringFlag{
-		Name:       "dns_zone",
-		Usage:      "use peers from the zone for state syncing",
-		Deprecated: "use --dns.zone",
+	dnsServerPortFlag = cli.IntFlag{
+		Name:     "dns.server-port",
+		DefValue: nodeconfig.DefaultDNSPort,
+		Usage:    "dns sync local server port",
 	}
-	legacyDNSPortFlag = cli.IntFlag{
-		Name:       "dns_port",
-		Usage:      "data port of the remote DNS service provider",
-		Deprecated: "use --dns.zone",
+	syncLegacyClientFlag = cli.BoolFlag{
+		Name:       "sync.legacy.client",
+		Usage:      "Enable the legacy centralized sync service for block synchronization",
+		Hidden:     true,
+		DefValue:   false,
+		Deprecated: "use dns.client instead",
 	}
-	legacyDNSFlag = cli.BoolFlag{
-		Name:       "dns",
+	dnsClientFlag = cli.BoolFlag{
+		Name:     "dns.client",
+		Usage:    "Enable the legacy centralized sync service for block synchronization",
+		Hidden:   true,
+		DefValue: false,
+	}
+	syncLegacyServerFlag = cli.BoolFlag{
+		Name:       "sync.legacy.server",
+		Usage:      "Enable the gRPC sync server for backward compatibility",
+		Hidden:     true,
 		DefValue:   true,
-		Usage:      "use dns for syncing",
-		Deprecated: "only set to false to use self discovered peers for syncing",
+		Deprecated: "use dns.server instead",
 	}
-	legacyNetworkTypeFlag = cli.StringFlag{
-		Name:       "network_type",
-		Usage:      "network to join (mainnet, testnet, pangaea, localnet, partner, stressnet, devnet)",
-		Deprecated: "use --network",
+	dnsServerFlag = cli.BoolFlag{
+		Name:     "dns.server",
+		Usage:    "Enable the gRPC sync server for backward compatibility",
+		Hidden:   true,
+		DefValue: true,
 	}
 )
 
@@ -391,30 +434,45 @@ func getNetworkType(cmd *cobra.Command) nodeconfig.NetworkType {
 	return parseNetworkType(raw)
 }
 
-func applyNetworkFlags(cmd *cobra.Command, cfg *harmonyConfig) {
-	if cli.IsFlagChanged(cmd, bootNodeFlag) {
-		cfg.Network.BootNodes = cli.GetStringSliceFlagValue(cmd, bootNodeFlag)
-	}
-
+func applyDNSSyncFlags(cmd *cobra.Command, cfg *harmonyConfig) {
 	if cli.IsFlagChanged(cmd, dnsZoneFlag) {
-		cfg.Network.DNSZone = cli.GetStringFlagValue(cmd, dnsZoneFlag)
+		cfg.DNSSync.Zone = cli.GetStringFlagValue(cmd, dnsZoneFlag)
 	} else if cli.IsFlagChanged(cmd, legacyDNSZoneFlag) {
-		cfg.Network.DNSZone = cli.GetStringFlagValue(cmd, legacyDNSZoneFlag)
+		cfg.DNSSync.Zone = cli.GetStringFlagValue(cmd, legacyDNSZoneFlag)
 	} else if cli.IsFlagChanged(cmd, legacyDNSFlag) {
 		val := cli.GetBoolFlagValue(cmd, legacyDNSFlag)
 		if !val {
-			cfg.Network.LegacySyncing = true
+			cfg.DNSSync.LegacySyncing = true
 		}
 	}
 
 	if cli.IsFlagChanged(cmd, dnsPortFlag) {
-		cfg.Network.DNSSyncPort = cli.GetIntFlagValue(cmd, dnsPortFlag)
+		cfg.DNSSync.Port = cli.GetIntFlagValue(cmd, dnsPortFlag)
 	} else if cli.IsFlagChanged(cmd, legacyDNSPortFlag) {
-		// Still using node.sh to launch the node. Flag --dns_port should have
-		// port arithmetic of actual port being val - 3000.
-		rawPort := cli.GetIntFlagValue(cmd, legacyDNSPortFlag)
-		mutatedPort, _ := strconv.Atoi(legacysync.GetSyncingPort(strconv.Itoa(rawPort)))
-		cfg.Network.DNSSyncPort = mutatedPort
+		cfg.DNSSync.Port = cli.GetIntFlagValue(cmd, legacyDNSPortFlag)
+	}
+
+	if cli.IsFlagChanged(cmd, syncLegacyServerFlag) {
+		cfg.DNSSync.Server = cli.GetBoolFlagValue(cmd, syncLegacyServerFlag)
+	} else if cli.IsFlagChanged(cmd, dnsServerFlag) {
+		cfg.DNSSync.Server = cli.GetBoolFlagValue(cmd, syncLegacyServerFlag)
+	}
+
+	if cli.IsFlagChanged(cmd, syncLegacyClientFlag) {
+		cfg.DNSSync.Client = cli.GetBoolFlagValue(cmd, syncLegacyClientFlag)
+	} else if cli.IsFlagChanged(cmd, dnsClientFlag) {
+		cfg.DNSSync.Client = cli.GetBoolFlagValue(cmd, dnsClientFlag)
+	}
+
+	if cli.IsFlagChanged(cmd, dnsServerPortFlag) {
+		cfg.DNSSync.ServerPort = cli.GetIntFlagValue(cmd, dnsServerPortFlag)
+	}
+
+}
+
+func applyNetworkFlags(cmd *cobra.Command, cfg *harmonyConfig) {
+	if cli.IsFlagChanged(cmd, bootNodeFlag) {
+		cfg.Network.BootNodes = cli.GetStringSliceFlagValue(cmd, bootNodeFlag)
 	}
 }
 
@@ -572,12 +630,31 @@ var (
 		DefValue: defaultConfig.RPCOpt.DebugEnabled,
 		Hidden:   true,
 	}
+
+	rpcRateLimiterEnabledFlag = cli.BoolFlag{
+		Name:     "rpc.ratelimiter",
+		Usage:    "enable rate limiter for RPCs",
+		DefValue: defaultConfig.RPCOpt.RateLimterEnabled,
+	}
+
+	rpcRateLimitFlag = cli.IntFlag{
+		Name:     "rpc.ratelimit",
+		Usage:    "the number of requests per second for RPCs",
+		DefValue: defaultConfig.RPCOpt.RequestsPerSecond,
+	}
 )
 
 func applyRPCOptFlags(cmd *cobra.Command, config *harmonyConfig) {
 	if cli.IsFlagChanged(cmd, rpcDebugEnabledFlag) {
 		config.RPCOpt.DebugEnabled = cli.GetBoolFlagValue(cmd, rpcDebugEnabledFlag)
 	}
+	if cli.IsFlagChanged(cmd, rpcRateLimiterEnabledFlag) {
+		config.RPCOpt.RateLimterEnabled = cli.GetBoolFlagValue(cmd, rpcRateLimiterEnabledFlag)
+	}
+	if cli.IsFlagChanged(cmd, rpcRateLimitFlag) {
+		config.RPCOpt.RequestsPerSecond = cli.GetIntFlagValue(cmd, rpcRateLimitFlag)
+	}
+
 }
 
 // bls flags
@@ -1194,8 +1271,8 @@ func applyLegacyMiscFlags(cmd *cobra.Command, config *harmonyConfig) {
 
 		legPortStr := strconv.Itoa(legacyPort)
 		syncPort, _ := strconv.Atoi(legacysync.GetSyncingPort(legPortStr))
-		config.Network.DNSSyncPort = syncPort
-		config.Sync.LegacyServerPort = syncPort
+		config.DNSSync.Port = syncPort
+		config.DNSSync.ServerPort = syncPort
 	}
 
 	if cli.IsFlagChanged(cmd, legacyIPFlag) {
@@ -1304,25 +1381,7 @@ var (
 		Name:     "sync.downloader",
 		Usage:    "Enable the downloader module to sync through stream sync protocol",
 		Hidden:   true,
-		DefValue: defaultConfig.Sync.Downloader,
-	}
-	syncLegacyServerFlag = cli.BoolFlag{
-		Name:     "sync.legacy.server",
-		Usage:    "Enable the gRPC sync server for backward compatibility",
-		Hidden:   true,
-		DefValue: defaultConfig.Sync.LegacyServer,
-	}
-	syncLegacyServerPortFlag = cli.IntFlag{
-		Name:     "sync.legacy.server.port",
-		Usage:    "port used for gRPC sync server",
-		Hidden:   true,
-		DefValue: defaultConfig.Sync.LegacyServerPort,
-	}
-	syncLegacyClientFlag = cli.BoolFlag{
-		Name:     "sync.legacy.client",
-		Usage:    "Enable the legacy centralized sync service for block synchronization",
-		Hidden:   true,
-		DefValue: defaultConfig.Sync.LegacyClient,
+		DefValue: false,
 	}
 	syncConcurrencyFlag = cli.IntFlag{
 		Name:   "sync.concurrency",
@@ -1365,18 +1424,6 @@ var (
 func applySyncFlags(cmd *cobra.Command, config *harmonyConfig) {
 	if cli.IsFlagChanged(cmd, syncDownloaderFlag) {
 		config.Sync.Downloader = cli.GetBoolFlagValue(cmd, syncDownloaderFlag)
-	}
-
-	if cli.IsFlagChanged(cmd, syncLegacyServerFlag) {
-		config.Sync.LegacyServer = cli.GetBoolFlagValue(cmd, syncLegacyServerFlag)
-	}
-
-	if cli.IsFlagChanged(cmd, syncLegacyServerPortFlag) {
-		config.Sync.LegacyServerPort = cli.GetIntFlagValue(cmd, syncLegacyServerPortFlag)
-	}
-
-	if cli.IsFlagChanged(cmd, syncLegacyClientFlag) {
-		config.Sync.LegacyClient = cli.GetBoolFlagValue(cmd, syncLegacyClientFlag)
 	}
 
 	if cli.IsFlagChanged(cmd, syncConcurrencyFlag) {

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -46,8 +46,13 @@ func TestHarmonyFlags(t *testing.T) {
 						"/ip4/13.113.101.219/tcp/12019/p2p/QmQayinFSgMMw5cSpDUiD9pQ2WeP6WNmGxpZ6ou3mdVFJX",
 						"/ip4/99.81.170.167/tcp/12019/p2p/QmRVbTpEYup8dSaURZfF6ByrMTSKa4UyUzJhSjahFzRqNj",
 					},
-					DNSZone:     "t.hmny.io",
-					DNSSyncPort: 6000,
+				},
+				DNSSync: dnsSync{
+					Port:       6000,
+					Zone:       "t.hmny.io",
+					Server:     true,
+					Client:     true,
+					ServerPort: nodeconfig.DefaultDNSPort,
 				},
 				P2P: p2pConfig{
 					Port:    9000,
@@ -60,6 +65,11 @@ func TestHarmonyFlags(t *testing.T) {
 					Port:           9500,
 					RosettaEnabled: false,
 					RosettaPort:    9700,
+				},
+				RPCOpt: rpcOptConfig{
+					DebugEnabled:      false,
+					RateLimterEnabled: true,
+					RequestsPerSecond: 300,
 				},
 				WS: wsConfig{
 					Enabled: true,
@@ -219,69 +229,91 @@ func TestGeneralFlags(t *testing.T) {
 func TestNetworkFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig networkConfig
+		expConfig harmonyConfig
 		expErr    error
 	}{
 		{
 			args: []string{},
-			expConfig: networkConfig{
-				NetworkType:   defNetworkType,
-				BootNodes:     nodeconfig.GetDefaultBootNodes(defNetworkType),
-				LegacySyncing: false,
-				DNSZone:       nodeconfig.GetDefaultDNSZone(defNetworkType),
-				DNSSyncPort:   nodeconfig.GetDefaultDNSPort(defNetworkType),
-			},
+			expConfig: harmonyConfig{
+				Network: networkConfig{
+					NetworkType: defNetworkType,
+					BootNodes:   nodeconfig.GetDefaultBootNodes(defNetworkType),
+				},
+				DNSSync: getDefaultDNSSyncConfig(defNetworkType)},
 		},
 		{
 			args: []string{"-n", "stn"},
-			expConfig: networkConfig{
-				NetworkType:   nodeconfig.Stressnet,
-				BootNodes:     nodeconfig.GetDefaultBootNodes(nodeconfig.Stressnet),
-				LegacySyncing: false,
-				DNSZone:       nodeconfig.GetDefaultDNSZone(nodeconfig.Stressnet),
-				DNSSyncPort:   nodeconfig.GetDefaultDNSPort(nodeconfig.Stressnet),
+			expConfig: harmonyConfig{
+				Network: networkConfig{
+					NetworkType: nodeconfig.Stressnet,
+					BootNodes:   nodeconfig.GetDefaultBootNodes(nodeconfig.Stressnet),
+				},
+				DNSSync: getDefaultDNSSyncConfig(nodeconfig.Stressnet),
 			},
 		},
 		{
 			args: []string{"--network", "stk", "--bootnodes", "1,2,3,4", "--dns.zone", "8.8.8.8",
-				"--dns.port", "9001"},
-			expConfig: networkConfig{
-				NetworkType:   "pangaea",
-				BootNodes:     []string{"1", "2", "3", "4"},
-				LegacySyncing: false,
-				DNSZone:       "8.8.8.8",
-				DNSSyncPort:   9001,
+				"--dns.port", "9001", "--dns.server-port", "9002"},
+			expConfig: harmonyConfig{
+				Network: networkConfig{
+					NetworkType: "pangaea",
+					BootNodes:   []string{"1", "2", "3", "4"},
+				},
+				DNSSync: dnsSync{
+					Port:          9001,
+					Zone:          "8.8.8.8",
+					LegacySyncing: false,
+					Server:        true,
+					ServerPort:    9002,
+				},
 			},
 		},
 		{
 			args: []string{"--network_type", "stk", "--bootnodes", "1,2,3,4", "--dns_zone", "8.8.8.8",
 				"--dns_port", "9001"},
-			expConfig: networkConfig{
-				NetworkType:   "pangaea",
-				BootNodes:     []string{"1", "2", "3", "4"},
-				LegacySyncing: false,
-				DNSZone:       "8.8.8.8",
-				DNSSyncPort:   6001,
-				LegacyDNSPort: nil,
+			expConfig: harmonyConfig{
+				Network: networkConfig{
+					NetworkType: "pangaea",
+					BootNodes:   []string{"1", "2", "3", "4"},
+				},
+				DNSSync: dnsSync{
+					Port:          9001,
+					Zone:          "8.8.8.8",
+					LegacySyncing: false,
+					Server:        true,
+					ServerPort:    nodeconfig.GetDefaultDNSPort(nodeconfig.Pangaea),
+				},
 			},
 		},
 		{
 			args: []string{"--dns=false"},
-			expConfig: networkConfig{
-				NetworkType:   defNetworkType,
-				BootNodes:     nodeconfig.GetDefaultBootNodes(defNetworkType),
-				LegacySyncing: true,
-				DNSZone:       nodeconfig.GetDefaultDNSZone(defNetworkType),
-				DNSSyncPort:   nodeconfig.GetDefaultDNSPort(defNetworkType),
+			expConfig: harmonyConfig{
+				Network: networkConfig{
+					NetworkType: defNetworkType,
+					BootNodes:   nodeconfig.GetDefaultBootNodes(defNetworkType),
+				},
+				DNSSync: dnsSync{
+					Port:          nodeconfig.GetDefaultDNSPort(defNetworkType),
+					Zone:          nodeconfig.GetDefaultDNSZone(defNetworkType),
+					LegacySyncing: true,
+					Client:        true,
+					Server:        true,
+					ServerPort:    nodeconfig.GetDefaultDNSPort(nodeconfig.Pangaea),
+				},
 			},
 		},
 	}
 	for i, test := range tests {
-		ts := newFlagTestSuite(t, networkFlags, func(cmd *cobra.Command, config *harmonyConfig) {
+		neededFlags := make([]cli.Flag, 0)
+		neededFlags = append(neededFlags, networkFlags...)
+		neededFlags = append(neededFlags, dnsSyncFlags...)
+		ts := newFlagTestSuite(t, neededFlags, func(cmd *cobra.Command, config *harmonyConfig) {
 			// This is the network related logic in function getHarmonyConfig
 			nt := getNetworkType(cmd)
 			config.Network = getDefaultNetworkConfig(nt)
+			config.DNSSync = getDefaultDNSSyncConfig(nt)
 			applyNetworkFlags(cmd, config)
+			applyDNSSyncFlags(cmd, config)
 		})
 
 		got, err := ts.run(test.args)
@@ -292,8 +324,11 @@ func TestNetworkFlags(t *testing.T) {
 		if err != nil || test.expErr != nil {
 			continue
 		}
-		if !reflect.DeepEqual(got.Network, test.expConfig) {
-			t.Errorf("Test %v: unexpected config: \n\t%+v\n\t%+v", i, got.Network, test.expConfig)
+		if !reflect.DeepEqual(got.Network, test.expConfig.Network) {
+			t.Errorf("Test %v: unexpected network config: \n\t%+v\n\t%+v", i, got.Network, test.expConfig.Network)
+		}
+		if !reflect.DeepEqual(got.DNSSync, test.expConfig.DNSSync) {
+			t.Errorf("Test %v: unexpected dnssync config: \n\t%+v\n\t%+v", i, got.DNSSync, test.expConfig.DNSSync)
 		}
 		ts.tearDown()
 	}
@@ -505,7 +540,36 @@ func TestRPCOptFlags(t *testing.T) {
 		{
 			args: []string{"--rpc.debug"},
 			expConfig: rpcOptConfig{
-				DebugEnabled: true,
+				DebugEnabled:      true,
+				RateLimterEnabled: true,
+				RequestsPerSecond: 300,
+			},
+		},
+
+		{
+			args: []string{},
+			expConfig: rpcOptConfig{
+				DebugEnabled:      false,
+				RateLimterEnabled: true,
+				RequestsPerSecond: 300,
+			},
+		},
+
+		{
+			args: []string{"--rpc.ratelimiter", "--rpc.ratelimit", "1000"},
+			expConfig: rpcOptConfig{
+				DebugEnabled:      false,
+				RateLimterEnabled: true,
+				RequestsPerSecond: 1000,
+			},
+		},
+
+		{
+			args: []string{"--rpc.ratelimiter=false", "--rpc.ratelimit", "1000"},
+			expConfig: rpcOptConfig{
+				DebugEnabled:      false,
+				RateLimterEnabled: false,
+				RequestsPerSecond: 1000,
 			},
 		},
 	}
@@ -949,6 +1013,60 @@ func TestRevertFlags(t *testing.T) {
 	}
 }
 
+func TestDNSSyncFlags(t *testing.T) {
+	tests := []struct {
+		args      []string
+		network   string
+		expConfig dnsSync
+		expErr    error
+	}{
+		{
+			args:      []string{},
+			network:   "mainnet",
+			expConfig: getDefaultDNSSyncConfig(nodeconfig.Mainnet),
+		},
+		{
+			args:      []string{"--sync.legacy.server", "--sync.legacy.client"},
+			network:   "mainnet",
+			expConfig: getDefaultDNSSyncConfig(nodeconfig.Mainnet),
+		},
+		{
+			args:    []string{"--sync.legacy.server", "--sync.legacy.client"},
+			network: "testnet",
+			expConfig: func() dnsSync {
+				cfg := getDefaultDNSSyncConfig(nodeconfig.Mainnet)
+				cfg.Client = true
+				cfg.Server = true
+				return cfg
+			}(),
+		},
+		{
+			args:      []string{"--dns.server", "--dns.client"},
+			network:   "mainnet",
+			expConfig: getDefaultDNSSyncConfig(nodeconfig.Mainnet),
+		},
+	}
+
+	for i, test := range tests {
+		ts := newFlagTestSuite(t, dnsSyncFlags, func(command *cobra.Command, config *harmonyConfig) {
+			config.Network.NetworkType = test.network
+			applyDNSSyncFlags(command, config)
+		})
+		hc, err := ts.run(test.args)
+
+		if assErr := assertError(err, test.expErr); assErr != nil {
+			t.Fatalf("Test %v: %v", i, assErr)
+		}
+		if err != nil || test.expErr != nil {
+			continue
+		}
+		if !reflect.DeepEqual(hc.DNSSync, test.expConfig) {
+			t.Errorf("Test %v:\n\t%+v\n\t%+v", i, hc.DNSSync, test.expConfig)
+		}
+
+		ts.tearDown()
+	}
+}
 func TestSyncFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
@@ -957,23 +1075,6 @@ func TestSyncFlags(t *testing.T) {
 		expErr    error
 	}{
 		{
-			args:      []string{},
-			network:   "mainnet",
-			expConfig: defaultMainnetSyncConfig,
-		},
-		{
-			args: []string{"--sync.legacy.server", "--sync.legacy.client",
-				"--sync.legacy.server.port", "6001"},
-			network: "mainnet",
-			expConfig: func() syncConfig {
-				cfg := defaultMainnetSyncConfig
-				cfg.LegacyClient = true
-				cfg.LegacyServer = true
-				cfg.LegacyServerPort = 6001
-				return cfg
-			}(),
-		},
-		{
 			args: []string{"--sync.downloader", "--sync.concurrency", "10", "--sync.min-peers", "10",
 				"--sync.init-peers", "10", "--sync.disc.soft-low-cap", "10",
 				"--sync.disc.hard-low-cap", "10", "--sync.disc.hi-cap", "10",
@@ -981,16 +1082,16 @@ func TestSyncFlags(t *testing.T) {
 			},
 			network: "mainnet",
 			expConfig: func() syncConfig {
-				cfg := defaultMainnetSyncConfig
-				cfg.Downloader = true
-				cfg.Concurrency = 10
-				cfg.MinPeers = 10
-				cfg.InitStreams = 10
-				cfg.DiscSoftLowCap = 10
-				cfg.DiscHardLowCap = 10
-				cfg.DiscHighCap = 10
-				cfg.DiscBatch = 10
-				return cfg
+				cfgSync := defaultMainnetSyncConfig
+				cfgSync.Downloader = true
+				cfgSync.Concurrency = 10
+				cfgSync.MinPeers = 10
+				cfgSync.InitStreams = 10
+				cfgSync.DiscSoftLowCap = 10
+				cfgSync.DiscHardLowCap = 10
+				cfgSync.DiscHighCap = 10
+				cfgSync.DiscBatch = 10
+				return cfgSync
 			}(),
 		},
 	}
@@ -1009,6 +1110,7 @@ func TestSyncFlags(t *testing.T) {
 		if !reflect.DeepEqual(hc.Sync, test.expConfig) {
 			t.Errorf("Test %v:\n\t%+v\n\t%+v", i, hc.Sync, test.expConfig)
 		}
+
 		ts.tearDown()
 	}
 }

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -90,8 +90,11 @@ func init() {
 	cli.SetParseErrorHandle(func(err error) {
 		os.Exit(128) // 128 - invalid command line arguments
 	})
-	rootCmd.AddCommand(dumpConfigCmd)
+	configCmd.AddCommand(dumpConfigCmd)
+	configCmd.AddCommand(updateConfigCmd)
+	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(dumpConfigLegacyCmd)
 
 	if err := registerRootCmdFlags(); err != nil {
 		os.Exit(2)
@@ -159,23 +162,40 @@ func raiseFdLimits() error {
 
 func getHarmonyConfig(cmd *cobra.Command) (harmonyConfig, error) {
 	var (
-		config harmonyConfig
-		err    error
+		config         harmonyConfig
+		err            error
+		migratedFrom   string
+		configFile     string
+		isUsingDefault bool
 	)
 	if cli.IsFlagChanged(cmd, configFlag) {
-		configFile := cli.GetStringFlagValue(cmd, configFlag)
-		config, err = loadHarmonyConfig(configFile)
+		configFile = cli.GetStringFlagValue(cmd, configFlag)
+		config, migratedFrom, err = loadHarmonyConfig(configFile)
 	} else {
 		nt := getNetworkType(cmd)
 		config = getDefaultHmyConfigCopy(nt)
+		isUsingDefault = true
 	}
 	if err != nil {
 		return harmonyConfig{}, err
 	}
-	if config.Version != defaultConfig.Version {
-		fmt.Printf("Loaded config version %s which is not latest (%s).\n",
-			config.Version, defaultConfig.Version)
-		fmt.Println("Update saved config with `./harmony dumpconfig [config_file]`")
+	if migratedFrom != defaultConfig.Version && !isUsingDefault {
+		fmt.Printf("Old config version detected %s\n",
+			migratedFrom)
+		stat, _ := os.Stdin.Stat()
+		// Ask to update if only using terminal
+		if stat.Mode()&os.ModeCharDevice != 0 {
+			if promptConfigUpdate() {
+				err := updateConfigFile(configFile)
+				if err != nil {
+					fmt.Printf("Could not update config - %s", err.Error())
+					fmt.Println("Update config manually with `./harmony config update [config_file]`")
+				}
+			}
+
+		} else {
+			fmt.Println("Update saved config with `./harmony config update [config_file]`")
+		}
 	}
 
 	applyRootFlags(cmd, &config)
@@ -193,6 +213,7 @@ func applyRootFlags(cmd *cobra.Command, config *harmonyConfig) {
 	applyLegacyMiscFlags(cmd, config)
 	applyGeneralFlags(cmd, config)
 	applyNetworkFlags(cmd, config)
+	applyDNSSyncFlags(cmd, config)
 	applyP2PFlags(cmd, config)
 	applyHTTPFlags(cmd, config)
 	applyWSFlags(cmd, config)
@@ -300,13 +321,15 @@ func setupNodeAndRun(hc harmonyConfig) {
 
 	// Parse RPC config
 	nodeConfig.RPCServer = nodeconfig.RPCServerConfig{
-		HTTPEnabled:  hc.HTTP.Enabled,
-		HTTPIp:       hc.HTTP.IP,
-		HTTPPort:     hc.HTTP.Port,
-		WSEnabled:    hc.WS.Enabled,
-		WSIp:         hc.WS.IP,
-		WSPort:       hc.WS.Port,
-		DebugEnabled: hc.RPCOpt.DebugEnabled,
+		HTTPEnabled:        hc.HTTP.Enabled,
+		HTTPIp:             hc.HTTP.IP,
+		HTTPPort:           hc.HTTP.Port,
+		WSEnabled:          hc.WS.Enabled,
+		WSIp:               hc.WS.IP,
+		WSPort:             hc.WS.Port,
+		DebugEnabled:       hc.RPCOpt.DebugEnabled,
+		RateLimiterEnabled: hc.RPCOpt.RateLimterEnabled,
+		RequestsPerSecond:  hc.RPCOpt.RequestsPerSecond,
 	}
 
 	// Parse rosetta config
@@ -370,11 +393,11 @@ func setupNodeAndRun(hc harmonyConfig) {
 		setupPrometheusService(currentNode, hc, nodeConfig.ShardID)
 	}
 
-	if hc.Sync.LegacyServer && !hc.General.IsOffline {
+	if hc.DNSSync.Server && !hc.General.IsOffline {
 		utils.Logger().Info().Msg("support gRPC sync server")
-		currentNode.SupportGRPCSyncServer(hc.Sync.LegacyServerPort)
+		currentNode.SupportGRPCSyncServer(hc.DNSSync.ServerPort)
 	}
-	if hc.Sync.LegacyClient && !hc.General.IsOffline {
+	if hc.DNSSync.Client && !hc.General.IsOffline {
 		utils.Logger().Info().Msg("go with gRPC sync client")
 		currentNode.StartGRPCSyncClient()
 	}
@@ -638,15 +661,15 @@ func setupConsensusAndNode(hc harmonyConfig, nodeConfig *nodeconfig.ConfigType) 
 		selfPort := hc.P2P.Port
 		currentNode.SyncingPeerProvider = node.NewLocalSyncingPeerProvider(
 			6000, uint16(selfPort), epochConfig.NumShards(), uint32(epochConfig.NumNodesPerShard()))
-	} else if hc.Network.LegacySyncing {
+	} else if hc.DNSSync.LegacySyncing {
 		currentNode.SyncingPeerProvider = node.NewLegacySyncingPeerProvider(currentNode)
 	} else {
-		currentNode.SyncingPeerProvider = node.NewDNSSyncingPeerProvider(hc.Network.DNSZone, strconv.Itoa(hc.Network.DNSSyncPort))
+		currentNode.SyncingPeerProvider = node.NewDNSSyncingPeerProvider(hc.DNSSync.Zone, strconv.Itoa(hc.DNSSync.Port))
 	}
 
 	// TODO: refactor the creation of blockchain out of node.New()
 	currentConsensus.Blockchain = currentNode.Blockchain()
-	currentNode.NodeConfig.DNSZone = hc.Network.DNSZone
+	currentNode.NodeConfig.DNSZone = hc.DNSSync.Zone
 
 	currentNode.NodeConfig.SetBeaconGroupID(
 		nodeconfig.NewGroupIDByShardID(shard.BeaconChainShardID),

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
 	google.golang.org/grpc v1.33.2
 	google.golang.org/protobuf v1.25.0

--- a/internal/configs/node/config.go
+++ b/internal/configs/node/config.go
@@ -107,6 +107,9 @@ type RPCServerConfig struct {
 	WSPort    int
 
 	DebugEnabled bool
+
+	RateLimiterEnabled bool
+	RequestsPerSecond  int
 }
 
 // RosettaServerConfig is the config for the rosetta server

--- a/internal/configs/node/network.go
+++ b/internal/configs/node/network.go
@@ -57,6 +57,11 @@ const (
 )
 
 const (
+	// DefaultRateLimit for RPC, the number of requests per second
+	DefaultRPCRateLimit = 300
+)
+
+const (
 	// rpcHTTPPortOffset is the port offset for RPC HTTP requests
 	rpcHTTPPortOffset = 500
 

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -70,7 +70,7 @@ func (n Version) Namespace() string {
 
 // StartServers starts the http & ws servers
 func StartServers(hmy *hmy.Harmony, apis []rpc.API, config nodeconfig.RPCServerConfig) error {
-	apis = append(apis, getAPIs(hmy, config.DebugEnabled)...)
+	apis = append(apis, getAPIs(hmy, config.DebugEnabled, config.RateLimiterEnabled, config.RequestsPerSecond)...)
 
 	if config.HTTPEnabled {
 		httpEndpoint = fmt.Sprintf("%v:%v", config.HTTPIp, config.HTTPPort)
@@ -121,15 +121,15 @@ func StopServers() error {
 }
 
 // getAPIs returns all the API methods for the RPC interface
-func getAPIs(hmy *hmy.Harmony, debugEnable bool) []rpc.API {
+func getAPIs(hmy *hmy.Harmony, debugEnable bool, rateLimiterEnable bool, ratelimit int) []rpc.API {
 	publicAPIs := []rpc.API{
 		// Public methods
 		NewPublicHarmonyAPI(hmy, V1),
 		NewPublicHarmonyAPI(hmy, V2),
 		NewPublicHarmonyAPI(hmy, Eth),
-		NewPublicBlockchainAPI(hmy, V1),
-		NewPublicBlockchainAPI(hmy, V2),
-		NewPublicBlockchainAPI(hmy, Eth),
+		NewPublicBlockchainAPI(hmy, V1, rateLimiterEnable, ratelimit),
+		NewPublicBlockchainAPI(hmy, V2, rateLimiterEnable, ratelimit),
+		NewPublicBlockchainAPI(hmy, Eth, rateLimiterEnable, ratelimit),
 		NewPublicContractAPI(hmy, V1),
 		NewPublicContractAPI(hmy, V2),
 		NewPublicContractAPI(hmy, Eth),


### PR DESCRIPTION
## Issue

https://github.com/harmony-one/harmony/issues/3696

- The current PR only supports BlockChain type RPCs, not other RPCs such as TxPool, Contract, etc. Because I don't know if restricting the flow of other RPCs will affect other products（ I'm not sure if I want to add rate limiter to all RPCs）
- I didn't add singleflight to `GetBlockByNumber` because I don't think it has much effect, because this needs to depend on the same key, but for explorer node, a large number of requests are not for the same key, because the block height is different. Unless a large number of requests are for blocks of the same height.

## Usage of rate limiter

- add two flags： `--rpc.ratelimiter` and `--rpc.ratelimit`. Or you can use it in config file, it all the same.
- the flag  `--rpc.ratelimiter` is default enabled, so you can ignore it
- the flag `-rpc.ratelimit` is used for control rate of requests, the value is the number of requests per sencond allowed with rate limiter.the default value is 100 (100/s).

so use rate limiter with shell, need to run as follows:

```bash
./harmony --rpc.ratelimiter --rpc.ratelimit=100
OR
./harmony
```

## Test

Use harmony explorer start a tons of requests, the real rate of requests is equal to config of `--rpc.ratelimit=<requests_per_second>`


## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**


8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**


11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

  **NO**


