### PR TITLE
[Rosetta]Implement the /call endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,15 +11,16 @@ require (
 	github.com/beevik/ntp v0.3.0
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/cespare/cp v1.1.1
-	github.com/coinbase/rosetta-sdk-go v0.4.6
+	github.com/coinbase/rosetta-sdk-go v0.6.10
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v1.7.1
-	github.com/ethereum/go-ethereum v1.9.23
+	github.com/ethereum/go-ethereum v1.9.25
 	github.com/fjl/memsize v0.0.0-20180929194037-2a09253e352a // indirect
 	github.com/garslo/gogen v0.0.0-20170307003452-d6ebae628c7c // indirect
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.4.3
 	github.com/golangci/golangci-lint v1.22.2
+	github.com/google/addlicense v0.0.0-20200827091314-d1655b921368 // indirect
 	github.com/gorilla/mux v1.8.0
 	github.com/harmony-ek/gencodec v0.0.0-20190215044613-e6740dbdd846
 	github.com/harmony-one/abool v1.0.1
@@ -47,23 +48,28 @@ require (
 	github.com/rjeczalik/notify v0.9.2
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/rs/zerolog v1.18.0
+	github.com/segmentio/golines v0.0.0-20200824192126-7f30d3046793 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.1
 	github.com/stretchr/testify v1.7.0
 	github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca
+	github.com/vmihailenco/msgpack/v4 v4.3.11 // indirect
 	go.uber.org/ratelimit v0.1.0
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	golang.org/x/tools/gopls v0.4.4 // indirect
 	google.golang.org/grpc v1.33.2
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200619000410-60c24ae608a6
 	gopkg.in/yaml.v2 v2.3.0
+	honnef.co/go/tools v0.0.1-2020.1.5 // indirect
+	mvdan.cc/gofumpt v0.0.0-20200802201014-ab5a8192947d // indirect
 )
 
 replace github.com/ethereum/go-ethereum => github.com/ethereum/go-ethereum v1.9.9

--- a/node/api.go
+++ b/node/api.go
@@ -84,7 +84,7 @@ func (node *Node) StopRPC() error {
 // StartRosetta start rosetta service
 func (node *Node) StartRosetta() error {
 	harmony := hmy.New(node, node.TxPool, node.CxPool, node.Consensus.ShardID)
-	return rosetta.StartServers(harmony, node.NodeConfig.RosettaServer)
+	return rosetta.StartServers(harmony, node.NodeConfig.RosettaServer, node.NodeConfig.RPCServer.RateLimiterEnabled, node.NodeConfig.RPCServer.RequestsPerSecond)
 }
 
 // StopRosetta stops rosetta service

--- a/rosetta/common/errors.go
+++ b/rosetta/common/errors.go
@@ -86,6 +86,34 @@ var (
 		Message:   "invalid staking transaction construction",
 		Retriable: false,
 	}
+
+	// ErrCallParametersInvalid ..
+	ErrCallParametersInvalid = types.Error{
+		Code:      11,
+		Message:   "invalid call parameters",
+		Retriable: false,
+	}
+
+	// ErrCallExecute ..
+	ErrCallExecute = types.Error{
+		Code:      12,
+		Message:   "call execute error",
+		Retriable: false,
+	}
+
+	// ErrCallMethodInvalid ..
+	ErrCallMethodInvalid = types.Error{
+		Code:      13,
+		Message:   "call method invalid",
+		Retriable: false,
+	}
+
+	// ErrGetStakingInfo ..
+	ErrGetStakingInfo = types.Error{
+		Code:      14,
+		Message:   "get staking info error",
+		Retriable: false,
+	}
 )
 
 // NewError create a new error with a given detail structure

--- a/rosetta/rosetta.go
+++ b/rosetta/rosetta.go
@@ -37,7 +37,7 @@ func StartServers(hmy *hmy.Harmony, config nodeconfig.RosettaServerConfig) error
 	serverAsserter, err := asserter.NewServer(
 		append(common.PlainOperationTypes, common.StakingOperationTypes...),
 		nodeconfig.GetShardConfig(hmy.ShardID).Role() == nodeconfig.ExplorerNode,
-		[]*types.NetworkIdentifier{network},
+		[]*types.NetworkIdentifier{network}, services.CallMethod, false,
 	)
 	if err != nil {
 		return err
@@ -84,6 +84,7 @@ func getRouter(asserter *asserter.Asserter, hmy *hmy.Harmony) http.Handler {
 		server.NewMempoolAPIController(services.NewMempoolAPI(hmy), asserter),
 		server.NewNetworkAPIController(services.NewNetworkAPI(hmy), asserter),
 		server.NewConstructionAPIController(services.NewConstructionAPI(hmy), asserter),
+		server.NewCallAPIController(services.NewCallAPIService(hmy), asserter),
 	)
 }
 

--- a/rosetta/services/account.go
+++ b/rosetta/services/account.go
@@ -21,6 +21,10 @@ type AccountAPI struct {
 	hmy *hmy.Harmony
 }
 
+func (s *AccountAPI) AccountCoins(ctx context.Context, request *types.AccountCoinsRequest) (*types.AccountCoinsResponse, *types.Error) {
+	panic("implement me")
+}
+
 // NewAccountAPI creates a new instance of a BlockAPI.
 func NewAccountAPI(hmy *hmy.Harmony) server.AccountAPIServicer {
 	return &AccountAPI{

--- a/rosetta/services/call_service.go
+++ b/rosetta/services/call_service.go
@@ -1,0 +1,552 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/coinbase/rosetta-sdk-go/server"
+	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/harmony-one/harmony/hmy"
+	"github.com/harmony-one/harmony/rosetta/common"
+	rpc2 "github.com/harmony-one/harmony/rpc"
+	"github.com/pkg/errors"
+)
+
+var CallMethod = []string{
+	"hmyv2_call",
+	"hmyv2_getCode",
+	"hmyv2_getStorageAt",
+	"hmyv2_getDelegationsByDelegator",
+	"hmyv2_getDelegationsByDelegatorByBlockNumber",
+	"hmyv2_getDelegationsByValidator",
+	"hmyv2_getAllValidatorAddresses",
+	"hmyv2_getAllValidatorInformation",
+	"hmyv2_getAllValidatorInformationByBlockNumber",
+	"hmyv2_getElectedValidatorAddresses",
+	"hmyv2_getValidatorInformation",
+	"hmyv2_getCurrentUtilityMetrics",
+	"hmyv2_getMedianRawStakeSnapshot",
+	"hmyv2_getStakingNetworkInfo",
+	"hmyv2_getSuperCommittees",
+}
+
+type CallAPIService struct {
+	hmy                 *hmy.Harmony
+	publicContractAPI   rpc.API
+	publicStakingAPI    rpc.API
+	publicBlockChainAPI rpc.API
+}
+
+// Call implements the /call endpoint.
+func (c *CallAPIService) Call(
+	ctx context.Context, request *types.CallRequest,
+) (*types.CallResponse, *types.Error) {
+	switch request.Method {
+	case "hmyv2_call":
+		return c.call(ctx, request)
+	case "hmyv2_getCode":
+		return c.getCode(ctx, request)
+	case "hmyv2_getStorageAt":
+		return c.getStorageAt(ctx, request)
+	case "hmyv2_getDelegationsByDelegator":
+		return c.getDelegationsByDelegator(ctx, request)
+	case "hmyv2_getDelegationsByDelegatorByBlockNumber":
+		return c.getDelegationsByDelegatorByBlockNumber(ctx, request)
+	case "hmyv2_getDelegationsByValidator":
+		return c.getDelegationsByValidator(ctx, request)
+	case "hmyv2_getAllValidatorAddresses":
+		return c.getAllValidatorAddresses(ctx)
+	case "hmyv2_getAllValidatorInformation":
+		return c.getAllValidatorInformation(ctx, request)
+	case "hmyv2_getAllValidatorInformationByBlockNumber":
+		return c.getAllValidatorInformationByBlockNumber(ctx, request)
+	case "hmyv2_getElectedValidatorAddresses":
+		return c.getElectedValidatorAddresses(ctx)
+	case "hmyv2_getValidatorInformation":
+		return c.getValidatorInformation(ctx, request)
+	case "hmyv2_getCurrentUtilityMetrics":
+		return c.getCurrentUtilityMetrics()
+	case "hmyv2_getMedianRawStakeSnapshot":
+		return c.getMedianRawStakeSnapshot()
+	case "hmyv2_getStakingNetworkInfo":
+		return c.getStakingNetworkInfo(ctx)
+	case "hmyv2_getSuperCommittees":
+		return c.getSuperCommittees()
+	}
+
+	return nil, common.NewError(common.ErrCallMethodInvalid, map[string]interface{}{
+		"message": "method not supported",
+	})
+
+}
+
+func NewCallAPIService(hmy *hmy.Harmony) server.CallAPIServicer {
+	return &CallAPIService{
+		hmy:                 hmy,
+		publicContractAPI:   rpc2.NewPublicContractAPI(hmy, rpc2.V2),
+		publicStakingAPI:    rpc2.NewPublicStakingAPI(hmy, rpc2.V2),
+		publicBlockChainAPI: rpc2.NewPublicBlockchainAPI(hmy, rpc2.V2),
+	}
+}
+
+func (c *CallAPIService) getSuperCommittees() (*types.CallResponse, *types.Error) {
+	committees, err := c.hmy.GetSuperCommittees()
+	if err != nil {
+		return nil, common.NewError(common.ErrGetStakingInfo, map[string]interface{}{
+			"message": errors.WithMessage(err, "get super committees error").Error(),
+		})
+	}
+	return &types.CallResponse{
+		Result: map[string]interface{}{
+			"result": committees,
+		},
+	}, nil
+}
+
+func (c *CallAPIService) getStakingNetworkInfo(
+	ctx context.Context,
+) (*types.CallResponse, *types.Error) {
+	publicBlockChainAPI := c.publicBlockChainAPI.Service.(*rpc2.PublicBlockchainService)
+	resp, err := publicBlockChainAPI.GetStakingNetworkInfo(ctx)
+	if err != nil {
+		return nil, common.NewError(common.ErrGetStakingInfo, map[string]interface{}{
+			"message": errors.WithMessage(err, "get staking network info error").Error(),
+		})
+	}
+	return &types.CallResponse{
+		Result: map[string]interface{}{
+			"result": resp,
+		},
+	}, nil
+}
+
+func (c *CallAPIService) getMedianRawStakeSnapshot() (*types.CallResponse, *types.Error) {
+	snapshot, err := c.hmy.GetMedianRawStakeSnapshot()
+	if err != nil {
+		return nil, common.NewError(common.ErrGetStakingInfo, map[string]interface{}{
+			"message": errors.WithMessage(err, "get median raw stake snapshot error").Error(),
+		})
+	}
+	return &types.CallResponse{
+		Result: map[string]interface{}{
+			"result": snapshot,
+		},
+	}, nil
+}
+
+func (c *CallAPIService) getCurrentUtilityMetrics() (*types.CallResponse, *types.Error) {
+	metric, err := c.hmy.GetCurrentUtilityMetrics()
+	if err != nil {
+		return nil, common.NewError(common.ErrGetStakingInfo, map[string]interface{}{
+			"message": errors.WithMessage(err, "get current utility metrics error").Error(),
+		})
+	}
+	return &types.CallResponse{
+		Result: map[string]interface{}{
+			"result": metric,
+		},
+	}, nil
+}
+
+func (c *CallAPIService) getValidatorInformation(
+	ctx context.Context, request *types.CallRequest,
+) (*types.CallResponse, *types.Error) {
+	stakingAPI := c.publicStakingAPI.Service.(*rpc2.PublicStakingService)
+	args := GetValidatorInformationRequest{}
+	if err := args.UnmarshalFromInterface(request.Parameters); err != nil {
+		return nil, common.NewError(common.ErrCallParametersInvalid, map[string]interface{}{
+			"message": errors.WithMessage(err, "invalid parameters").Error(),
+		})
+	}
+	resp, err := stakingAPI.GetValidatorInformation(ctx, args.ValidatorAddr)
+	if err != nil {
+		return nil, common.NewError(common.ErrGetStakingInfo, map[string]interface{}{
+			"message": errors.WithMessage(err, "get validator information error").Error(),
+		})
+	}
+	return &types.CallResponse{
+		Result: map[string]interface{}{
+			"result": resp,
+		},
+	}, nil
+}
+
+func (c *CallAPIService) getElectedValidatorAddresses(
+	ctx context.Context,
+) (*types.CallResponse, *types.Error) {
+	stakingAPI := c.publicStakingAPI.Service.(*rpc2.PublicStakingService)
+	addresses, err := stakingAPI.GetElectedValidatorAddresses(ctx)
+	if err != nil {
+		return nil, common.NewError(common.ErrGetStakingInfo, map[string]interface{}{
+			"message": errors.WithMessage(err, "get elected validator addresses error").Error(),
+		})
+	}
+	return &types.CallResponse{
+		Result: map[string]interface{}{
+			"result": addresses,
+		},
+	}, nil
+}
+
+func (c *CallAPIService) getAllValidatorInformationByBlockNumber(
+	ctx context.Context, request *types.CallRequest,
+) (*types.CallResponse, *types.Error) {
+	stakingAPI := c.publicStakingAPI.Service.(*rpc2.PublicStakingService)
+	args := GetAllValidatorInformationByBlockNumberRequest{}
+	if err := args.UnmarshalFromInterface(request.Parameters); err != nil {
+		return nil, common.NewError(common.ErrCallParametersInvalid, map[string]interface{}{
+			"message": errors.WithMessage(err, "invalid parameters").Error(),
+		})
+	}
+	resp, err := stakingAPI.GetAllValidatorInformationByBlockNumber(ctx, args.PageNumber, rpc2.BlockNumber(args.BlockNumber))
+	if err != nil {
+		return nil, common.NewError(common.ErrGetStakingInfo, map[string]interface{}{
+			"message": errors.WithMessage(err, "get all validator information by block number error").Error(),
+		})
+	}
+	return &types.CallResponse{
+		Result: map[string]interface{}{
+			"result": resp,
+		},
+	}, nil
+}
+
+func (c *CallAPIService) getAllValidatorInformation(
+	ctx context.Context, request *types.CallRequest,
+) (*types.CallResponse, *types.Error) {
+	stakingAPI := c.publicStakingAPI.Service.(*rpc2.PublicStakingService)
+	args := GetAllValidatorInformationRequest{}
+	if err := args.UnmarshalFromInterface(request.Parameters); err != nil {
+		return nil, common.NewError(common.ErrCallParametersInvalid, map[string]interface{}{
+			"message": errors.WithMessage(err, "invalid parameters").Error(),
+		})
+	}
+	resp, err := stakingAPI.GetAllValidatorInformation(ctx, args.PageNumber)
+	if err != nil {
+		return nil, common.NewError(common.ErrGetStakingInfo, map[string]interface{}{
+			"message": errors.WithMessage(err, "get all validator information error").Error(),
+		})
+	}
+	return &types.CallResponse{
+		Result: map[string]interface{}{
+			"result": resp,
+		},
+	}, nil
+
+}
+
+func (c *CallAPIService) getAllValidatorAddresses(
+	ctx context.Context,
+) (*types.CallResponse, *types.Error) {
+	stakingAPI := c.publicStakingAPI.Service.(*rpc2.PublicStakingService)
+	addresses, err := stakingAPI.GetAllValidatorAddresses(ctx)
+	if err != nil {
+		return nil, common.NewError(common.ErrGetStakingInfo, map[string]interface{}{
+			"message": errors.WithMessage(err, "get all validator addresses error").Error(),
+		})
+	}
+	return &types.CallResponse{
+		Result: map[string]interface{}{
+			"result": addresses,
+		},
+	}, nil
+}
+
+func (c *CallAPIService) getDelegationsByValidator(
+	ctx context.Context, request *types.CallRequest,
+) (*types.CallResponse, *types.Error) {
+	stakingAPI := c.publicStakingAPI.Service.(*rpc2.PublicStakingService)
+	args := GetDelegationsByValidatorRequest{}
+	if err := args.UnmarshalFromInterface(request.Parameters); err != nil {
+		return nil, common.NewError(common.ErrCallParametersInvalid, map[string]interface{}{
+			"message": errors.WithMessage(err, "invalid parameters").Error(),
+		})
+	}
+	resp, err := stakingAPI.GetDelegationsByValidator(ctx, args.ValidatorAddr)
+	if err != nil {
+		return nil, common.NewError(common.ErrGetStakingInfo, map[string]interface{}{
+			"message": errors.WithMessage(err, "get delegations by validator error").Error(),
+		})
+	}
+	return &types.CallResponse{
+		Result: map[string]interface{}{
+			"result": resp,
+		},
+	}, nil
+}
+
+func (c *CallAPIService) getDelegationsByDelegatorByBlockNumber(
+	ctx context.Context, request *types.CallRequest,
+) (*types.CallResponse, *types.Error) {
+	stakingAPI := c.publicStakingAPI.Service.(*rpc2.PublicStakingService)
+	args := GetDelegationByDelegatorAddrAndBlockNumRequest{}
+	if err := args.UnmarshalFromInterface(request.Parameters); err != nil {
+		return nil, common.NewError(common.ErrCallParametersInvalid, map[string]interface{}{
+			"message": errors.WithMessage(err, "invalid parameters").Error(),
+		})
+	}
+	resp, err := stakingAPI.GetDelegationsByDelegatorByBlockNumber(ctx, args.DelegatorAddr, rpc2.BlockNumber(args.BlockNum))
+	if err != nil {
+		return nil, common.NewError(common.ErrGetStakingInfo, map[string]interface{}{
+			"message": errors.WithMessage(err, "get delegations by delegator and number error").Error(),
+		})
+	}
+	return &types.CallResponse{
+		Result: map[string]interface{}{
+			"result": resp,
+		},
+	}, nil
+}
+
+func (c *CallAPIService) getDelegationsByDelegator(
+	ctx context.Context, request *types.CallRequest,
+) (*types.CallResponse, *types.Error) {
+	stakingAPI := c.publicStakingAPI.Service.(*rpc2.PublicStakingService)
+	args := GetDelegationsByDelegatorAddrRequest{}
+	if err := args.UnmarshalFromInterface(request.Parameters); err != nil {
+		return nil, common.NewError(common.ErrCallParametersInvalid, map[string]interface{}{
+			"message": errors.WithMessage(err, "invalid parameters").Error(),
+		})
+	}
+	resp, err := stakingAPI.GetDelegationsByDelegator(ctx, args.DelegatorAddr)
+	if err != nil {
+		return nil, common.NewError(common.ErrGetStakingInfo, map[string]interface{}{
+			"message": errors.WithMessage(err, "get delegations by delegator error").Error(),
+		})
+	}
+	return &types.CallResponse{
+		Result: map[string]interface{}{
+			"result": resp,
+		},
+	}, nil
+}
+
+func (c *CallAPIService) getStorageAt(
+	ctx context.Context, request *types.CallRequest,
+) (*types.CallResponse, *types.Error) {
+	contractAPI := c.publicContractAPI.Service.(*rpc2.PublicContractService)
+	args := GetStorageAtRequest{}
+	if err := args.UnmarshalFromInterface(request.Parameters); err != nil {
+		return nil, common.NewError(common.ErrCallParametersInvalid, map[string]interface{}{
+			"message": errors.WithMessage(err, "invalid parameters").Error(),
+		})
+	}
+
+	res, err := contractAPI.GetStorageAt(ctx, args.Addr, args.Key, rpc2.BlockNumber(args.BlockNum))
+	if err != nil {
+		return nil, common.NewError(common.ErrCallExecute, map[string]interface{}{
+			"message": errors.WithMessage(err, "get storage at error").Error(),
+		})
+	}
+	return &types.CallResponse{
+		Result: map[string]interface{}{
+			"result": res.String(),
+		},
+	}, nil
+}
+
+func (c *CallAPIService) getCode(
+	ctx context.Context, request *types.CallRequest,
+) (*types.CallResponse, *types.Error) {
+	contractAPI := c.publicContractAPI.Service.(*rpc2.PublicContractService)
+	args := GetCodeRequest{}
+	if err := args.UnmarshalFromInterface(request.Parameters); err != nil {
+		return nil, common.NewError(common.ErrCallParametersInvalid, map[string]interface{}{
+			"message": errors.WithMessage(err, "invalid parameters").Error(),
+		})
+	}
+	code, err := contractAPI.GetCode(ctx, args.Addr, rpc2.BlockNumber(args.BlockNum))
+	if err != nil {
+		return nil, common.NewError(common.ErrCallExecute, map[string]interface{}{
+			"message": errors.WithMessage(err, "get code error").Error(),
+		})
+	}
+	return &types.CallResponse{
+		Result: map[string]interface{}{
+			"result": code.String(),
+		},
+	}, nil
+}
+
+func (c *CallAPIService) call(
+	ctx context.Context, request *types.CallRequest,
+) (*types.CallResponse, *types.Error) {
+	contractAPI := c.publicContractAPI.Service.(*rpc2.PublicContractService)
+	args := CallRequest{}
+	if err := args.UnmarshalFromInterface(request.Parameters); err != nil {
+		return nil, common.NewError(common.ErrCallParametersInvalid, map[string]interface{}{
+			"message": errors.WithMessage(err, "invalid parameters").Error(),
+		})
+	}
+	data, err := contractAPI.Call(ctx, args.CallArgs, rpc2.BlockNumber(args.BlockNum))
+	if err != nil {
+		return nil, common.NewError(common.ErrCallExecute, map[string]interface{}{
+			"message": errors.WithMessage(err, "call smart contract error").Error(),
+		})
+	}
+	return &types.CallResponse{
+		Result: map[string]interface{}{
+			"result": data.String(),
+		},
+	}, nil
+}
+
+type CallRequest struct {
+	rpc2.CallArgs
+	BlockNum int64 `json:"block_num"`
+}
+
+func (cr *CallRequest) UnmarshalFromInterface(args interface{}) error {
+	var callRequest CallRequest
+	data, err := json.Marshal(args)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &callRequest); err != nil {
+		return err
+	}
+	*cr = callRequest
+	return nil
+}
+
+type GetCodeRequest struct {
+	Addr     string `json:"addr"`
+	BlockNum int64  `json:"block_num"`
+}
+
+func (cr *GetCodeRequest) UnmarshalFromInterface(args interface{}) error {
+	var getCodeRequest GetCodeRequest
+	data, err := json.Marshal(args)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &getCodeRequest); err != nil {
+		return err
+	}
+	*cr = getCodeRequest
+	return nil
+}
+
+type GetStorageAtRequest struct {
+	Addr     string `json:"addr"`
+	Key      string `json:"key"`
+	BlockNum int64  `json:"block_num"`
+}
+
+func (sr *GetStorageAtRequest) UnmarshalFromInterface(args interface{}) error {
+	var getStorageAt GetStorageAtRequest
+	data, err := json.Marshal(args)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &getStorageAt); err != nil {
+		return err
+	}
+	*sr = getStorageAt
+	return nil
+}
+
+type GetDelegationsByDelegatorAddrRequest struct {
+	DelegatorAddr string `json:"delegator_addr"`
+}
+
+func (r *GetDelegationsByDelegatorAddrRequest) UnmarshalFromInterface(args interface{}) error {
+	var getDelegationsByDelegatorAddrRequest GetDelegationsByDelegatorAddrRequest
+	data, err := json.Marshal(args)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &getDelegationsByDelegatorAddrRequest); err != nil {
+		return err
+	}
+	*r = getDelegationsByDelegatorAddrRequest
+	return nil
+}
+
+type GetDelegationByDelegatorAddrAndBlockNumRequest struct {
+	DelegatorAddr string `json:"delegator_addr"`
+	BlockNum      int64  `json:"block_num"`
+}
+
+func (r *GetDelegationByDelegatorAddrAndBlockNumRequest) UnmarshalFromInterface(args interface{}) error {
+	var getDelegationByDelegatorAddrAndBlockNumRequest GetDelegationByDelegatorAddrAndBlockNumRequest
+	data, err := json.Marshal(args)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &getDelegationByDelegatorAddrAndBlockNumRequest); err != nil {
+		return err
+	}
+	*r = getDelegationByDelegatorAddrAndBlockNumRequest
+	return nil
+}
+
+type GetDelegationsByValidatorRequest struct {
+	ValidatorAddr string `json:"validator_addr"`
+}
+
+func (r *GetDelegationsByValidatorRequest) UnmarshalFromInterface(args interface{}) error {
+	var getDelegationsByValidatorRequest GetDelegationsByValidatorRequest
+	data, err := json.Marshal(args)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &getDelegationsByValidatorRequest); err != nil {
+		return err
+	}
+	*r = getDelegationsByValidatorRequest
+	return nil
+}
+
+type GetAllValidatorInformationRequest struct {
+	PageNumber int `json:"page_number"`
+}
+
+func (r *GetAllValidatorInformationRequest) UnmarshalFromInterface(args interface{}) error {
+	var getAllValidatorInformationRequest GetAllValidatorInformationRequest
+	data, err := json.Marshal(args)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &getAllValidatorInformationRequest); err != nil {
+		return err
+	}
+	*r = getAllValidatorInformationRequest
+	return nil
+}
+
+type GetAllValidatorInformationByBlockNumberRequest struct {
+	PageNumber  int   `json:"page_number"`
+	BlockNumber int64 `json:"block_number"`
+}
+
+func (r *GetAllValidatorInformationByBlockNumberRequest) UnmarshalFromInterface(args interface{}) error {
+	var getAllValidatorInformationByBlockNumber GetAllValidatorInformationByBlockNumberRequest
+	data, err := json.Marshal(args)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &getAllValidatorInformationByBlockNumber); err != nil {
+		return err
+	}
+	*r = getAllValidatorInformationByBlockNumber
+	return nil
+}
+
+type GetValidatorInformationRequest struct {
+	ValidatorAddr string `json:"validator_addr"`
+}
+
+func (r *GetValidatorInformationRequest) UnmarshalFromInterface(args interface{}) error {
+	var getValidatorInformationRequest GetValidatorInformationRequest
+	data, err := json.Marshal(args)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &getValidatorInformationRequest); err != nil {
+		return err
+	}
+	*r = getValidatorInformationRequest
+	return nil
+}

