### PR TITLE
[rpc] Fix cache lead to inconsistent result

### DIFF
--- a/rpc/blockchain.go
+++ b/rpc/blockchain.go
@@ -229,8 +229,8 @@ func (s *PublicBlockchainService) GetBlockByNumber(
 			}
 		}
 
-		if blockNum != rpc.LatestBlockNumber && blockNum != rpc.PendingBlockNumber {
-			s.blockCache.Add(uint64(blockNum), response)
+		if blockNum != rpc.PendingBlockNumber {
+			s.blockCache.Add(blk.NumberU64(), response)
 		}
 		return response, err
 	}

--- a/rpc/blockchain.go
+++ b/rpc/blockchain.go
@@ -161,8 +161,10 @@ func (s *PublicBlockchainService) GetBlockByNumber(
 ) (response StructuredResponse, err error) {
 
 	blockNum := blockNumber.EthBlockNumber()
-	if block, ok := s.blockCache.Get(uint64(blockNum)); ok {
-		return block.(StructuredResponse), nil
+	if blockNum != rpc.LatestBlockNumber && blockNum != rpc.PendingBlockNumber {
+		if block, ok := s.blockCache.Get(blockNum.Int64()); ok {
+			return block.(StructuredResponse), nil
+		}
 	}
 
 	err = s.wait(ctx)
@@ -227,7 +229,9 @@ func (s *PublicBlockchainService) GetBlockByNumber(
 			}
 		}
 
-		s.blockCache.Add(uint64(blockNum), response)
+		if blockNum != rpc.LatestBlockNumber && blockNum != rpc.PendingBlockNumber {
+			s.blockCache.Add(blockNum.Int64(), response)
+		}
 		return response, err
 	}
 

--- a/rpc/blockchain.go
+++ b/rpc/blockchain.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"strconv"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -160,18 +161,6 @@ func (s *PublicBlockchainService) GetBlockByNumber(
 	ctx context.Context, blockNumber BlockNumber, opts interface{},
 ) (response StructuredResponse, err error) {
 
-	blockNum := blockNumber.EthBlockNumber()
-	if blockNum != rpc.LatestBlockNumber && blockNum != rpc.PendingBlockNumber {
-		if block, ok := s.blockCache.Get(uint64(blockNum)); ok {
-			return block.(StructuredResponse), nil
-		}
-	}
-
-	err = s.wait(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	// Process arguments based on version
 	var blockArgs *rpc_common.BlockArgs
 	blockArgs, ok := opts.(*rpc_common.BlockArgs)
@@ -182,6 +171,19 @@ func (s *PublicBlockchainService) GetBlockByNumber(
 		}
 	}
 	blockArgs.InclTx = true
+
+	blockNum := blockNumber.EthBlockNumber()
+	if blockNum != rpc.LatestBlockNumber && blockNum != rpc.PendingBlockNumber {
+		cacheKey := combineCacheKey(uint64(blockNum), s.version, blockArgs)
+		if block, ok := s.blockCache.Get(cacheKey); ok {
+			return block.(StructuredResponse), nil
+		}
+	}
+
+	err = s.wait(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	// Some Ethereum tools (such as Truffle) rely on being able to query for future blocks without the chain returning errors.
 	// These tools implement retry mechanisms that will query & retry for a given block until it has been finalized.
@@ -230,7 +232,8 @@ func (s *PublicBlockchainService) GetBlockByNumber(
 		}
 
 		if blockNum != rpc.PendingBlockNumber {
-			s.blockCache.Add(blk.NumberU64(), response)
+			cacheKey := combineCacheKey(blk.NumberU64(), s.version, blockArgs)
+			s.blockCache.Add(cacheKey, response)
 		}
 		return response, err
 	}
@@ -815,4 +818,10 @@ func isBlockGreaterThanLatest(hmy *hmy.Harmony, blockNum rpc.BlockNumber) bool {
 		return false
 	}
 	return uint64(blockNum) > hmy.CurrentBlock().NumberU64()
+}
+
+func combineCacheKey(number uint64, version Version, blockArgs *rpc_common.BlockArgs) string {
+	// no need format blockArgs.Signers[] as a part of cache key
+	// because it's not input from rpc caller, it's caculate with blockArgs.WithSigners
+	return strconv.FormatUint(number, 10) + strconv.FormatInt(int64(version), 10) + strconv.FormatBool(blockArgs.WithSigners) + strconv.FormatBool(blockArgs.InclTx) + strconv.FormatBool(blockArgs.FullTx) + strconv.FormatBool(blockArgs.InclStaking)
 }

