### PR TITLE
[feature] expose all configuration variables and values

### DIFF
--- a/cmd/harmony/bls.go
+++ b/cmd/harmony/bls.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	harmonyconfig "github.com/harmony-one/harmony/internal/configs/harmony"
 	"os"
 	"sync"
 
@@ -16,7 +17,7 @@ var (
 )
 
 // setupConsensusKeys load bls keys and set the keys to nodeConfig. Return the loaded public keys.
-func setupConsensusKeys(hc harmonyConfig, config *nodeconfig.ConfigType) multibls.PublicKeys {
+func setupConsensusKeys(hc harmonyconfig.HarmonyConfig, config *nodeconfig.ConfigType) multibls.PublicKeys {
 	onceLoadBLSKey.Do(func() {
 		var err error
 		multiBLSPriKey, err = loadBLSKeys(hc.BLSKeys)
@@ -30,7 +31,7 @@ func setupConsensusKeys(hc harmonyConfig, config *nodeconfig.ConfigType) multibl
 	return multiBLSPriKey.GetPublicKeys()
 }
 
-func loadBLSKeys(raw blsConfig) (multibls.PrivateKeys, error) {
+func loadBLSKeys(raw harmonyconfig.BlsConfig) (multibls.PrivateKeys, error) {
 	config, err := parseBLSLoadingConfig(raw)
 	if err != nil {
 		return nil, err
@@ -48,7 +49,7 @@ func loadBLSKeys(raw blsConfig) (multibls.PrivateKeys, error) {
 	return keys.Dedup(), err
 }
 
-func parseBLSLoadingConfig(raw blsConfig) (blsgen.Config, error) {
+func parseBLSLoadingConfig(raw harmonyconfig.BlsConfig) (blsgen.Config, error) {
 	var (
 		config blsgen.Config
 		err    error
@@ -69,7 +70,7 @@ func parseBLSLoadingConfig(raw blsConfig) (blsgen.Config, error) {
 	return config, nil
 }
 
-func parseBLSPassConfig(cfg blsgen.Config, raw blsConfig) (blsgen.Config, error) {
+func parseBLSPassConfig(cfg blsgen.Config, raw harmonyconfig.BlsConfig) (blsgen.Config, error) {
 	if !raw.PassEnabled {
 		cfg.PassSrcType = blsgen.PassSrcNil
 		return blsgen.Config{}, nil
@@ -90,7 +91,7 @@ func parseBLSPassConfig(cfg blsgen.Config, raw blsConfig) (blsgen.Config, error)
 	return cfg, nil
 }
 
-func parseBLSKmsConfig(cfg blsgen.Config, raw blsConfig) (blsgen.Config, error) {
+func parseBLSKmsConfig(cfg blsgen.Config, raw harmonyconfig.BlsConfig) (blsgen.Config, error) {
 	if !raw.KMSEnabled {
 		cfg.AwsCfgSrcType = blsgen.AwsCfgSrcNil
 		return cfg, nil

--- a/cmd/harmony/bls.go
+++ b/cmd/harmony/bls.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
-	harmonyconfig "github.com/harmony-one/harmony/internal/configs/harmony"
 	"os"
 	"sync"
+
+	harmonyconfig "github.com/harmony-one/harmony/internal/configs/harmony"
 
 	"github.com/harmony-one/harmony/internal/blsgen"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"

--- a/cmd/harmony/config_migrations.go
+++ b/cmd/harmony/config_migrations.go
@@ -157,4 +157,14 @@ func init() {
 		confTree.Set("Version", "2.0.0")
 		return confTree
 	}
+
+	migrations["2.0.0"] = func(confTree *toml.Tree) *toml.Tree {
+		// Legacy conf missing fields
+		if confTree.Get("Log.VerbosePrints") == nil {
+			confTree.Set("Log.VerbosePrints", defaultConfig.Log.VerbosePrints)
+		}
+
+		confTree.Set("Version", "2.1.0")
+		return confTree
+	}
 }

--- a/cmd/harmony/config_migrations.go
+++ b/cmd/harmony/config_migrations.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/harmony-one/harmony/api/service/legacysync"
+	harmonyconfig "github.com/harmony-one/harmony/internal/configs/harmony"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	goversion "github.com/hashicorp/go-version"
 	"github.com/pelletier/go-toml"
@@ -38,31 +39,31 @@ func doMigrations(confVersion string, confTree *toml.Tree) error {
 	return nil
 }
 
-func migrateConf(confBytes []byte) (harmonyConfig, string, error) {
+func migrateConf(confBytes []byte) (harmonyconfig.HarmonyConfig, string, error) {
 	var (
 		migratedFrom string
 	)
 	confTree, err := toml.LoadBytes(confBytes)
 	if err != nil {
-		return harmonyConfig{}, "", fmt.Errorf("config file parse error - %s", err.Error())
+		return harmonyconfig.HarmonyConfig{}, "", fmt.Errorf("config file parse error - %s", err.Error())
 	}
 	confVersion, found := confTree.Get("Version").(string)
 	if !found {
-		return harmonyConfig{}, "", errors.New("config file invalid - no version entry found")
+		return harmonyconfig.HarmonyConfig{}, "", errors.New("config file invalid - no version entry found")
 	}
 	migratedFrom = confVersion
 	if confVersion != tomlConfigVersion {
 		err = doMigrations(confVersion, confTree)
 		if err != nil {
-			return harmonyConfig{}, "", err
+			return harmonyconfig.HarmonyConfig{}, "", err
 		}
 	}
 
 	// At this point we must be at current config version so
 	// we can safely unmarshal it
-	var config harmonyConfig
+	var config harmonyconfig.HarmonyConfig
 	if err := confTree.Unmarshal(&config); err != nil {
-		return harmonyConfig{}, "", err
+		return harmonyconfig.HarmonyConfig{}, "", err
 	}
 	return config, migratedFrom, nil
 }

--- a/cmd/harmony/config_migrations_test.go
+++ b/cmd/harmony/config_migrations_test.go
@@ -308,7 +308,7 @@ func Test_migrateConf(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    harmonyConfig
+		want    HarmonyConfig
 		wantErr bool
 	}{
 		{
@@ -340,7 +340,7 @@ func Test_migrateConf(t *testing.T) {
 			args: args{
 				confBytes: V1_0_4ConfigDownloaderOn,
 			},
-			want: func() harmonyConfig {
+			want: func() HarmonyConfig {
 				hc := defConf
 				hc.Sync.Downloader = true
 				hc.Sync.Enabled = true

--- a/cmd/harmony/config_migrations_test.go
+++ b/cmd/harmony/config_migrations_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 
+	harmonyconfig "github.com/harmony-one/harmony/internal/configs/harmony"
+
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 )
 
@@ -308,7 +310,7 @@ func Test_migrateConf(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    HarmonyConfig
+		want    harmonyconfig.HarmonyConfig
 		wantErr bool
 	}{
 		{
@@ -340,7 +342,7 @@ func Test_migrateConf(t *testing.T) {
 			args: args{
 				confBytes: V1_0_4ConfigDownloaderOn,
 			},
-			want: func() HarmonyConfig {
+			want: func() harmonyconfig.HarmonyConfig {
 				hc := defConf
 				hc.Sync.Downloader = true
 				hc.Sync.Enabled = true

--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -11,9 +11,9 @@ import (
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 )
 
-type testCfgOpt func(config *harmonyConfig)
+type testCfgOpt func(config *HarmonyConfig)
 
-func makeTestConfig(nt nodeconfig.NetworkType, opt testCfgOpt) harmonyConfig {
+func makeTestConfig(nt nodeconfig.NetworkType, opt testCfgOpt) HarmonyConfig {
 	cfg := getDefaultHmyConfigCopy(nt)
 	if opt != nil {
 		opt(&cfg)
@@ -133,7 +133,7 @@ func TestPersistConfig(t *testing.T) {
 	os.MkdirAll(testDir, 0777)
 
 	tests := []struct {
-		config harmonyConfig
+		config HarmonyConfig
 	}{
 		{
 			config: makeTestConfig("mainnet", nil),
@@ -142,7 +142,7 @@ func TestPersistConfig(t *testing.T) {
 			config: makeTestConfig("devnet", nil),
 		},
 		{
-			config: makeTestConfig("mainnet", func(cfg *harmonyConfig) {
+			config: makeTestConfig("mainnet", func(cfg *HarmonyConfig) {
 				consensus := getDefaultConsensusConfigCopy()
 				cfg.Consensus = &consensus
 

--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -8,12 +8,14 @@ import (
 	"reflect"
 	"testing"
 
+	harmonyconfig "github.com/harmony-one/harmony/internal/configs/harmony"
+
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 )
 
-type testCfgOpt func(config *HarmonyConfig)
+type testCfgOpt func(config *harmonyconfig.HarmonyConfig)
 
-func makeTestConfig(nt nodeconfig.NetworkType, opt testCfgOpt) HarmonyConfig {
+func makeTestConfig(nt nodeconfig.NetworkType, opt testCfgOpt) harmonyconfig.HarmonyConfig {
 	cfg := getDefaultHmyConfigCopy(nt)
 	if opt != nil {
 		opt(&cfg)
@@ -133,7 +135,7 @@ func TestPersistConfig(t *testing.T) {
 	os.MkdirAll(testDir, 0777)
 
 	tests := []struct {
-		config HarmonyConfig
+		config harmonyconfig.HarmonyConfig
 	}{
 		{
 			config: makeTestConfig("mainnet", nil),
@@ -142,7 +144,7 @@ func TestPersistConfig(t *testing.T) {
 			config: makeTestConfig("devnet", nil),
 		},
 		{
-			config: makeTestConfig("mainnet", func(cfg *HarmonyConfig) {
+			config: makeTestConfig("mainnet", func(cfg *harmonyconfig.HarmonyConfig) {
 				consensus := getDefaultConsensusConfigCopy()
 				cfg.Consensus = &consensus
 
@@ -153,7 +155,7 @@ func TestPersistConfig(t *testing.T) {
 				cfg.Revert = &revert
 
 				webHook := "web hook"
-				cfg.Legacy = &legacyConfig{
+				cfg.Legacy = &harmonyconfig.LegacyConfig{
 					WebHookConfig:         &webHook,
 					TPBroadcastInvalidTxn: &trueBool,
 				}

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -1,6 +1,9 @@
 package main
 
-import nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
+import (
+	harmonyconfig "github.com/harmony-one/harmony/internal/configs/harmony"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
+)
 
 const tomlConfigVersion = "2.0.0"
 
@@ -8,9 +11,9 @@ const (
 	defNetworkType = nodeconfig.Mainnet
 )
 
-var defaultConfig = harmonyConfig{
+var defaultConfig = harmonyconfig.HarmonyConfig{
 	Version: tomlConfigVersion,
-	General: generalConfig{
+	General: harmonyconfig.GeneralConfig{
 		NodeType:         "validator",
 		NoStaking:        false,
 		ShardID:          -1,
@@ -20,29 +23,29 @@ var defaultConfig = harmonyConfig{
 		DataDir:          "./",
 	},
 	Network: getDefaultNetworkConfig(defNetworkType),
-	P2P: p2pConfig{
+	P2P: harmonyconfig.P2pConfig{
 		Port:    nodeconfig.DefaultP2PPort,
 		IP:      nodeconfig.DefaultPublicListenIP,
 		KeyFile: "./.hmykey",
 	},
-	HTTP: httpConfig{
+	HTTP: harmonyconfig.HttpConfig{
 		Enabled:        true,
 		RosettaEnabled: false,
 		IP:             "127.0.0.1",
 		Port:           nodeconfig.DefaultRPCPort,
 		RosettaPort:    nodeconfig.DefaultRosettaPort,
 	},
-	WS: wsConfig{
+	WS: harmonyconfig.WsConfig{
 		Enabled: true,
 		IP:      "127.0.0.1",
 		Port:    nodeconfig.DefaultWSPort,
 	},
-	RPCOpt: rpcOptConfig{
+	RPCOpt: harmonyconfig.RpcOptConfig{
 		DebugEnabled:      false,
 		RateLimterEnabled: true,
 		RequestsPerSecond: nodeconfig.DefaultRPCRateLimit,
 	},
-	BLSKeys: blsConfig{
+	BLSKeys: harmonyconfig.BlsConfig{
 		KeyDir:   "./.hmy/blskeys",
 		KeyFiles: []string{},
 		MaxKeys:  10,
@@ -55,15 +58,15 @@ var defaultConfig = harmonyConfig{
 		KMSConfigSrcType: kmsConfigTypeShared,
 		KMSConfigFile:    "",
 	},
-	TxPool: txPoolConfig{
+	TxPool: harmonyconfig.TxPoolConfig{
 		BlacklistFile: "./.hmy/blacklist.txt",
 	},
 	Sync: getDefaultSyncConfig(defNetworkType),
-	Pprof: pprofConfig{
+	Pprof: harmonyconfig.PprofConfig{
 		Enabled:    false,
 		ListenAddr: "127.0.0.1:6060",
 	},
-	Log: logConfig{
+	Log: harmonyconfig.LogConfig{
 		Folder:     "./latest",
 		FileName:   "harmony.log",
 		RotateSize: 100,
@@ -72,33 +75,33 @@ var defaultConfig = harmonyConfig{
 	DNSSync: getDefaultDNSSyncConfig(defNetworkType),
 }
 
-var defaultSysConfig = sysConfig{
+var defaultSysConfig = harmonyconfig.SysConfig{
 	NtpServer: "1.pool.ntp.org",
 }
 
-var defaultDevnetConfig = devnetConfig{
+var defaultDevnetConfig = harmonyconfig.DevnetConfig{
 	NumShards:   2,
 	ShardSize:   10,
 	HmyNodeSize: 10,
 }
 
-var defaultRevertConfig = revertConfig{
+var defaultRevertConfig = harmonyconfig.RevertConfig{
 	RevertBeacon: false,
 	RevertBefore: 0,
 	RevertTo:     0,
 }
 
-var defaultLogContext = logContext{
+var defaultLogContext = harmonyconfig.LogContext{
 	IP:   "127.0.0.1",
 	Port: 9000,
 }
 
-var defaultConsensusConfig = consensusConfig{
+var defaultConsensusConfig = harmonyconfig.ConsensusConfig{
 	MinPeers:     6,
 	AggregateSig: true,
 }
 
-var defaultPrometheusConfig = prometheusConfig{
+var defaultPrometheusConfig = harmonyconfig.PrometheusConfig{
 	Enabled:    true,
 	IP:         "0.0.0.0",
 	Port:       9900,
@@ -107,7 +110,7 @@ var defaultPrometheusConfig = prometheusConfig{
 }
 
 var (
-	defaultMainnetSyncConfig = syncConfig{
+	defaultMainnetSyncConfig = harmonyconfig.SyncConfig{
 		Enabled:        false,
 		Downloader:     false,
 		Concurrency:    6,
@@ -119,7 +122,7 @@ var (
 		DiscBatch:      8,
 	}
 
-	defaultTestNetSyncConfig = syncConfig{
+	defaultTestNetSyncConfig = harmonyconfig.SyncConfig{
 		Enabled:        true,
 		Downloader:     false,
 		Concurrency:    4,
@@ -131,7 +134,7 @@ var (
 		DiscBatch:      8,
 	}
 
-	defaultLocalNetSyncConfig = syncConfig{
+	defaultLocalNetSyncConfig = harmonyconfig.SyncConfig{
 		Enabled:        true,
 		Downloader:     false,
 		Concurrency:    4,
@@ -143,7 +146,7 @@ var (
 		DiscBatch:      8,
 	}
 
-	defaultElseSyncConfig = syncConfig{
+	defaultElseSyncConfig = harmonyconfig.SyncConfig{
 		Enabled:        true,
 		Downloader:     true,
 		Concurrency:    4,
@@ -160,7 +163,7 @@ const (
 	defaultBroadcastInvalidTx = false
 )
 
-func getDefaultHmyConfigCopy(nt nodeconfig.NetworkType) harmonyConfig {
+func getDefaultHmyConfigCopy(nt nodeconfig.NetworkType) harmonyconfig.HarmonyConfig {
 	config := defaultConfig
 
 	config.Network = getDefaultNetworkConfig(nt)
@@ -174,32 +177,32 @@ func getDefaultHmyConfigCopy(nt nodeconfig.NetworkType) harmonyConfig {
 	return config
 }
 
-func getDefaultSysConfigCopy() sysConfig {
+func getDefaultSysConfigCopy() harmonyconfig.SysConfig {
 	config := defaultSysConfig
 	return config
 }
 
-func getDefaultDevnetConfigCopy() devnetConfig {
+func getDefaultDevnetConfigCopy() harmonyconfig.DevnetConfig {
 	config := defaultDevnetConfig
 	return config
 }
 
-func getDefaultRevertConfigCopy() revertConfig {
+func getDefaultRevertConfigCopy() harmonyconfig.RevertConfig {
 	config := defaultRevertConfig
 	return config
 }
 
-func getDefaultLogContextCopy() logContext {
+func getDefaultLogContextCopy() harmonyconfig.LogContext {
 	config := defaultLogContext
 	return config
 }
 
-func getDefaultConsensusConfigCopy() consensusConfig {
+func getDefaultConsensusConfigCopy() harmonyconfig.ConsensusConfig {
 	config := defaultConsensusConfig
 	return config
 }
 
-func getDefaultPrometheusConfigCopy() prometheusConfig {
+func getDefaultPrometheusConfigCopy() harmonyconfig.PrometheusConfig {
 	config := defaultPrometheusConfig
 	return config
 }

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -5,7 +5,7 @@ import (
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 )
 
-const tomlConfigVersion = "2.0.0"
+const tomlConfigVersion = "2.1.0"
 
 const (
 	defNetworkType = nodeconfig.Mainnet
@@ -71,6 +71,9 @@ var defaultConfig = harmonyconfig.HarmonyConfig{
 		FileName:   "harmony.log",
 		RotateSize: 100,
 		Verbosity:  3,
+		VerbosePrints: harmonyconfig.LogVerbosePrints{
+			Config: false,
+		},
 	},
 	DNSSync: getDefaultDNSSyncConfig(defNetworkType),
 }

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
-	harmonyconfig "github.com/harmony-one/harmony/internal/configs/harmony"
 	"strconv"
 	"strings"
+
+	harmonyconfig "github.com/harmony-one/harmony/internal/configs/harmony"
 
 	"github.com/harmony-one/harmony/api/service/legacysync"
 	"github.com/harmony-one/harmony/internal/cli"
@@ -996,8 +997,8 @@ var (
 		DefValue:  defaultConfig.Log.Verbosity,
 	}
 	verbosePrintsFlag = cli.StringSliceFlag{
-		Name:	   "verbose-prints",
-		Usage:     "verbose prints, available options: config",
+		Name:  "verbose-prints",
+		Usage: "verbose prints, available options: config",
 	}
 	// TODO: remove context (this shall not be in the log)
 	logContextIPFlag = cli.StringFlag{

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	harmonyconfig "github.com/harmony-one/harmony/internal/configs/harmony"
 	"strconv"
 	"strings"
 
@@ -133,6 +134,7 @@ var (
 		logContextIPFlag,
 		logContextPortFlag,
 		logVerbosityFlag,
+		verbosePrintsFlag,
 		legacyVerbosityFlag,
 
 		legacyLogFolderFlag,
@@ -297,7 +299,7 @@ func getRootFlags() []cli.Flag {
 	return flags
 }
 
-func applyGeneralFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyGeneralFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, nodeTypeFlag) {
 		config.General.NodeType = cli.GetStringFlagValue(cmd, nodeTypeFlag)
 	} else if cli.IsFlagChanged(cmd, legacyNodeTypeFlag) {
@@ -434,7 +436,7 @@ func getNetworkType(cmd *cobra.Command) nodeconfig.NetworkType {
 	return parseNetworkType(raw)
 }
 
-func applyDNSSyncFlags(cmd *cobra.Command, cfg *harmonyConfig) {
+func applyDNSSyncFlags(cmd *cobra.Command, cfg *harmonyconfig.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, dnsZoneFlag) {
 		cfg.DNSSync.Zone = cli.GetStringFlagValue(cmd, dnsZoneFlag)
 	} else if cli.IsFlagChanged(cmd, legacyDNSZoneFlag) {
@@ -470,7 +472,7 @@ func applyDNSSyncFlags(cmd *cobra.Command, cfg *harmonyConfig) {
 
 }
 
-func applyNetworkFlags(cmd *cobra.Command, cfg *harmonyConfig) {
+func applyNetworkFlags(cmd *cobra.Command, cfg *harmonyconfig.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, bootNodeFlag) {
 		cfg.Network.BootNodes = cli.GetStringSliceFlagValue(cmd, bootNodeFlag)
 	}
@@ -507,7 +509,7 @@ var (
 	}
 )
 
-func applyP2PFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyP2PFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, p2pPortFlag) {
 		config.P2P.Port = cli.GetIntFlagValue(cmd, p2pPortFlag)
 	}
@@ -559,7 +561,7 @@ var (
 	}
 )
 
-func applyHTTPFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyHTTPFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	var isRPCSpecified, isRosettaSpecified bool
 
 	if cli.IsFlagChanged(cmd, httpIPFlag) {
@@ -610,7 +612,7 @@ var (
 	}
 )
 
-func applyWSFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyWSFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, wsEnabledFlag) {
 		config.WS.Enabled = cli.GetBoolFlagValue(cmd, wsEnabledFlag)
 	}
@@ -644,7 +646,7 @@ var (
 	}
 )
 
-func applyRPCOptFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyRPCOptFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, rpcDebugEnabledFlag) {
 		config.RPCOpt.DebugEnabled = cli.GetBoolFlagValue(cmd, rpcDebugEnabledFlag)
 	}
@@ -749,7 +751,7 @@ var (
 	}
 )
 
-func applyBLSFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyBLSFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, blsDirFlag) {
 		config.BLSKeys.KeyDir = cli.GetStringFlagValue(cmd, blsDirFlag)
 	} else if cli.IsFlagChanged(cmd, legacyBLSFolderFlag) {
@@ -777,7 +779,7 @@ func applyBLSFlags(cmd *cobra.Command, config *harmonyConfig) {
 	}
 }
 
-func applyBLSPassFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyBLSPassFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	var passFileSpecified bool
 
 	if cli.IsFlagChanged(cmd, passEnabledFlag) {
@@ -797,7 +799,7 @@ func applyBLSPassFlags(cmd *cobra.Command, config *harmonyConfig) {
 	}
 }
 
-func applyKMSFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyKMSFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	var fileSpecified bool
 
 	if cli.IsFlagChanged(cmd, kmsEnabledFlag) {
@@ -814,7 +816,7 @@ func applyKMSFlags(cmd *cobra.Command, config *harmonyConfig) {
 	}
 }
 
-func applyLegacyBLSPassFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyLegacyBLSPassFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, legacyBLSPassFlag) {
 		val := cli.GetStringFlagValue(cmd, legacyBLSPassFlag)
 		legacyApplyBLSPassVal(val, config)
@@ -824,14 +826,14 @@ func applyLegacyBLSPassFlags(cmd *cobra.Command, config *harmonyConfig) {
 	}
 }
 
-func applyLegacyKMSFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyLegacyKMSFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, legacyKMSConfigSourceFlag) {
 		val := cli.GetStringFlagValue(cmd, legacyKMSConfigSourceFlag)
 		legacyApplyKMSSourceVal(val, config)
 	}
 }
 
-func legacyApplyBLSPassVal(src string, config *harmonyConfig) {
+func legacyApplyBLSPassVal(src string, config *harmonyconfig.HarmonyConfig) {
 	methodArgs := strings.SplitN(src, ":", 2)
 	method := methodArgs[0]
 
@@ -852,7 +854,7 @@ func legacyApplyBLSPassVal(src string, config *harmonyConfig) {
 	}
 }
 
-func legacyApplyKMSSourceVal(src string, config *harmonyConfig) {
+func legacyApplyKMSSourceVal(src string, config *harmonyconfig.HarmonyConfig) {
 	methodArgs := strings.SplitN(src, ":", 2)
 	method := methodArgs[0]
 
@@ -903,7 +905,7 @@ var (
 	}
 )
 
-func applyConsensusFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyConsensusFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	if config.Consensus == nil && cli.HasFlagsChanged(cmd, consensusValidFlags) {
 		cfg := getDefaultConsensusConfigCopy()
 		config.Consensus = &cfg
@@ -935,7 +937,7 @@ var (
 	}
 )
 
-func applyTxPoolFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyTxPoolFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, tpBlacklistFileFlag) {
 		config.TxPool.BlacklistFile = cli.GetStringFlagValue(cmd, tpBlacklistFileFlag)
 	} else if cli.IsFlagChanged(cmd, legacyTPBlacklistFileFlag) {
@@ -957,7 +959,7 @@ var (
 	}
 )
 
-func applyPprofFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyPprofFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	var pprofSet bool
 	if cli.IsFlagChanged(cmd, pprofListenAddrFlag) {
 		config.Pprof.ListenAddr = cli.GetStringFlagValue(cmd, pprofListenAddrFlag)
@@ -993,6 +995,10 @@ var (
 		Usage:     "logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail",
 		DefValue:  defaultConfig.Log.Verbosity,
 	}
+	verbosePrintsFlag = cli.StringSliceFlag{
+		Name:	   "verbose-prints",
+		Usage:     "verbose prints, available options: config",
+	}
 	// TODO: remove context (this shall not be in the log)
 	logContextIPFlag = cli.StringFlag{
 		Name:     "log.ctx.ip",
@@ -1026,7 +1032,7 @@ var (
 	}
 )
 
-func applyLogFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyLogFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, logFolderFlag) {
 		config.Log.Folder = cli.GetStringFlagValue(cmd, logFolderFlag)
 	} else if cli.IsFlagChanged(cmd, legacyLogFolderFlag) {
@@ -1047,6 +1053,15 @@ func applyLogFlags(cmd *cobra.Command, config *harmonyConfig) {
 		config.Log.Verbosity = cli.GetIntFlagValue(cmd, logVerbosityFlag)
 	} else if cli.IsFlagChanged(cmd, legacyVerbosityFlag) {
 		config.Log.Verbosity = cli.GetIntFlagValue(cmd, legacyVerbosityFlag)
+	}
+
+	if cli.IsFlagChanged(cmd, verbosePrintsFlag) {
+		verbosePrintsSlice := cli.GetStringSliceFlagValue(cmd, verbosePrintsFlag)
+		verbosePrintsMap := make(map[string]bool, 0)
+		for _, verbosePrint := range verbosePrintsSlice {
+			verbosePrintsMap[verbosePrint] = true
+		}
+		config.Log.VerbosePrints = verbosePrintsMap
 	}
 
 	if cli.HasFlagsChanged(cmd, []cli.Flag{logContextIPFlag, logContextPortFlag}) {
@@ -1071,7 +1086,7 @@ var (
 	}
 )
 
-func applySysFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applySysFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	if cli.HasFlagsChanged(cmd, sysFlags) || config.Sys == nil {
 		cfg := getDefaultSysConfigCopy()
 		config.Sys = &cfg
@@ -1121,7 +1136,7 @@ var (
 	}
 )
 
-func applyDevnetFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyDevnetFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	if cli.HasFlagsChanged(cmd, devnetFlags) && config.Devnet == nil {
 		cfg := getDefaultDevnetConfigCopy()
 		config.Devnet = &cfg
@@ -1196,7 +1211,7 @@ var (
 	}
 )
 
-func applyRevertFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyRevertFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	if cli.HasFlagsChanged(cmd, revertFlags) {
 		cfg := getDefaultRevertConfigCopy()
 		config.Revert = &cfg
@@ -1261,7 +1276,7 @@ var (
 )
 
 // Note: this function need to be called before parse other flags
-func applyLegacyMiscFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyLegacyMiscFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, legacyPortFlag) {
 		legacyPort := cli.GetIntFlagValue(cmd, legacyPortFlag)
 		config.P2P.Port = legacyPort
@@ -1296,7 +1311,7 @@ func applyLegacyMiscFlags(cmd *cobra.Command, config *harmonyConfig) {
 		logPort := cli.GetIntFlagValue(cmd, legacyPortFlag)
 		config.Log.FileName = fmt.Sprintf("validator-%v-%v.log", logIP, logPort)
 
-		logCtx := &logContext{
+		logCtx := &harmonyconfig.LogContext{
 			IP:   logIP,
 			Port: logPort,
 		}
@@ -1304,7 +1319,7 @@ func applyLegacyMiscFlags(cmd *cobra.Command, config *harmonyConfig) {
 	}
 
 	if cli.HasFlagsChanged(cmd, []cli.Flag{legacyWebHookConfigFlag, legacyTPBroadcastInvalidTxFlag}) {
-		config.Legacy = &legacyConfig{}
+		config.Legacy = &harmonyconfig.LegacyConfig{}
 		if cli.IsFlagChanged(cmd, legacyWebHookConfigFlag) {
 			val := cli.GetStringFlagValue(cmd, legacyWebHookConfigFlag)
 			config.Legacy.WebHookConfig = &val
@@ -1345,7 +1360,7 @@ var (
 	}
 )
 
-func applyPrometheusFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyPrometheusFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	if config.Prometheus == nil {
 		cfg := getDefaultPrometheusConfigCopy()
 		config.Prometheus = &cfg
@@ -1426,7 +1441,7 @@ var (
 )
 
 // applySyncFlags apply the sync flags.
-func applySyncFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applySyncFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, syncStreamEnabledFlag) {
 		config.Sync.Enabled = cli.GetBoolFlagValue(cmd, syncStreamEnabledFlag)
 	}

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -135,7 +135,7 @@ var (
 		logContextIPFlag,
 		logContextPortFlag,
 		logVerbosityFlag,
-		verbosePrintsFlag,
+		logVerbosePrintsFlag,
 		legacyVerbosityFlag,
 
 		legacyLogFolderFlag,
@@ -996,9 +996,10 @@ var (
 		Usage:     "logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail",
 		DefValue:  defaultConfig.Log.Verbosity,
 	}
-	verbosePrintsFlag = cli.StringSliceFlag{
-		Name:  "verbose-prints",
-		Usage: "verbose prints, available options: config",
+	logVerbosePrintsFlag = cli.StringSliceFlag{
+		Name:      "log.verbose-prints",
+		Usage:     "debugging feature. to print verbose internal objects as JSON in log file. available internal objects: config",
+		DefValue:  []string{},
 	}
 	// TODO: remove context (this shall not be in the log)
 	logContextIPFlag = cli.StringFlag{
@@ -1056,13 +1057,9 @@ func applyLogFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 		config.Log.Verbosity = cli.GetIntFlagValue(cmd, legacyVerbosityFlag)
 	}
 
-	if cli.IsFlagChanged(cmd, verbosePrintsFlag) {
-		verbosePrintsSlice := cli.GetStringSliceFlagValue(cmd, verbosePrintsFlag)
-		verbosePrintsMap := make(map[string]bool, 0)
-		for _, verbosePrint := range verbosePrintsSlice {
-			verbosePrintsMap[verbosePrint] = true
-		}
-		config.Log.VerbosePrints = verbosePrintsMap
+	if cli.IsFlagChanged(cmd, logVerbosePrintsFlag) {
+		verbosePrintsFlagSlice := cli.GetStringSliceFlagValue(cmd, logVerbosePrintsFlag)
+		config.Log.VerbosePrints = harmonyconfig.FlagSliceToLogVerbosePrints(verbosePrintsFlagSlice)
 	}
 
 	if cli.HasFlagsChanged(cmd, []cli.Flag{logContextIPFlag, logContextPortFlag}) {

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -997,9 +997,9 @@ var (
 		DefValue:  defaultConfig.Log.Verbosity,
 	}
 	logVerbosePrintsFlag = cli.StringSliceFlag{
-		Name:      "log.verbose-prints",
-		Usage:     "debugging feature. to print verbose internal objects as JSON in log file. available internal objects: config",
-		DefValue:  []string{},
+		Name:     "log.verbose-prints",
+		Usage:    "debugging feature. to print verbose internal objects as JSON in log file. available internal objects: config",
+		DefValue: []string{},
 	}
 	// TODO: remove context (this shall not be in the log)
 	logContextIPFlag = cli.StringFlag{

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	harmonyconfig "github.com/harmony-one/harmony/internal/configs/harmony"
+
 	"github.com/harmony-one/harmony/internal/cli"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/spf13/cobra"
@@ -18,7 +20,7 @@ var (
 func TestHarmonyFlags(t *testing.T) {
 	tests := []struct {
 		argStr    string
-		expConfig HarmonyConfig
+		expConfig harmonyconfig.HarmonyConfig
 	}{
 		{
 			// running staking command from legacy node.sh
@@ -29,16 +31,16 @@ func TestHarmonyFlags(t *testing.T) {
 				"et --dns_zone=t.hmny.io --blacklist=./.hmy/blacklist.txt --min_peers=6 --max_bls_keys_per_node=" +
 				"10 --broadcast_invalid_tx=true --verbosity=3 --is_archival=false --shard_id=-1 --staking=true -" +
 				"-aws-config-source file:config.json",
-			expConfig: HarmonyConfig{
+			expConfig: harmonyconfig.HarmonyConfig{
 				Version: tomlConfigVersion,
-				General: generalConfig{
+				General: harmonyconfig.GeneralConfig{
 					NodeType:   "validator",
 					NoStaking:  false,
 					ShardID:    -1,
 					IsArchival: false,
 					DataDir:    "./",
 				},
-				Network: networkConfig{
+				Network: harmonyconfig.NetworkConfig{
 					NetworkType: "mainnet",
 					BootNodes: []string{
 						"/ip4/100.26.90.187/tcp/9874/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv",
@@ -47,40 +49,40 @@ func TestHarmonyFlags(t *testing.T) {
 						"/ip4/99.81.170.167/tcp/12019/p2p/QmRVbTpEYup8dSaURZfF6ByrMTSKa4UyUzJhSjahFzRqNj",
 					},
 				},
-				DNSSync: dnsSync{
+				DNSSync: harmonyconfig.DnsSync{
 					Port:       6000,
 					Zone:       "t.hmny.io",
 					Server:     true,
 					Client:     true,
 					ServerPort: nodeconfig.DefaultDNSPort,
 				},
-				P2P: p2pConfig{
+				P2P: harmonyconfig.P2pConfig{
 					Port:    9000,
 					IP:      defaultConfig.P2P.IP,
 					KeyFile: defaultConfig.P2P.KeyFile,
 				},
-				HTTP: httpConfig{
+				HTTP: harmonyconfig.HttpConfig{
 					Enabled:        true,
 					IP:             "127.0.0.1",
 					Port:           9500,
 					RosettaEnabled: false,
 					RosettaPort:    9700,
 				},
-				RPCOpt: rpcOptConfig{
+				RPCOpt: harmonyconfig.RpcOptConfig{
 					DebugEnabled:      false,
 					RateLimterEnabled: true,
 					RequestsPerSecond: 1000,
 				},
-				WS: wsConfig{
+				WS: harmonyconfig.WsConfig{
 					Enabled: true,
 					IP:      "127.0.0.1",
 					Port:    9800,
 				},
-				Consensus: &consensusConfig{
+				Consensus: &harmonyconfig.ConsensusConfig{
 					MinPeers:     6,
 					AggregateSig: true,
 				},
-				BLSKeys: blsConfig{
+				BLSKeys: harmonyconfig.BlsConfig{
 					KeyDir:           "./.hmy/blskeys",
 					KeyFiles:         []string{},
 					MaxKeys:          10,
@@ -92,30 +94,30 @@ func TestHarmonyFlags(t *testing.T) {
 					KMSConfigSrcType: "file",
 					KMSConfigFile:    "config.json",
 				},
-				TxPool: txPoolConfig{
+				TxPool: harmonyconfig.TxPoolConfig{
 					BlacklistFile: "./.hmy/blacklist.txt",
 				},
-				Pprof: pprofConfig{
+				Pprof: harmonyconfig.PprofConfig{
 					Enabled:    false,
 					ListenAddr: "127.0.0.1:6060",
 				},
-				Log: logConfig{
+				Log: harmonyconfig.LogConfig{
 					Folder:     "./latest",
 					FileName:   "validator-8.8.8.8-9000.log",
 					RotateSize: 100,
 					Verbosity:  3,
-					Context: &logContext{
+					Context: &harmonyconfig.LogContext{
 						IP:   "8.8.8.8",
 						Port: 9000,
 					},
 				},
-				Sys: &sysConfig{
+				Sys: &harmonyconfig.SysConfig{
 					NtpServer: defaultSysConfig.NtpServer,
 				},
-				Legacy: &legacyConfig{
+				Legacy: &harmonyconfig.LegacyConfig{
 					TPBroadcastInvalidTxn: &trueBool,
 				},
-				Prometheus: &prometheusConfig{
+				Prometheus: &harmonyconfig.PrometheusConfig{
 					Enabled:    true,
 					IP:         "0.0.0.0",
 					Port:       9900,
@@ -142,12 +144,12 @@ func TestHarmonyFlags(t *testing.T) {
 func TestGeneralFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig generalConfig
+		expConfig harmonyconfig.GeneralConfig
 		expErr    error
 	}{
 		{
 			args: []string{},
-			expConfig: generalConfig{
+			expConfig: harmonyconfig.GeneralConfig{
 				NodeType:   "validator",
 				NoStaking:  false,
 				ShardID:    -1,
@@ -158,7 +160,7 @@ func TestGeneralFlags(t *testing.T) {
 		{
 			args: []string{"--run", "explorer", "--run.legacy", "--run.shard=0",
 				"--run.archive=true", "--datadir=./.hmy"},
-			expConfig: generalConfig{
+			expConfig: harmonyconfig.GeneralConfig{
 				NodeType:   "explorer",
 				NoStaking:  true,
 				ShardID:    0,
@@ -169,7 +171,7 @@ func TestGeneralFlags(t *testing.T) {
 		{
 			args: []string{"--node_type", "explorer", "--staking", "--shard_id", "0",
 				"--is_archival", "--db_dir", "./"},
-			expConfig: generalConfig{
+			expConfig: harmonyconfig.GeneralConfig{
 				NodeType:   "explorer",
 				NoStaking:  false,
 				ShardID:    0,
@@ -179,7 +181,7 @@ func TestGeneralFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--staking=false", "--is_archival=false"},
-			expConfig: generalConfig{
+			expConfig: harmonyconfig.GeneralConfig{
 				NodeType:   "validator",
 				NoStaking:  true,
 				ShardID:    -1,
@@ -189,7 +191,7 @@ func TestGeneralFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--run", "explorer", "--run.shard", "0"},
-			expConfig: generalConfig{
+			expConfig: harmonyconfig.GeneralConfig{
 				NodeType:   "explorer",
 				NoStaking:  false,
 				ShardID:    0,
@@ -199,7 +201,7 @@ func TestGeneralFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--run", "explorer", "--run.shard", "0", "--run.archive=false"},
-			expConfig: generalConfig{
+			expConfig: harmonyconfig.GeneralConfig{
 				NodeType:   "explorer",
 				NoStaking:  false,
 				ShardID:    0,
@@ -229,13 +231,13 @@ func TestGeneralFlags(t *testing.T) {
 func TestNetworkFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig HarmonyConfig
+		expConfig harmonyconfig.HarmonyConfig
 		expErr    error
 	}{
 		{
 			args: []string{},
-			expConfig: HarmonyConfig{
-				Network: networkConfig{
+			expConfig: harmonyconfig.HarmonyConfig{
+				Network: harmonyconfig.NetworkConfig{
 					NetworkType: defNetworkType,
 					BootNodes:   nodeconfig.GetDefaultBootNodes(defNetworkType),
 				},
@@ -243,8 +245,8 @@ func TestNetworkFlags(t *testing.T) {
 		},
 		{
 			args: []string{"-n", "stn"},
-			expConfig: HarmonyConfig{
-				Network: networkConfig{
+			expConfig: harmonyconfig.HarmonyConfig{
+				Network: harmonyconfig.NetworkConfig{
 					NetworkType: nodeconfig.Stressnet,
 					BootNodes:   nodeconfig.GetDefaultBootNodes(nodeconfig.Stressnet),
 				},
@@ -254,12 +256,12 @@ func TestNetworkFlags(t *testing.T) {
 		{
 			args: []string{"--network", "stk", "--bootnodes", "1,2,3,4", "--dns.zone", "8.8.8.8",
 				"--dns.port", "9001", "--dns.server-port", "9002"},
-			expConfig: HarmonyConfig{
-				Network: networkConfig{
+			expConfig: harmonyconfig.HarmonyConfig{
+				Network: harmonyconfig.NetworkConfig{
 					NetworkType: "pangaea",
 					BootNodes:   []string{"1", "2", "3", "4"},
 				},
-				DNSSync: dnsSync{
+				DNSSync: harmonyconfig.DnsSync{
 					Port:          9001,
 					Zone:          "8.8.8.8",
 					LegacySyncing: false,
@@ -271,12 +273,12 @@ func TestNetworkFlags(t *testing.T) {
 		{
 			args: []string{"--network_type", "stk", "--bootnodes", "1,2,3,4", "--dns_zone", "8.8.8.8",
 				"--dns_port", "9001"},
-			expConfig: HarmonyConfig{
-				Network: networkConfig{
+			expConfig: harmonyconfig.HarmonyConfig{
+				Network: harmonyconfig.NetworkConfig{
 					NetworkType: "pangaea",
 					BootNodes:   []string{"1", "2", "3", "4"},
 				},
-				DNSSync: dnsSync{
+				DNSSync: harmonyconfig.DnsSync{
 					Port:          9001,
 					Zone:          "8.8.8.8",
 					LegacySyncing: false,
@@ -287,12 +289,12 @@ func TestNetworkFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--dns=false"},
-			expConfig: HarmonyConfig{
-				Network: networkConfig{
+			expConfig: harmonyconfig.HarmonyConfig{
+				Network: harmonyconfig.NetworkConfig{
 					NetworkType: defNetworkType,
 					BootNodes:   nodeconfig.GetDefaultBootNodes(defNetworkType),
 				},
-				DNSSync: dnsSync{
+				DNSSync: harmonyconfig.DnsSync{
 					Port:          nodeconfig.GetDefaultDNSPort(defNetworkType),
 					Zone:          nodeconfig.GetDefaultDNSZone(defNetworkType),
 					LegacySyncing: true,
@@ -307,8 +309,8 @@ func TestNetworkFlags(t *testing.T) {
 		neededFlags := make([]cli.Flag, 0)
 		neededFlags = append(neededFlags, networkFlags...)
 		neededFlags = append(neededFlags, dnsSyncFlags...)
-		ts := newFlagTestSuite(t, neededFlags, func(cmd *cobra.Command, config *HarmonyConfig) {
-			// This is the network related logic in function getHarmonyConfig
+		ts := newFlagTestSuite(t, neededFlags, func(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
+			// This is the network related logic in function getharmonyconfig.HarmonyConfig
 			nt := getNetworkType(cmd)
 			config.Network = getDefaultNetworkConfig(nt)
 			config.DNSSync = getDefaultDNSSyncConfig(nt)
@@ -339,7 +341,7 @@ var defDataStore = ".dht-127.0.0.1"
 func TestP2PFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig p2pConfig
+		expConfig harmonyconfig.P2pConfig
 		expErr    error
 	}{
 		{
@@ -349,7 +351,7 @@ func TestP2PFlags(t *testing.T) {
 		{
 			args: []string{"--p2p.port", "9001", "--p2p.keyfile", "./key.file", "--p2p.dht.datastore",
 				defDataStore},
-			expConfig: p2pConfig{
+			expConfig: harmonyconfig.P2pConfig{
 				Port:         9001,
 				IP:           nodeconfig.DefaultPublicListenIP,
 				KeyFile:      "./key.file",
@@ -358,7 +360,7 @@ func TestP2PFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--port", "9001", "--key", "./key.file"},
-			expConfig: p2pConfig{
+			expConfig: harmonyconfig.P2pConfig{
 				Port:    9001,
 				IP:      nodeconfig.DefaultPublicListenIP,
 				KeyFile: "./key.file",
@@ -367,7 +369,7 @@ func TestP2PFlags(t *testing.T) {
 	}
 	for i, test := range tests {
 		ts := newFlagTestSuite(t, append(p2pFlags, legacyMiscFlags...),
-			func(cmd *cobra.Command, config *HarmonyConfig) {
+			func(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 				applyLegacyMiscFlags(cmd, config)
 				applyP2PFlags(cmd, config)
 			},
@@ -391,7 +393,7 @@ func TestP2PFlags(t *testing.T) {
 func TestRPCFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig httpConfig
+		expConfig harmonyconfig.HttpConfig
 		expErr    error
 	}{
 		{
@@ -400,7 +402,7 @@ func TestRPCFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--http=false"},
-			expConfig: httpConfig{
+			expConfig: harmonyconfig.HttpConfig{
 				Enabled:        false,
 				RosettaEnabled: false,
 				IP:             defaultConfig.HTTP.IP,
@@ -410,7 +412,7 @@ func TestRPCFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--http.ip", "8.8.8.8", "--http.port", "9001"},
-			expConfig: httpConfig{
+			expConfig: harmonyconfig.HttpConfig{
 				Enabled:        true,
 				RosettaEnabled: false,
 				IP:             "8.8.8.8",
@@ -420,7 +422,7 @@ func TestRPCFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--http.ip", "8.8.8.8", "--http.port", "9001", "--http.rosetta.port", "10001"},
-			expConfig: httpConfig{
+			expConfig: harmonyconfig.HttpConfig{
 				Enabled:        true,
 				RosettaEnabled: true,
 				IP:             "8.8.8.8",
@@ -430,7 +432,7 @@ func TestRPCFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--http.ip", "8.8.8.8", "--http.rosetta.port", "10001"},
-			expConfig: httpConfig{
+			expConfig: harmonyconfig.HttpConfig{
 				Enabled:        true,
 				RosettaEnabled: true,
 				IP:             "8.8.8.8",
@@ -440,7 +442,7 @@ func TestRPCFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--ip", "8.8.8.8", "--port", "9001", "--public_rpc"},
-			expConfig: httpConfig{
+			expConfig: harmonyconfig.HttpConfig{
 				Enabled:        true,
 				RosettaEnabled: false,
 				IP:             nodeconfig.DefaultPublicListenIP,
@@ -451,7 +453,7 @@ func TestRPCFlags(t *testing.T) {
 	}
 	for i, test := range tests {
 		ts := newFlagTestSuite(t, append(httpFlags, legacyMiscFlags...),
-			func(cmd *cobra.Command, config *HarmonyConfig) {
+			func(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 				applyLegacyMiscFlags(cmd, config)
 				applyHTTPFlags(cmd, config)
 			},
@@ -476,7 +478,7 @@ func TestRPCFlags(t *testing.T) {
 func TestWSFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig wsConfig
+		expConfig harmonyconfig.WsConfig
 		expErr    error
 	}{
 		{
@@ -485,7 +487,7 @@ func TestWSFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--ws=false"},
-			expConfig: wsConfig{
+			expConfig: harmonyconfig.WsConfig{
 				Enabled: false,
 				IP:      defaultConfig.WS.IP,
 				Port:    defaultConfig.WS.Port,
@@ -493,7 +495,7 @@ func TestWSFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--ws", "--ws.ip", "8.8.8.8", "--ws.port", "9001"},
-			expConfig: wsConfig{
+			expConfig: harmonyconfig.WsConfig{
 				Enabled: true,
 				IP:      "8.8.8.8",
 				Port:    9001,
@@ -501,7 +503,7 @@ func TestWSFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--ip", "8.8.8.8", "--port", "9001", "--public_rpc"},
-			expConfig: wsConfig{
+			expConfig: harmonyconfig.WsConfig{
 				Enabled: true,
 				IP:      nodeconfig.DefaultPublicListenIP,
 				Port:    9801,
@@ -510,7 +512,7 @@ func TestWSFlags(t *testing.T) {
 	}
 	for i, test := range tests {
 		ts := newFlagTestSuite(t, append(wsFlags, legacyMiscFlags...),
-			func(cmd *cobra.Command, config *HarmonyConfig) {
+			func(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 				applyLegacyMiscFlags(cmd, config)
 				applyWSFlags(cmd, config)
 			},
@@ -535,11 +537,11 @@ func TestWSFlags(t *testing.T) {
 func TestRPCOptFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig rpcOptConfig
+		expConfig harmonyconfig.RpcOptConfig
 	}{
 		{
 			args: []string{"--rpc.debug"},
-			expConfig: rpcOptConfig{
+			expConfig: harmonyconfig.RpcOptConfig{
 				DebugEnabled:      true,
 				RateLimterEnabled: true,
 				RequestsPerSecond: 1000,
@@ -548,7 +550,7 @@ func TestRPCOptFlags(t *testing.T) {
 
 		{
 			args: []string{},
-			expConfig: rpcOptConfig{
+			expConfig: harmonyconfig.RpcOptConfig{
 				DebugEnabled:      false,
 				RateLimterEnabled: true,
 				RequestsPerSecond: 1000,
@@ -557,7 +559,7 @@ func TestRPCOptFlags(t *testing.T) {
 
 		{
 			args: []string{"--rpc.ratelimiter", "--rpc.ratelimit", "2000"},
-			expConfig: rpcOptConfig{
+			expConfig: harmonyconfig.RpcOptConfig{
 				DebugEnabled:      false,
 				RateLimterEnabled: true,
 				RequestsPerSecond: 2000,
@@ -566,7 +568,7 @@ func TestRPCOptFlags(t *testing.T) {
 
 		{
 			args: []string{"--rpc.ratelimiter=false", "--rpc.ratelimit", "2000"},
-			expConfig: rpcOptConfig{
+			expConfig: harmonyconfig.RpcOptConfig{
 				DebugEnabled:      false,
 				RateLimterEnabled: false,
 				RequestsPerSecond: 2000,
@@ -589,7 +591,7 @@ func TestRPCOptFlags(t *testing.T) {
 func TestBLSFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig blsConfig
+		expConfig harmonyconfig.BlsConfig
 		expErr    error
 	}{
 		{
@@ -601,7 +603,7 @@ func TestBLSFlags(t *testing.T) {
 				"--bls.maxkeys", "8", "--bls.pass", "--bls.pass.src", "auto", "--bls.pass.save",
 				"--bls.kms", "--bls.kms.src", "shared",
 			},
-			expConfig: blsConfig{
+			expConfig: harmonyconfig.BlsConfig{
 				KeyDir:           "./blskeys",
 				KeyFiles:         []string{"key1", "key2"},
 				MaxKeys:          8,
@@ -616,7 +618,7 @@ func TestBLSFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--bls.pass.file", "xxx.pass", "--bls.kms.config", "config.json"},
-			expConfig: blsConfig{
+			expConfig: harmonyconfig.BlsConfig{
 				KeyDir:           defaultConfig.BLSKeys.KeyDir,
 				KeyFiles:         defaultConfig.BLSKeys.KeyFiles,
 				MaxKeys:          defaultConfig.BLSKeys.MaxKeys,
@@ -634,7 +636,7 @@ func TestBLSFlags(t *testing.T) {
 				"--max_bls_keys_per_node", "5", "--blspass", "file:xxx.pass", "--save-passphrase",
 				"--aws-config-source", "file:config.json",
 			},
-			expConfig: blsConfig{
+			expConfig: harmonyconfig.BlsConfig{
 				KeyDir:           "./hmykeys",
 				KeyFiles:         []string{"key1", "key2"},
 				MaxKeys:          5,
@@ -670,7 +672,7 @@ func TestBLSFlags(t *testing.T) {
 func TestConsensusFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig *consensusConfig
+		expConfig *harmonyconfig.ConsensusConfig
 		expErr    error
 	}{
 		{
@@ -679,7 +681,7 @@ func TestConsensusFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--consensus.min-peers", "10", "--consensus.aggregate-sig=false"},
-			expConfig: &consensusConfig{
+			expConfig: &harmonyconfig.ConsensusConfig{
 				MinPeers:     10,
 				AggregateSig: false,
 			},
@@ -687,7 +689,7 @@ func TestConsensusFlags(t *testing.T) {
 		{
 			args: []string{"--delay_commit", "10ms", "--block_period", "5", "--min_peers", "10",
 				"--consensus.aggregate-sig=true"},
-			expConfig: &consensusConfig{
+			expConfig: &harmonyconfig.ConsensusConfig{
 				MinPeers:     10,
 				AggregateSig: true,
 			},
@@ -715,24 +717,24 @@ func TestConsensusFlags(t *testing.T) {
 func TestTxPoolFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig txPoolConfig
+		expConfig harmonyconfig.TxPoolConfig
 		expErr    error
 	}{
 		{
 			args: []string{},
-			expConfig: txPoolConfig{
+			expConfig: harmonyconfig.TxPoolConfig{
 				BlacklistFile: defaultConfig.TxPool.BlacklistFile,
 			},
 		},
 		{
 			args: []string{"--txpool.blacklist", "blacklist.file"},
-			expConfig: txPoolConfig{
+			expConfig: harmonyconfig.TxPoolConfig{
 				BlacklistFile: "blacklist.file",
 			},
 		},
 		{
 			args: []string{"--blacklist", "blacklist.file"},
-			expConfig: txPoolConfig{
+			expConfig: harmonyconfig.TxPoolConfig{
 				BlacklistFile: "blacklist.file",
 			},
 		},
@@ -758,7 +760,7 @@ func TestTxPoolFlags(t *testing.T) {
 func TestPprofFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig pprofConfig
+		expConfig harmonyconfig.PprofConfig
 		expErr    error
 	}{
 		{
@@ -767,21 +769,21 @@ func TestPprofFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--pprof"},
-			expConfig: pprofConfig{
+			expConfig: harmonyconfig.PprofConfig{
 				Enabled:    true,
 				ListenAddr: defaultConfig.Pprof.ListenAddr,
 			},
 		},
 		{
 			args: []string{"--pprof.addr", "8.8.8.8:9001"},
-			expConfig: pprofConfig{
+			expConfig: harmonyconfig.PprofConfig{
 				Enabled:    true,
 				ListenAddr: "8.8.8.8:9001",
 			},
 		},
 		{
 			args: []string{"--pprof=false", "--pprof.addr", "8.8.8.8:9001"},
-			expConfig: pprofConfig{
+			expConfig: harmonyconfig.PprofConfig{
 				Enabled:    false,
 				ListenAddr: "8.8.8.8:9001",
 			},
@@ -807,7 +809,7 @@ func TestPprofFlags(t *testing.T) {
 func TestLogFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig logConfig
+		expConfig harmonyconfig.LogConfig
 		expErr    error
 	}{
 		{
@@ -817,7 +819,7 @@ func TestLogFlags(t *testing.T) {
 		{
 			args: []string{"--log.dir", "latest_log", "--log.max-size", "10", "--log.name", "harmony.log",
 				"--log.verb", "5"},
-			expConfig: logConfig{
+			expConfig: harmonyconfig.LogConfig{
 				Folder:     "latest_log",
 				FileName:   "harmony.log",
 				RotateSize: 10,
@@ -827,12 +829,12 @@ func TestLogFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--log.ctx.ip", "8.8.8.8", "--log.ctx.port", "9001"},
-			expConfig: logConfig{
+			expConfig: harmonyconfig.LogConfig{
 				Folder:     defaultConfig.Log.Folder,
 				FileName:   defaultConfig.Log.FileName,
 				RotateSize: defaultConfig.Log.RotateSize,
 				Verbosity:  defaultConfig.Log.Verbosity,
-				Context: &logContext{
+				Context: &harmonyconfig.LogContext{
 					IP:   "8.8.8.8",
 					Port: 9001,
 				},
@@ -841,12 +843,12 @@ func TestLogFlags(t *testing.T) {
 		{
 			args: []string{"--log_folder", "latest_log", "--log_max_size", "10", "--verbosity",
 				"5", "--ip", "8.8.8.8", "--port", "9001"},
-			expConfig: logConfig{
+			expConfig: harmonyconfig.LogConfig{
 				Folder:     "latest_log",
 				FileName:   "validator-8.8.8.8-9001.log",
 				RotateSize: 10,
 				Verbosity:  5,
-				Context: &logContext{
+				Context: &harmonyconfig.LogContext{
 					IP:   "8.8.8.8",
 					Port: 9001,
 				},
@@ -854,19 +856,19 @@ func TestLogFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--verbose-prints", "config"},
-			expConfig: logConfig{
+			expConfig: harmonyconfig.LogConfig{
 				Folder:        defaultConfig.Log.Folder,
 				FileName:      defaultConfig.Log.FileName,
 				RotateSize:    defaultConfig.Log.RotateSize,
 				Verbosity:     defaultConfig.Log.Verbosity,
-				VerbosePrints: []string{"config"},
+				VerbosePrints: map[string]bool{"config": true},
 				Context:       nil,
 			},
 		},
 	}
 	for i, test := range tests {
 		ts := newFlagTestSuite(t, append(logFlags, legacyMiscFlags...),
-			func(cmd *cobra.Command, config *HarmonyConfig) {
+			func(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 				applyLegacyMiscFlags(cmd, config)
 				applyLogFlags(cmd, config)
 			},
@@ -890,18 +892,18 @@ func TestLogFlags(t *testing.T) {
 func TestSysFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig *sysConfig
+		expConfig *harmonyconfig.SysConfig
 		expErr    error
 	}{
 		{
 			args: []string{},
-			expConfig: &sysConfig{
+			expConfig: &harmonyconfig.SysConfig{
 				NtpServer: defaultSysConfig.NtpServer,
 			},
 		},
 		{
 			args: []string{"--sys.ntp", "0.pool.ntp.org"},
-			expConfig: &sysConfig{
+			expConfig: &harmonyconfig.SysConfig{
 				NtpServer: "0.pool.ntp.org",
 			},
 		},
@@ -928,7 +930,7 @@ func TestSysFlags(t *testing.T) {
 func TestDevnetFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig *devnetConfig
+		expConfig *harmonyconfig.DevnetConfig
 		expErr    error
 	}{
 		{
@@ -938,7 +940,7 @@ func TestDevnetFlags(t *testing.T) {
 		{
 			args: []string{"--devnet.num-shard", "3", "--devnet.shard-size", "100",
 				"--devnet.hmy-node-size", "60"},
-			expConfig: &devnetConfig{
+			expConfig: &harmonyconfig.DevnetConfig{
 				NumShards:   3,
 				ShardSize:   100,
 				HmyNodeSize: 60,
@@ -947,7 +949,7 @@ func TestDevnetFlags(t *testing.T) {
 		{
 			args: []string{"--dn_num_shards", "3", "--dn_shard_size", "100", "--dn_hmy_size",
 				"60"},
-			expConfig: &devnetConfig{
+			expConfig: &harmonyconfig.DevnetConfig{
 				NumShards:   3,
 				ShardSize:   100,
 				HmyNodeSize: 60,
@@ -975,7 +977,7 @@ func TestDevnetFlags(t *testing.T) {
 func TestRevertFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig *revertConfig
+		expConfig *harmonyconfig.RevertConfig
 		expErr    error
 	}{
 		{
@@ -984,7 +986,7 @@ func TestRevertFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--revert.beacon"},
-			expConfig: &revertConfig{
+			expConfig: &harmonyconfig.RevertConfig{
 				RevertBeacon: true,
 				RevertTo:     defaultRevertConfig.RevertTo,
 				RevertBefore: defaultRevertConfig.RevertBefore,
@@ -992,7 +994,7 @@ func TestRevertFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--revert.beacon", "--revert.to", "100", "--revert.do-before", "10000"},
-			expConfig: &revertConfig{
+			expConfig: &harmonyconfig.RevertConfig{
 				RevertBeacon: true,
 				RevertTo:     100,
 				RevertBefore: 10000,
@@ -1000,7 +1002,7 @@ func TestRevertFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--revert_beacon", "--do_revert_before", "10000", "--revert_to", "100"},
-			expConfig: &revertConfig{
+			expConfig: &harmonyconfig.RevertConfig{
 				RevertBeacon: true,
 				RevertTo:     100,
 				RevertBefore: 10000,
@@ -1028,7 +1030,7 @@ func TestDNSSyncFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
 		network   string
-		expConfig dnsSync
+		expConfig harmonyconfig.DnsSync
 		expErr    error
 	}{
 		{
@@ -1044,7 +1046,7 @@ func TestDNSSyncFlags(t *testing.T) {
 		{
 			args:    []string{"--sync.legacy.server", "--sync.legacy.client"},
 			network: "testnet",
-			expConfig: func() dnsSync {
+			expConfig: func() harmonyconfig.DnsSync {
 				cfg := getDefaultDNSSyncConfig(nodeconfig.Mainnet)
 				cfg.Client = true
 				cfg.Server = true
@@ -1059,7 +1061,7 @@ func TestDNSSyncFlags(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		ts := newFlagTestSuite(t, dnsSyncFlags, func(command *cobra.Command, config *HarmonyConfig) {
+		ts := newFlagTestSuite(t, dnsSyncFlags, func(command *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 			config.Network.NetworkType = test.network
 			applyDNSSyncFlags(command, config)
 		})
@@ -1082,7 +1084,7 @@ func TestSyncFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
 		network   string
-		expConfig syncConfig
+		expConfig harmonyconfig.SyncConfig
 		expErr    error
 	}{
 		{
@@ -1092,7 +1094,7 @@ func TestSyncFlags(t *testing.T) {
 				"--sync.disc.batch", "10",
 			},
 			network: "mainnet",
-			expConfig: func() syncConfig {
+			expConfig: func() harmonyconfig.SyncConfig {
 				cfgSync := defaultMainnetSyncConfig
 				cfgSync.Enabled = true
 				cfgSync.Downloader = true
@@ -1108,7 +1110,7 @@ func TestSyncFlags(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		ts := newFlagTestSuite(t, syncFlags, func(command *cobra.Command, config *HarmonyConfig) {
+		ts := newFlagTestSuite(t, syncFlags, func(command *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 			applySyncFlags(command, config)
 		})
 		hc, err := ts.run(test.args)
@@ -1131,10 +1133,10 @@ type flagTestSuite struct {
 	t *testing.T
 
 	cmd *cobra.Command
-	hc  HarmonyConfig
+	hc  harmonyconfig.HarmonyConfig
 }
 
-func newFlagTestSuite(t *testing.T, flags []cli.Flag, applyFlags func(*cobra.Command, *HarmonyConfig)) *flagTestSuite {
+func newFlagTestSuite(t *testing.T, flags []cli.Flag, applyFlags func(*cobra.Command, *harmonyconfig.HarmonyConfig)) *flagTestSuite {
 	cli.SetParseErrorHandle(func(err error) { t.Fatal(err) })
 
 	ts := &flagTestSuite{hc: getDefaultHmyConfigCopy(defNetworkType)}
@@ -1148,7 +1150,7 @@ func newFlagTestSuite(t *testing.T, flags []cli.Flag, applyFlags func(*cobra.Com
 	return ts
 }
 
-func (ts *flagTestSuite) run(args []string) (HarmonyConfig, error) {
+func (ts *flagTestSuite) run(args []string) (harmonyconfig.HarmonyConfig, error) {
 	ts.cmd.SetArgs(args)
 	err := ts.cmd.Execute()
 	return ts.hc, err

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -855,12 +855,12 @@ func TestLogFlags(t *testing.T) {
 		{
 			args: []string{"--verbose-prints", "config"},
 			expConfig: logConfig{
-				Folder:     defaultConfig.Log.Folder,
-				FileName:   defaultConfig.Log.FileName,
-				RotateSize: defaultConfig.Log.RotateSize,
-				Verbosity:  defaultConfig.Log.Verbosity,
+				Folder:        defaultConfig.Log.Folder,
+				FileName:      defaultConfig.Log.FileName,
+				RotateSize:    defaultConfig.Log.RotateSize,
+				Verbosity:     defaultConfig.Log.Verbosity,
 				VerbosePrints: []string{"config"},
-				Context: nil,
+				Context:       nil,
 			},
 		},
 	}

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -827,16 +827,16 @@ func TestLogFlags(t *testing.T) {
 				VerbosePrints: harmonyconfig.LogVerbosePrints{
 					Config: true,
 				},
-				Context:    nil,
+				Context: nil,
 			},
 		},
 		{
 			args: []string{"--log.ctx.ip", "8.8.8.8", "--log.ctx.port", "9001"},
 			expConfig: harmonyconfig.LogConfig{
-				Folder:     defaultConfig.Log.Folder,
-				FileName:   defaultConfig.Log.FileName,
-				RotateSize: defaultConfig.Log.RotateSize,
-				Verbosity:  defaultConfig.Log.Verbosity,
+				Folder:        defaultConfig.Log.Folder,
+				FileName:      defaultConfig.Log.FileName,
+				RotateSize:    defaultConfig.Log.RotateSize,
+				Verbosity:     defaultConfig.Log.Verbosity,
 				VerbosePrints: defaultConfig.Log.VerbosePrints,
 				Context: &harmonyconfig.LogContext{
 					IP:   "8.8.8.8",
@@ -848,10 +848,10 @@ func TestLogFlags(t *testing.T) {
 			args: []string{"--log_folder", "latest_log", "--log_max_size", "10", "--verbosity",
 				"5", "--ip", "8.8.8.8", "--port", "9001"},
 			expConfig: harmonyconfig.LogConfig{
-				Folder:     "latest_log",
-				FileName:   "validator-8.8.8.8-9001.log",
-				RotateSize: 10,
-				Verbosity:  5,
+				Folder:        "latest_log",
+				FileName:      "validator-8.8.8.8-9001.log",
+				RotateSize:    10,
+				Verbosity:     5,
 				VerbosePrints: defaultConfig.Log.VerbosePrints,
 				Context: &harmonyconfig.LogContext{
 					IP:   "8.8.8.8",

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -818,12 +818,15 @@ func TestLogFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--log.dir", "latest_log", "--log.max-size", "10", "--log.name", "harmony.log",
-				"--log.verb", "5"},
+				"--log.verb", "5", "--log.verbose-prints", "config"},
 			expConfig: harmonyconfig.LogConfig{
 				Folder:     "latest_log",
 				FileName:   "harmony.log",
 				RotateSize: 10,
 				Verbosity:  5,
+				VerbosePrints: harmonyconfig.LogVerbosePrints{
+					Config: true,
+				},
 				Context:    nil,
 			},
 		},
@@ -834,6 +837,7 @@ func TestLogFlags(t *testing.T) {
 				FileName:   defaultConfig.Log.FileName,
 				RotateSize: defaultConfig.Log.RotateSize,
 				Verbosity:  defaultConfig.Log.Verbosity,
+				VerbosePrints: defaultConfig.Log.VerbosePrints,
 				Context: &harmonyconfig.LogContext{
 					IP:   "8.8.8.8",
 					Port: 9001,
@@ -848,21 +852,11 @@ func TestLogFlags(t *testing.T) {
 				FileName:   "validator-8.8.8.8-9001.log",
 				RotateSize: 10,
 				Verbosity:  5,
+				VerbosePrints: defaultConfig.Log.VerbosePrints,
 				Context: &harmonyconfig.LogContext{
 					IP:   "8.8.8.8",
 					Port: 9001,
 				},
-			},
-		},
-		{
-			args: []string{"--verbose-prints", "config"},
-			expConfig: harmonyconfig.LogConfig{
-				Folder:        defaultConfig.Log.Folder,
-				FileName:      defaultConfig.Log.FileName,
-				RotateSize:    defaultConfig.Log.RotateSize,
-				Verbosity:     defaultConfig.Log.Verbosity,
-				VerbosePrints: map[string]bool{"config": true},
-				Context:       nil,
 			},
 		},
 	}

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -18,7 +18,7 @@ var (
 func TestHarmonyFlags(t *testing.T) {
 	tests := []struct {
 		argStr    string
-		expConfig harmonyConfig
+		expConfig HarmonyConfig
 	}{
 		{
 			// running staking command from legacy node.sh
@@ -29,7 +29,7 @@ func TestHarmonyFlags(t *testing.T) {
 				"et --dns_zone=t.hmny.io --blacklist=./.hmy/blacklist.txt --min_peers=6 --max_bls_keys_per_node=" +
 				"10 --broadcast_invalid_tx=true --verbosity=3 --is_archival=false --shard_id=-1 --staking=true -" +
 				"-aws-config-source file:config.json",
-			expConfig: harmonyConfig{
+			expConfig: HarmonyConfig{
 				Version: tomlConfigVersion,
 				General: generalConfig{
 					NodeType:   "validator",
@@ -229,12 +229,12 @@ func TestGeneralFlags(t *testing.T) {
 func TestNetworkFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig harmonyConfig
+		expConfig HarmonyConfig
 		expErr    error
 	}{
 		{
 			args: []string{},
-			expConfig: harmonyConfig{
+			expConfig: HarmonyConfig{
 				Network: networkConfig{
 					NetworkType: defNetworkType,
 					BootNodes:   nodeconfig.GetDefaultBootNodes(defNetworkType),
@@ -243,7 +243,7 @@ func TestNetworkFlags(t *testing.T) {
 		},
 		{
 			args: []string{"-n", "stn"},
-			expConfig: harmonyConfig{
+			expConfig: HarmonyConfig{
 				Network: networkConfig{
 					NetworkType: nodeconfig.Stressnet,
 					BootNodes:   nodeconfig.GetDefaultBootNodes(nodeconfig.Stressnet),
@@ -254,7 +254,7 @@ func TestNetworkFlags(t *testing.T) {
 		{
 			args: []string{"--network", "stk", "--bootnodes", "1,2,3,4", "--dns.zone", "8.8.8.8",
 				"--dns.port", "9001", "--dns.server-port", "9002"},
-			expConfig: harmonyConfig{
+			expConfig: HarmonyConfig{
 				Network: networkConfig{
 					NetworkType: "pangaea",
 					BootNodes:   []string{"1", "2", "3", "4"},
@@ -271,7 +271,7 @@ func TestNetworkFlags(t *testing.T) {
 		{
 			args: []string{"--network_type", "stk", "--bootnodes", "1,2,3,4", "--dns_zone", "8.8.8.8",
 				"--dns_port", "9001"},
-			expConfig: harmonyConfig{
+			expConfig: HarmonyConfig{
 				Network: networkConfig{
 					NetworkType: "pangaea",
 					BootNodes:   []string{"1", "2", "3", "4"},
@@ -287,7 +287,7 @@ func TestNetworkFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--dns=false"},
-			expConfig: harmonyConfig{
+			expConfig: HarmonyConfig{
 				Network: networkConfig{
 					NetworkType: defNetworkType,
 					BootNodes:   nodeconfig.GetDefaultBootNodes(defNetworkType),
@@ -307,7 +307,7 @@ func TestNetworkFlags(t *testing.T) {
 		neededFlags := make([]cli.Flag, 0)
 		neededFlags = append(neededFlags, networkFlags...)
 		neededFlags = append(neededFlags, dnsSyncFlags...)
-		ts := newFlagTestSuite(t, neededFlags, func(cmd *cobra.Command, config *harmonyConfig) {
+		ts := newFlagTestSuite(t, neededFlags, func(cmd *cobra.Command, config *HarmonyConfig) {
 			// This is the network related logic in function getHarmonyConfig
 			nt := getNetworkType(cmd)
 			config.Network = getDefaultNetworkConfig(nt)
@@ -367,7 +367,7 @@ func TestP2PFlags(t *testing.T) {
 	}
 	for i, test := range tests {
 		ts := newFlagTestSuite(t, append(p2pFlags, legacyMiscFlags...),
-			func(cmd *cobra.Command, config *harmonyConfig) {
+			func(cmd *cobra.Command, config *HarmonyConfig) {
 				applyLegacyMiscFlags(cmd, config)
 				applyP2PFlags(cmd, config)
 			},
@@ -451,7 +451,7 @@ func TestRPCFlags(t *testing.T) {
 	}
 	for i, test := range tests {
 		ts := newFlagTestSuite(t, append(httpFlags, legacyMiscFlags...),
-			func(cmd *cobra.Command, config *harmonyConfig) {
+			func(cmd *cobra.Command, config *HarmonyConfig) {
 				applyLegacyMiscFlags(cmd, config)
 				applyHTTPFlags(cmd, config)
 			},
@@ -510,7 +510,7 @@ func TestWSFlags(t *testing.T) {
 	}
 	for i, test := range tests {
 		ts := newFlagTestSuite(t, append(wsFlags, legacyMiscFlags...),
-			func(cmd *cobra.Command, config *harmonyConfig) {
+			func(cmd *cobra.Command, config *HarmonyConfig) {
 				applyLegacyMiscFlags(cmd, config)
 				applyWSFlags(cmd, config)
 			},
@@ -852,10 +852,21 @@ func TestLogFlags(t *testing.T) {
 				},
 			},
 		},
+		{
+			args: []string{"--verbose-prints", "config"},
+			expConfig: logConfig{
+				Folder:     defaultConfig.Log.Folder,
+				FileName:   defaultConfig.Log.FileName,
+				RotateSize: defaultConfig.Log.RotateSize,
+				Verbosity:  defaultConfig.Log.Verbosity,
+				VerbosePrints: []string{"config"},
+				Context: nil,
+			},
+		},
 	}
 	for i, test := range tests {
 		ts := newFlagTestSuite(t, append(logFlags, legacyMiscFlags...),
-			func(cmd *cobra.Command, config *harmonyConfig) {
+			func(cmd *cobra.Command, config *HarmonyConfig) {
 				applyLegacyMiscFlags(cmd, config)
 				applyLogFlags(cmd, config)
 			},
@@ -1048,7 +1059,7 @@ func TestDNSSyncFlags(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		ts := newFlagTestSuite(t, dnsSyncFlags, func(command *cobra.Command, config *harmonyConfig) {
+		ts := newFlagTestSuite(t, dnsSyncFlags, func(command *cobra.Command, config *HarmonyConfig) {
 			config.Network.NetworkType = test.network
 			applyDNSSyncFlags(command, config)
 		})
@@ -1097,7 +1108,7 @@ func TestSyncFlags(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		ts := newFlagTestSuite(t, syncFlags, func(command *cobra.Command, config *harmonyConfig) {
+		ts := newFlagTestSuite(t, syncFlags, func(command *cobra.Command, config *HarmonyConfig) {
 			applySyncFlags(command, config)
 		})
 		hc, err := ts.run(test.args)
@@ -1120,10 +1131,10 @@ type flagTestSuite struct {
 	t *testing.T
 
 	cmd *cobra.Command
-	hc  harmonyConfig
+	hc  HarmonyConfig
 }
 
-func newFlagTestSuite(t *testing.T, flags []cli.Flag, applyFlags func(*cobra.Command, *harmonyConfig)) *flagTestSuite {
+func newFlagTestSuite(t *testing.T, flags []cli.Flag, applyFlags func(*cobra.Command, *HarmonyConfig)) *flagTestSuite {
 	cli.SetParseErrorHandle(func(err error) { t.Fatal(err) })
 
 	ts := &flagTestSuite{hc: getDefaultHmyConfigCopy(defNetworkType)}
@@ -1137,7 +1148,7 @@ func newFlagTestSuite(t *testing.T, flags []cli.Flag, applyFlags func(*cobra.Com
 	return ts
 }
 
-func (ts *flagTestSuite) run(args []string) (harmonyConfig, error) {
+func (ts *flagTestSuite) run(args []string) (HarmonyConfig, error) {
 	ts.cmd.SetArgs(args)
 	err := ts.cmd.Execute()
 	return ts.hc, err

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	harmonyconfig "github.com/harmony-one/harmony/internal/configs/harmony"
 	rpc_common "github.com/harmony-one/harmony/rpc/common"
@@ -297,17 +296,6 @@ func setupNodeAndRun(hc harmonyconfig.HarmonyConfig) {
 		os.Exit(1)
 	}
 
-	if hc.Log.VerbosePrints["config"] {
-		if cfgJson, err := json.MarshalIndent(rpc_common.Config{
-			HarmonyConfig: hc,
-			NodeConfig:    *nodeConfig,
-		}, "", " "); err != nil {
-			panic(err)
-		} else {
-			println(string(cfgJson))
-		}
-	}
-
 	// Update ethereum compatible chain ids
 	params.UpdateEthChainIDByShard(nodeConfig.ShardID)
 
@@ -392,6 +380,14 @@ func setupNodeAndRun(hc harmonyconfig.HarmonyConfig) {
 		Msg(startMsg)
 
 	nodeconfig.SetPeerID(myHost.GetID())
+
+	if hc.Log.VerbosePrints["config"] {
+		utils.Logger().Info().Interface("config", rpc_common.Config{
+			HarmonyConfig: hc,
+			NodeConfig:    *nodeConfig,
+			ChainConfig:   *currentNode.Blockchain().Config(),
+		}).Msg("verbose prints config")
+	}
 
 	// Setup services
 	if hc.Sync.Enabled {

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -382,7 +382,7 @@ func setupNodeAndRun(hc harmonyconfig.HarmonyConfig) {
 
 	nodeconfig.SetPeerID(myHost.GetID())
 
-	if val, ok := hc.Log.VerbosePrints["config"]; ok && val {
+	if hc.Log.VerbosePrints.Config {
 		utils.Logger().Info().Interface("config", rpc_common.Config{
 			HarmonyConfig: hc,
 			NodeConfig:    *nodeConfig,

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -382,7 +382,7 @@ func setupNodeAndRun(hc harmonyconfig.HarmonyConfig) {
 
 	nodeconfig.SetPeerID(myHost.GetID())
 
-	if hc.Log.VerbosePrints["config"] {
+	if val, ok := hc.Log.VerbosePrints["config"]; ok && val {
 		utils.Logger().Info().Interface("config", rpc_common.Config{
 			HarmonyConfig: hc,
 			NodeConfig:    *nodeConfig,

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -653,7 +653,7 @@ func setupConsensusAndNode(hc harmonyconfig.HarmonyConfig, nodeConfig *nodeconfi
 	// Current node.
 	chainDBFactory := &shardchain.LDBFactory{RootDir: nodeConfig.DBDir}
 
-	currentNode := node.New(myHost, currentConsensus, chainDBFactory, blacklist, nodeConfig.ArchiveModes())
+	currentNode := node.New(myHost, currentConsensus, chainDBFactory, blacklist, nodeConfig.ArchiveModes(), &hc)
 
 	if hc.Legacy != nil && hc.Legacy.TPBroadcastInvalidTxn != nil {
 		currentNode.BroadcastInvalidTx = *hc.Legacy.TPBroadcastInvalidTxn

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"fmt"
-	harmonyconfig "github.com/harmony-one/harmony/internal/configs/harmony"
-	rpc_common "github.com/harmony-one/harmony/rpc/common"
 	"io/ioutil"
 	"math/big"
 	"math/rand"
@@ -17,6 +15,9 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	harmonyconfig "github.com/harmony-one/harmony/internal/configs/harmony"
+	rpc_common "github.com/harmony-one/harmony/rpc/common"
 
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
@@ -207,7 +208,7 @@ func getHarmonyConfig(cmd *cobra.Command) (harmonyconfig.HarmonyConfig, error) {
 	return config, nil
 }
 
-func applyRootFlags(cmd *cobra.Command, config * harmonyconfig.HarmonyConfig) {
+func applyRootFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	// Misc flags shall be applied first since legacy ip / port is overwritten
 	// by new ip / port flags
 	applyLegacyMiscFlags(cmd, config)

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	harmonyconfig "github.com/harmony-one/harmony/internal/configs/harmony"
+	rpc_common "github.com/harmony-one/harmony/rpc/common"
 	"io/ioutil"
 	"math/big"
 	"math/rand"
@@ -158,9 +161,9 @@ func raiseFdLimits() error {
 	return nil
 }
 
-func getHarmonyConfig(cmd *cobra.Command) (harmonyConfig, error) {
+func getHarmonyConfig(cmd *cobra.Command) (harmonyconfig.HarmonyConfig, error) {
 	var (
-		config         harmonyConfig
+		config         harmonyconfig.HarmonyConfig
 		err            error
 		migratedFrom   string
 		configFile     string
@@ -175,7 +178,7 @@ func getHarmonyConfig(cmd *cobra.Command) (harmonyConfig, error) {
 		isUsingDefault = true
 	}
 	if err != nil {
-		return harmonyConfig{}, err
+		return harmonyconfig.HarmonyConfig{}, err
 	}
 	if migratedFrom != defaultConfig.Version && !isUsingDefault {
 		fmt.Printf("Old config version detected %s\n",
@@ -199,13 +202,13 @@ func getHarmonyConfig(cmd *cobra.Command) (harmonyConfig, error) {
 	applyRootFlags(cmd, &config)
 
 	if err := validateHarmonyConfig(config); err != nil {
-		return harmonyConfig{}, err
+		return harmonyconfig.HarmonyConfig{}, err
 	}
 	sanityFixHarmonyConfig(&config)
 	return config, nil
 }
 
-func applyRootFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyRootFlags(cmd *cobra.Command, config * harmonyconfig.HarmonyConfig) {
 	// Misc flags shall be applied first since legacy ip / port is overwritten
 	// by new ip / port flags
 	applyLegacyMiscFlags(cmd, config)
@@ -228,7 +231,7 @@ func applyRootFlags(cmd *cobra.Command, config *harmonyConfig) {
 	applySyncFlags(cmd, config)
 }
 
-func setupNodeLog(config harmonyConfig) {
+func setupNodeLog(config harmonyconfig.HarmonyConfig) {
 	logPath := filepath.Join(config.Log.Folder, config.Log.FileName)
 	rotateSize := config.Log.RotateSize
 	verbosity := config.Log.Verbosity
@@ -242,7 +245,7 @@ func setupNodeLog(config harmonyConfig) {
 	}
 }
 
-func setupPprof(config harmonyConfig) {
+func setupPprof(config harmonyconfig.HarmonyConfig) {
 	enabled := config.Pprof.Enabled
 	addr := config.Pprof.ListenAddr
 
@@ -253,7 +256,7 @@ func setupPprof(config harmonyConfig) {
 	}
 }
 
-func setupNodeAndRun(hc harmonyConfig) {
+func setupNodeAndRun(hc harmonyconfig.HarmonyConfig) {
 	var err error
 
 	nodeconfigSetShardSchedule(hc)
@@ -292,6 +295,17 @@ func setupNodeAndRun(hc harmonyConfig) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR cannot configure node: %s\n", err)
 		os.Exit(1)
+	}
+
+	if hc.Log.VerbosePrints["config"] {
+		if cfgJson, err := json.MarshalIndent(rpc_common.Config{
+			HarmonyConfig: hc,
+			NodeConfig:    *nodeConfig,
+		}, "", " "); err != nil {
+			panic(err)
+		} else {
+			println(string(cfgJson))
+		}
 	}
 
 	// Update ethereum compatible chain ids
@@ -443,7 +457,7 @@ func setupNodeAndRun(hc harmonyConfig) {
 	select {}
 }
 
-func nodeconfigSetShardSchedule(config harmonyConfig) {
+func nodeconfigSetShardSchedule(config harmonyconfig.HarmonyConfig) {
 	switch config.Network.NetworkType {
 	case nodeconfig.Mainnet:
 		shard.Schedule = shardingconfig.MainnetSchedule
@@ -458,7 +472,7 @@ func nodeconfigSetShardSchedule(config harmonyConfig) {
 	case nodeconfig.Stressnet:
 		shard.Schedule = shardingconfig.StressNetSchedule
 	case nodeconfig.Devnet:
-		var dnConfig devnetConfig
+		var dnConfig harmonyconfig.DevnetConfig
 		if config.Devnet != nil {
 			dnConfig = *config.Devnet
 		} else {
@@ -486,7 +500,7 @@ func findAccountsByPubKeys(config shardingconfig.Instance, pubKeys multibls.Publ
 	}
 }
 
-func setupLegacyNodeAccount(hc harmonyConfig) error {
+func setupLegacyNodeAccount(hc harmonyconfig.HarmonyConfig) error {
 	genesisShardingConfig := shard.Schedule.InstanceForEpoch(big.NewInt(core.GenesisEpoch))
 	multiBLSPubKey := setupConsensusKeys(hc, nodeconfig.GetDefaultConfig())
 
@@ -518,7 +532,7 @@ func setupLegacyNodeAccount(hc harmonyConfig) error {
 	return nil
 }
 
-func setupStakingNodeAccount(hc harmonyConfig) error {
+func setupStakingNodeAccount(hc harmonyconfig.HarmonyConfig) error {
 	pubKeys := setupConsensusKeys(hc, nodeconfig.GetDefaultConfig())
 	shardID, err := nodeconfig.GetDefaultConfig().ShardIDFromConsensusKey()
 	if err != nil {
@@ -539,7 +553,7 @@ func setupStakingNodeAccount(hc harmonyConfig) error {
 	return nil
 }
 
-func createGlobalConfig(hc harmonyConfig) (*nodeconfig.ConfigType, error) {
+func createGlobalConfig(hc harmonyconfig.HarmonyConfig) (*nodeconfig.ConfigType, error) {
 	var err error
 
 	if len(initialAccounts) == 0 {
@@ -604,7 +618,7 @@ func createGlobalConfig(hc harmonyConfig) (*nodeconfig.ConfigType, error) {
 	return nodeConfig, nil
 }
 
-func setupConsensusAndNode(hc harmonyConfig, nodeConfig *nodeconfig.ConfigType) *node.Node {
+func setupConsensusAndNode(hc harmonyconfig.HarmonyConfig, nodeConfig *nodeconfig.ConfigType) *node.Node {
 	// Consensus object.
 	// TODO: consensus object shouldn't start here
 	decider := quorum.NewDecider(quorum.SuperMajorityVote, uint32(hc.General.ShardID))
@@ -621,7 +635,7 @@ func setupConsensusAndNode(hc harmonyConfig, nodeConfig *nodeconfig.ConfigType) 
 		os.Exit(1)
 	}
 
-	// Parse minPeers from harmonyConfig
+	// Parse minPeers from harmonyconfig.HarmonyConfig
 	var minPeers int
 	var aggregateSig bool
 	if hc.Consensus != nil {
@@ -712,7 +726,7 @@ func setupConsensusAndNode(hc harmonyConfig, nodeConfig *nodeconfig.ConfigType) 
 	return currentNode
 }
 
-func setupPrometheusService(node *node.Node, hc harmonyConfig, sid uint32) {
+func setupPrometheusService(node *node.Node, hc harmonyconfig.HarmonyConfig, sid uint32) {
 	prometheusConfig := prometheus.Config{
 		Enabled:    hc.Prometheus.Enabled,
 		IP:         hc.Prometheus.IP,
@@ -729,7 +743,7 @@ func setupPrometheusService(node *node.Node, hc harmonyConfig, sid uint32) {
 	node.RegisterService(service.Prometheus, p)
 }
 
-func setupSyncService(node *node.Node, host p2p.Host, hc harmonyConfig) {
+func setupSyncService(node *node.Node, host p2p.Host, hc harmonyconfig.HarmonyConfig) {
 	blockchains := []*core.BlockChain{node.Blockchain()}
 	if !node.IsRunningBeaconChain() {
 		blockchains = append(blockchains, node.Beaconchain())
@@ -762,7 +776,7 @@ func setupSyncService(node *node.Node, host p2p.Host, hc harmonyConfig) {
 	node.Consensus.SetDownloader(d)
 }
 
-func setupBlacklist(hc harmonyConfig) (map[ethCommon.Address]struct{}, error) {
+func setupBlacklist(hc harmonyconfig.HarmonyConfig) (map[ethCommon.Address]struct{}, error) {
 	utils.Logger().Debug().Msgf("Using blacklist file at `%s`", hc.TxPool.BlacklistFile)
 	dat, err := ioutil.ReadFile(hc.TxPool.BlacklistFile)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/pborman/uuid v1.2.0
-	github.com/pelletier/go-toml v1.9.2
+	github.com/pelletier/go-toml v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.8.0
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/pborman/uuid v1.2.0
-	github.com/pelletier/go-toml v1.2.0
+	github.com/pelletier/go-toml v1.9.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.8.0
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0

--- a/hmy/hmy.go
+++ b/hmy/hmy.go
@@ -106,6 +106,7 @@ type NodeAPI interface {
 	GetConsensusPhase() string
 	GetConsensusViewChangingID() uint64
 	GetConsensusCurViewID() uint64
+	GetConfig() commonRPC.Config
 	ShutDown()
 }
 

--- a/internal/configs/harmony/harmony.go
+++ b/internal/configs/harmony/harmony.go
@@ -1,5 +1,10 @@
 package harmony
 
+import (
+	"reflect"
+	"strings"
+)
+
 // HarmonyConfig contains all the configs user can set for running harmony binary. Served as the bridge
 // from user set flags to internal node configs. Also user can persist this structure to a toml file
 // to avoid inputting all arguments.
@@ -90,8 +95,26 @@ type LogConfig struct {
 	FileName      string
 	RotateSize    int
 	Verbosity     int
-	VerbosePrints map[string]bool `toml:",omitempty"`
+	VerbosePrints LogVerbosePrints
 	Context       *LogContext     `toml:",omitempty"`
+}
+
+type LogVerbosePrints struct {
+	Config bool
+}
+
+func FlagSliceToLogVerbosePrints(verbosePrintsFlagSlice []string) LogVerbosePrints {
+	verbosePrints := LogVerbosePrints{}
+	verbosePrintsReflect := reflect.Indirect(reflect.ValueOf(&verbosePrints))
+	for _, verbosePrint := range verbosePrintsFlagSlice {
+		verbosePrint = strings.Title(verbosePrint)
+		field := verbosePrintsReflect.FieldByName(verbosePrint)
+		if field.IsValid() && field.CanSet() {
+			field.SetBool(true)
+		}
+	}
+
+	return verbosePrints
 }
 
 type LogContext struct {

--- a/internal/configs/harmony/harmony.go
+++ b/internal/configs/harmony/harmony.go
@@ -90,8 +90,8 @@ type LogConfig struct {
 	FileName      string
 	RotateSize    int
 	Verbosity     int
-	VerbosePrints map[string]bool
-	Context       *LogContext `toml:",omitempty"`
+	VerbosePrints map[string]bool `toml:",omitempty"`
+	Context       *LogContext     `toml:",omitempty"`
 }
 
 type LogContext struct {

--- a/internal/configs/harmony/harmony.go
+++ b/internal/configs/harmony/harmony.go
@@ -1,0 +1,163 @@
+package harmony
+
+// HarmonyConfig contains all the configs user can set for running harmony binary. Served as the bridge
+// from user set flags to internal node configs. Also user can persist this structure to a toml file
+// to avoid inputting all arguments.
+type HarmonyConfig struct {
+	Version    string
+	General    GeneralConfig
+	Network    NetworkConfig
+	P2P        P2pConfig
+	HTTP       HttpConfig
+	WS         WsConfig
+	RPCOpt     RpcOptConfig
+	BLSKeys    BlsConfig
+	TxPool     TxPoolConfig
+	Pprof      PprofConfig
+	Log        LogConfig
+	Sync       SyncConfig
+	Sys        *SysConfig        `toml:",omitempty"`
+	Consensus  *ConsensusConfig  `toml:",omitempty"`
+	Devnet     *DevnetConfig     `toml:",omitempty"`
+	Revert     *RevertConfig     `toml:",omitempty"`
+	Legacy     *LegacyConfig     `toml:",omitempty"`
+	Prometheus *PrometheusConfig `toml:",omitempty"`
+	DNSSync    DnsSync
+}
+
+type DnsSync struct {
+	Port          int    // replaces: Network.DNSSyncPort
+	Zone          string // replaces: Network.DNSZone
+	LegacySyncing bool   // replaces: Network.LegacySyncing
+	Client        bool   // replaces: Sync.LegacyClient
+	Server        bool   // replaces: Sync.LegacyServer
+	ServerPort    int
+}
+
+type NetworkConfig struct {
+	NetworkType string
+	BootNodes   []string
+}
+
+type P2pConfig struct {
+	Port         int
+	IP           string
+	KeyFile      string
+	DHTDataStore *string `toml:",omitempty"`
+}
+
+type GeneralConfig struct {
+	NodeType         string
+	NoStaking        bool
+	ShardID          int
+	IsArchival       bool
+	IsBeaconArchival bool
+	IsOffline        bool
+	DataDir          string
+}
+
+type ConsensusConfig struct {
+	MinPeers     int
+	AggregateSig bool
+}
+
+type BlsConfig struct {
+	KeyDir   string
+	KeyFiles []string
+	MaxKeys  int
+
+	PassEnabled    bool
+	PassSrcType    string
+	PassFile       string
+	SavePassphrase bool
+
+	KMSEnabled       bool
+	KMSConfigSrcType string
+	KMSConfigFile    string
+}
+
+type TxPoolConfig struct {
+	BlacklistFile string
+}
+
+type PprofConfig struct {
+	Enabled    bool
+	ListenAddr string
+}
+
+type LogConfig struct {
+	Folder        string
+	FileName      string
+	RotateSize    int
+	Verbosity     int
+	VerbosePrints map[string]bool
+	Context       *LogContext `toml:",omitempty"`
+}
+
+type LogContext struct {
+	IP   string
+	Port int
+}
+
+type SysConfig struct {
+	NtpServer string
+}
+
+type HttpConfig struct {
+	Enabled        bool
+	IP             string
+	Port           int
+	RosettaEnabled bool
+	RosettaPort    int
+}
+
+type WsConfig struct {
+	Enabled bool
+	IP      string
+	Port    int
+}
+
+type RpcOptConfig struct {
+	DebugEnabled      bool // Enables PrivateDebugService APIs, including the EVM tracer
+	RateLimterEnabled bool // Enable Rate limiter for RPC
+	RequestsPerSecond int  // for RPC rate limiter
+}
+
+type DevnetConfig struct {
+	NumShards   int
+	ShardSize   int
+	HmyNodeSize int
+}
+
+// TODO: make `revert` to a separate command
+type RevertConfig struct {
+	RevertBeacon bool
+	RevertTo     int
+	RevertBefore int
+}
+
+type LegacyConfig struct {
+	WebHookConfig         *string `toml:",omitempty"`
+	TPBroadcastInvalidTxn *bool   `toml:",omitempty"`
+}
+
+type PrometheusConfig struct {
+	Enabled    bool
+	IP         string
+	Port       int
+	EnablePush bool
+	Gateway    string
+}
+
+type SyncConfig struct {
+	// TODO: Remove this bool after stream sync is fully up.
+	Enabled        bool // enable the stream sync protocol
+	Downloader     bool // start the sync downloader client
+	Concurrency    int  // concurrency used for stream sync protocol
+	MinPeers       int  // minimum streams to start a sync task.
+	InitStreams    int  // minimum streams in bootstrap to start sync loop.
+	DiscSoftLowCap int  // when number of streams is below this value, spin discover during check
+	DiscHardLowCap int  // when removing stream, num is below this value, spin discovery immediately
+	DiscHighCap    int  // upper limit of streams in one sync protocol
+	DiscBatch      int  // size of each discovery
+}

--- a/internal/configs/harmony/harmony.go
+++ b/internal/configs/harmony/harmony.go
@@ -96,7 +96,7 @@ type LogConfig struct {
 	RotateSize    int
 	Verbosity     int
 	VerbosePrints LogVerbosePrints
-	Context       *LogContext     `toml:",omitempty"`
+	Context       *LogContext `toml:",omitempty"`
 }
 
 type LogVerbosePrints struct {

--- a/internal/configs/node/config.go
+++ b/internal/configs/node/config.go
@@ -83,8 +83,8 @@ type ConfigType struct {
 	Downloader      bool // Whether stream downloader is running; TODO: remove this after sync up
 	NtpServer       string
 	StringRole      string
-	P2PPriKey       p2p_crypto.PrivKey
-	ConsensusPriKey multibls.PrivateKeys
+	P2PPriKey       p2p_crypto.PrivKey   `json:"-"`
+	ConsensusPriKey multibls.PrivateKeys `json:"-"`
 	// Database directory
 	DBDir            string
 	networkType      NetworkType

--- a/node/api.go
+++ b/node/api.go
@@ -145,7 +145,7 @@ func (node *Node) GetConsensusInternal() rpc_common.ConsensusInternal {
 
 func (node *Node) GetConfig() rpc_common.Config {
 	return rpc_common.Config{
-		HarmonyConfig: node.HarmonyConfig,
+		HarmonyConfig: *node.HarmonyConfig,
 		NodeConfig:    *node.NodeConfig,
 		ChainConfig:   node.chainConfig,
 	}

--- a/node/api.go
+++ b/node/api.go
@@ -142,3 +142,11 @@ func (node *Node) GetConsensusInternal() rpc_common.ConsensusInternal {
 		ConsensusTime: node.Consensus.GetFinality(),
 	}
 }
+
+func (node *Node) GetConfig() rpc_common.Config {
+	return rpc_common.Config{
+		HarmonyConfig: node.HarmonyConfig,
+		NodeConfig: *node.NodeConfig,
+		ChainConfig: node.chainConfig,
+	}
+}

--- a/node/api.go
+++ b/node/api.go
@@ -146,7 +146,7 @@ func (node *Node) GetConsensusInternal() rpc_common.ConsensusInternal {
 func (node *Node) GetConfig() rpc_common.Config {
 	return rpc_common.Config{
 		HarmonyConfig: node.HarmonyConfig,
-		NodeConfig: *node.NodeConfig,
-		ChainConfig: node.chainConfig,
+		NodeConfig:    *node.NodeConfig,
+		ChainConfig:   node.chainConfig,
 	}
 }

--- a/node/node.go
+++ b/node/node.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/harmony-one/harmony/internal/configs/harmony"
+	harmonyconfig "github.com/harmony-one/harmony/internal/configs/harmony"
 
 	"github.com/ethereum/go-ethereum/common"
 	protobuf "github.com/golang/protobuf/proto"
@@ -106,7 +106,7 @@ type Node struct {
 	ContractAddresses            []common.Address
 	// Channel to notify consensus service to really start consensus
 	startConsensus chan struct{}
-	HarmonyConfig  harmony.HarmonyConfig
+	HarmonyConfig  *harmonyconfig.HarmonyConfig
 	// node configuration, including group ID, shard ID, etc
 	NodeConfig *nodeconfig.ConfigType
 	// Chain configuration.
@@ -940,6 +940,7 @@ func New(
 	chainDBFactory shardchain.DBFactory,
 	blacklist map[common.Address]struct{},
 	isArchival map[uint32]bool,
+	harmonyconfig *harmonyconfig.HarmonyConfig,
 ) *Node {
 	node := Node{}
 	node.unixTimeAtNodeStart = time.Now().Unix()
@@ -950,6 +951,7 @@ func New(
 	} else {
 		node.NodeConfig = nodeconfig.GetDefaultConfig()
 	}
+	node.HarmonyConfig = harmonyconfig
 
 	copy(node.syncID[:], GenerateRandomString(SyncIDLength))
 	if host != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"fmt"
+	"github.com/harmony-one/harmony/internal/configs/harmony"
 	"math/big"
 	"os"
 	"strings"
@@ -105,6 +106,7 @@ type Node struct {
 	ContractAddresses            []common.Address
 	// Channel to notify consensus service to really start consensus
 	startConsensus chan struct{}
+	HarmonyConfig harmony.HarmonyConfig
 	// node configuration, including group ID, shard ID, etc
 	NodeConfig *nodeconfig.ConfigType
 	// Chain configuration.

--- a/node/node.go
+++ b/node/node.go
@@ -3,7 +3,6 @@ package node
 import (
 	"context"
 	"fmt"
-	"github.com/harmony-one/harmony/internal/configs/harmony"
 	"math/big"
 	"os"
 	"strings"
@@ -11,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/harmony-one/harmony/internal/configs/harmony"
 
 	"github.com/ethereum/go-ethereum/common"
 	protobuf "github.com/golang/protobuf/proto"
@@ -106,7 +106,7 @@ type Node struct {
 	ContractAddresses            []common.Address
 	// Channel to notify consensus service to really start consensus
 	startConsensus chan struct{}
-	HarmonyConfig harmony.HarmonyConfig
+	HarmonyConfig  harmony.HarmonyConfig
 	// node configuration, including group ID, shard ID, etc
 	NodeConfig *nodeconfig.ConfigType
 	// Chain configuration.

--- a/node/node_handler_test.go
+++ b/node/node_handler_test.go
@@ -39,7 +39,7 @@ func TestAddNewBlock(t *testing.T) {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
 	nodeconfig.SetNetworkType(nodeconfig.Devnet)
-	node := New(host, consensus, testDBFactory, nil, nil)
+	node := New(host, consensus, testDBFactory, nil, nil, nil)
 
 	txs := make(map[common.Address]types.Transactions)
 	stks := staking.StakingTransactions{}
@@ -88,7 +88,7 @@ func TestVerifyNewBlock(t *testing.T) {
 	archiveMode := make(map[uint32]bool)
 	archiveMode[0] = true
 	archiveMode[1] = false
-	node := New(host, consensus, testDBFactory, nil, archiveMode)
+	node := New(host, consensus, testDBFactory, nil, archiveMode, nil)
 
 	txs := make(map[common.Address]types.Transactions)
 	stks := staking.StakingTransactions{}
@@ -134,7 +134,7 @@ func TestVerifyVRF(t *testing.T) {
 	archiveMode := make(map[uint32]bool)
 	archiveMode[0] = true
 	archiveMode[1] = false
-	node := New(host, consensus, testDBFactory, nil, archiveMode)
+	node := New(host, consensus, testDBFactory, nil, archiveMode, nil)
 
 	consensus.Blockchain = node.Blockchain()
 	txs := make(map[common.Address]types.Transactions)

--- a/node/node_newblock_test.go
+++ b/node/node_newblock_test.go
@@ -40,7 +40,7 @@ func TestFinalizeNewBlockAsync(t *testing.T) {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
 	var testDBFactory = &shardchain.MemDBFactory{}
-	node := New(host, consensus, testDBFactory, nil, nil)
+	node := New(host, consensus, testDBFactory, nil, nil, nil)
 
 	node.Worker.UpdateCurrent()
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -39,7 +39,7 @@ func TestNewNode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
-	node := New(host, consensus, testDBFactory, nil, nil)
+	node := New(host, consensus, testDBFactory, nil, nil, nil)
 	if node.Consensus == nil {
 		t.Error("Consensus is not initialized for the node")
 	}
@@ -216,7 +216,7 @@ func TestAddBeaconPeer(t *testing.T) {
 	archiveMode := make(map[uint32]bool)
 	archiveMode[0] = true
 	archiveMode[1] = false
-	node := New(host, consensus, testDBFactory, nil, archiveMode)
+	node := New(host, consensus, testDBFactory, nil, archiveMode, nil)
 	for _, p := range peers1 {
 		ret := node.AddBeaconPeer(p)
 		if ret {

--- a/rpc/common/types.go
+++ b/rpc/common/types.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"encoding/json"
+
 	harmonyconfig "github.com/harmony-one/harmony/internal/configs/harmony"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 
@@ -85,6 +86,6 @@ type NodePeerInfo struct {
 
 type Config struct {
 	HarmonyConfig harmonyconfig.HarmonyConfig
-	NodeConfig nodeconfig.ConfigType
-	ChainConfig params.ChainConfig
+	NodeConfig    nodeconfig.ConfigType
+	ChainConfig   params.ChainConfig
 }

--- a/rpc/common/types.go
+++ b/rpc/common/types.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"encoding/json"
+	harmonyconfig "github.com/harmony-one/harmony/internal/configs/harmony"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 
 	"github.com/harmony-one/harmony/internal/params"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -79,4 +81,9 @@ type NodePeerInfo struct {
 	PeerID       peer.ID   `json:"peerid"`
 	BlockedPeers []peer.ID `json:"blocked-peers"`
 	P            []P       `json:"connected-peers"`
+}
+
+type Config struct {
+	HarmonyConfig harmonyconfig.HarmonyConfig
+	NodeConfig nodeconfig.ConfigType
 }

--- a/rpc/common/types.go
+++ b/rpc/common/types.go
@@ -86,4 +86,5 @@ type NodePeerInfo struct {
 type Config struct {
 	HarmonyConfig harmonyconfig.HarmonyConfig
 	NodeConfig nodeconfig.ConfigType
+	ChainConfig params.ChainConfig
 }

--- a/rpc/debug.go
+++ b/rpc/debug.go
@@ -3,8 +3,6 @@ package rpc
 import (
 	"context"
 
-	commonRPC "github.com/harmony-one/harmony/rpc/common"
-
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/harmony-one/harmony/hmy"
@@ -70,6 +68,6 @@ func (s *PrivateDebugService) GetConsensusPhase(
 // GetConfig get harmony config
 func (s *PrivateDebugService) GetConfig(
 	ctx context.Context,
-) commonRPC.Config {
-	return s.hmy.NodeAPI.GetConfig()
+) (StructuredResponse, error) {
+	return NewStructuredResponse(s.hmy.NodeAPI.GetConfig())
 }

--- a/rpc/debug.go
+++ b/rpc/debug.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+
 	commonRPC "github.com/harmony-one/harmony/rpc/common"
 
 	"github.com/ethereum/go-ethereum/log"

--- a/rpc/debug.go
+++ b/rpc/debug.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	commonRPC "github.com/harmony-one/harmony/rpc/common"
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -63,4 +64,11 @@ func (s *PrivateDebugService) GetConsensusPhase(
 	ctx context.Context,
 ) string {
 	return s.hmy.NodeAPI.GetConsensusPhase()
+}
+
+// GetConfig get harmony config
+func (s *PrivateDebugService) GetConfig(
+	ctx context.Context,
+) commonRPC.Config {
+	return s.hmy.NodeAPI.GetConfig()
 }


### PR DESCRIPTION
## Issue

@LeoHChen

https://github.com/harmony-one/bounties/issues/41

## Added Features

- [x] adding `--log.verbose-prints config` flag
- [x] adding `hmyv2_getConfig` rpc that can be enabled with `--rpc.debug` flag

## Major Changes

- moving private config structs from within `cmd/harmony/config.go` to `internal/configs/harmony/harmony.go` exported as `harmonyconfig` package for `hmyv2_getConfig` RPC
- adding config migration from `2.0.0` to `2.1.0` which sets `Log.VerbosePrints` to default value of:
https://github.com/harmony-one/harmony/blob/b87f17f0effdcb2e186251e96df95390c1929fd1/cmd/harmony/default.go#L69-L77
- adding a RPC struct `Config` for printing internal config objects 
https://github.com/harmony-one/harmony/blob/b87f17f0effdcb2e186251e96df95390c1929fd1/node/api.go#L146-L152

## Notices

- flag `--rpc.debug` must be added for enabling `hmyv2_getConfig`

## Test

### Test/Run Logs

#### Log Outputs
```
./bin/harmony --log.dir . --log.name harmony.log --verbose-prints config --rpc.debug --network devnet 
```

outputs: https://gist.github.com/touhonoob/a8336b11e33eee7f14361e30a793e757


#### JSON-RPC
```bash
curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":"id","method":"hmyv2_getConfig"}' http://127.0.0.1:9500                
```

outputs: https://gist.github.com/touhonoob/85909ce19f32d7eb0c6684db56ba7d18

#### Migrated TOML
https://gist.github.com/touhonoob/b94cc499a334f1e94ae0f8faa1240823

### Unit Test Coverage

Before:

```
PASS
coverage: 47.8% of statements
ok  	github.com/harmony-one/harmony/cmd/harmony	0.050s
```

After:

```
PASS
coverage: 48.1% of statements
ok  	github.com/harmony-one/harmony/cmd/harmony	0.041s
```


## Operational Checklist

*1.* **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)
*NO*


*8.* **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)
*NO*


*11.* **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**
*NO*