### PR TITLE
[rpc] Add Rate Limiter and cache for RPCs

### DIFF
--- a/cmd/harmony/config.go
+++ b/cmd/harmony/config.go
@@ -131,7 +131,9 @@ type wsConfig struct {
 }
 
 type rpcOptConfig struct {
-	DebugEnabled bool // Enables PrivateDebugService APIs, including the EVM tracer
+	DebugEnabled      bool // Enables PrivateDebugService APIs, including the EVM tracer
+	RateLimterEnabled bool // Enable Rate limiter for RPC
+	RequestsPerSecond int  // for RPC rate limiter
 }
 
 type devnetConfig struct {

--- a/cmd/harmony/config_migrations.go
+++ b/cmd/harmony/config_migrations.go
@@ -90,6 +90,14 @@ func init() {
 			confTree.Set("HTTP.RosettaPort", defaultConfig.HTTP.RosettaPort)
 		}
 
+		if confTree.Get("RPCOpt.RateLimterEnabled") == nil {
+			confTree.Set("RPCOpt.RateLimterEnabled", defaultConfig.RPCOpt.RateLimterEnabled)
+		}
+
+		if confTree.Get("RPCOpt.RequestsPerSecond") == nil {
+			confTree.Set("RPCOpt.RequestsPerSecond", defaultConfig.RPCOpt.RequestsPerSecond)
+		}
+
 		if confTree.Get("P2P.IP") == nil {
 			confTree.Set("P2P.IP", defaultConfig.P2P.IP)
 		}

--- a/cmd/harmony/config_migrations_test.go
+++ b/cmd/harmony/config_migrations_test.go
@@ -62,8 +62,6 @@ Version = "1.0.2"
 
 [RPCOpt]
   DebugEnabled = false
-  RateLimterEnabled = true
-  RequestsPerSecond = 300
 
 [TxPool]
   BlacklistFile = "./.hmy/blacklist.txt"
@@ -129,8 +127,6 @@ Version = "1.0.3"
 
 [RPCOpt]
   DebugEnabled = false
-  RateLimterEnabled = true
-  RequestsPerSecond = 300
 
 [TxPool]
   BlacklistFile = "./.hmy/blacklist.txt"
@@ -196,8 +192,6 @@ Version = "1.0.4"
 
 [RPCOpt]
   DebugEnabled = false
-  RateLimterEnabled = true
-  RequestsPerSecond = 300
 
 [Sync]
   Concurrency = 6

--- a/cmd/harmony/config_migrations_test.go
+++ b/cmd/harmony/config_migrations_test.go
@@ -62,6 +62,8 @@ Version = "1.0.2"
 
 [RPCOpt]
   DebugEnabled = false
+  RateLimterEnabled = true
+  RequestsPerSecond = 300
 
 [TxPool]
   BlacklistFile = "./.hmy/blacklist.txt"
@@ -127,6 +129,8 @@ Version = "1.0.3"
 
 [RPCOpt]
   DebugEnabled = false
+  RateLimterEnabled = true
+  RequestsPerSecond = 300
 
 [TxPool]
   BlacklistFile = "./.hmy/blacklist.txt"
@@ -135,7 +139,6 @@ Version = "1.0.3"
   Enabled = true
   IP = "127.0.0.1"
   Port = 9800
-
 `)
 
 	V1_0_4ConfigDefault = []byte(`
@@ -193,6 +196,8 @@ Version = "1.0.4"
 
 [RPCOpt]
   DebugEnabled = false
+  RateLimterEnabled = true
+  RequestsPerSecond = 300
 
 [Sync]
   Concurrency = 6

--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -95,7 +95,11 @@ Version = "1.0.4"
 [WS]
   Enabled = true
   IP = "127.0.0.1"
-  Port = 9800`
+  Port = 9800
+  
+[RPCOpt]
+  RateLimterEnabled = true
+  RequestsPerSecond = 300`
 	testDir := filepath.Join(testBaseDir, t.Name())
 	os.RemoveAll(testDir)
 	os.MkdirAll(testDir, 0777)

--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -95,11 +95,7 @@ Version = "1.0.4"
 [WS]
   Enabled = true
   IP = "127.0.0.1"
-  Port = 9800
-  
-[RPCOpt]
-  RateLimterEnabled = true
-  RequestsPerSecond = 300`
+  Port = 9800`
 	testDir := filepath.Join(testBaseDir, t.Name())
 	os.RemoveAll(testDir)
 	os.MkdirAll(testDir, 0777)

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -38,7 +38,9 @@ var defaultConfig = harmonyConfig{
 		Port:    nodeconfig.DefaultWSPort,
 	},
 	RPCOpt: rpcOptConfig{
-		DebugEnabled: false,
+		DebugEnabled:      false,
+		RateLimterEnabled: true,
+		RequestsPerSecond: nodeconfig.DefaultRPCRateLimit,
 	},
 	BLSKeys: blsConfig{
 		KeyDir:   "./.hmy/blskeys",

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -74,6 +74,8 @@ var (
 
 	rpcOptFlags = []cli.Flag{
 		rpcDebugEnabledFlag,
+		rpcRateLimiterEnabledFlag,
+		rpcRateLimitFlag,
 	}
 
 	blsFlags = append(newBLSFlags, legacyBLSFlags...)
@@ -628,12 +630,31 @@ var (
 		DefValue: defaultConfig.RPCOpt.DebugEnabled,
 		Hidden:   true,
 	}
+
+	rpcRateLimiterEnabledFlag = cli.BoolFlag{
+		Name:     "rpc.ratelimiter",
+		Usage:    "enable rate limiter for RPCs",
+		DefValue: defaultConfig.RPCOpt.RateLimterEnabled,
+	}
+
+	rpcRateLimitFlag = cli.IntFlag{
+		Name:     "rpc.ratelimit",
+		Usage:    "the number of requests per second for RPCs",
+		DefValue: defaultConfig.RPCOpt.RequestsPerSecond,
+	}
 )
 
 func applyRPCOptFlags(cmd *cobra.Command, config *harmonyConfig) {
 	if cli.IsFlagChanged(cmd, rpcDebugEnabledFlag) {
 		config.RPCOpt.DebugEnabled = cli.GetBoolFlagValue(cmd, rpcDebugEnabledFlag)
 	}
+	if cli.IsFlagChanged(cmd, rpcRateLimiterEnabledFlag) {
+		config.RPCOpt.RateLimterEnabled = cli.GetBoolFlagValue(cmd, rpcRateLimiterEnabledFlag)
+	}
+	if cli.IsFlagChanged(cmd, rpcRateLimitFlag) {
+		config.RPCOpt.RequestsPerSecond = cli.GetIntFlagValue(cmd, rpcRateLimitFlag)
+	}
+
 }
 
 // bls flags

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -66,6 +66,11 @@ func TestHarmonyFlags(t *testing.T) {
 					RosettaEnabled: false,
 					RosettaPort:    9700,
 				},
+				RPCOpt: rpcOptConfig{
+					DebugEnabled:      false,
+					RateLimterEnabled: true,
+					RequestsPerSecond: 300,
+				},
 				WS: wsConfig{
 					Enabled: true,
 					IP:      "127.0.0.1",
@@ -535,7 +540,36 @@ func TestRPCOptFlags(t *testing.T) {
 		{
 			args: []string{"--rpc.debug"},
 			expConfig: rpcOptConfig{
-				DebugEnabled: true,
+				DebugEnabled:      true,
+				RateLimterEnabled: true,
+				RequestsPerSecond: 300,
+			},
+		},
+
+		{
+			args: []string{},
+			expConfig: rpcOptConfig{
+				DebugEnabled:      false,
+				RateLimterEnabled: true,
+				RequestsPerSecond: 300,
+			},
+		},
+
+		{
+			args: []string{"--rpc.ratelimiter", "--rpc.ratelimit", "1000"},
+			expConfig: rpcOptConfig{
+				DebugEnabled:      false,
+				RateLimterEnabled: true,
+				RequestsPerSecond: 1000,
+			},
+		},
+
+		{
+			args: []string{"--rpc.ratelimiter=false", "--rpc.ratelimit", "1000"},
+			expConfig: rpcOptConfig{
+				DebugEnabled:      false,
+				RateLimterEnabled: false,
+				RequestsPerSecond: 1000,
 			},
 		},
 	}

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -321,13 +321,15 @@ func setupNodeAndRun(hc harmonyConfig) {
 
 	// Parse RPC config
 	nodeConfig.RPCServer = nodeconfig.RPCServerConfig{
-		HTTPEnabled:  hc.HTTP.Enabled,
-		HTTPIp:       hc.HTTP.IP,
-		HTTPPort:     hc.HTTP.Port,
-		WSEnabled:    hc.WS.Enabled,
-		WSIp:         hc.WS.IP,
-		WSPort:       hc.WS.Port,
-		DebugEnabled: hc.RPCOpt.DebugEnabled,
+		HTTPEnabled:        hc.HTTP.Enabled,
+		HTTPIp:             hc.HTTP.IP,
+		HTTPPort:           hc.HTTP.Port,
+		WSEnabled:          hc.WS.Enabled,
+		WSIp:               hc.WS.IP,
+		WSPort:             hc.WS.Port,
+		DebugEnabled:       hc.RPCOpt.DebugEnabled,
+		RateLimiterEnabled: hc.RPCOpt.RateLimterEnabled,
+		RequestsPerSecond:  hc.RPCOpt.RequestsPerSecond,
 	}
 
 	// Parse rosetta config

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
 	google.golang.org/grpc v1.33.2
 	google.golang.org/protobuf v1.25.0

--- a/internal/configs/node/config.go
+++ b/internal/configs/node/config.go
@@ -107,6 +107,9 @@ type RPCServerConfig struct {
 	WSPort    int
 
 	DebugEnabled bool
+
+	RateLimiterEnabled bool
+	RequestsPerSecond  int
 }
 
 // RosettaServerConfig is the config for the rosetta server

--- a/internal/configs/node/network.go
+++ b/internal/configs/node/network.go
@@ -57,6 +57,11 @@ const (
 )
 
 const (
+	// DefaultRateLimit for RPC, the number of requests per second
+	DefaultRPCRateLimit = 300
+)
+
+const (
 	// rpcHTTPPortOffset is the port offset for RPC HTTP requests
 	rpcHTTPPortOffset = 500
 

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -70,7 +70,7 @@ func (n Version) Namespace() string {
 
 // StartServers starts the http & ws servers
 func StartServers(hmy *hmy.Harmony, apis []rpc.API, config nodeconfig.RPCServerConfig) error {
-	apis = append(apis, getAPIs(hmy, config.DebugEnabled)...)
+	apis = append(apis, getAPIs(hmy, config.DebugEnabled, config.RateLimiterEnabled, config.RequestsPerSecond)...)
 
 	if config.HTTPEnabled {
 		httpEndpoint = fmt.Sprintf("%v:%v", config.HTTPIp, config.HTTPPort)
@@ -121,15 +121,15 @@ func StopServers() error {
 }
 
 // getAPIs returns all the API methods for the RPC interface
-func getAPIs(hmy *hmy.Harmony, debugEnable bool) []rpc.API {
+func getAPIs(hmy *hmy.Harmony, debugEnable bool, rateLimiterEnable bool, ratelimit int) []rpc.API {
 	publicAPIs := []rpc.API{
 		// Public methods
 		NewPublicHarmonyAPI(hmy, V1),
 		NewPublicHarmonyAPI(hmy, V2),
 		NewPublicHarmonyAPI(hmy, Eth),
-		NewPublicBlockchainAPI(hmy, V1),
-		NewPublicBlockchainAPI(hmy, V2),
-		NewPublicBlockchainAPI(hmy, Eth),
+		NewPublicBlockchainAPI(hmy, V1, rateLimiterEnable, ratelimit),
+		NewPublicBlockchainAPI(hmy, V2, rateLimiterEnable, ratelimit),
+		NewPublicBlockchainAPI(hmy, Eth, rateLimiterEnable, ratelimit),
 		NewPublicContractAPI(hmy, V1),
 		NewPublicContractAPI(hmy, V2),
 		NewPublicContractAPI(hmy, Eth),


### PR DESCRIPTION
## Issue

https://github.com/harmony-one/harmony/issues/3696

- The current PR only supports BlockChain type RPCs, not other RPCs such as TxPool, Contract, etc. Because I don't know if restricting the flow of other RPCs will affect other products（ I'm not sure if I want to add rate limiter to all RPCs）
- add LRU cache for `GetBlockByNumber`. if it triggers rate limiter wait timeout, the RPC will return empty, This results in a large number of visits in an instant while reducing the user experience. so need to add cache for json body of block
- combine https://github.com/harmony-one/harmony/pull/3698 into this

## Usage of rate limiter

- add two flags： `--rpc.ratelimiter` and `--rpc.ratelimit`. Or you can use it in config file, it all the same.
- the flag  `--rpc.ratelimiter` is default enabled, so you can ignore it
- the flag `-rpc.ratelimit` is used for control rate of requests, the value is the number of requests per sencond allowed with rate limiter.the default value is 100 (100/s).

so use rate limiter with shell, need to run as follows:

```bash
./harmony --rpc.ratelimiter --rpc.ratelimit=100
OR
./harmony
```

## Test

- Use harmony explorer start a tons of requests, the real rate of requests is equal to config of `--rpc.ratelimit=<requests_per_second>`

- Request same height using RPC, to check if block json is get from cache：

```bash
./hmy  blockchain block-by-number 10000
```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**


8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**


11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

  **NO**
