### PR TITLE
[stream] make doRequestAsync channel buffered

### DIFF
--- a/p2p/stream/common/requestmanager/requestmanager.go
+++ b/p2p/stream/common/requestmanager/requestmanager.go
@@ -92,7 +92,7 @@ func (rm *requestManager) DoRequest(ctx context.Context, raw sttypes.Request, op
 func (rm *requestManager) doRequestAsync(ctx context.Context, raw sttypes.Request, options ...RequestOption) <-chan responseData {
 	req := &request{
 		Request: raw,
-		respC:   make(chan responseData),
+		respC:   make(chan responseData, 1),
 		doneC:   make(chan struct{}),
 	}
 	for _, opt := range options {


### PR DESCRIPTION
## Issue

A fix to go unit test happened at request manager https://travis-ci.com/github/harmony-one/harmony/jobs/504879644. The problem is that an unbuffered response channel will block manager from delivering response data. After the fix, the unit test timing issue is gone.

This change will not effect `RequestManager` behavior. Only test cases are effected. 

## Test

Tests passed on local harmony rpc tests.