--- a/rpc/blockchain.go
+++ b/rpc/blockchain.go
@@ -162,7 +162,7 @@ func (s *PublicBlockchainService) GetBlockByNumber(
 
 	blockNum := blockNumber.EthBlockNumber()
 	if blockNum != rpc.LatestBlockNumber && blockNum != rpc.PendingBlockNumber {
-		if block, ok := s.blockCache.Get(blockNum.Int64()); ok {
+		if block, ok := s.blockCache.Get(uint64(blockNum)); ok {
 			return block.(StructuredResponse), nil
 		}
 	}
@@ -230,7 +230,7 @@ func (s *PublicBlockchainService) GetBlockByNumber(
 		}
 
 		if blockNum != rpc.LatestBlockNumber && blockNum != rpc.PendingBlockNumber {
-			s.blockCache.Add(blockNum.Int64(), response)
+			s.blockCache.Add(uint64(blockNum), response)
 		}
 		return response, err
 	}


### PR DESCRIPTION
## Issue

https://github.com/harmony-one/harmony/issues/3732

## Test

test locally and have not test it with @hypnagonia 

test locally result：

```
mathxh@MathxH:~/harmony-explorer-v2$ curl -d '{ "jsonrpc":"2.0", "method":"eth_getBlockByNumber", "params":[ "0xbaa39d", true], "id":1 }' -H "Content-Type:application/json" -X POST "http://127.0.0.1:9500"
{"jsonrpc":"2.0","id":1,"result":{"difficulty":"0x0","extraData":"0x","gasLimit":"0x4c4b400","gasUsed":"0x32c4b","hash":"0xc71c4bfce57e68a2e4b0636c04b7aeb4fcf1083cf39d5010e31f7722e52f83cc","logsBloom":"0x00200000000000000002000080000000020001000000000000000000000000000000000040000000000000000000000000020000000000000008000000000000000000000000000000000008000000200000000000000000000000008000000200800000000000001000000000000000000008000000000000000010000000000001000000000000000000000010000000000001000000090000004200800000000000003000088000000000080000000000000000000000000000000000000000000002000000000000000000000000000000000000001400000000000000000000000000000000000000120000000400002000000000490000000000000000","miner":"0x45df588b05a675b5f16e253aa15d90333df9fedf","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0000000000000000","number":"0xbaa39d","parentHash":"0x800fb7e592d06e076a5b906a9aa66bd7695de67aefe0cc685c73b9c23ec903fc","receiptsRoot":"0x45efd95fda7a436f7f7f6dbd0f91752bfa6d361cba8c225b4d932f6ca115d94b","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","size":"0x6e3","stateRoot":"0xfa2c494fe109f4e23247afb349ad1f9755314c6966f419e77fe923f90f18d6ea","timestamp":"0x60867345","transactions":[{"blockHash":"0xc71c4bfce57e68a2e4b0636c04b7aeb4fcf1083cf39d5010e31f7722e52f83cc","blockNumber":"0xbaa39d","from":"0x185877050ccfda4d1d28cff047fe84237c97405e","gas":"0x39f49","gasPrice":"0x1","hash":"0xf1100037377c05890cb341557d15253b704050742e38d3778eb4d19f5c2091e6","input":"0x7ff36ab5000000000000000000000000000000000000000000000000000275c5abde384e0000000000000000000000000000000000000000000000000000000000000080000000000000000000000000185877050ccfda4d1d28cff047fe84237c97405e00000000000000000000000000000000000000000000000000000000608677e00000000000000000000000000000000000000000000000000000000000000003000000000000000000000000cf664087a5bb0237a0bad6742852ec6c8d69a27a000000000000000000000000ea589e93ff18b1a1f1e9bac7ef3e86ab62addc79000000000000000000000000a0dc05f84a27fccbd341305839019ab86576bc07","nonce":"0x9d","r":"0x87510bed63c97abed8db70c214dab9effe5149af0592258fe21d373f6b14dee1","s":"0x1c1e7bb20458d8a5504a798cf991ccd257a4402df317b35399f6de8e75437ef5","timestamp":"0x60867345","to":"0xf012702a5f0e54015362cbca26a26fc90aa832a3","transactionIndex":"0x0","v":"0xc6ac98a3","value":"0xd8d726b7177a80000"}],"transactionsRoot":"0xb6094a3acb7a1a4ee355f8d176ba9b3f6699c2b886e9deb27a5cd1ec383d246f","uncles":[]}}
mathxh@MathxH:~/harmony-explorer-v2$ curl -d '{ "jsonrpc":"2.0", "method":"hmy_getBlockByNumber", "params":[ "0xbaa39d", true], "id":1 }' -H "Content-Type:application/json" -X POST "http://127.0.0.1:9500"
{"jsonrpc":"2.0","id":1,"result":{"difficulty":0,"epoch":"0x222","extraData":"0x","gasLimit":"0x4c4b400","gasUsed":"0x32c4b","hash":"0xc71c4bfce57e68a2e4b0636c04b7aeb4fcf1083cf39d5010e31f7722e52f83cc","logsBloom":"0x00200000000000000002000080000000020001000000000000000000000000000000000040000000000000000000000000020000000000000008000000000000000000000000000000000008000000200000000000000000000000008000000200800000000000001000000000000000000008000000000000000010000000000001000000000000000000000010000000000001000000090000004200800000000000003000088000000000080000000000000000000000000000000000000000000002000000000000000000000000000000000000001400000000000000000000000000000000000000120000000400002000000000490000000000000000","miner":"one1gh043zc95e6mtutwy5a2zhvsxv7lnlklkj42ux","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":0,"number":"0xbaa39d","parentHash":"0x800fb7e592d06e076a5b906a9aa66bd7695de67aefe0cc685c73b9c23ec903fc","receiptsRoot":"0x45efd95fda7a436f7f7f6dbd0f91752bfa6d361cba8c225b4d932f6ca115d94b","size":"0x6e3","stakingTransactions":[{"blockHash":"0xc71c4bfce57e68a2e4b0636c04b7aeb4fcf1083cf39d5010e31f7722e52f83cc","blockNumber":"0xbaa39d","from":"one1c0czkglt42lf4regz57v4tys583lxxj6xplt0f","gas":"0xafc8","gasPrice":"0x3b9aca00","hash":"0x7f64710c33a517d7b41bc75a045b6c0673cf5741b91d84963fe659ce2f4b2f03","msg":{"amount":"0x49ca6a465b24002c8000","delegatorAddress":"one1c0czkglt42lf4regz57v4tys583lxxj6xplt0f","validatorAddress":"one1kf42rl6yg2avkjsu34ch2jn8yjs64ycn4n9wdj"},"nonce":"0x1a","r":"0x9f1412988d56ed48d2b1e43354d08f2d10ee37752a73216cc5ddcd3230ffccc1","s":"0x1677b01281370558648a07d198027ba7bae8503b091c599059b6a575d7abde7c","timestamp":"0x60867345","transactionIndex":"0x0","type":"Undelegate","v":"0x25"}],"stateRoot":"0xfa2c494fe109f4e23247afb349ad1f9755314c6966f419e77fe923f90f18d6ea","timestamp":"0x60867345","transactions":[{"blockHash":"0xc71c4bfce57e68a2e4b0636c04b7aeb4fcf1083cf39d5010e31f7722e52f83cc","blockNumber":"0xbaa39d","ethHash":"0xf1100037377c05890cb341557d15253b704050742e38d3778eb4d19f5c2091e6","from":"one1rpv8wpgveldy68fgelcy0l5yyd7fwsz7ks3269","gas":"0x39f49","gasPrice":"0x1","hash":"0xdca69d399070ba9f1de2fb79a0ca7d4ba51c04bf418163dfeaa040a177c8b3e3","input":"0x7ff36ab5000000000000000000000000000000000000000000000000000275c5abde384e0000000000000000000000000000000000000000000000000000000000000080000000000000000000000000185877050ccfda4d1d28cff047fe84237c97405e00000000000000000000000000000000000000000000000000000000608677e00000000000000000000000000000000000000000000000000000000000000003000000000000000000000000cf664087a5bb0237a0bad6742852ec6c8d69a27a000000000000000000000000ea589e93ff18b1a1f1e9bac7ef3e86ab62addc79000000000000000000000000a0dc05f84a27fccbd341305839019ab86576bc07","nonce":"0x9d","r":"0x87510bed63c97abed8db70c214dab9effe5149af0592258fe21d373f6b14dee1","s":"0x1c1e7bb20458d8a5504a798cf991ccd257a4402df317b35399f6de8e75437ef5","shardID":0,"timestamp":"0x60867345","to":"one17qf8q2jlpe2qz5mze09zdgn0ey92sv4r323k20","toShardID":0,"transactionIndex":"0x0","v":"0xc6ac98a3","value":"0xd8d726b7177a80000"}],"transactionsRoot":"0xb6094a3acb7a1a4ee355f8d176ba9b3f6699c2b886e9deb27a5cd1ec383d246f","uncles":[],"viewID":"0xbaa4f1"}}
mathxh@MathxH:~/harmony-explorer-v2$
```

Why will happen this issue:

cause BlockNumber have latest(-1) and pending value(-2)

but cache have not handle this two Special value， and latest block will change every time when block syncing, but the first latest param request is cached , So the subsequent real latest block must not be the same as the latest block inside the cache. 

## Solution

 <del>As long as the cache does not add these two types of BlockNumber, it is fine </del>
  add latest real number + version + block args as cache key for block json
