### PR TITLE
[rpc] added multiaddress in GetDelegationsByDelegatorByBlockNumber

### DIFF
--- a/rpc/types.go
+++ b/rpc/types.go
@@ -4,10 +4,14 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"strconv"
 	"strings"
 	"time"
+
+	internal_common "github.com/harmony-one/harmony/internal/common"
+	"github.com/pkg/errors"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -245,4 +249,46 @@ func NewHeaderInformation(header *block.Header, leader string) *HeaderInformatio
 	}
 
 	return result
+}
+
+// AddressOrList represents an address or a list of addresses
+type AddressOrList struct {
+	Address     *common.Address
+	AddressList []common.Address
+}
+
+// UnmarshalJSON defines the input parsing of AddressOrList
+func (aol *AddressOrList) UnmarshalJSON(data []byte) (err error) {
+	var itf interface{}
+	if err := json.Unmarshal(data, &itf); err != nil {
+		return err
+	}
+	switch d := itf.(type) {
+	case string: // Single address
+		addr, err := internal_common.ParseAddr(d)
+		if err != nil {
+			return err
+		}
+		aol.Address = &addr
+		return nil
+
+	case []interface{}: // Address array
+		var addrs []common.Address
+		for _, addrItf := range d {
+			addrStr, ok := addrItf.(string)
+			if !ok {
+				return errors.New("not invalid address array")
+			}
+			addr, err := internal_common.ParseAddr(addrStr)
+			if err != nil {
+				return fmt.Errorf("invalid address: %v", addrStr)
+			}
+			addrs = append(addrs, addr)
+		}
+		aol.AddressList = addrs
+		return nil
+
+	default:
+		return errors.New("must provide one address or address list")
+	}
 }

--- a/rpc/types_test.go
+++ b/rpc/types_test.go
@@ -1,0 +1,72 @@
+package rpc
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	internal_common "github.com/harmony-one/harmony/internal/common"
+	"github.com/pkg/errors"
+)
+
+var (
+	testAddr1Str  = "one1upj2dzv5ayuqy5x0aclgcr32chqfy32glsdusk"
+	testAddr2Str  = "one1k860e6h0sen6ap5fymzwpqtmqlkut2fcus840l"
+	testAddr1JStr = fmt.Sprintf(`"%v"`, testAddr1Str)
+	testAddr2JStr = fmt.Sprintf(`"%v"`, testAddr2Str)
+
+	testAddr1, _ = internal_common.Bech32ToAddress(testAddr1Str)
+	testAddr2, _ = internal_common.Bech32ToAddress(testAddr2Str)
+)
+
+func TestAddressOrList_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		input string
+		exp   AddressOrList
+	}{
+		{
+			input: testAddr1JStr,
+			exp: AddressOrList{
+				Address:     &testAddr1,
+				AddressList: nil,
+			},
+		},
+		{
+			input: fmt.Sprintf("[%v, %v]", testAddr1JStr, testAddr2JStr),
+			exp: AddressOrList{
+				Address:     nil,
+				AddressList: []common.Address{testAddr1, testAddr2},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		var aol *AddressOrList
+		if err := json.Unmarshal([]byte(test.input), &aol); err != nil {
+			t.Fatal(err)
+		}
+		if err := checkAddressOrListEqual(aol, &test.exp); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func checkAddressOrListEqual(a, b *AddressOrList) error {
+	if (a.Address != nil) != (b.Address != nil) {
+		return errors.New("address not equal")
+	}
+	if a.Address != nil && *a.Address != *b.Address {
+		return errors.New("address not equal")
+	}
+	if len(a.AddressList) != len(b.AddressList) {
+		return errors.New("address list size not equal")
+	}
+	for i, addr1 := range a.AddressList {
+		addr2 := b.AddressList[i]
+		if addr1 != addr2 {
+			return errors.New("address list elem not equal")
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Issue

https://github.com/harmony-one/harmony/issues/3695

Added multiple address support in rpc hmy_getDelegationsByDelegatorByBlockNumber. Now the first argument accepts a single address or an address list. If an address list is given, a list of results will be returned.

## Test

Tested locally on mainnet with explorer config. Example output:

```
▶ curl -d '{
    "jsonrpc":"2.0",
    "method":"hmy_getDelegationsByDelegatorByBlockNumber",
    "params":[
      "one1...",
      13239347
    ],
    "id":1
}' -H 'Content-Type:application/json' -X POST 'localhost:9500'
{"jsonrpc":"2.0","id":1,"result":[{"Undelegations":[],"amount":...}]}

▶ curl -d '{
    "jsonrpc":"2.0",
    "method":"hmy_getDelegationsByDelegatorByBlockNumber",
    "params":[
      ["one1...","one1..."],
      13239347
    ],
    "id":1
}' -H 'Content-Type:application/json' -X POST 'localhost:9500'
{"jsonrpc":"2.0","id":1,"result":[[{"Undelegations":[],"amount":...}],[{"Undelegations":[],"amount":...}]]}
```
