### PR TITLE
Add min commission rate logic

### DIFF
--- a/core/evm.go
+++ b/core/evm.go
@@ -19,6 +19,8 @@ package core
 import (
 	"math/big"
 
+	"github.com/harmony-one/harmony/internal/params"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/block"
 	consensus_engine "github.com/harmony-one/harmony/consensus/engine"
@@ -44,6 +46,9 @@ type ChainContext interface {
 
 	// ReadValidatorList returns the list of all validators
 	ReadValidatorList() ([]common.Address, error)
+
+	// Config returns chain config
+	Config() *params.ChainConfig
 }
 
 // NewEVMContext creates a new context for use in the EVM.

--- a/core/staking_verifier.go
+++ b/core/staking_verifier.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/harmony-one/harmony/staking/availability"
 
-	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/params"
 
 	"github.com/harmony-one/harmony/crypto/bls"
@@ -171,11 +170,8 @@ func VerifyAndEditValidatorFromMsg(
 
 	if chainContext.Config().IsMinCommissionRate(epoch) && newRate.LT(availability.MinCommissionRate) {
 		firstEpoch := stateDB.GetValidatorFirstElectionEpoch(msg.ValidatorAddress)
-		promoPeriod := 100
-		if nodeconfig.GetDefaultConfig().GetNetworkType() != nodeconfig.Mainnet {
-			promoPeriod = 10
-		}
-		if firstEpoch.Uint64() != 0 && big.NewInt(0).Sub(epoch, firstEpoch).Int64() >= int64(promoPeriod) {
+		promoPeriod := chainContext.Config().MinCommissionPromoPeriod.Int64()
+		if firstEpoch.Uint64() != 0 && big.NewInt(0).Sub(epoch, firstEpoch).Int64() >= promoPeriod {
 			return nil, errCommissionRateChangeTooLow
 		}
 	}

--- a/core/staking_verifier.go
+++ b/core/staking_verifier.go
@@ -175,7 +175,7 @@ func VerifyAndEditValidatorFromMsg(
 		if nodeconfig.GetDefaultConfig().GetNetworkType() != nodeconfig.Mainnet {
 			promoPeriod = 10
 		}
-		if firstEpoch.Uint64() != 0 && firstEpoch.Sub(epoch, firstEpoch).Int64() >= int64(promoPeriod) {
+		if firstEpoch.Uint64() != 0 && big.NewInt(0).Sub(epoch, firstEpoch).Int64() >= int64(promoPeriod) {
 			return nil, errCommissionRateChangeTooLow
 		}
 	}

--- a/core/staking_verifier_test.go
+++ b/core/staking_verifier_test.go
@@ -1675,6 +1675,12 @@ func (chain *fakeChainContext) Engine() consensus_engine.Engine {
 	return nil
 }
 
+func (chain *fakeChainContext) Config() *params.ChainConfig {
+	config := &params.ChainConfig{}
+	config.MinCommissionRateEpoch = big.NewInt(10)
+	return config
+}
+
 func (chain *fakeChainContext) GetHeader(common.Hash, uint64) *block.Header {
 	return nil
 }
@@ -1707,6 +1713,12 @@ func (chain *fakeErrChainContext) Engine() consensus_engine.Engine {
 
 func (chain *fakeErrChainContext) GetHeader(common.Hash, uint64) *block.Header {
 	return nil
+}
+
+func (chain *fakeErrChainContext) Config() *params.ChainConfig {
+	config := &params.ChainConfig{}
+	config.MinCommissionRateEpoch = big.NewInt(10)
+	return config
 }
 
 func (chain *fakeErrChainContext) ReadDelegationsByDelegator(common.Address) (staking.DelegationIndexes, error) {

--- a/core/staking_verifier_test.go
+++ b/core/staking_verifier_test.go
@@ -1726,6 +1726,7 @@ func (chain *fakeChainContext) Engine() consensus_engine.Engine {
 func (chain *fakeChainContext) Config() *params.ChainConfig {
 	config := &params.ChainConfig{}
 	config.MinCommissionRateEpoch = big.NewInt(0)
+	config.MinCommissionPromoPeriod = big.NewInt(10)
 	return config
 }
 

--- a/core/staking_verifier_test.go
+++ b/core/staking_verifier_test.go
@@ -58,6 +58,7 @@ var (
 	pointZeroOneDec   = numeric.NewDecWithPrec(1, 2)
 	pointOneDec       = numeric.NewDecWithPrec(1, 1)
 	pointTwoDec       = numeric.NewDecWithPrec(2, 1)
+	pointFourDec      = numeric.NewDecWithPrec(4, 1)
 	pointFiveDec      = numeric.NewDecWithPrec(5, 1)
 	pointSevenDec     = numeric.NewDecWithPrec(7, 1)
 	pointEightFiveDec = numeric.NewDecWithPrec(85, 2)
@@ -466,7 +467,7 @@ func TestVerifyAndEditValidatorFromMsg(t *testing.T) {
 			expWrapper: func() staking.ValidatorWrapper {
 				vw := defaultExpWrapperEditValidator()
 				vw.UpdateHeight = big.NewInt(defaultSnapBlockNumber)
-				vw.Rate = pointFiveDec
+				vw.Rate = pointFourDec
 				return vw
 			}(),
 		},
@@ -662,7 +663,7 @@ func TestVerifyAndEditValidatorFromMsg(t *testing.T) {
 			bc: func() *fakeChainContext {
 				chain := makeFakeChainContextForStake()
 				vw := chain.vWrappers[validatorAddr]
-				vw.Rate = pointSevenDec
+				vw.Rate = pointFourDec
 				chain.vWrappers[validatorAddr] = vw
 				return chain
 			}(),
@@ -682,7 +683,7 @@ func TestVerifyAndEditValidatorFromMsg(t *testing.T) {
 			bc: func() *fakeChainContext {
 				chain := makeFakeChainContextForStake()
 				vw := chain.vWrappers[validatorAddr]
-				vw.Rate = pointSevenDec
+				vw.Rate = pointFourDec
 				chain.vWrappers[validatorAddr] = vw
 				return chain
 			}(),
@@ -692,6 +693,13 @@ func TestVerifyAndEditValidatorFromMsg(t *testing.T) {
 				msg := defaultMsgEditValidator()
 				msg.CommissionRate = &pointZeroOneDec
 				return msg
+			}(),
+
+			expWrapper: func() staking.ValidatorWrapper {
+				vw := defaultExpWrapperEditValidator()
+				vw.UpdateHeight = big.NewInt(defaultBlockNumber)
+				vw.Rate = pointZeroOneDec
+				return vw
 			}(),
 		},
 	}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -859,6 +859,23 @@ func (db *DB) UpdateValidatorWrapper(
 	return nil
 }
 
+// SetValidatorFirstElectionEpoch sets the epoch when the validator is first elected
+func (db *DB) SetValidatorFirstElectionEpoch(addr common.Address, epoch *big.Int) {
+	firstEpoch := db.GetValidatorFirstElectionEpoch(addr)
+	if firstEpoch.Uint64() == 0 {
+		// Set only when it's not set (or it's 0)
+		bytes := common.BigToHash(epoch)
+		db.SetState(addr, staking.FirstElectionEpoch, bytes)
+	}
+}
+
+// GetValidatorFirstElectionEpoch gets the epoch when the validator was first elected
+func (db *DB) GetValidatorFirstElectionEpoch(addr common.Address) *big.Int {
+	so := db.getStateObject(addr)
+	value := so.GetState(db.db, staking.IsValidatorKey)
+	return value.Big()
+}
+
 // SetValidatorFlag checks whether it is a validator object
 func (db *DB) SetValidatorFlag(addr common.Address) {
 	db.SetState(addr, staking.IsValidatorKey, staking.IsValidator)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -865,14 +865,14 @@ func (db *DB) SetValidatorFirstElectionEpoch(addr common.Address, epoch *big.Int
 	if firstEpoch.Uint64() == 0 {
 		// Set only when it's not set (or it's 0)
 		bytes := common.BigToHash(epoch)
-		db.SetState(addr, staking.FirstElectionEpoch, bytes)
+		db.SetState(addr, staking.FirstElectionEpochKey, bytes)
 	}
 }
 
 // GetValidatorFirstElectionEpoch gets the epoch when the validator was first elected
 func (db *DB) GetValidatorFirstElectionEpoch(addr common.Address) *big.Int {
 	so := db.getStateObject(addr)
-	value := so.GetState(db.db, staking.IsValidatorKey)
+	value := so.GetState(db.db, staking.FirstElectionEpochKey)
 	return value.Big()
 }
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -43,6 +43,7 @@ var (
 	errNoDelegationToUndelegate    = errors.New("no delegation to undelegate")
 	errCommissionRateChangeTooFast = errors.New("change on commission rate can not be more than max change rate within the same epoch")
 	errCommissionRateChangeTooHigh = errors.New("commission rate can not be higher than maximum commission rate")
+	errCommissionRateChangeTooLow  = errors.New("commission rate can not be lower than min rate of 5%")
 	errNoRewardsToCollect          = errors.New("no rewards to collect")
 	errNegativeAmount              = errors.New("amount can not be negative")
 	errDupIdentity                 = errors.New("validator identity exists")

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -47,6 +47,7 @@ type StateDB interface {
 	SetValidatorFlag(common.Address)
 	UnsetValidatorFlag(common.Address)
 	IsValidator(common.Address) bool
+	GetValidatorFirstElectionEpoch(addr common.Address) *big.Int
 	AddReward(*staking.ValidatorWrapper, *big.Int, map[common.Address]numeric.Dec) error
 
 	AddRefund(uint64)

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -416,7 +416,7 @@ func setElectionEpochAndMinFee(header *block.Header, state *state.DB, config *pa
 
 			// Update minimum commission fee
 			if err := availability.UpdateMinimumCommissionFee(
-				newShardState.Epoch, state, addr,
+				newShardState.Epoch, state, addr, config.MinCommissionPromoPeriod.Int64(),
 			); err != nil {
 				return err
 			}

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -5,6 +5,8 @@ import (
 	"math/big"
 	"sort"
 
+	"github.com/harmony-one/harmony/internal/params"
+
 	bls2 "github.com/harmony-one/bls/ffi/go/bls"
 	blsvrf "github.com/harmony-one/harmony/crypto/vrf/bls"
 
@@ -290,7 +292,7 @@ func (e *engineImpl) Finalize(
 
 		// Needs to be after payoutUndelegations because payoutUndelegations
 		// depends on the old LastEpochInCommittee
-		if err := setLastEpochInCommittee(header, state); err != nil {
+		if err := setElectionEpochAndMinFee(header, state, chain.Config()); err != nil {
 			return nil, nil, err
 		}
 
@@ -392,7 +394,7 @@ func IsCommitteeSelectionBlock(chain engine.ChainReader, header *block.Header) b
 	return isBeaconChain && header.IsLastBlockInEpoch() && inPreStakingEra
 }
 
-func setLastEpochInCommittee(header *block.Header, state *state.DB) error {
+func setElectionEpochAndMinFee(header *block.Header, state *state.DB, config *params.ChainConfig) error {
 	newShardState, err := header.GetShardState()
 	if err != nil {
 		const msg = "[Finalize] failed to read shard state"
@@ -405,7 +407,20 @@ func setLastEpochInCommittee(header *block.Header, state *state.DB) error {
 				"[Finalize] failed to get validator from state to finalize",
 			)
 		}
+		// Set last epoch in committee
 		wrapper.LastEpochInCommittee = newShardState.Epoch
+
+		if config.IsMinCommissionRate(newShardState.Epoch) {
+			// Set first election epoch
+			state.SetValidatorFirstElectionEpoch(addr, newShardState.Epoch)
+
+			// Update minimum commission fee
+			if err := availability.UpdateMinimumCommissionFee(
+				newShardState.Epoch, state, addr,
+			); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -52,6 +52,7 @@ var (
 		NoEarlyUnlockEpoch:         big.NewInt(530), // Around Monday Apr 12th 2021, 22:30 UTC
 		VRFEpoch:                   EpochTBD,
 		MinDelegation100Epoch:      EpochTBD,
+		MinCommissionRateEpoch:     EpochTBD,
 		EPoSBound35Epoch:           EpochTBD,
 		EIP155Epoch:                big.NewInt(28),
 		S3Epoch:                    big.NewInt(28),
@@ -77,6 +78,7 @@ var (
 		NoEarlyUnlockEpoch:         big.NewInt(73580),
 		VRFEpoch:                   EpochTBD,
 		MinDelegation100Epoch:      EpochTBD,
+		MinCommissionRateEpoch:     EpochTBD,
 		EPoSBound35Epoch:           EpochTBD,
 		EIP155Epoch:                big.NewInt(0),
 		S3Epoch:                    big.NewInt(0),
@@ -103,6 +105,7 @@ var (
 		NoEarlyUnlockEpoch:         big.NewInt(0),
 		VRFEpoch:                   big.NewInt(0),
 		MinDelegation100Epoch:      big.NewInt(0),
+		MinCommissionRateEpoch:     big.NewInt(0),
 		EPoSBound35Epoch:           big.NewInt(0),
 		EIP155Epoch:                big.NewInt(0),
 		S3Epoch:                    big.NewInt(0),
@@ -129,6 +132,7 @@ var (
 		NoEarlyUnlockEpoch:         big.NewInt(0),
 		VRFEpoch:                   big.NewInt(0),
 		MinDelegation100Epoch:      big.NewInt(0),
+		MinCommissionRateEpoch:     big.NewInt(0),
 		EPoSBound35Epoch:           big.NewInt(0),
 		EIP155Epoch:                big.NewInt(0),
 		S3Epoch:                    big.NewInt(0),
@@ -155,6 +159,7 @@ var (
 		NoEarlyUnlockEpoch:         big.NewInt(0),
 		VRFEpoch:                   big.NewInt(0),
 		MinDelegation100Epoch:      big.NewInt(0),
+		MinCommissionRateEpoch:     big.NewInt(0),
 		EPoSBound35Epoch:           big.NewInt(0),
 		EIP155Epoch:                big.NewInt(0),
 		S3Epoch:                    big.NewInt(0),
@@ -180,6 +185,7 @@ var (
 		NoEarlyUnlockEpoch:         big.NewInt(0),
 		VRFEpoch:                   big.NewInt(0),
 		MinDelegation100Epoch:      big.NewInt(0),
+		MinCommissionRateEpoch:     big.NewInt(0),
 		EPoSBound35Epoch:           big.NewInt(0),
 		EIP155Epoch:                big.NewInt(0),
 		S3Epoch:                    big.NewInt(0),
@@ -207,6 +213,7 @@ var (
 		big.NewInt(0),                      // NoEarlyUnlockEpoch
 		big.NewInt(0),                      // VRFEpoch
 		big.NewInt(0),                      // MinDelegation100Epoch
+		big.NewInt(0),                      // MinCommissionRateEpoch
 		big.NewInt(0),                      // EPoSBound35Epoch
 		big.NewInt(0),                      // EIP155Epoch
 		big.NewInt(0),                      // S3Epoch
@@ -234,6 +241,7 @@ var (
 		big.NewInt(0),        // NoEarlyUnlockEpoch
 		big.NewInt(0),        // VRFEpoch
 		big.NewInt(0),        // MinDelegation100Epoch
+		big.NewInt(0),        // MinCommissionRateEpoch
 		big.NewInt(0),        // EPoSBound35Epoch
 		big.NewInt(0),        // EIP155Epoch
 		big.NewInt(0),        // S3Epoch
@@ -317,6 +325,9 @@ type ChainConfig struct {
 
 	// MinDelegation100Epoch is the epoch when min delegation is reduced from 1000 ONE to 100 ONE
 	MinDelegation100Epoch *big.Int `json:"min-delegation-100-epoch,omitempty"`
+
+	// MinCommissionRateEpoch is the epoch when policy for minimum comission rate of 5% is started
+	MinCommissionRateEpoch *big.Int `json:"min-commission-rate-epoch,omitempty"`
 
 	// EPoSBound35Epoch is the epoch when the EPoS bound parameter c is changed from 15% to 35%
 	EPoSBound35Epoch *big.Int `json:"epos-bound-35-epoch,omitempty"`
@@ -415,6 +426,11 @@ func (c *ChainConfig) IsVRF(epoch *big.Int) bool {
 // IsMinDelegation100 determines whether it is the epoch to reduce min delegation to 100
 func (c *ChainConfig) IsMinDelegation100(epoch *big.Int) bool {
 	return isForked(c.MinDelegation100Epoch, epoch)
+}
+
+// IsMinCommissionRate determines whether it is the epoch to start the policy of 5% min commission
+func (c *ChainConfig) IsMinCommissionRate(epoch *big.Int) bool {
+	return isForked(c.MinCommissionRateEpoch, epoch)
 }
 
 // IsEPoSBound35 determines whether it is the epoch to extend the EPoS bound to 35%

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -53,6 +53,7 @@ var (
 		VRFEpoch:                   EpochTBD,
 		MinDelegation100Epoch:      EpochTBD,
 		MinCommissionRateEpoch:     EpochTBD,
+		MinCommissionPromoPeriod:   big.NewInt(100),
 		EPoSBound35Epoch:           EpochTBD,
 		EIP155Epoch:                big.NewInt(28),
 		S3Epoch:                    big.NewInt(28),
@@ -79,6 +80,7 @@ var (
 		VRFEpoch:                   EpochTBD,
 		MinDelegation100Epoch:      EpochTBD,
 		MinCommissionRateEpoch:     EpochTBD,
+		MinCommissionPromoPeriod:   big.NewInt(10),
 		EPoSBound35Epoch:           EpochTBD,
 		EIP155Epoch:                big.NewInt(0),
 		S3Epoch:                    big.NewInt(0),
@@ -106,6 +108,7 @@ var (
 		VRFEpoch:                   big.NewInt(0),
 		MinDelegation100Epoch:      big.NewInt(0),
 		MinCommissionRateEpoch:     big.NewInt(0),
+		MinCommissionPromoPeriod:   big.NewInt(10),
 		EPoSBound35Epoch:           big.NewInt(0),
 		EIP155Epoch:                big.NewInt(0),
 		S3Epoch:                    big.NewInt(0),
@@ -133,6 +136,7 @@ var (
 		VRFEpoch:                   big.NewInt(0),
 		MinDelegation100Epoch:      big.NewInt(0),
 		MinCommissionRateEpoch:     big.NewInt(0),
+		MinCommissionPromoPeriod:   big.NewInt(10),
 		EPoSBound35Epoch:           big.NewInt(0),
 		EIP155Epoch:                big.NewInt(0),
 		S3Epoch:                    big.NewInt(0),
@@ -160,6 +164,7 @@ var (
 		VRFEpoch:                   big.NewInt(0),
 		MinDelegation100Epoch:      big.NewInt(0),
 		MinCommissionRateEpoch:     big.NewInt(0),
+		MinCommissionPromoPeriod:   big.NewInt(10),
 		EPoSBound35Epoch:           big.NewInt(0),
 		EIP155Epoch:                big.NewInt(0),
 		S3Epoch:                    big.NewInt(0),
@@ -186,6 +191,7 @@ var (
 		VRFEpoch:                   big.NewInt(0),
 		MinDelegation100Epoch:      big.NewInt(0),
 		MinCommissionRateEpoch:     big.NewInt(0),
+		MinCommissionPromoPeriod:   big.NewInt(10),
 		EPoSBound35Epoch:           big.NewInt(0),
 		EIP155Epoch:                big.NewInt(0),
 		S3Epoch:                    big.NewInt(0),
@@ -214,6 +220,7 @@ var (
 		big.NewInt(0),                      // VRFEpoch
 		big.NewInt(0),                      // MinDelegation100Epoch
 		big.NewInt(0),                      // MinCommissionRateEpoch
+		big.NewInt(10),                     // MinCommissionPromoPeriod
 		big.NewInt(0),                      // EPoSBound35Epoch
 		big.NewInt(0),                      // EIP155Epoch
 		big.NewInt(0),                      // S3Epoch
@@ -242,6 +249,7 @@ var (
 		big.NewInt(0),        // VRFEpoch
 		big.NewInt(0),        // MinDelegation100Epoch
 		big.NewInt(0),        // MinCommissionRateEpoch
+		big.NewInt(10),       // MinCommissionPromoPeriod
 		big.NewInt(0),        // EPoSBound35Epoch
 		big.NewInt(0),        // EIP155Epoch
 		big.NewInt(0),        // S3Epoch
@@ -328,6 +336,9 @@ type ChainConfig struct {
 
 	// MinCommissionRateEpoch is the epoch when policy for minimum comission rate of 5% is started
 	MinCommissionRateEpoch *big.Int `json:"min-commission-rate-epoch,omitempty"`
+
+	// MinCommissionPromoPeriod is the number of epochs when newly elected validators can have 0% commission
+	MinCommissionPromoPeriod *big.Int `json:"commission-promo-period,omitempty"`
 
 	// EPoSBound35Epoch is the epoch when the EPoS bound parameter c is changed from 15% to 35%
 	EPoSBound35Epoch *big.Int `json:"epos-bound-35-epoch,omitempty"`

--- a/staking/availability/measure.go
+++ b/staking/availability/measure.go
@@ -243,7 +243,7 @@ func UpdateMinimumCommissionFee(
 	if nodeconfig.GetDefaultConfig().GetNetworkType() != nodeconfig.Mainnet {
 		promoPeriod = 10
 	}
-	if firstElectionEpoch.Uint64() != 0 && firstElectionEpoch.Sub(electionEpoch, firstElectionEpoch).Int64() >= int64(promoPeriod) {
+	if firstElectionEpoch.Uint64() != 0 && big.NewInt(0).Sub(electionEpoch, firstElectionEpoch).Int64() >= int64(promoPeriod) {
 		if wrapper.Rate.LT(MinCommissionRate) {
 			utils.Logger().Info().
 				Str("addr", addr.Hex()).

--- a/staking/availability/measure.go
+++ b/staking/availability/measure.go
@@ -3,6 +3,10 @@ package availability
 import (
 	"math/big"
 
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
+
+	"github.com/harmony-one/harmony/core/state"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/crypto/bls"
 	"github.com/harmony-one/harmony/internal/utils"
@@ -15,6 +19,8 @@ import (
 
 var (
 	measure = numeric.NewDec(2).Quo(numeric.NewDec(3))
+
+	MinCommissionRate = numeric.MustNewDecFromStr("0.05")
 	// ErrDivByZero ..
 	ErrDivByZero = errors.New("toSign of availability cannot be 0, mistake in protocol")
 )
@@ -213,5 +219,39 @@ func ComputeAndMutateEPOSStatus(
 		// to leave the committee can actually leave.
 	}
 
+	return nil
+}
+
+// UpdateMinimumCommissionFee update the validator commission fee to the minimum 5%
+// if the validator has a lower commission rate and 100 epochs have passed after
+// the validator was first elected.
+func UpdateMinimumCommissionFee(
+	electionEpoch *big.Int,
+	state *state.DB,
+	addr common.Address,
+) error {
+	utils.Logger().Info().Msg("begin update min commission fee")
+
+	wrapper, err := state.ValidatorWrapper(addr)
+	if err != nil {
+		return err
+	}
+
+	firstElectionEpoch := state.GetValidatorFirstElectionEpoch(addr)
+
+	promoPeriod := 100
+	if nodeconfig.GetDefaultConfig().GetNetworkType() != nodeconfig.Mainnet {
+		promoPeriod = 10
+	}
+	if firstElectionEpoch.Uint64() != 0 && firstElectionEpoch.Sub(electionEpoch, firstElectionEpoch).Int64() >= int64(promoPeriod) {
+		if wrapper.Rate.LT(MinCommissionRate) {
+			utils.Logger().Info().
+				Str("addr", addr.Hex()).
+				Str("old rate", wrapper.Rate.String()).
+				Str("firstElectionEpoch", firstElectionEpoch.String()).
+				Msg("updating min commission rate")
+			wrapper.Rate.SetBytes(MinCommissionRate.Bytes())
+		}
+	}
 	return nil
 }

--- a/staking/availability/measure.go
+++ b/staking/availability/measure.go
@@ -3,8 +3,6 @@ package availability
 import (
 	"math/big"
 
-	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
-
 	"github.com/harmony-one/harmony/core/state"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -229,6 +227,7 @@ func UpdateMinimumCommissionFee(
 	electionEpoch *big.Int,
 	state *state.DB,
 	addr common.Address,
+	promoPeriod int64,
 ) error {
 	utils.Logger().Info().Msg("begin update min commission fee")
 
@@ -239,10 +238,6 @@ func UpdateMinimumCommissionFee(
 
 	firstElectionEpoch := state.GetValidatorFirstElectionEpoch(addr)
 
-	promoPeriod := 100
-	if nodeconfig.GetDefaultConfig().GetNetworkType() != nodeconfig.Mainnet {
-		promoPeriod = 10
-	}
 	if firstElectionEpoch.Uint64() != 0 && big.NewInt(0).Sub(electionEpoch, firstElectionEpoch).Int64() >= int64(promoPeriod) {
 		if wrapper.Rate.LT(MinCommissionRate) {
 			utils.Logger().Info().

--- a/staking/params.go
+++ b/staking/params.go
@@ -5,10 +5,11 @@ import (
 )
 
 const (
-	isValidatorKeyStr = "Harmony/IsValidator/Key/v1"
-	isValidatorStr    = "Harmony/IsValidator/Value/v1"
-	collectRewardsStr = "Harmony/CollectRewards"
-	delegateStr       = "Harmony/Delegate"
+	isValidatorKeyStr     = "Harmony/IsValidator/Key/v1"
+	isValidatorStr        = "Harmony/IsValidator/Value/v1"
+	collectRewardsStr     = "Harmony/CollectRewards"
+	delegateStr           = "Harmony/Delegate"
+	firstElectionEpochStr = "Harmony/FirstElectionEpoch/Key/v1"
 )
 
 // keys used to retrieve staking related informatio
@@ -17,4 +18,5 @@ var (
 	IsValidator         = crypto.Keccak256Hash([]byte(isValidatorStr))
 	CollectRewardsTopic = crypto.Keccak256Hash([]byte(collectRewardsStr))
 	DelegateTopic       = crypto.Keccak256Hash([]byte(delegateStr))
+	FirstElectionEpoch  = crypto.Keccak256Hash([]byte(firstElectionEpochStr))
 )

--- a/staking/params.go
+++ b/staking/params.go
@@ -14,9 +14,9 @@ const (
 
 // keys used to retrieve staking related informatio
 var (
-	IsValidatorKey      = crypto.Keccak256Hash([]byte(isValidatorKeyStr))
-	IsValidator         = crypto.Keccak256Hash([]byte(isValidatorStr))
-	CollectRewardsTopic = crypto.Keccak256Hash([]byte(collectRewardsStr))
-	DelegateTopic       = crypto.Keccak256Hash([]byte(delegateStr))
-	FirstElectionEpoch  = crypto.Keccak256Hash([]byte(firstElectionEpochStr))
+	IsValidatorKey        = crypto.Keccak256Hash([]byte(isValidatorKeyStr))
+	IsValidator           = crypto.Keccak256Hash([]byte(isValidatorStr))
+	CollectRewardsTopic   = crypto.Keccak256Hash([]byte(collectRewardsStr))
+	DelegateTopic         = crypto.Keccak256Hash([]byte(delegateStr))
+	FirstElectionEpochKey = crypto.Keccak256Hash([]byte(firstElectionEpochStr))
 )

--- a/staking/types/test/prototype.go
+++ b/staking/types/test/prototype.go
@@ -59,9 +59,9 @@ var (
 	}
 
 	commissionRates = staking.CommissionRates{
-		Rate:          numeric.NewDecWithPrec(5, 1),
+		Rate:          numeric.NewDecWithPrec(4, 1),
 		MaxRate:       numeric.NewDecWithPrec(9, 1),
-		MaxChangeRate: numeric.NewDecWithPrec(3, 1),
+		MaxChangeRate: numeric.NewDecWithPrec(4, 1),
 	}
 
 	commission = staking.Commission{


### PR DESCRIPTION
As per requested in this governance proposal: https://governance.harmony.one/#/staking-mainnet/proposal/QmYbBQuDSZbMVa6RBi3kzFiNkXxv8PMp9rrT25drkxQnTb

Specifically:
1. Add logic to set first elected epoch for all elected validators starting from the fork epoch (note the first elected epoch setting is not retroactive and only take effect after the fork epoch)
2. Enforce the minimum commission fee of 5% if the current epoch is 100/10 (mainnet/testnet) more than the validator's first elected epoch.
3. Add logic to enforce the minimum commission fee in EditValidator so validators can't go below 5% for commission fee once it's pass 100/10 (mainnet/testnet) epochs after first elected.