--- a/rosetta/services/call_service_test.go
+++ b/rosetta/services/call_service_test.go
@@ -1,0 +1,51 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCallRequest_UnmarshalFromInterface(t *testing.T) {
+	args := map[string]interface{}{
+		"to":        "0x08AE1abFE01aEA60a47663bCe0794eCCD5763c19",
+		"block_num": 370000,
+	}
+	callRequest := &CallRequest{}
+	err := callRequest.UnmarshalFromInterface(args)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	assert.Equal(t, callRequest.To.String(), "0x08AE1abFE01aEA60a47663bCe0794eCCD5763c19")
+	assert.Equal(t, callRequest.BlockNum, int64(370000))
+}
+
+func TestGetCodeRequest_UnmarshalFromInterface(t *testing.T) {
+	args := map[string]interface{}{
+		"addr":      "0x08AE1abFE01aEA60a47663bCe0794eCCD5763c19",
+		"block_num": 370000,
+	}
+	getCodeRequest := &GetCodeRequest{}
+	err := getCodeRequest.UnmarshalFromInterface(args)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	assert.Equal(t, getCodeRequest.Addr, "0x08AE1abFE01aEA60a47663bCe0794eCCD5763c19")
+	assert.Equal(t, getCodeRequest.BlockNum, int64(370000))
+}
+
+func TestGetStorageAtRequest_UnmarshalFromInterface(t *testing.T) {
+	args := map[string]interface{}{
+		"addr":      "0x295a70b2de5e3953354a6a8344e616ed314d7251",
+		"key":       "0x0",
+		"block_num": 370000,
+	}
+	getStorageAtRequest := &GetStorageAtRequest{}
+	err := getStorageAtRequest.UnmarshalFromInterface(args)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	assert.Equal(t, getStorageAtRequest.Addr, "0x295a70b2de5e3953354a6a8344e616ed314d7251")
+	assert.Equal(t, getStorageAtRequest.Key, "0x0")
+	assert.Equal(t, getStorageAtRequest.BlockNum, int64(370000))
+}

