### PR TITLE
[cmd] Disable stream sync protocol as default on mainnet.

### DIFF
--- a/cmd/harmony/config.go
+++ b/cmd/harmony/config.go
@@ -218,7 +218,7 @@ func validateHarmonyConfig(config harmonyConfig) error {
 
 	if config.Sync.Downloader && !config.Sync.Enabled {
 		// Node must run sync protocol to enable downloader
-		return errors.New("--sync must be set to true to support stream sync downloader")
+		return errors.New("--sync must be set to true to support --sync.downloader")
 	}
 
 	return nil
@@ -341,11 +341,12 @@ var dumpConfigCmd = &cobra.Command{
 }
 
 var dumpConfigLegacyCmd = &cobra.Command{
-	Use:   "dumpconfig [config_file]",
-	Short: "depricated - use config dump instead",
-	Long:  "depricated - use config dump instead",
-	Args:  cobra.MinimumNArgs(1),
-	Run:   dumpConfig,
+	Use:    "dumpconfig [config_file]",
+	Short:  "depricated - use config dump instead",
+	Long:   "depricated - use config dump instead",
+	Args:   cobra.MinimumNArgs(1),
+	Hidden: true,
+	Run:    dumpConfig,
 }
 
 func registerDumpConfigFlags() error {

--- a/cmd/harmony/config.go
+++ b/cmd/harmony/config.go
@@ -164,6 +164,7 @@ type prometheusConfig struct {
 
 type syncConfig struct {
 	// TODO: Remove this bool after stream sync is fully up.
+	Enabled        bool // enable the stream sync protocol
 	Downloader     bool // start the sync downloader client
 	Concurrency    int  // concurrency used for stream sync protocol
 	MinPeers       int  // minimum streams to start a sync task.
@@ -213,6 +214,11 @@ func validateHarmonyConfig(config harmonyConfig) error {
 	if !config.Sync.Downloader && !config.DNSSync.Client {
 		// There is no module up for sync
 		return errors.New("either --sync.downloader or --sync.legacy.client shall be enabled")
+	}
+
+	if config.Sync.Downloader && !config.Sync.Enabled {
+		// Node must run sync protocol to enable downloader
+		return errors.New("--sync must be set to true to support stream sync downloader")
 	}
 
 	return nil

--- a/cmd/harmony/config.go
+++ b/cmd/harmony/config.go
@@ -216,12 +216,15 @@ func validateHarmonyConfig(config harmonyConfig) error {
 		return errors.New("either --sync.downloader or --sync.legacy.client shall be enabled")
 	}
 
-	if config.Sync.Downloader && !config.Sync.Enabled {
-		// Node must run sync protocol to enable downloader
-		return errors.New("--sync must be set to true to support --sync.downloader")
-	}
-
 	return nil
+}
+
+func sanityFixHarmonyConfig(hc *harmonyConfig) {
+	// When running sync downloader, set sync.Enabled to true
+	if hc.Sync.Downloader && !hc.Sync.Enabled {
+		fmt.Println("Set Sync.Enabled to true when running stream downloader")
+		hc.Sync.Enabled = true
+	}
 }
 
 func checkStringAccepted(flag string, val string, accepts []string) error {

--- a/cmd/harmony/config_migrations.go
+++ b/cmd/harmony/config_migrations.go
@@ -147,6 +147,12 @@ func init() {
 		}
 		confTree.Set("DNSSync.ServerPort", serverPort)
 
+		downloaderEnabledField := confTree.Get("Sync.Downloader")
+		if downloaderEnabled, ok := downloaderEnabledField.(bool); ok && downloaderEnabled {
+			// If we enabled downloader previously, run stream sync protocol.
+			confTree.Set("Sync.Enabled", true)
+		}
+
 		confTree.Set("Version", "2.0.0")
 		return confTree
 	}

--- a/cmd/harmony/config_migrations_test.go
+++ b/cmd/harmony/config_migrations_test.go
@@ -213,6 +213,83 @@ Version = "1.0.4"
   IP = "127.0.0.1"
   Port = 9800
 `)
+
+	V1_0_4ConfigDownloaderOn = []byte(`
+Version = "1.0.4"
+
+[BLSKeys]
+  KMSConfigFile = ""
+  KMSConfigSrcType = "shared"
+  KMSEnabled = false
+  KeyDir = "./.hmy/blskeys"
+  KeyFiles = []
+  MaxKeys = 10
+  PassEnabled = true
+  PassFile = ""
+  PassSrcType = "auto"
+  SavePassphrase = false
+
+[General]
+  DataDir = "./"
+  IsArchival = false
+  IsBeaconArchival = false
+  IsOffline = false
+  NoStaking = false
+  NodeType = "validator"
+  ShardID = -1
+
+[HTTP]
+  Enabled = true
+  IP = "127.0.0.1"
+  Port = 9500
+  RosettaEnabled = false
+  RosettaPort = 9700
+
+[Log]
+  FileName = "harmony.log"
+  Folder = "./latest"
+  RotateSize = 100
+  Verbosity = 3
+
+[Network]
+  BootNodes = ["/dnsaddr/bootstrap.t.hmny.io"]
+  DNSPort = 9000
+  DNSZone = "t.hmny.io"
+  LegacySyncing = false
+  NetworkType = "mainnet"
+
+[P2P]
+  IP = "0.0.0.0"
+  KeyFile = "./.hmykey"
+  Port = 9000
+
+[Pprof]
+  Enabled = false
+  ListenAddr = "127.0.0.1:6060"
+
+[RPCOpt]
+  DebugEnabled = false
+
+[Sync]
+  Concurrency = 6
+  DiscBatch = 8
+  DiscHardLowCap = 6
+  DiscHighCap = 128
+  DiscSoftLowCap = 8
+  Downloader = true
+  InitStreams = 8
+  LegacyClient = true
+  LegacyServer = true
+  MinPeers = 6
+
+[TxPool]
+  BlacklistFile = "./.hmy/blacklist.txt"
+
+[WS]
+  Enabled = true
+  IP = "127.0.0.1"
+  Port = 9800
+`)
 )
 
 func Test_migrateConf(t *testing.T) {
@@ -258,8 +335,24 @@ func Test_migrateConf(t *testing.T) {
 			want:    defConf,
 			wantErr: false,
 		},
+		{
+			name: "1.0.4 with sync downloaders on",
+			args: args{
+				confBytes: V1_0_4ConfigDownloaderOn,
+			},
+			want: func() harmonyConfig {
+				hc := defConf
+				hc.Sync.Downloader = true
+				hc.Sync.Enabled = true
+				return hc
+			}(),
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
+		if tt.name != "1.0.4 with sync downloaders on" {
+			continue
+		}
 		t.Run(tt.name, func(t *testing.T) {
 			got, _, err := migrateConf(tt.args.confBytes)
 			if (err != nil) != tt.wantErr {
@@ -267,7 +360,7 @@ func Test_migrateConf(t *testing.T) {
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("migrateConf() = %v, want %v", got, tt.want)
+				t.Errorf("migrateConf() = %+v, want %+v", got, tt.want)
 			}
 		})
 	}

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -108,6 +108,7 @@ var defaultPrometheusConfig = prometheusConfig{
 
 var (
 	defaultMainnetSyncConfig = syncConfig{
+		Enabled:        false,
 		Downloader:     false,
 		Concurrency:    6,
 		MinPeers:       6,
@@ -119,6 +120,7 @@ var (
 	}
 
 	defaultTestNetSyncConfig = syncConfig{
+		Enabled:        true,
 		Downloader:     false,
 		Concurrency:    4,
 		MinPeers:       4,
@@ -130,6 +132,7 @@ var (
 	}
 
 	defaultLocalNetSyncConfig = syncConfig{
+		Enabled:        true,
 		Downloader:     false,
 		Concurrency:    4,
 		MinPeers:       4,
@@ -141,6 +144,7 @@ var (
 	}
 
 	defaultElseSyncConfig = syncConfig{
+		Enabled:        true,
 		Downloader:     true,
 		Concurrency:    4,
 		MinPeers:       4,

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/harmony-one/harmony/api/service/legacysync"
-
 	"github.com/harmony-one/harmony/internal/cli"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/spf13/cobra"
@@ -190,6 +189,7 @@ var (
 	}
 
 	syncFlags = []cli.Flag{
+		syncStreamEnabledFlag,
 		syncDownloaderFlag,
 		syncConcurrencyFlag,
 		syncMinPeersFlag,
@@ -1376,6 +1376,11 @@ func applyPrometheusFlags(cmd *cobra.Command, config *harmonyConfig) {
 }
 
 var (
+	syncStreamEnabledFlag = cli.BoolFlag{
+		Name:     "sync",
+		Usage:    "Enable the stream sync protocol (experimental feature)",
+		DefValue: false,
+	}
 	// TODO: Deprecate this flag, and always set to true after stream sync is fully up.
 	syncDownloaderFlag = cli.BoolFlag{
 		Name:     "sync.downloader",
@@ -1422,6 +1427,10 @@ var (
 
 // applySyncFlags apply the sync flags.
 func applySyncFlags(cmd *cobra.Command, config *harmonyConfig) {
+	if cli.IsFlagChanged(cmd, syncStreamEnabledFlag) {
+		config.Sync.Enabled = cli.GetBoolFlagValue(cmd, syncStreamEnabledFlag)
+	}
+
 	if cli.IsFlagChanged(cmd, syncDownloaderFlag) {
 		config.Sync.Downloader = cli.GetBoolFlagValue(cmd, syncDownloaderFlag)
 	}

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -1075,7 +1075,7 @@ func TestSyncFlags(t *testing.T) {
 		expErr    error
 	}{
 		{
-			args: []string{"--sync.downloader", "--sync.concurrency", "10", "--sync.min-peers", "10",
+			args: []string{"--sync", "--sync.downloader", "--sync.concurrency", "10", "--sync.min-peers", "10",
 				"--sync.init-peers", "10", "--sync.disc.soft-low-cap", "10",
 				"--sync.disc.hard-low-cap", "10", "--sync.disc.hi-cap", "10",
 				"--sync.disc.batch", "10",
@@ -1083,6 +1083,7 @@ func TestSyncFlags(t *testing.T) {
 			network: "mainnet",
 			expConfig: func() syncConfig {
 				cfgSync := defaultMainnetSyncConfig
+				cfgSync.Enabled = true
 				cfgSync.Downloader = true
 				cfgSync.Concurrency = 10
 				cfgSync.MinPeers = 10

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -127,8 +127,6 @@ func runHarmonyNode(cmd *cobra.Command, args []string) {
 	cfg, err := getHarmonyConfig(cmd)
 	if err != nil {
 		fmt.Fprint(os.Stderr, err)
-		fmt.Println()
-		cmd.Help()
 		os.Exit(128)
 	}
 

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -382,8 +382,9 @@ func setupNodeAndRun(hc harmonyConfig) {
 	nodeconfig.SetPeerID(myHost.GetID())
 
 	// Setup services
-	setupSyncService(currentNode, myHost, hc)
-
+	if hc.Sync.Enabled {
+		setupSyncService(currentNode, myHost, hc)
+	}
 	if currentNode.NodeConfig.Role() == nodeconfig.Validator {
 		currentNode.RegisterValidatorServices()
 	} else if currentNode.NodeConfig.Role() == nodeconfig.ExplorerNode {

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -201,7 +201,7 @@ func getHarmonyConfig(cmd *cobra.Command) (harmonyConfig, error) {
 	if err := validateHarmonyConfig(config); err != nil {
 		return harmonyConfig{}, err
 	}
-
+	sanityFixHarmonyConfig(&config)
 	return config, nil
 }
 


### PR DESCRIPTION
## Issue

As requested by @rlan35 , added flag to disable stream sync protocol on mainnet. All changes are backward compatible.

For backward compatibility, all legacy config running `sync.downloader` will have `sync.Enabled` on by default.

## Test

Cmd related unit test added accordingly.

Tested locally with following options:

1. v1.0.4 default config file.
2. v1.0.4 with downloaders turned on.
3. With `--sync` flags.
4. With `--sync=true` flags.