### PR TITLE
[rpc] rpc skip delegations with zero amount and empty undelegation

### DIFF
--- a/rpc/staking.go
+++ b/rpc/staking.go
@@ -6,15 +6,13 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	staking "github.com/harmony-one/harmony/staking/types"
-
-	"github.com/pkg/errors"
-
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/harmony-one/harmony/hmy"
 	internal_common "github.com/harmony-one/harmony/internal/common"
 	"github.com/harmony-one/harmony/shard"
+	staking "github.com/harmony-one/harmony/staking/types"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -601,6 +599,11 @@ func (s *PublicStakingService) GetDelegationsByValidator(
 		}
 		valAddr, _ := internal_common.AddressToBech32(validatorAddress)
 		delAddr, _ := internal_common.AddressToBech32(delegation.DelegatorAddress)
+
+		// Skip delegations with zero amount and empty undelegation
+		if delegation.Amount.Cmp(common.Big0) == 0 || len(undelegations) == 0 {
+			continue
+		}
 
 		// Response output is the same for all versions
 		del, err := NewStructuredResponse(Delegation{

--- a/rpc/staking.go
+++ b/rpc/staking.go
@@ -8,6 +8,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/pkg/errors"
+
 	"github.com/harmony-one/harmony/hmy"
 	internal_common "github.com/harmony-one/harmony/internal/common"
 	"github.com/harmony-one/harmony/shard"

--- a/rpc/staking.go
+++ b/rpc/staking.go
@@ -8,8 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/pkg/errors"
-
 	"github.com/harmony-one/harmony/hmy"
 	internal_common "github.com/harmony-one/harmony/internal/common"
 	"github.com/harmony-one/harmony/shard"


### PR DESCRIPTION
## Issue

As requested in https://github.com/harmony-one/harmony/issues/3694, now delegation rpc will not return delegation with zero amount and empty undelegation.

This will potentially break the backward compatibility. Please make sure there is not external dependency on this two functions before going forward.

```
hmy_getDelegationsByValidator
hmy_getAllDelegationInformation
```

## Test

Tested locally with explorer node on mainnet.

Result dumped here: https://gist.github.com/JackyWYX/a77f78f432971aed85a950b76d712fa5

Noticed that there are validators with zero delegation entries, is this expected? Any further change request? @jhd2best 