--- a/rosetta/services/construction_parse.go
+++ b/rosetta/services/construction_parse.go
@@ -65,7 +65,6 @@ func parseUnsignedTransaction(
 		})
 	}
 
-	// TODO (dm): implement intended receipt for staking transactions
 	intendedReceipt := &hmyTypes.Receipt{
 		GasUsed: tx.GasLimit(),
 	}
@@ -86,7 +85,7 @@ func parseUnsignedTransaction(
 			foundSender = true
 			op.Account = wrappedTransaction.From
 		}
-		op.Status = ""
+		op.Status = nil
 	}
 	if !foundSender {
 		return nil, common.NewError(common.CatchAllError, map[string]interface{}{
@@ -108,7 +107,6 @@ func parseSignedTransaction(
 		})
 	}
 
-	// TODO (dm): implement intended receipt for staking transactions
 	intendedReceipt := &hmyTypes.Receipt{
 		GasUsed: tx.GasLimit(),
 	}
@@ -134,7 +132,7 @@ func parseSignedTransaction(
 		})
 	}
 	for _, op := range formattedTx.Operations {
-		op.Status = ""
+		op.Status = nil
 	}
 	return &types.ConstructionParseResponse{
 		Operations:               formattedTx.Operations,

--- a/rosetta/services/construction_parse_test.go
+++ b/rosetta/services/construction_parse_test.go
@@ -62,7 +62,7 @@ func TestParseUnsignedTransaction(t *testing.T) {
 		t.Fatal(rosettaError)
 	}
 	for _, op := range parsedResponse.Operations {
-		if op.Status != "" {
+		if op.Status != nil {
 			t.Error("expect operation status to be empty for construction")
 		}
 	}
@@ -144,7 +144,7 @@ func TestParseSignedTransaction(t *testing.T) {
 		t.Fatal(rosettaError)
 	}
 	for _, op := range parsedResponse.Operations {
-		if op.Status != "" {
+		if op.Status != nil {
 			t.Error("expect operation status to be empty for construction")
 		}
 	}

--- a/rosetta/services/network.go
+++ b/rosetta/services/network.go
@@ -117,8 +117,9 @@ func (s *NetworkAPI) NetworkStatus(
 	}
 
 	targetInt := int64(targetHeight)
+	currentIndex := currentHeader.Number().Int64()
 	ss := &types.SyncStatus{
-		CurrentIndex: currentHeader.Number().Int64(),
+		CurrentIndex: &currentIndex,
 		TargetIndex:  &targetInt,
 		Stage:        &stage,
 	}

--- a/rosetta/services/tx_format.go
+++ b/rosetta/services/tx_format.go
@@ -146,7 +146,7 @@ func FormatCrossShardReceiverTransaction(
 					Index: 0, // There is no gas expenditure for cross-shard transaction payout
 				},
 				Type:    common.NativeCrossShardTransferOperation,
-				Status:  common.SuccessOperationStatus.Status,
+				Status:  &common.SuccessOperationStatus.Status,
 				Account: receiverAccountID,
 				Amount: &types.Amount{
 					Value:    cxReceipt.Amount.String(),

--- a/rosetta/services/tx_format_test.go
+++ b/rosetta/services/tx_format_test.go
@@ -263,7 +263,7 @@ func TestFormatCrossShardReceiverTransaction(t *testing.T) {
 				Index: 0, // There is no gas expenditure for cross-shard payout
 			},
 			Type:    common.NativeCrossShardTransferOperation,
-			Status:  common.SuccessOperationStatus.Status,
+			Status:  &common.SuccessOperationStatus.Status,
 			Account: receiverAccID,
 			Amount: &types.Amount{
 				Value:    fmt.Sprintf("%v", tx.Value().Uint64()),

--- a/rosetta/services/tx_operation.go
+++ b/rosetta/services/tx_operation.go
@@ -280,7 +280,7 @@ func GetSideEffectOperationsFromGenesisSpec(
 }
 
 // GetTransactionStatus for any valid harmony transaction given its receipt.
-func GetTransactionStatus(tx hmytypes.PoolTransaction, receipt *hmytypes.Receipt) string {
+func GetTransactionStatus(tx hmytypes.PoolTransaction, receipt *hmytypes.Receipt) *string {
 	if _, ok := tx.(*hmytypes.Transaction); ok {
 		status := common.SuccessOperationStatus.Status
 		if receipt.Status == hmytypes.ReceiptStatusFailed {
@@ -290,12 +290,12 @@ func GetTransactionStatus(tx hmytypes.PoolTransaction, receipt *hmytypes.Receipt
 				status = common.ContractFailureOperationStatus.Status
 			}
 		}
-		return status
+		return &status
 	} else if _, ok := tx.(*stakingTypes.StakingTransaction); ok {
-		return common.SuccessOperationStatus.Status
+		return &common.SuccessOperationStatus.Status
 	}
 	// Type of tx unknown, so default to failure
-	return common.FailureOperationStatus.Status
+	return &common.FailureOperationStatus.Status
 }
 
 // getBasicTransferNativeOperations extracts & formats the basic native operations for non-staking transaction.
@@ -321,7 +321,7 @@ func getBasicTransferNativeOperations(
 		return nil, rosettaError
 	}
 
-	return newSameShardTransferNativeOperations(from, to, tx.Value(), status, startingOperationIndex), nil
+	return newSameShardTransferNativeOperations(from, to, tx.Value(), *status, startingOperationIndex), nil
 }
 
 // getContractTransferNativeOperations extracts & formats the native operations for any
@@ -341,7 +341,7 @@ func getContractTransferNativeOperations(
 	status := GetTransactionStatus(tx, receipt)
 	startingIndex := basicOps[len(basicOps)-1].OperationIdentifier.Index + 1
 	internalTxOps, rosettaError := getContractInternalTransferNativeOperations(
-		contractInfo.ExecutionResult, status, &startingIndex,
+		contractInfo.ExecutionResult, *status, &startingIndex,
 	)
 	if rosettaError != nil {
 		return nil, rosettaError
@@ -368,7 +368,7 @@ func getContractCreationNativeOperations(
 	status := GetTransactionStatus(tx, receipt)
 	startingIndex := basicOps[len(basicOps)-1].OperationIdentifier.Index + 1
 	internalTxOps, rosettaError := getContractInternalTransferNativeOperations(
-		contractInfo.ExecutionResult, status, &startingIndex,
+		contractInfo.ExecutionResult, *status, &startingIndex,
 	)
 	if rosettaError != nil {
 		return nil, rosettaError
@@ -466,7 +466,7 @@ func getCrossShardSenderTransferNativeOperations(
 				Index: opIndex,
 			},
 			Type:    common.NativeCrossShardTransferOperation,
-			Status:  common.SuccessOperationStatus.Status,
+			Status:  &common.SuccessOperationStatus.Status,
 			Account: senderAccountID,
 			Amount: &types.Amount{
 				Value:    negativeBigValue(tx.Value()),
@@ -499,7 +499,7 @@ func getSideEffectOperationsFromUndelegationPayoutsMap(
 				Index: opIndex,
 			},
 			Type:    opType,
-			Status:  common.SuccessOperationStatus.Status,
+			Status:  &common.SuccessOperationStatus.Status,
 			Account: accID,
 		}
 
@@ -547,7 +547,7 @@ func getOperationAndTotalAmountFromUndelegationMap(
 				relatedOpIdentifier,
 			},
 			Type:    opType,
-			Status:  common.SuccessOperationStatus.Status,
+			Status:  &common.SuccessOperationStatus.Status,
 			Account: subAccId,
 			Amount: &types.Amount{
 				Value:    negativeBigValue(amount),
@@ -582,7 +582,7 @@ func getSideEffectOperationsFromValueMap(
 				Index: opIndex,
 			},
 			Type:    opType,
-			Status:  common.SuccessOperationStatus.Status,
+			Status:  &common.SuccessOperationStatus.Status,
 			Account: accID,
 			Amount: &types.Amount{
 				Value:    value.String(),
@@ -694,7 +694,7 @@ func newSameShardTransferNativeOperations(
 		{
 			OperationIdentifier: subOperationID,
 			Type:                common.NativeTransferOperation,
-			Status:              status,
+			Status:              &status,
 			Account:             from,
 			Amount:              subAmount,
 		},
@@ -702,7 +702,7 @@ func newSameShardTransferNativeOperations(
 			OperationIdentifier: addOperationID,
 			RelatedOperations:   addRelatedID,
 			Type:                common.NativeTransferOperation,
-			Status:              status,
+			Status:              &status,
 			Account:             to,
 			Amount:              addAmount,
 		},
@@ -720,7 +720,7 @@ func newNativeOperationsWithGas(
 				Index: 0, // gas operation is always first
 			},
 			Type:    common.ExpendGasOperation,
-			Status:  common.SuccessOperationStatus.Status,
+			Status:  &common.SuccessOperationStatus.Status,
 			Account: accountID,
 			Amount: &types.Amount{
 				Value:    negativeBigValue(gasFeeInATTO),

--- a/rosetta/services/tx_operation_test.go
+++ b/rosetta/services/tx_operation_test.go
@@ -67,7 +67,7 @@ func TestGetStakingOperationsFromCreateValidator(t *testing.T) {
 	refOperations = append(refOperations, &types.Operation{
 		OperationIdentifier: &types.OperationIdentifier{Index: 1},
 		Type:                tx.StakingType().String(),
-		Status:              common.SuccessOperationStatus.Status,
+		Status:              &common.SuccessOperationStatus.Status,
 		Account:             senderAccID,
 		Amount: &types.Amount{
 			Value:    negativeBigValue(tenOnes),
@@ -210,7 +210,7 @@ func TestGetStakingOperationsFromDelegate(t *testing.T) {
 	refOperations = append(refOperations, &types.Operation{
 		OperationIdentifier: &types.OperationIdentifier{Index: 1},
 		Type:                tx.StakingType().String(),
-		Status:              common.SuccessOperationStatus.Status,
+		Status:              &common.SuccessOperationStatus.Status,
 		Account:             senderAccID,
 		Amount: &types.Amount{
 			Value:    negativeBigValue(tenOnes),
@@ -226,7 +226,7 @@ func TestGetStakingOperationsFromDelegate(t *testing.T) {
 			},
 		},
 		Type:    tx.StakingType().String(),
-		Status:  common.SuccessOperationStatus.Status,
+		Status:  &common.SuccessOperationStatus.Status,
 		Account: senderAccIDWithSubAccount,
 		Amount: &types.Amount{
 			Value:    tenOnes.String(),
@@ -271,7 +271,7 @@ func TestGetSideEffectOperationsFromUndelegationPayouts(t *testing.T) {
 	refOperations = append(refOperations, &types.Operation{
 		OperationIdentifier: &types.OperationIdentifier{Index: 0},
 		Type:                UndelegationPayout,
-		Status:              common.SuccessOperationStatus.Status,
+		Status:              &common.SuccessOperationStatus.Status,
 		Account:             receiverAccId,
 		Amount: &types.Amount{
 			Value:    fmt.Sprintf("9000"),
@@ -285,7 +285,7 @@ func TestGetSideEffectOperationsFromUndelegationPayouts(t *testing.T) {
 			},
 		},
 		Type:    UndelegationPayout,
-		Status:  common.SuccessOperationStatus.Status,
+		Status:  &common.SuccessOperationStatus.Status,
 		Account: reveiverSubAccId1,
 		Amount: &types.Amount{
 			Value:    fmt.Sprintf("-9000"),
@@ -349,7 +349,7 @@ func TestGetStakingOperationsFromUndelegate(t *testing.T) {
 	refOperations = append(refOperations, &types.Operation{
 		OperationIdentifier: &types.OperationIdentifier{Index: 1},
 		Type:                tx.StakingType().String(),
-		Status:              common.SuccessOperationStatus.Status,
+		Status:              &common.SuccessOperationStatus.Status,
 		Account:             senderAccID,
 		Amount: &types.Amount{
 			Value:    fmt.Sprintf("0"),
@@ -360,7 +360,7 @@ func TestGetStakingOperationsFromUndelegate(t *testing.T) {
 	refOperations = append(refOperations, &types.Operation{
 		OperationIdentifier: &types.OperationIdentifier{Index: 2},
 		Type:                tx.StakingType().String(),
-		Status:              common.SuccessOperationStatus.Status,
+		Status:              &common.SuccessOperationStatus.Status,
 		Account:             receiverAccId,
 		Amount: &types.Amount{
 			Value:    fmt.Sprintf("0"),
@@ -421,7 +421,7 @@ func TestGetStakingOperationsFromCollectRewards(t *testing.T) {
 	refOperations = append(refOperations, &types.Operation{
 		OperationIdentifier: &types.OperationIdentifier{Index: 1},
 		Type:                tx.StakingType().String(),
-		Status:              common.SuccessOperationStatus.Status,
+		Status:              &common.SuccessOperationStatus.Status,
 		Account:             senderAccID,
 		Amount: &types.Amount{
 			Value:    fmt.Sprintf("%v", tenOnes.Uint64()),
@@ -475,7 +475,7 @@ func TestGetStakingOperationsFromEditValidator(t *testing.T) {
 	refOperations = append(refOperations, &types.Operation{
 		OperationIdentifier: &types.OperationIdentifier{Index: 1},
 		Type:                tx.StakingType().String(),
-		Status:              common.SuccessOperationStatus.Status,
+		Status:              &common.SuccessOperationStatus.Status,
 		Account:             senderAccID,
 		Amount: &types.Amount{
 			Value:    fmt.Sprintf("0"),
@@ -524,7 +524,7 @@ func TestGetBasicTransferOperations(t *testing.T) {
 				Index: startingOpID.Index + 1,
 			},
 			Type:    common.NativeTransferOperation,
-			Status:  common.ContractFailureOperationStatus.Status,
+			Status:  &common.ContractFailureOperationStatus.Status,
 			Account: senderAccID,
 			Amount: &types.Amount{
 				Value:    negativeBigValue(tx.Value()),
@@ -541,7 +541,7 @@ func TestGetBasicTransferOperations(t *testing.T) {
 				},
 			},
 			Type:    common.NativeTransferOperation,
-			Status:  common.ContractFailureOperationStatus.Status,
+			Status:  &common.ContractFailureOperationStatus.Status,
 			Account: receiverAccID,
 			Amount: &types.Amount{
 				Value:    fmt.Sprintf("%v", tx.Value().Uint64()),
@@ -565,8 +565,8 @@ func TestGetBasicTransferOperations(t *testing.T) {
 	}
 
 	// Test successful plain / contract transaction
-	refOperations[0].Status = common.SuccessOperationStatus.Status
-	refOperations[1].Status = common.SuccessOperationStatus.Status
+	refOperations[0].Status = &common.SuccessOperationStatus.Status
+	refOperations[1].Status = &common.SuccessOperationStatus.Status
 	receipt.Status = hmytypes.ReceiptStatusSuccessful
 	operations, rosettaError = getBasicTransferNativeOperations(tx, receipt, senderAddr, tx.To(), &opIndex)
 	if rosettaError != nil {
@@ -615,7 +615,7 @@ func TestGetCrossShardSenderTransferNativeOperations(t *testing.T) {
 				Index: startingOpID.Index + 1,
 			},
 			Type:    common.NativeCrossShardTransferOperation,
-			Status:  common.SuccessOperationStatus.Status,
+			Status:  &common.SuccessOperationStatus.Status,
 			Account: senderAccID,
 			Amount: &types.Amount{
 				Value:    negativeBigValue(tx.Value()),
@@ -792,7 +792,7 @@ func TestGetContractInternalTransferNativeOperations(t *testing.T) {
 				)
 			}
 			prevIndex = op.OperationIdentifier.Index
-			if op.Status != refStatus {
+			if op.Status == nil || *op.Status != refStatus {
 				t.Errorf("wrong status for op %v", i)
 			}
 			if op.Type != common.NativeTransferOperation {
@@ -909,7 +909,7 @@ func TestGetContractTransferNativeOperations(t *testing.T) {
 				)
 			}
 			prevIndex = op.OperationIdentifier.Index
-			if op.Status != refStatus {
+			if op.Status == nil || *op.Status != refStatus {
 				t.Errorf("wrong status for op %v", i)
 			}
 			if types.Hash(op.Amount.Currency) != common.NativeCurrencyHash {
@@ -1030,7 +1030,7 @@ func TestGetContractCreationNativeOperations(t *testing.T) {
 				Index: startingOpID.Index + 1,
 			},
 			Type:    common.ContractCreationOperation,
-			Status:  common.ContractFailureOperationStatus.Status,
+			Status:  &common.ContractFailureOperationStatus.Status,
 			Account: senderAccID,
 			Amount: &types.Amount{
 				Value:    negativeBigValue(tx.Value()),
@@ -1047,7 +1047,7 @@ func TestGetContractCreationNativeOperations(t *testing.T) {
 				},
 			},
 			Type:    common.ContractCreationOperation,
-			Status:  common.ContractFailureOperationStatus.Status,
+			Status:  &common.ContractFailureOperationStatus.Status,
 			Account: contractAddressID,
 			Amount: &types.Amount{
 				Value:    tx.Value().String(),
@@ -1072,8 +1072,8 @@ func TestGetContractCreationNativeOperations(t *testing.T) {
 	}
 
 	// Test successful contract creation
-	refOperations[0].Status = common.SuccessOperationStatus.Status
-	refOperations[1].Status = common.SuccessOperationStatus.Status
+	refOperations[0].Status = &common.SuccessOperationStatus.Status
+	refOperations[1].Status = &common.SuccessOperationStatus.Status
 	receipt.Status = hmytypes.ReceiptStatusSuccessful // Indicate successful tx
 	operations, rosettaError = getContractCreationNativeOperations(tx, receipt, senderAddr, &ContractInfo{}, &opIndex)
 	if rosettaError != nil {
@@ -1097,7 +1097,7 @@ func TestGetContractCreationNativeOperations(t *testing.T) {
 				)
 			}
 			prevIndex = op.OperationIdentifier.Index
-			if op.Status != refOperations[0].Status {
+			if *op.Status != *refOperations[0].Status {
 				t.Errorf("wrong status for op %v", i)
 			}
 			if types.Hash(op.Amount.Currency) != common.NativeCurrencyHash {
@@ -1169,7 +1169,10 @@ func TestNewNativeOperations(t *testing.T) {
 	if ops[0].OperationIdentifier.Index != 0 {
 		t.Errorf("Expected operational ID to be of index 0")
 	}
-	if ops[0].Status != common.SuccessOperationStatus.Status {
+	if ops[0].Status == nil {
+		t.Error("Expected operation status should not be nil")
+	}
+	if *ops[0].Status != common.SuccessOperationStatus.Status {
 		t.Errorf("Expected operation status to be %v", common.SuccessOperationStatus.Status)
 	}
 }


### PR DESCRIPTION
## Issue

#3428 

## Test

### Unit Test Coverage

Before:

```
?   	github.com/harmony-one/harmony/rosetta	[no test files]
ok  	github.com/harmony-one/harmony/rosetta/common	(cached)	coverage: 41.4% of statements
ok  	github.com/harmony-one/harmony/rosetta/services	0.217s	coverage: 43.8% of statements
```

After:

```
?   	github.com/harmony-one/harmony/rosetta	[no test files]
ok  	github.com/harmony-one/harmony/rosetta/common	(cached)	coverage: 41.4% of statements
ok  	github.com/harmony-one/harmony/rosetta/services	0.190s	coverage: 39.6% of statements
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

   No

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    No

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

  No

## TODO
