### PR TITLE
Fix Ticker cannot stop for releasing resource

### DIFF
--- a/hmy/downloader/beaconhelper.go
+++ b/hmy/downloader/beaconhelper.go
@@ -58,6 +58,7 @@ func (bh *beaconHelper) close() {
 
 func (bh *beaconHelper) loop() {
 	t := time.NewTicker(10 * time.Second)
+	defer t.Stop()
 	for {
 		select {
 		case <-t.C:

--- a/hmy/downloader/downloader.go
+++ b/hmy/downloader/downloader.go
@@ -157,7 +157,7 @@ func (d *Downloader) waitForBootFinish() {
 	trigger()
 
 	t := time.NewTicker(10 * time.Second)
-
+	defer t.Stop()
 	for {
 		d.logger.Info().Msg("waiting for initial bootstrap discovery")
 		select {
@@ -179,6 +179,7 @@ func (d *Downloader) waitForBootFinish() {
 
 func (d *Downloader) loop() {
 	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
 	initSync := true
 	trigger := func() {
 		select {

--- a/hmy/downloader/longrange.go
+++ b/hmy/downloader/longrange.go
@@ -165,6 +165,7 @@ func (lsi *lrSyncIter) insertChainLoop(targetBN uint64) {
 		t       = time.NewTicker(100 * time.Millisecond)
 		resultC = make(chan struct{}, 1)
 	)
+	defer t.Stop()
 
 	trigger := func() {
 		select {

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -261,6 +261,7 @@ func (node *Node) DoSyncing(bc *core.BlockChain, worker *worker.Worker, willJoin
 	}
 
 	ticker := time.NewTicker(time.Duration(SyncFrequency) * time.Second)
+	defer ticker.Stop()
 	// TODO ek – infinite loop; add shutdown/cleanup logic
 	for {
 		select {

--- a/p2p/stream/common/requestmanager/requestmanager.go
+++ b/p2p/stream/common/requestmanager/requestmanager.go
@@ -134,6 +134,7 @@ func (rm *requestManager) loop() {
 		throttleC = make(chan struct{}, 1) // throttle the waiting requests periodically
 		ticker    = time.NewTicker(throttleInterval)
 	)
+	defer ticker.Stop()
 	throttle := func() {
 		select {
 		case throttleC <- struct{}{}:

--- a/p2p/stream/common/streammanager/streammanager.go
+++ b/p2p/stream/common/streammanager/streammanager.go
@@ -109,6 +109,7 @@ func (sm *streamManager) loop() {
 		discCtx    context.Context
 		discCancel func()
 	)
+	defer discTicker.Stop()
 	// bootstrap discovery
 	sm.discCh <- discTask{}
 

--- a/rpc/filters/api.go
+++ b/rpc/filters/api.go
@@ -67,6 +67,7 @@ func (api *PublicFilterAPI) isEth() bool {
 func (api *PublicFilterAPI) timeoutLoop() {
 	// TODO ek – infinite loop; add shutdown/cleanup logic
 	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
 	for {
 		<-ticker.C
 		api.filtersMu.Lock()


### PR DESCRIPTION
Ticker Need to use like this: https://github.com/harmony-one/harmony/blob/b602e8d454694373ab8f68b4e95cfd3a60670bb9/core/tx_pool.go#L317-L324

Do not forget 

```go
defer ticker.Stop()
```

if forget do such thing, maybe leading this meory leak like this: 
- https://github.com/google/goexpect/issues/3
- https://github.com/google/goexpect/pull/4
