### PR TITLE
[Feature] Expose All Configuration Variables And Values

### DIFF
--- a/cmd/harmony/bls.go
+++ b/cmd/harmony/bls.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	conf "github.com/harmony-one/harmony/cmd/harmony/config"
 	"os"
 	"sync"
 
@@ -16,7 +17,7 @@ var (
 )
 
 // setupConsensusKeys load bls keys and set the keys to nodeConfig. Return the loaded public keys.
-func setupConsensusKeys(hc harmonyConfig, config *nodeconfig.ConfigType) multibls.PublicKeys {
+func setupConsensusKeys(hc conf.HarmonyConfig, config *nodeconfig.ConfigType) multibls.PublicKeys {
 	onceLoadBLSKey.Do(func() {
 		var err error
 		multiBLSPriKey, err = loadBLSKeys(hc.BLSKeys)
@@ -30,7 +31,7 @@ func setupConsensusKeys(hc harmonyConfig, config *nodeconfig.ConfigType) multibl
 	return multiBLSPriKey.GetPublicKeys()
 }
 
-func loadBLSKeys(raw blsConfig) (multibls.PrivateKeys, error) {
+func loadBLSKeys(raw conf.BlsConfig) (multibls.PrivateKeys, error) {
 	config, err := parseBLSLoadingConfig(raw)
 	if err != nil {
 		return nil, err
@@ -48,7 +49,7 @@ func loadBLSKeys(raw blsConfig) (multibls.PrivateKeys, error) {
 	return keys.Dedup(), err
 }
 
-func parseBLSLoadingConfig(raw blsConfig) (blsgen.Config, error) {
+func parseBLSLoadingConfig(raw conf.BlsConfig) (blsgen.Config, error) {
 	var (
 		config blsgen.Config
 		err    error
@@ -69,7 +70,7 @@ func parseBLSLoadingConfig(raw blsConfig) (blsgen.Config, error) {
 	return config, nil
 }
 
-func parseBLSPassConfig(cfg blsgen.Config, raw blsConfig) (blsgen.Config, error) {
+func parseBLSPassConfig(cfg blsgen.Config, raw conf.BlsConfig) (blsgen.Config, error) {
 	if !raw.PassEnabled {
 		cfg.PassSrcType = blsgen.PassSrcNil
 		return blsgen.Config{}, nil
@@ -90,7 +91,7 @@ func parseBLSPassConfig(cfg blsgen.Config, raw blsConfig) (blsgen.Config, error)
 	return cfg, nil
 }
 
-func parseBLSKmsConfig(cfg blsgen.Config, raw blsConfig) (blsgen.Config, error) {
+func parseBLSKmsConfig(cfg blsgen.Config, raw conf.BlsConfig) (blsgen.Config, error) {
 	if !raw.KMSEnabled {
 		cfg.AwsCfgSrcType = blsgen.AwsCfgSrcNil
 		return cfg, nil

--- a/cmd/harmony/bls.go
+++ b/cmd/harmony/bls.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
-	conf "github.com/harmony-one/harmony/cmd/harmony/config"
 	"os"
 	"sync"
+
+	conf "github.com/harmony-one/harmony/cmd/harmony/config"
 
 	"github.com/harmony-one/harmony/internal/blsgen"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"

--- a/cmd/harmony/config.go
+++ b/cmd/harmony/config.go
@@ -8,175 +8,15 @@ import (
 	"strings"
 	"time"
 
+	conf "github.com/harmony-one/harmony/cmd/harmony/config"
 	"github.com/harmony-one/harmony/internal/cli"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/pelletier/go-toml"
 	"github.com/spf13/cobra"
 )
 
-// harmonyConfig contains all the configs user can set for running harmony binary. Served as the bridge
-// from user set flags to internal node configs. Also user can persist this structure to a toml file
-// to avoid inputting all arguments.
-type harmonyConfig struct {
-	Version    string
-	General    generalConfig
-	Network    networkConfig
-	P2P        p2pConfig
-	HTTP       httpConfig
-	WS         wsConfig
-	RPCOpt     rpcOptConfig
-	BLSKeys    blsConfig
-	TxPool     txPoolConfig
-	Pprof      pprofConfig
-	Log        logConfig
-	Sync       syncConfig
-	Sys        *sysConfig        `toml:",omitempty"`
-	Consensus  *consensusConfig  `toml:",omitempty"`
-	Devnet     *devnetConfig     `toml:",omitempty"`
-	Revert     *revertConfig     `toml:",omitempty"`
-	Legacy     *legacyConfig     `toml:",omitempty"`
-	Prometheus *prometheusConfig `toml:",omitempty"`
-	DNSSync    dnsSync
-}
-
-type dnsSync struct {
-	Port          int    // replaces: Network.DNSSyncPort
-	Zone          string // replaces: Network.DNSZone
-	LegacySyncing bool   // replaces: Network.LegacySyncing
-	Client        bool   // replaces: Sync.LegacyClient
-	Server        bool   // replaces: Sync.LegacyServer
-	ServerPort    int
-}
-
-type networkConfig struct {
-	NetworkType string
-	BootNodes   []string
-}
-
-type p2pConfig struct {
-	Port         int
-	IP           string
-	KeyFile      string
-	DHTDataStore *string `toml:",omitempty"`
-}
-
-type generalConfig struct {
-	NodeType         string
-	NoStaking        bool
-	ShardID          int
-	IsArchival       bool
-	IsBeaconArchival bool
-	IsOffline        bool
-	DataDir          string
-}
-
-type consensusConfig struct {
-	MinPeers     int
-	AggregateSig bool
-}
-
-type blsConfig struct {
-	KeyDir   string
-	KeyFiles []string
-	MaxKeys  int
-
-	PassEnabled    bool
-	PassSrcType    string
-	PassFile       string
-	SavePassphrase bool
-
-	KMSEnabled       bool
-	KMSConfigSrcType string
-	KMSConfigFile    string
-}
-
-type txPoolConfig struct {
-	BlacklistFile string
-}
-
-type pprofConfig struct {
-	Enabled    bool
-	ListenAddr string
-}
-
-type logConfig struct {
-	Folder     string
-	FileName   string
-	RotateSize int
-	Verbosity  int
-	Context    *logContext `toml:",omitempty"`
-}
-
-type logContext struct {
-	IP   string
-	Port int
-}
-
-type sysConfig struct {
-	NtpServer string
-}
-
-type httpConfig struct {
-	Enabled        bool
-	IP             string
-	Port           int
-	RosettaEnabled bool
-	RosettaPort    int
-}
-
-type wsConfig struct {
-	Enabled bool
-	IP      string
-	Port    int
-}
-
-type rpcOptConfig struct {
-	DebugEnabled      bool // Enables PrivateDebugService APIs, including the EVM tracer
-	RateLimterEnabled bool // Enable Rate limiter for RPC
-	RequestsPerSecond int  // for RPC rate limiter
-}
-
-type devnetConfig struct {
-	NumShards   int
-	ShardSize   int
-	HmyNodeSize int
-}
-
-// TODO: make `revert` to a separate command
-type revertConfig struct {
-	RevertBeacon bool
-	RevertTo     int
-	RevertBefore int
-}
-
-type legacyConfig struct {
-	WebHookConfig         *string `toml:",omitempty"`
-	TPBroadcastInvalidTxn *bool   `toml:",omitempty"`
-}
-
-type prometheusConfig struct {
-	Enabled    bool
-	IP         string
-	Port       int
-	EnablePush bool
-	Gateway    string
-}
-
-type syncConfig struct {
-	// TODO: Remove this bool after stream sync is fully up.
-	Enabled        bool // enable the stream sync protocol
-	Downloader     bool // start the sync downloader client
-	Concurrency    int  // concurrency used for stream sync protocol
-	MinPeers       int  // minimum streams to start a sync task.
-	InitStreams    int  // minimum streams in bootstrap to start sync loop.
-	DiscSoftLowCap int  // when number of streams is below this value, spin discover during check
-	DiscHardLowCap int  // when removing stream, num is below this value, spin discovery immediately
-	DiscHighCap    int  // upper limit of streams in one sync protocol
-	DiscBatch      int  // size of each discovery
-}
-
 // TODO: use specific type wise validation instead of general string types assertion.
-func validateHarmonyConfig(config harmonyConfig) error {
+func validateHarmonyConfig(config conf.HarmonyConfig) error {
 	var accepts []string
 
 	nodeType := config.General.NodeType
@@ -219,7 +59,7 @@ func validateHarmonyConfig(config harmonyConfig) error {
 	return nil
 }
 
-func sanityFixHarmonyConfig(hc *harmonyConfig) {
+func sanityFixHarmonyConfig(hc *conf.HarmonyConfig) {
 	// When running sync downloader, set sync.Enabled to true
 	if hc.Sync.Downloader && !hc.Sync.Enabled {
 		fmt.Println("Set Sync.Enabled to true when running stream downloader")
@@ -237,10 +77,10 @@ func checkStringAccepted(flag string, val string, accepts []string) error {
 	return fmt.Errorf("unknown arg for %s: %s (%v)", flag, val, acceptsStr)
 }
 
-func getDefaultDNSSyncConfig(nt nodeconfig.NetworkType) dnsSync {
+func getDefaultDNSSyncConfig(nt nodeconfig.NetworkType) conf.DnsSync {
 	zone := nodeconfig.GetDefaultDNSZone(nt)
 	port := nodeconfig.GetDefaultDNSPort(nt)
-	dnsSync := dnsSync{
+	dnsSync := conf.DnsSync{
 		Port:          port,
 		Zone:          zone,
 		LegacySyncing: false,
@@ -263,9 +103,9 @@ func getDefaultDNSSyncConfig(nt nodeconfig.NetworkType) dnsSync {
 	return dnsSync
 }
 
-func getDefaultNetworkConfig(nt nodeconfig.NetworkType) networkConfig {
+func getDefaultNetworkConfig(nt nodeconfig.NetworkType) conf.NetworkConfig {
 	bn := nodeconfig.GetDefaultBootNodes(nt)
-	return networkConfig{
+	return conf.NetworkConfig{
 		NetworkType: string(nt),
 		BootNodes:   bn,
 	}
@@ -292,7 +132,7 @@ func parseNetworkType(nt string) nodeconfig.NetworkType {
 	}
 }
 
-func getDefaultSyncConfig(nt nodeconfig.NetworkType) syncConfig {
+func getDefaultSyncConfig(nt nodeconfig.NetworkType) conf.SyncConfig {
 	switch nt {
 	case nodeconfig.Mainnet:
 		return defaultMainnetSyncConfig
@@ -380,14 +220,14 @@ func promptConfigUpdate() bool {
 	}
 }
 
-func loadHarmonyConfig(file string) (harmonyConfig, string, error) {
+func loadHarmonyConfig(file string) (conf.HarmonyConfig, string, error) {
 	b, err := ioutil.ReadFile(file)
 	if err != nil {
-		return harmonyConfig{}, "", err
+		return conf.HarmonyConfig{}, "", err
 	}
 	config, migratedVer, err := migrateConf(b)
 	if err != nil {
-		return harmonyConfig{}, "", err
+		return conf.HarmonyConfig{}, "", err
 	}
 
 	return config, migratedVer, nil
@@ -414,7 +254,7 @@ func updateConfigFile(file string) error {
 	return nil
 }
 
-func writeHarmonyConfigToFile(config harmonyConfig, file string) error {
+func writeHarmonyConfigToFile(config conf.HarmonyConfig, file string) error {
 	b, err := toml.Marshal(config)
 	if err != nil {
 		return err

--- a/cmd/harmony/config/config.go
+++ b/cmd/harmony/config/config.go
@@ -1,0 +1,162 @@
+package config
+
+// HarmonyConfig contains all the configs user can set for running harmony binary. Served as the bridge
+// from user set flags to internal node configs. Also user can persist this structure to a toml file
+// to avoid inputting all arguments.
+type HarmonyConfig struct {
+	Version    string
+	General    GeneralConfig
+	Network    NetworkConfig
+	P2P        P2pConfig
+	HTTP       HttpConfig
+	WS         WsConfig
+	RPCOpt     RpcOptConfig
+	BLSKeys    BlsConfig
+	TxPool     TxPoolConfig
+	Pprof      PprofConfig
+	Log        LogConfig
+	Sync       SyncConfig
+	Sys        *SysConfig        `toml:",omitempty"`
+	Consensus  *ConsensusConfig  `toml:",omitempty"`
+	Devnet     *DevnetConfig     `toml:",omitempty"`
+	Revert     *RevertConfig     `toml:",omitempty"`
+	Legacy     *LegacyConfig     `toml:",omitempty"`
+	Prometheus *PrometheusConfig `toml:",omitempty"`
+	DNSSync    DnsSync
+}
+
+type DnsSync struct {
+	Port          int    // replaces: Network.DNSSyncPort
+	Zone          string // replaces: Network.DNSZone
+	LegacySyncing bool   // replaces: Network.LegacySyncing
+	Client        bool   // replaces: Sync.LegacyClient
+	Server        bool   // replaces: Sync.LegacyServer
+	ServerPort    int
+}
+
+type NetworkConfig struct {
+	NetworkType string
+	BootNodes   []string
+}
+
+type P2pConfig struct {
+	Port         int
+	IP           string
+	KeyFile      string
+	DHTDataStore *string `toml:",omitempty"`
+}
+
+type GeneralConfig struct {
+	NodeType         string
+	NoStaking        bool
+	ShardID          int
+	IsArchival       bool
+	IsBeaconArchival bool
+	IsOffline        bool
+	DataDir          string
+}
+
+type ConsensusConfig struct {
+	MinPeers     int
+	AggregateSig bool
+}
+
+type BlsConfig struct {
+	KeyDir   string
+	KeyFiles []string
+	MaxKeys  int
+
+	PassEnabled    bool
+	PassSrcType    string
+	PassFile       string
+	SavePassphrase bool
+
+	KMSEnabled       bool
+	KMSConfigSrcType string
+	KMSConfigFile    string
+}
+
+type TxPoolConfig struct {
+	BlacklistFile string
+}
+
+type PprofConfig struct {
+	Enabled    bool
+	ListenAddr string
+}
+
+type LogConfig struct {
+	Folder     string
+	FileName   string
+	RotateSize int
+	Verbosity  int
+	Context    *LogContext `toml:",omitempty"`
+}
+
+type LogContext struct {
+	IP   string
+	Port int
+}
+
+type SysConfig struct {
+	NtpServer string
+}
+
+type HttpConfig struct {
+	Enabled        bool
+	IP             string
+	Port           int
+	RosettaEnabled bool
+	RosettaPort    int
+}
+
+type WsConfig struct {
+	Enabled bool
+	IP      string
+	Port    int
+}
+
+type RpcOptConfig struct {
+	DebugEnabled      bool // Enables PrivateDebugService APIs, including the EVM tracer
+	RateLimterEnabled bool // Enable Rate limiter for RPC
+	RequestsPerSecond int  // for RPC rate limiter
+}
+
+type DevnetConfig struct {
+	NumShards   int
+	ShardSize   int
+	HmyNodeSize int
+}
+
+// TODO: make `revert` to a separate command
+type RevertConfig struct {
+	RevertBeacon bool
+	RevertTo     int
+	RevertBefore int
+}
+
+type LegacyConfig struct {
+	WebHookConfig         *string `toml:",omitempty"`
+	TPBroadcastInvalidTxn *bool   `toml:",omitempty"`
+}
+
+type PrometheusConfig struct {
+	Enabled    bool
+	IP         string
+	Port       int
+	EnablePush bool
+	Gateway    string
+}
+
+type SyncConfig struct {
+	// TODO: Remove this bool after stream sync is fully up.
+	Enabled        bool // enable the stream sync protocol
+	Downloader     bool // start the sync downloader client
+	Concurrency    int  // concurrency used for stream sync protocol
+	MinPeers       int  // minimum streams to start a sync task.
+	InitStreams    int  // minimum streams in bootstrap to start sync loop.
+	DiscSoftLowCap int  // when number of streams is below this value, spin discover during check
+	DiscHardLowCap int  // when removing stream, num is below this value, spin discovery immediately
+	DiscHighCap    int  // upper limit of streams in one sync protocol
+	DiscBatch      int  // size of each discovery
+}

--- a/cmd/harmony/config_migrations.go
+++ b/cmd/harmony/config_migrations.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	conf "github.com/harmony-one/harmony/cmd/harmony/config"
 
 	"github.com/harmony-one/harmony/api/service/legacysync"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
@@ -38,31 +39,31 @@ func doMigrations(confVersion string, confTree *toml.Tree) error {
 	return nil
 }
 
-func migrateConf(confBytes []byte) (harmonyConfig, string, error) {
+func migrateConf(confBytes []byte) (conf.HarmonyConfig, string, error) {
 	var (
 		migratedFrom string
 	)
 	confTree, err := toml.LoadBytes(confBytes)
 	if err != nil {
-		return harmonyConfig{}, "", fmt.Errorf("config file parse error - %s", err.Error())
+		return conf.HarmonyConfig{}, "", fmt.Errorf("config file parse error - %s", err.Error())
 	}
 	confVersion, found := confTree.Get("Version").(string)
 	if !found {
-		return harmonyConfig{}, "", errors.New("config file invalid - no version entry found")
+		return conf.HarmonyConfig{}, "", errors.New("config file invalid - no version entry found")
 	}
 	migratedFrom = confVersion
 	if confVersion != tomlConfigVersion {
 		err = doMigrations(confVersion, confTree)
 		if err != nil {
-			return harmonyConfig{}, "", err
+			return conf.HarmonyConfig{}, "", err
 		}
 	}
 
 	// At this point we must be at current config version so
 	// we can safely unmarshal it
-	var config harmonyConfig
+	var config conf.HarmonyConfig
 	if err := confTree.Unmarshal(&config); err != nil {
-		return harmonyConfig{}, "", err
+		return conf.HarmonyConfig{}, "", err
 	}
 	return config, migratedFrom, nil
 }

--- a/cmd/harmony/config_migrations.go
+++ b/cmd/harmony/config_migrations.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+
 	conf "github.com/harmony-one/harmony/cmd/harmony/config"
 
 	"github.com/harmony-one/harmony/api/service/legacysync"

--- a/cmd/harmony/config_migrations_test.go
+++ b/cmd/harmony/config_migrations_test.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	conf "github.com/harmony-one/harmony/cmd/harmony/config"
 	"reflect"
 	"testing"
+
+	conf "github.com/harmony-one/harmony/cmd/harmony/config"
 
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 )

--- a/cmd/harmony/config_migrations_test.go
+++ b/cmd/harmony/config_migrations_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	conf "github.com/harmony-one/harmony/cmd/harmony/config"
 	"reflect"
 	"testing"
 
@@ -308,7 +309,7 @@ func Test_migrateConf(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    harmonyConfig
+		want    conf.HarmonyConfig
 		wantErr bool
 	}{
 		{
@@ -340,7 +341,7 @@ func Test_migrateConf(t *testing.T) {
 			args: args{
 				confBytes: V1_0_4ConfigDownloaderOn,
 			},
-			want: func() harmonyConfig {
+			want: func() conf.HarmonyConfig {
 				hc := defConf
 				hc.Sync.Downloader = true
 				hc.Sync.Enabled = true

--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
-	conf "github.com/harmony-one/harmony/cmd/harmony/config"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	conf "github.com/harmony-one/harmony/cmd/harmony/config"
 
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 )

--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	conf "github.com/harmony-one/harmony/cmd/harmony/config"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -11,9 +12,9 @@ import (
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 )
 
-type testCfgOpt func(config *harmonyConfig)
+type testCfgOpt func(config *conf.HarmonyConfig)
 
-func makeTestConfig(nt nodeconfig.NetworkType, opt testCfgOpt) harmonyConfig {
+func makeTestConfig(nt nodeconfig.NetworkType, opt testCfgOpt) conf.HarmonyConfig {
 	cfg := getDefaultHmyConfigCopy(nt)
 	if opt != nil {
 		opt(&cfg)
@@ -133,7 +134,7 @@ func TestPersistConfig(t *testing.T) {
 	os.MkdirAll(testDir, 0777)
 
 	tests := []struct {
-		config harmonyConfig
+		config conf.HarmonyConfig
 	}{
 		{
 			config: makeTestConfig("mainnet", nil),
@@ -142,7 +143,7 @@ func TestPersistConfig(t *testing.T) {
 			config: makeTestConfig("devnet", nil),
 		},
 		{
-			config: makeTestConfig("mainnet", func(cfg *harmonyConfig) {
+			config: makeTestConfig("mainnet", func(cfg *conf.HarmonyConfig) {
 				consensus := getDefaultConsensusConfigCopy()
 				cfg.Consensus = &consensus
 
@@ -153,7 +154,7 @@ func TestPersistConfig(t *testing.T) {
 				cfg.Revert = &revert
 
 				webHook := "web hook"
-				cfg.Legacy = &legacyConfig{
+				cfg.Legacy = &conf.LegacyConfig{
 					WebHookConfig:         &webHook,
 					TPBroadcastInvalidTxn: &trueBool,
 				}

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -1,6 +1,9 @@
 package main
 
-import nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
+import (
+	conf "github.com/harmony-one/harmony/cmd/harmony/config"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
+)
 
 const tomlConfigVersion = "2.0.0"
 
@@ -8,9 +11,9 @@ const (
 	defNetworkType = nodeconfig.Mainnet
 )
 
-var defaultConfig = harmonyConfig{
+var defaultConfig = conf.HarmonyConfig{
 	Version: tomlConfigVersion,
-	General: generalConfig{
+	General: conf.GeneralConfig{
 		NodeType:         "validator",
 		NoStaking:        false,
 		ShardID:          -1,
@@ -20,29 +23,29 @@ var defaultConfig = harmonyConfig{
 		DataDir:          "./",
 	},
 	Network: getDefaultNetworkConfig(defNetworkType),
-	P2P: p2pConfig{
+	P2P: conf.P2pConfig{
 		Port:    nodeconfig.DefaultP2PPort,
 		IP:      nodeconfig.DefaultPublicListenIP,
 		KeyFile: "./.hmykey",
 	},
-	HTTP: httpConfig{
+	HTTP: conf.HttpConfig{
 		Enabled:        true,
 		RosettaEnabled: false,
 		IP:             "127.0.0.1",
 		Port:           nodeconfig.DefaultRPCPort,
 		RosettaPort:    nodeconfig.DefaultRosettaPort,
 	},
-	WS: wsConfig{
+	WS: conf.WsConfig{
 		Enabled: true,
 		IP:      "127.0.0.1",
 		Port:    nodeconfig.DefaultWSPort,
 	},
-	RPCOpt: rpcOptConfig{
+	RPCOpt: conf.RpcOptConfig{
 		DebugEnabled:      false,
 		RateLimterEnabled: true,
 		RequestsPerSecond: nodeconfig.DefaultRPCRateLimit,
 	},
-	BLSKeys: blsConfig{
+	BLSKeys: conf.BlsConfig{
 		KeyDir:   "./.hmy/blskeys",
 		KeyFiles: []string{},
 		MaxKeys:  10,
@@ -55,15 +58,15 @@ var defaultConfig = harmonyConfig{
 		KMSConfigSrcType: kmsConfigTypeShared,
 		KMSConfigFile:    "",
 	},
-	TxPool: txPoolConfig{
+	TxPool: conf.TxPoolConfig{
 		BlacklistFile: "./.hmy/blacklist.txt",
 	},
 	Sync: getDefaultSyncConfig(defNetworkType),
-	Pprof: pprofConfig{
+	Pprof: conf.PprofConfig{
 		Enabled:    false,
 		ListenAddr: "127.0.0.1:6060",
 	},
-	Log: logConfig{
+	Log: conf.LogConfig{
 		Folder:     "./latest",
 		FileName:   "harmony.log",
 		RotateSize: 100,
@@ -72,33 +75,33 @@ var defaultConfig = harmonyConfig{
 	DNSSync: getDefaultDNSSyncConfig(defNetworkType),
 }
 
-var defaultSysConfig = sysConfig{
+var defaultSysConfig = conf.SysConfig{
 	NtpServer: "1.pool.ntp.org",
 }
 
-var defaultDevnetConfig = devnetConfig{
+var defaultDevnetConfig = conf.DevnetConfig{
 	NumShards:   2,
 	ShardSize:   10,
 	HmyNodeSize: 10,
 }
 
-var defaultRevertConfig = revertConfig{
+var defaultRevertConfig = conf.RevertConfig{
 	RevertBeacon: false,
 	RevertBefore: 0,
 	RevertTo:     0,
 }
 
-var defaultLogContext = logContext{
+var defaultLogContext = conf.LogContext{
 	IP:   "127.0.0.1",
 	Port: 9000,
 }
 
-var defaultConsensusConfig = consensusConfig{
+var defaultConsensusConfig = conf.ConsensusConfig{
 	MinPeers:     6,
 	AggregateSig: true,
 }
 
-var defaultPrometheusConfig = prometheusConfig{
+var defaultPrometheusConfig = conf.PrometheusConfig{
 	Enabled:    true,
 	IP:         "0.0.0.0",
 	Port:       9900,
@@ -107,7 +110,7 @@ var defaultPrometheusConfig = prometheusConfig{
 }
 
 var (
-	defaultMainnetSyncConfig = syncConfig{
+	defaultMainnetSyncConfig = conf.SyncConfig{
 		Enabled:        false,
 		Downloader:     false,
 		Concurrency:    6,
@@ -119,7 +122,7 @@ var (
 		DiscBatch:      8,
 	}
 
-	defaultTestNetSyncConfig = syncConfig{
+	defaultTestNetSyncConfig = conf.SyncConfig{
 		Enabled:        true,
 		Downloader:     false,
 		Concurrency:    4,
@@ -131,7 +134,7 @@ var (
 		DiscBatch:      8,
 	}
 
-	defaultLocalNetSyncConfig = syncConfig{
+	defaultLocalNetSyncConfig = conf.SyncConfig{
 		Enabled:        true,
 		Downloader:     false,
 		Concurrency:    4,
@@ -143,7 +146,7 @@ var (
 		DiscBatch:      8,
 	}
 
-	defaultElseSyncConfig = syncConfig{
+	defaultElseSyncConfig = conf.SyncConfig{
 		Enabled:        true,
 		Downloader:     true,
 		Concurrency:    4,
@@ -160,7 +163,7 @@ const (
 	defaultBroadcastInvalidTx = true
 )
 
-func getDefaultHmyConfigCopy(nt nodeconfig.NetworkType) harmonyConfig {
+func getDefaultHmyConfigCopy(nt nodeconfig.NetworkType) conf.HarmonyConfig {
 	config := defaultConfig
 
 	config.Network = getDefaultNetworkConfig(nt)
@@ -174,32 +177,32 @@ func getDefaultHmyConfigCopy(nt nodeconfig.NetworkType) harmonyConfig {
 	return config
 }
 
-func getDefaultSysConfigCopy() sysConfig {
+func getDefaultSysConfigCopy() conf.SysConfig {
 	config := defaultSysConfig
 	return config
 }
 
-func getDefaultDevnetConfigCopy() devnetConfig {
+func getDefaultDevnetConfigCopy() conf.DevnetConfig {
 	config := defaultDevnetConfig
 	return config
 }
 
-func getDefaultRevertConfigCopy() revertConfig {
+func getDefaultRevertConfigCopy() conf.RevertConfig {
 	config := defaultRevertConfig
 	return config
 }
 
-func getDefaultLogContextCopy() logContext {
+func getDefaultLogContextCopy() conf.LogContext {
 	config := defaultLogContext
 	return config
 }
 
-func getDefaultConsensusConfigCopy() consensusConfig {
+func getDefaultConsensusConfigCopy() conf.ConsensusConfig {
 	config := defaultConsensusConfig
 	return config
 }
 
-func getDefaultPrometheusConfigCopy() prometheusConfig {
+func getDefaultPrometheusConfigCopy() conf.PrometheusConfig {
 	config := defaultPrometheusConfig
 	return config
 }

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -275,6 +275,7 @@ func getRootFlags() []cli.Flag {
 
 	flags = append(flags, versionFlag)
 	flags = append(flags, configFlag)
+	flags = append(flags, enableConfigLoggingFlag)
 	flags = append(flags, generalFlags...)
 	flags = append(flags, networkFlags...)
 	flags = append(flags, dnsSyncFlags...)

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	conf "github.com/harmony-one/harmony/cmd/harmony/config"
 	"strconv"
 	"strings"
 
@@ -298,7 +299,7 @@ func getRootFlags() []cli.Flag {
 	return flags
 }
 
-func applyGeneralFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyGeneralFlags(cmd *cobra.Command, config *conf.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, nodeTypeFlag) {
 		config.General.NodeType = cli.GetStringFlagValue(cmd, nodeTypeFlag)
 	} else if cli.IsFlagChanged(cmd, legacyNodeTypeFlag) {
@@ -435,7 +436,7 @@ func getNetworkType(cmd *cobra.Command) nodeconfig.NetworkType {
 	return parseNetworkType(raw)
 }
 
-func applyDNSSyncFlags(cmd *cobra.Command, cfg *harmonyConfig) {
+func applyDNSSyncFlags(cmd *cobra.Command, cfg *conf.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, dnsZoneFlag) {
 		cfg.DNSSync.Zone = cli.GetStringFlagValue(cmd, dnsZoneFlag)
 	} else if cli.IsFlagChanged(cmd, legacyDNSZoneFlag) {
@@ -471,7 +472,7 @@ func applyDNSSyncFlags(cmd *cobra.Command, cfg *harmonyConfig) {
 
 }
 
-func applyNetworkFlags(cmd *cobra.Command, cfg *harmonyConfig) {
+func applyNetworkFlags(cmd *cobra.Command, cfg *conf.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, bootNodeFlag) {
 		cfg.Network.BootNodes = cli.GetStringSliceFlagValue(cmd, bootNodeFlag)
 	}
@@ -508,7 +509,7 @@ var (
 	}
 )
 
-func applyP2PFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyP2PFlags(cmd *cobra.Command, config *conf.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, p2pPortFlag) {
 		config.P2P.Port = cli.GetIntFlagValue(cmd, p2pPortFlag)
 	}
@@ -560,7 +561,7 @@ var (
 	}
 )
 
-func applyHTTPFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyHTTPFlags(cmd *cobra.Command, config *conf.HarmonyConfig) {
 	var isRPCSpecified, isRosettaSpecified bool
 
 	if cli.IsFlagChanged(cmd, httpIPFlag) {
@@ -611,7 +612,7 @@ var (
 	}
 )
 
-func applyWSFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyWSFlags(cmd *cobra.Command, config *conf.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, wsEnabledFlag) {
 		config.WS.Enabled = cli.GetBoolFlagValue(cmd, wsEnabledFlag)
 	}
@@ -645,7 +646,7 @@ var (
 	}
 )
 
-func applyRPCOptFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyRPCOptFlags(cmd *cobra.Command, config *conf.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, rpcDebugEnabledFlag) {
 		config.RPCOpt.DebugEnabled = cli.GetBoolFlagValue(cmd, rpcDebugEnabledFlag)
 	}
@@ -750,7 +751,7 @@ var (
 	}
 )
 
-func applyBLSFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyBLSFlags(cmd *cobra.Command, config *conf.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, blsDirFlag) {
 		config.BLSKeys.KeyDir = cli.GetStringFlagValue(cmd, blsDirFlag)
 	} else if cli.IsFlagChanged(cmd, legacyBLSFolderFlag) {
@@ -778,7 +779,7 @@ func applyBLSFlags(cmd *cobra.Command, config *harmonyConfig) {
 	}
 }
 
-func applyBLSPassFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyBLSPassFlags(cmd *cobra.Command, config *conf.HarmonyConfig) {
 	var passFileSpecified bool
 
 	if cli.IsFlagChanged(cmd, passEnabledFlag) {
@@ -798,7 +799,7 @@ func applyBLSPassFlags(cmd *cobra.Command, config *harmonyConfig) {
 	}
 }
 
-func applyKMSFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyKMSFlags(cmd *cobra.Command, config *conf.HarmonyConfig) {
 	var fileSpecified bool
 
 	if cli.IsFlagChanged(cmd, kmsEnabledFlag) {
@@ -815,7 +816,7 @@ func applyKMSFlags(cmd *cobra.Command, config *harmonyConfig) {
 	}
 }
 
-func applyLegacyBLSPassFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyLegacyBLSPassFlags(cmd *cobra.Command, config *conf.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, legacyBLSPassFlag) {
 		val := cli.GetStringFlagValue(cmd, legacyBLSPassFlag)
 		legacyApplyBLSPassVal(val, config)
@@ -825,14 +826,14 @@ func applyLegacyBLSPassFlags(cmd *cobra.Command, config *harmonyConfig) {
 	}
 }
 
-func applyLegacyKMSFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyLegacyKMSFlags(cmd *cobra.Command, config *conf.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, legacyKMSConfigSourceFlag) {
 		val := cli.GetStringFlagValue(cmd, legacyKMSConfigSourceFlag)
 		legacyApplyKMSSourceVal(val, config)
 	}
 }
 
-func legacyApplyBLSPassVal(src string, config *harmonyConfig) {
+func legacyApplyBLSPassVal(src string, config *conf.HarmonyConfig) {
 	methodArgs := strings.SplitN(src, ":", 2)
 	method := methodArgs[0]
 
@@ -853,7 +854,7 @@ func legacyApplyBLSPassVal(src string, config *harmonyConfig) {
 	}
 }
 
-func legacyApplyKMSSourceVal(src string, config *harmonyConfig) {
+func legacyApplyKMSSourceVal(src string, config *conf.HarmonyConfig) {
 	methodArgs := strings.SplitN(src, ":", 2)
 	method := methodArgs[0]
 
@@ -904,7 +905,7 @@ var (
 	}
 )
 
-func applyConsensusFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyConsensusFlags(cmd *cobra.Command, config *conf.HarmonyConfig) {
 	if config.Consensus == nil && cli.HasFlagsChanged(cmd, consensusValidFlags) {
 		cfg := getDefaultConsensusConfigCopy()
 		config.Consensus = &cfg
@@ -936,7 +937,7 @@ var (
 	}
 )
 
-func applyTxPoolFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyTxPoolFlags(cmd *cobra.Command, config *conf.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, tpBlacklistFileFlag) {
 		config.TxPool.BlacklistFile = cli.GetStringFlagValue(cmd, tpBlacklistFileFlag)
 	} else if cli.IsFlagChanged(cmd, legacyTPBlacklistFileFlag) {
@@ -958,7 +959,7 @@ var (
 	}
 )
 
-func applyPprofFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyPprofFlags(cmd *cobra.Command, config *conf.HarmonyConfig) {
 	var pprofSet bool
 	if cli.IsFlagChanged(cmd, pprofListenAddrFlag) {
 		config.Pprof.ListenAddr = cli.GetStringFlagValue(cmd, pprofListenAddrFlag)
@@ -1027,7 +1028,7 @@ var (
 	}
 )
 
-func applyLogFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyLogFlags(cmd *cobra.Command, config *conf.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, logFolderFlag) {
 		config.Log.Folder = cli.GetStringFlagValue(cmd, logFolderFlag)
 	} else if cli.IsFlagChanged(cmd, legacyLogFolderFlag) {
@@ -1072,7 +1073,7 @@ var (
 	}
 )
 
-func applySysFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applySysFlags(cmd *cobra.Command, config *conf.HarmonyConfig) {
 	if cli.HasFlagsChanged(cmd, sysFlags) || config.Sys == nil {
 		cfg := getDefaultSysConfigCopy()
 		config.Sys = &cfg
@@ -1122,7 +1123,7 @@ var (
 	}
 )
 
-func applyDevnetFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyDevnetFlags(cmd *cobra.Command, config *conf.HarmonyConfig) {
 	if cli.HasFlagsChanged(cmd, devnetFlags) && config.Devnet == nil {
 		cfg := getDefaultDevnetConfigCopy()
 		config.Devnet = &cfg
@@ -1197,7 +1198,7 @@ var (
 	}
 )
 
-func applyRevertFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyRevertFlags(cmd *cobra.Command, config *conf.HarmonyConfig) {
 	if cli.HasFlagsChanged(cmd, revertFlags) {
 		cfg := getDefaultRevertConfigCopy()
 		config.Revert = &cfg
@@ -1262,7 +1263,7 @@ var (
 )
 
 // Note: this function need to be called before parse other flags
-func applyLegacyMiscFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyLegacyMiscFlags(cmd *cobra.Command, config *conf.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, legacyPortFlag) {
 		legacyPort := cli.GetIntFlagValue(cmd, legacyPortFlag)
 		config.P2P.Port = legacyPort
@@ -1297,7 +1298,7 @@ func applyLegacyMiscFlags(cmd *cobra.Command, config *harmonyConfig) {
 		logPort := cli.GetIntFlagValue(cmd, legacyPortFlag)
 		config.Log.FileName = fmt.Sprintf("validator-%v-%v.log", logIP, logPort)
 
-		logCtx := &logContext{
+		logCtx := &conf.LogContext{
 			IP:   logIP,
 			Port: logPort,
 		}
@@ -1305,7 +1306,7 @@ func applyLegacyMiscFlags(cmd *cobra.Command, config *harmonyConfig) {
 	}
 
 	if cli.HasFlagsChanged(cmd, []cli.Flag{legacyWebHookConfigFlag, legacyTPBroadcastInvalidTxFlag}) {
-		config.Legacy = &legacyConfig{}
+		config.Legacy = &conf.LegacyConfig{}
 		if cli.IsFlagChanged(cmd, legacyWebHookConfigFlag) {
 			val := cli.GetStringFlagValue(cmd, legacyWebHookConfigFlag)
 			config.Legacy.WebHookConfig = &val
@@ -1346,7 +1347,7 @@ var (
 	}
 )
 
-func applyPrometheusFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applyPrometheusFlags(cmd *cobra.Command, config *conf.HarmonyConfig) {
 	if config.Prometheus == nil {
 		cfg := getDefaultPrometheusConfigCopy()
 		config.Prometheus = &cfg
@@ -1427,7 +1428,7 @@ var (
 )
 
 // applySyncFlags apply the sync flags.
-func applySyncFlags(cmd *cobra.Command, config *harmonyConfig) {
+func applySyncFlags(cmd *cobra.Command, config *conf.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, syncStreamEnabledFlag) {
 		config.Sync.Enabled = cli.GetBoolFlagValue(cmd, syncStreamEnabledFlag)
 	}

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
-	conf "github.com/harmony-one/harmony/cmd/harmony/config"
 	"strconv"
 	"strings"
+
+	conf "github.com/harmony-one/harmony/cmd/harmony/config"
 
 	"github.com/harmony-one/harmony/api/service/legacysync"
 	"github.com/harmony-one/harmony/internal/cli"

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	conf "github.com/harmony-one/harmony/cmd/harmony/config"
 	"reflect"
 	"strings"
 	"testing"
+
+	conf "github.com/harmony-one/harmony/cmd/harmony/config"
 
 	"github.com/harmony-one/harmony/internal/cli"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	conf "github.com/harmony-one/harmony/cmd/harmony/config"
 	"reflect"
 	"strings"
 	"testing"
@@ -18,7 +19,7 @@ var (
 func TestHarmonyFlags(t *testing.T) {
 	tests := []struct {
 		argStr    string
-		expConfig harmonyConfig
+		expConfig conf.HarmonyConfig
 	}{
 		{
 			// running staking command from legacy node.sh
@@ -29,16 +30,16 @@ func TestHarmonyFlags(t *testing.T) {
 				"et --dns_zone=t.hmny.io --blacklist=./.hmy/blacklist.txt --min_peers=6 --max_bls_keys_per_node=" +
 				"10 --broadcast_invalid_tx=true --verbosity=3 --is_archival=false --shard_id=-1 --staking=true -" +
 				"-aws-config-source file:config.json",
-			expConfig: harmonyConfig{
+			expConfig: conf.HarmonyConfig{
 				Version: tomlConfigVersion,
-				General: generalConfig{
+				General: conf.GeneralConfig{
 					NodeType:   "validator",
 					NoStaking:  false,
 					ShardID:    -1,
 					IsArchival: false,
 					DataDir:    "./",
 				},
-				Network: networkConfig{
+				Network: conf.NetworkConfig{
 					NetworkType: "mainnet",
 					BootNodes: []string{
 						"/ip4/100.26.90.187/tcp/9874/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv",
@@ -47,40 +48,40 @@ func TestHarmonyFlags(t *testing.T) {
 						"/ip4/99.81.170.167/tcp/12019/p2p/QmRVbTpEYup8dSaURZfF6ByrMTSKa4UyUzJhSjahFzRqNj",
 					},
 				},
-				DNSSync: dnsSync{
+				DNSSync: conf.DnsSync{
 					Port:       6000,
 					Zone:       "t.hmny.io",
 					Server:     true,
 					Client:     true,
 					ServerPort: nodeconfig.DefaultDNSPort,
 				},
-				P2P: p2pConfig{
+				P2P: conf.P2pConfig{
 					Port:    9000,
 					IP:      defaultConfig.P2P.IP,
 					KeyFile: defaultConfig.P2P.KeyFile,
 				},
-				HTTP: httpConfig{
+				HTTP: conf.HttpConfig{
 					Enabled:        true,
 					IP:             "127.0.0.1",
 					Port:           9500,
 					RosettaEnabled: false,
 					RosettaPort:    9700,
 				},
-				RPCOpt: rpcOptConfig{
+				RPCOpt: conf.RpcOptConfig{
 					DebugEnabled:      false,
 					RateLimterEnabled: true,
 					RequestsPerSecond: 300,
 				},
-				WS: wsConfig{
+				WS: conf.WsConfig{
 					Enabled: true,
 					IP:      "127.0.0.1",
 					Port:    9800,
 				},
-				Consensus: &consensusConfig{
+				Consensus: &conf.ConsensusConfig{
 					MinPeers:     6,
 					AggregateSig: true,
 				},
-				BLSKeys: blsConfig{
+				BLSKeys: conf.BlsConfig{
 					KeyDir:           "./.hmy/blskeys",
 					KeyFiles:         []string{},
 					MaxKeys:          10,
@@ -92,30 +93,30 @@ func TestHarmonyFlags(t *testing.T) {
 					KMSConfigSrcType: "file",
 					KMSConfigFile:    "config.json",
 				},
-				TxPool: txPoolConfig{
+				TxPool: conf.TxPoolConfig{
 					BlacklistFile: "./.hmy/blacklist.txt",
 				},
-				Pprof: pprofConfig{
+				Pprof: conf.PprofConfig{
 					Enabled:    false,
 					ListenAddr: "127.0.0.1:6060",
 				},
-				Log: logConfig{
+				Log: conf.LogConfig{
 					Folder:     "./latest",
 					FileName:   "validator-8.8.8.8-9000.log",
 					RotateSize: 100,
 					Verbosity:  3,
-					Context: &logContext{
+					Context: &conf.LogContext{
 						IP:   "8.8.8.8",
 						Port: 9000,
 					},
 				},
-				Sys: &sysConfig{
+				Sys: &conf.SysConfig{
 					NtpServer: defaultSysConfig.NtpServer,
 				},
-				Legacy: &legacyConfig{
+				Legacy: &conf.LegacyConfig{
 					TPBroadcastInvalidTxn: &trueBool,
 				},
-				Prometheus: &prometheusConfig{
+				Prometheus: &conf.PrometheusConfig{
 					Enabled:    true,
 					IP:         "0.0.0.0",
 					Port:       9900,
@@ -142,12 +143,12 @@ func TestHarmonyFlags(t *testing.T) {
 func TestGeneralFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig generalConfig
+		expConfig conf.GeneralConfig
 		expErr    error
 	}{
 		{
 			args: []string{},
-			expConfig: generalConfig{
+			expConfig: conf.GeneralConfig{
 				NodeType:   "validator",
 				NoStaking:  false,
 				ShardID:    -1,
@@ -158,7 +159,7 @@ func TestGeneralFlags(t *testing.T) {
 		{
 			args: []string{"--run", "explorer", "--run.legacy", "--run.shard=0",
 				"--run.archive=true", "--datadir=./.hmy"},
-			expConfig: generalConfig{
+			expConfig: conf.GeneralConfig{
 				NodeType:   "explorer",
 				NoStaking:  true,
 				ShardID:    0,
@@ -169,7 +170,7 @@ func TestGeneralFlags(t *testing.T) {
 		{
 			args: []string{"--node_type", "explorer", "--staking", "--shard_id", "0",
 				"--is_archival", "--db_dir", "./"},
-			expConfig: generalConfig{
+			expConfig: conf.GeneralConfig{
 				NodeType:   "explorer",
 				NoStaking:  false,
 				ShardID:    0,
@@ -179,7 +180,7 @@ func TestGeneralFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--staking=false", "--is_archival=false"},
-			expConfig: generalConfig{
+			expConfig: conf.GeneralConfig{
 				NodeType:   "validator",
 				NoStaking:  true,
 				ShardID:    -1,
@@ -189,7 +190,7 @@ func TestGeneralFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--run", "explorer", "--run.shard", "0"},
-			expConfig: generalConfig{
+			expConfig: conf.GeneralConfig{
 				NodeType:   "explorer",
 				NoStaking:  false,
 				ShardID:    0,
@@ -199,7 +200,7 @@ func TestGeneralFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--run", "explorer", "--run.shard", "0", "--run.archive=false"},
-			expConfig: generalConfig{
+			expConfig: conf.GeneralConfig{
 				NodeType:   "explorer",
 				NoStaking:  false,
 				ShardID:    0,
@@ -229,13 +230,13 @@ func TestGeneralFlags(t *testing.T) {
 func TestNetworkFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig harmonyConfig
+		expConfig conf.HarmonyConfig
 		expErr    error
 	}{
 		{
 			args: []string{},
-			expConfig: harmonyConfig{
-				Network: networkConfig{
+			expConfig: conf.HarmonyConfig{
+				Network: conf.NetworkConfig{
 					NetworkType: defNetworkType,
 					BootNodes:   nodeconfig.GetDefaultBootNodes(defNetworkType),
 				},
@@ -243,8 +244,8 @@ func TestNetworkFlags(t *testing.T) {
 		},
 		{
 			args: []string{"-n", "stn"},
-			expConfig: harmonyConfig{
-				Network: networkConfig{
+			expConfig: conf.HarmonyConfig{
+				Network: conf.NetworkConfig{
 					NetworkType: nodeconfig.Stressnet,
 					BootNodes:   nodeconfig.GetDefaultBootNodes(nodeconfig.Stressnet),
 				},
@@ -254,12 +255,12 @@ func TestNetworkFlags(t *testing.T) {
 		{
 			args: []string{"--network", "stk", "--bootnodes", "1,2,3,4", "--dns.zone", "8.8.8.8",
 				"--dns.port", "9001", "--dns.server-port", "9002"},
-			expConfig: harmonyConfig{
-				Network: networkConfig{
+			expConfig: conf.HarmonyConfig{
+				Network: conf.NetworkConfig{
 					NetworkType: "pangaea",
 					BootNodes:   []string{"1", "2", "3", "4"},
 				},
-				DNSSync: dnsSync{
+				DNSSync: conf.DnsSync{
 					Port:          9001,
 					Zone:          "8.8.8.8",
 					LegacySyncing: false,
@@ -271,12 +272,12 @@ func TestNetworkFlags(t *testing.T) {
 		{
 			args: []string{"--network_type", "stk", "--bootnodes", "1,2,3,4", "--dns_zone", "8.8.8.8",
 				"--dns_port", "9001"},
-			expConfig: harmonyConfig{
-				Network: networkConfig{
+			expConfig: conf.HarmonyConfig{
+				Network: conf.NetworkConfig{
 					NetworkType: "pangaea",
 					BootNodes:   []string{"1", "2", "3", "4"},
 				},
-				DNSSync: dnsSync{
+				DNSSync: conf.DnsSync{
 					Port:          9001,
 					Zone:          "8.8.8.8",
 					LegacySyncing: false,
@@ -287,12 +288,12 @@ func TestNetworkFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--dns=false"},
-			expConfig: harmonyConfig{
-				Network: networkConfig{
+			expConfig: conf.HarmonyConfig{
+				Network: conf.NetworkConfig{
 					NetworkType: defNetworkType,
 					BootNodes:   nodeconfig.GetDefaultBootNodes(defNetworkType),
 				},
-				DNSSync: dnsSync{
+				DNSSync: conf.DnsSync{
 					Port:          nodeconfig.GetDefaultDNSPort(defNetworkType),
 					Zone:          nodeconfig.GetDefaultDNSZone(defNetworkType),
 					LegacySyncing: true,
@@ -307,7 +308,7 @@ func TestNetworkFlags(t *testing.T) {
 		neededFlags := make([]cli.Flag, 0)
 		neededFlags = append(neededFlags, networkFlags...)
 		neededFlags = append(neededFlags, dnsSyncFlags...)
-		ts := newFlagTestSuite(t, neededFlags, func(cmd *cobra.Command, config *harmonyConfig) {
+		ts := newFlagTestSuite(t, neededFlags, func(cmd *cobra.Command, config *conf.HarmonyConfig) {
 			// This is the network related logic in function getHarmonyConfig
 			nt := getNetworkType(cmd)
 			config.Network = getDefaultNetworkConfig(nt)
@@ -339,7 +340,7 @@ var defDataStore = ".dht-127.0.0.1"
 func TestP2PFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig p2pConfig
+		expConfig conf.P2pConfig
 		expErr    error
 	}{
 		{
@@ -349,7 +350,7 @@ func TestP2PFlags(t *testing.T) {
 		{
 			args: []string{"--p2p.port", "9001", "--p2p.keyfile", "./key.file", "--p2p.dht.datastore",
 				defDataStore},
-			expConfig: p2pConfig{
+			expConfig: conf.P2pConfig{
 				Port:         9001,
 				IP:           nodeconfig.DefaultPublicListenIP,
 				KeyFile:      "./key.file",
@@ -358,7 +359,7 @@ func TestP2PFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--port", "9001", "--key", "./key.file"},
-			expConfig: p2pConfig{
+			expConfig: conf.P2pConfig{
 				Port:    9001,
 				IP:      nodeconfig.DefaultPublicListenIP,
 				KeyFile: "./key.file",
@@ -367,7 +368,7 @@ func TestP2PFlags(t *testing.T) {
 	}
 	for i, test := range tests {
 		ts := newFlagTestSuite(t, append(p2pFlags, legacyMiscFlags...),
-			func(cmd *cobra.Command, config *harmonyConfig) {
+			func(cmd *cobra.Command, config *conf.HarmonyConfig) {
 				applyLegacyMiscFlags(cmd, config)
 				applyP2PFlags(cmd, config)
 			},
@@ -391,7 +392,7 @@ func TestP2PFlags(t *testing.T) {
 func TestRPCFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig httpConfig
+		expConfig conf.HttpConfig
 		expErr    error
 	}{
 		{
@@ -400,7 +401,7 @@ func TestRPCFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--http=false"},
-			expConfig: httpConfig{
+			expConfig: conf.HttpConfig{
 				Enabled:        false,
 				RosettaEnabled: false,
 				IP:             defaultConfig.HTTP.IP,
@@ -410,7 +411,7 @@ func TestRPCFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--http.ip", "8.8.8.8", "--http.port", "9001"},
-			expConfig: httpConfig{
+			expConfig: conf.HttpConfig{
 				Enabled:        true,
 				RosettaEnabled: false,
 				IP:             "8.8.8.8",
@@ -420,7 +421,7 @@ func TestRPCFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--http.ip", "8.8.8.8", "--http.port", "9001", "--http.rosetta.port", "10001"},
-			expConfig: httpConfig{
+			expConfig: conf.HttpConfig{
 				Enabled:        true,
 				RosettaEnabled: true,
 				IP:             "8.8.8.8",
@@ -430,7 +431,7 @@ func TestRPCFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--http.ip", "8.8.8.8", "--http.rosetta.port", "10001"},
-			expConfig: httpConfig{
+			expConfig: conf.HttpConfig{
 				Enabled:        true,
 				RosettaEnabled: true,
 				IP:             "8.8.8.8",
@@ -440,7 +441,7 @@ func TestRPCFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--ip", "8.8.8.8", "--port", "9001", "--public_rpc"},
-			expConfig: httpConfig{
+			expConfig: conf.HttpConfig{
 				Enabled:        true,
 				RosettaEnabled: false,
 				IP:             nodeconfig.DefaultPublicListenIP,
@@ -451,7 +452,7 @@ func TestRPCFlags(t *testing.T) {
 	}
 	for i, test := range tests {
 		ts := newFlagTestSuite(t, append(httpFlags, legacyMiscFlags...),
-			func(cmd *cobra.Command, config *harmonyConfig) {
+			func(cmd *cobra.Command, config *conf.HarmonyConfig) {
 				applyLegacyMiscFlags(cmd, config)
 				applyHTTPFlags(cmd, config)
 			},
@@ -476,7 +477,7 @@ func TestRPCFlags(t *testing.T) {
 func TestWSFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig wsConfig
+		expConfig conf.WsConfig
 		expErr    error
 	}{
 		{
@@ -485,7 +486,7 @@ func TestWSFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--ws=false"},
-			expConfig: wsConfig{
+			expConfig: conf.WsConfig{
 				Enabled: false,
 				IP:      defaultConfig.WS.IP,
 				Port:    defaultConfig.WS.Port,
@@ -493,7 +494,7 @@ func TestWSFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--ws", "--ws.ip", "8.8.8.8", "--ws.port", "9001"},
-			expConfig: wsConfig{
+			expConfig: conf.WsConfig{
 				Enabled: true,
 				IP:      "8.8.8.8",
 				Port:    9001,
@@ -501,7 +502,7 @@ func TestWSFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--ip", "8.8.8.8", "--port", "9001", "--public_rpc"},
-			expConfig: wsConfig{
+			expConfig: conf.WsConfig{
 				Enabled: true,
 				IP:      nodeconfig.DefaultPublicListenIP,
 				Port:    9801,
@@ -510,7 +511,7 @@ func TestWSFlags(t *testing.T) {
 	}
 	for i, test := range tests {
 		ts := newFlagTestSuite(t, append(wsFlags, legacyMiscFlags...),
-			func(cmd *cobra.Command, config *harmonyConfig) {
+			func(cmd *cobra.Command, config *conf.HarmonyConfig) {
 				applyLegacyMiscFlags(cmd, config)
 				applyWSFlags(cmd, config)
 			},
@@ -535,11 +536,11 @@ func TestWSFlags(t *testing.T) {
 func TestRPCOptFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig rpcOptConfig
+		expConfig conf.RpcOptConfig
 	}{
 		{
 			args: []string{"--rpc.debug"},
-			expConfig: rpcOptConfig{
+			expConfig: conf.RpcOptConfig{
 				DebugEnabled:      true,
 				RateLimterEnabled: true,
 				RequestsPerSecond: 300,
@@ -548,7 +549,7 @@ func TestRPCOptFlags(t *testing.T) {
 
 		{
 			args: []string{},
-			expConfig: rpcOptConfig{
+			expConfig: conf.RpcOptConfig{
 				DebugEnabled:      false,
 				RateLimterEnabled: true,
 				RequestsPerSecond: 300,
@@ -557,7 +558,7 @@ func TestRPCOptFlags(t *testing.T) {
 
 		{
 			args: []string{"--rpc.ratelimiter", "--rpc.ratelimit", "1000"},
-			expConfig: rpcOptConfig{
+			expConfig: conf.RpcOptConfig{
 				DebugEnabled:      false,
 				RateLimterEnabled: true,
 				RequestsPerSecond: 1000,
@@ -566,7 +567,7 @@ func TestRPCOptFlags(t *testing.T) {
 
 		{
 			args: []string{"--rpc.ratelimiter=false", "--rpc.ratelimit", "1000"},
-			expConfig: rpcOptConfig{
+			expConfig: conf.RpcOptConfig{
 				DebugEnabled:      false,
 				RateLimterEnabled: false,
 				RequestsPerSecond: 1000,
@@ -589,7 +590,7 @@ func TestRPCOptFlags(t *testing.T) {
 func TestBLSFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig blsConfig
+		expConfig conf.BlsConfig
 		expErr    error
 	}{
 		{
@@ -601,7 +602,7 @@ func TestBLSFlags(t *testing.T) {
 				"--bls.maxkeys", "8", "--bls.pass", "--bls.pass.src", "auto", "--bls.pass.save",
 				"--bls.kms", "--bls.kms.src", "shared",
 			},
-			expConfig: blsConfig{
+			expConfig: conf.BlsConfig{
 				KeyDir:           "./blskeys",
 				KeyFiles:         []string{"key1", "key2"},
 				MaxKeys:          8,
@@ -616,7 +617,7 @@ func TestBLSFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--bls.pass.file", "xxx.pass", "--bls.kms.config", "config.json"},
-			expConfig: blsConfig{
+			expConfig: conf.BlsConfig{
 				KeyDir:           defaultConfig.BLSKeys.KeyDir,
 				KeyFiles:         defaultConfig.BLSKeys.KeyFiles,
 				MaxKeys:          defaultConfig.BLSKeys.MaxKeys,
@@ -634,7 +635,7 @@ func TestBLSFlags(t *testing.T) {
 				"--max_bls_keys_per_node", "5", "--blspass", "file:xxx.pass", "--save-passphrase",
 				"--aws-config-source", "file:config.json",
 			},
-			expConfig: blsConfig{
+			expConfig: conf.BlsConfig{
 				KeyDir:           "./hmykeys",
 				KeyFiles:         []string{"key1", "key2"},
 				MaxKeys:          5,
@@ -670,7 +671,7 @@ func TestBLSFlags(t *testing.T) {
 func TestConsensusFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig *consensusConfig
+		expConfig *conf.ConsensusConfig
 		expErr    error
 	}{
 		{
@@ -679,7 +680,7 @@ func TestConsensusFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--consensus.min-peers", "10", "--consensus.aggregate-sig=false"},
-			expConfig: &consensusConfig{
+			expConfig: &conf.ConsensusConfig{
 				MinPeers:     10,
 				AggregateSig: false,
 			},
@@ -687,7 +688,7 @@ func TestConsensusFlags(t *testing.T) {
 		{
 			args: []string{"--delay_commit", "10ms", "--block_period", "5", "--min_peers", "10",
 				"--consensus.aggregate-sig=true"},
-			expConfig: &consensusConfig{
+			expConfig: &conf.ConsensusConfig{
 				MinPeers:     10,
 				AggregateSig: true,
 			},
@@ -715,24 +716,24 @@ func TestConsensusFlags(t *testing.T) {
 func TestTxPoolFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig txPoolConfig
+		expConfig conf.TxPoolConfig
 		expErr    error
 	}{
 		{
 			args: []string{},
-			expConfig: txPoolConfig{
+			expConfig: conf.TxPoolConfig{
 				BlacklistFile: defaultConfig.TxPool.BlacklistFile,
 			},
 		},
 		{
 			args: []string{"--txpool.blacklist", "blacklist.file"},
-			expConfig: txPoolConfig{
+			expConfig: conf.TxPoolConfig{
 				BlacklistFile: "blacklist.file",
 			},
 		},
 		{
 			args: []string{"--blacklist", "blacklist.file"},
-			expConfig: txPoolConfig{
+			expConfig: conf.TxPoolConfig{
 				BlacklistFile: "blacklist.file",
 			},
 		},
@@ -758,7 +759,7 @@ func TestTxPoolFlags(t *testing.T) {
 func TestPprofFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig pprofConfig
+		expConfig conf.PprofConfig
 		expErr    error
 	}{
 		{
@@ -767,21 +768,21 @@ func TestPprofFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--pprof"},
-			expConfig: pprofConfig{
+			expConfig: conf.PprofConfig{
 				Enabled:    true,
 				ListenAddr: defaultConfig.Pprof.ListenAddr,
 			},
 		},
 		{
 			args: []string{"--pprof.addr", "8.8.8.8:9001"},
-			expConfig: pprofConfig{
+			expConfig: conf.PprofConfig{
 				Enabled:    true,
 				ListenAddr: "8.8.8.8:9001",
 			},
 		},
 		{
 			args: []string{"--pprof=false", "--pprof.addr", "8.8.8.8:9001"},
-			expConfig: pprofConfig{
+			expConfig: conf.PprofConfig{
 				Enabled:    false,
 				ListenAddr: "8.8.8.8:9001",
 			},
@@ -807,7 +808,7 @@ func TestPprofFlags(t *testing.T) {
 func TestLogFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig logConfig
+		expConfig conf.LogConfig
 		expErr    error
 	}{
 		{
@@ -817,7 +818,7 @@ func TestLogFlags(t *testing.T) {
 		{
 			args: []string{"--log.dir", "latest_log", "--log.max-size", "10", "--log.name", "harmony.log",
 				"--log.verb", "5"},
-			expConfig: logConfig{
+			expConfig: conf.LogConfig{
 				Folder:     "latest_log",
 				FileName:   "harmony.log",
 				RotateSize: 10,
@@ -827,12 +828,12 @@ func TestLogFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--log.ctx.ip", "8.8.8.8", "--log.ctx.port", "9001"},
-			expConfig: logConfig{
+			expConfig: conf.LogConfig{
 				Folder:     defaultConfig.Log.Folder,
 				FileName:   defaultConfig.Log.FileName,
 				RotateSize: defaultConfig.Log.RotateSize,
 				Verbosity:  defaultConfig.Log.Verbosity,
-				Context: &logContext{
+				Context: &conf.LogContext{
 					IP:   "8.8.8.8",
 					Port: 9001,
 				},
@@ -841,12 +842,12 @@ func TestLogFlags(t *testing.T) {
 		{
 			args: []string{"--log_folder", "latest_log", "--log_max_size", "10", "--verbosity",
 				"5", "--ip", "8.8.8.8", "--port", "9001"},
-			expConfig: logConfig{
+			expConfig: conf.LogConfig{
 				Folder:     "latest_log",
 				FileName:   "validator-8.8.8.8-9001.log",
 				RotateSize: 10,
 				Verbosity:  5,
-				Context: &logContext{
+				Context: &conf.LogContext{
 					IP:   "8.8.8.8",
 					Port: 9001,
 				},
@@ -855,7 +856,7 @@ func TestLogFlags(t *testing.T) {
 	}
 	for i, test := range tests {
 		ts := newFlagTestSuite(t, append(logFlags, legacyMiscFlags...),
-			func(cmd *cobra.Command, config *harmonyConfig) {
+			func(cmd *cobra.Command, config *conf.HarmonyConfig) {
 				applyLegacyMiscFlags(cmd, config)
 				applyLogFlags(cmd, config)
 			},
@@ -879,18 +880,18 @@ func TestLogFlags(t *testing.T) {
 func TestSysFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig *sysConfig
+		expConfig *conf.SysConfig
 		expErr    error
 	}{
 		{
 			args: []string{},
-			expConfig: &sysConfig{
+			expConfig: &conf.SysConfig{
 				NtpServer: defaultSysConfig.NtpServer,
 			},
 		},
 		{
 			args: []string{"--sys.ntp", "0.pool.ntp.org"},
-			expConfig: &sysConfig{
+			expConfig: &conf.SysConfig{
 				NtpServer: "0.pool.ntp.org",
 			},
 		},
@@ -917,7 +918,7 @@ func TestSysFlags(t *testing.T) {
 func TestDevnetFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig *devnetConfig
+		expConfig *conf.DevnetConfig
 		expErr    error
 	}{
 		{
@@ -927,7 +928,7 @@ func TestDevnetFlags(t *testing.T) {
 		{
 			args: []string{"--devnet.num-shard", "3", "--devnet.shard-size", "100",
 				"--devnet.hmy-node-size", "60"},
-			expConfig: &devnetConfig{
+			expConfig: &conf.DevnetConfig{
 				NumShards:   3,
 				ShardSize:   100,
 				HmyNodeSize: 60,
@@ -936,7 +937,7 @@ func TestDevnetFlags(t *testing.T) {
 		{
 			args: []string{"--dn_num_shards", "3", "--dn_shard_size", "100", "--dn_hmy_size",
 				"60"},
-			expConfig: &devnetConfig{
+			expConfig: &conf.DevnetConfig{
 				NumShards:   3,
 				ShardSize:   100,
 				HmyNodeSize: 60,
@@ -964,7 +965,7 @@ func TestDevnetFlags(t *testing.T) {
 func TestRevertFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
-		expConfig *revertConfig
+		expConfig *conf.RevertConfig
 		expErr    error
 	}{
 		{
@@ -973,7 +974,7 @@ func TestRevertFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--revert.beacon"},
-			expConfig: &revertConfig{
+			expConfig: &conf.RevertConfig{
 				RevertBeacon: true,
 				RevertTo:     defaultRevertConfig.RevertTo,
 				RevertBefore: defaultRevertConfig.RevertBefore,
@@ -981,7 +982,7 @@ func TestRevertFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--revert.beacon", "--revert.to", "100", "--revert.do-before", "10000"},
-			expConfig: &revertConfig{
+			expConfig: &conf.RevertConfig{
 				RevertBeacon: true,
 				RevertTo:     100,
 				RevertBefore: 10000,
@@ -989,7 +990,7 @@ func TestRevertFlags(t *testing.T) {
 		},
 		{
 			args: []string{"--revert_beacon", "--do_revert_before", "10000", "--revert_to", "100"},
-			expConfig: &revertConfig{
+			expConfig: &conf.RevertConfig{
 				RevertBeacon: true,
 				RevertTo:     100,
 				RevertBefore: 10000,
@@ -1017,7 +1018,7 @@ func TestDNSSyncFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
 		network   string
-		expConfig dnsSync
+		expConfig conf.DnsSync
 		expErr    error
 	}{
 		{
@@ -1033,7 +1034,7 @@ func TestDNSSyncFlags(t *testing.T) {
 		{
 			args:    []string{"--sync.legacy.server", "--sync.legacy.client"},
 			network: "testnet",
-			expConfig: func() dnsSync {
+			expConfig: func() conf.DnsSync {
 				cfg := getDefaultDNSSyncConfig(nodeconfig.Mainnet)
 				cfg.Client = true
 				cfg.Server = true
@@ -1048,7 +1049,7 @@ func TestDNSSyncFlags(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		ts := newFlagTestSuite(t, dnsSyncFlags, func(command *cobra.Command, config *harmonyConfig) {
+		ts := newFlagTestSuite(t, dnsSyncFlags, func(command *cobra.Command, config *conf.HarmonyConfig) {
 			config.Network.NetworkType = test.network
 			applyDNSSyncFlags(command, config)
 		})
@@ -1071,7 +1072,7 @@ func TestSyncFlags(t *testing.T) {
 	tests := []struct {
 		args      []string
 		network   string
-		expConfig syncConfig
+		expConfig conf.SyncConfig
 		expErr    error
 	}{
 		{
@@ -1081,7 +1082,7 @@ func TestSyncFlags(t *testing.T) {
 				"--sync.disc.batch", "10",
 			},
 			network: "mainnet",
-			expConfig: func() syncConfig {
+			expConfig: func() conf.SyncConfig {
 				cfgSync := defaultMainnetSyncConfig
 				cfgSync.Enabled = true
 				cfgSync.Downloader = true
@@ -1097,7 +1098,7 @@ func TestSyncFlags(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		ts := newFlagTestSuite(t, syncFlags, func(command *cobra.Command, config *harmonyConfig) {
+		ts := newFlagTestSuite(t, syncFlags, func(command *cobra.Command, config *conf.HarmonyConfig) {
 			applySyncFlags(command, config)
 		})
 		hc, err := ts.run(test.args)
@@ -1120,10 +1121,10 @@ type flagTestSuite struct {
 	t *testing.T
 
 	cmd *cobra.Command
-	hc  harmonyConfig
+	hc  conf.HarmonyConfig
 }
 
-func newFlagTestSuite(t *testing.T, flags []cli.Flag, applyFlags func(*cobra.Command, *harmonyConfig)) *flagTestSuite {
+func newFlagTestSuite(t *testing.T, flags []cli.Flag, applyFlags func(*cobra.Command, *conf.HarmonyConfig)) *flagTestSuite {
 	cli.SetParseErrorHandle(func(err error) { t.Fatal(err) })
 
 	ts := &flagTestSuite{hc: getDefaultHmyConfigCopy(defNetworkType)}
@@ -1137,7 +1138,7 @@ func newFlagTestSuite(t *testing.T, flags []cli.Flag, applyFlags func(*cobra.Com
 	return ts
 }
 
-func (ts *flagTestSuite) run(args []string) (harmonyConfig, error) {
+func (ts *flagTestSuite) run(args []string) (conf.HarmonyConfig, error) {
 	ts.cmd.SetArgs(args)
 	err := ts.cmd.Execute()
 	return ts.hc, err

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -209,11 +209,11 @@ func getHarmonyConfig(cmd *cobra.Command) (conf.HarmonyConfig, error) {
 		enableConfigLogging = cli.GetBoolFlagValue(cmd, enableConfigLoggingFlag)
 	}
 	if enableConfigLogging {
-		b, err := toml.Marshal(config)
+		bytes, err := toml.Marshal(config)
 		if err != nil {
-			fmt.Printf("Could not log config - %s", err.Error())
+			fmt.Printf("Could not read harmony configuration - %s", err.Error())
 		} else {
-			fmt.Printf("Node Configuration:\n%s", b)
+			fmt.Printf("Harmony Node configuration:\n%s", bytes)
 		}
 	}
 
@@ -663,7 +663,7 @@ func setupConsensusAndNode(hc conf.HarmonyConfig, nodeConfig *nodeconfig.ConfigT
 	// Current node.
 	chainDBFactory := &shardchain.LDBFactory{RootDir: nodeConfig.DBDir}
 
-	currentNode := node.New(myHost, currentConsensus, chainDBFactory, blacklist, nodeConfig.ArchiveModes())
+	currentNode := node.New(myHost, currentConsensus, chainDBFactory, blacklist, nodeConfig.ArchiveModes(), &hc)
 
 	if hc.Legacy != nil && hc.Legacy.TPBroadcastInvalidTxn != nil {
 		currentNode.BroadcastInvalidTx = *hc.Legacy.TPBroadcastInvalidTxn

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"fmt"
-	conf "github.com/harmony-one/harmony/cmd/harmony/config"
-	"github.com/pelletier/go-toml"
 	"io/ioutil"
 	"math/big"
 	"math/rand"
@@ -17,6 +15,9 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	conf "github.com/harmony-one/harmony/cmd/harmony/config"
+	"github.com/pelletier/go-toml"
 
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"

--- a/hmy/hmy.go
+++ b/hmy/hmy.go
@@ -2,8 +2,9 @@ package hmy
 
 import (
 	"context"
-	"github.com/harmony-one/harmony/cmd/harmony/config"
 	"math/big"
+
+	"github.com/harmony-one/harmony/cmd/harmony/config"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"

--- a/hmy/hmy.go
+++ b/hmy/hmy.go
@@ -2,6 +2,7 @@ package hmy
 
 import (
 	"context"
+	"github.com/harmony-one/harmony/cmd/harmony/config"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -100,6 +101,7 @@ type NodeAPI interface {
 	ListBlockedPeer() []peer.ID
 
 	GetConsensusInternal() commonRPC.ConsensusInternal
+	GetHarmonyConfiguration() *config.HarmonyConfig
 
 	// debug API
 	GetConsensusMode() string
@@ -233,4 +235,9 @@ func (hmy *Harmony) EventMux() *event.TypeMux {
 func (hmy *Harmony) BloomStatus() (uint64, uint64) {
 	sections, _, _ := hmy.BloomIndexer.Sections()
 	return BloomBitsBlocks, sections
+}
+
+// GetNodeHarmonyConfiguration ...
+func (hmy *Harmony) GetNodeHarmonyConfiguration() *config.HarmonyConfig {
+	return hmy.NodeAPI.GetHarmonyConfiguration()
 }

--- a/node/node.go
+++ b/node/node.go
@@ -3,12 +3,13 @@ package node
 import (
 	"context"
 	"fmt"
-	"github.com/harmony-one/harmony/cmd/harmony/config"
 	"math/big"
 	"os"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/harmony-one/harmony/cmd/harmony/config"
 
 	"github.com/ethereum/go-ethereum/common"
 	protobuf "github.com/golang/protobuf/proto"

--- a/node/node.go
+++ b/node/node.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"fmt"
+	"github.com/harmony-one/harmony/cmd/harmony/config"
 	"math/big"
 	"os"
 	"strings"
@@ -130,6 +131,8 @@ type Node struct {
 	// context control for pub-sub handling
 	psCtx    context.Context
 	psCancel func()
+
+	NodeHarmonyConfig *config.HarmonyConfig
 }
 
 // Blockchain returns the blockchain for the node's current shard.
@@ -912,8 +915,11 @@ func New(
 	chainDBFactory shardchain.DBFactory,
 	blacklist map[common.Address]struct{},
 	isArchival map[uint32]bool,
+	hc *config.HarmonyConfig,
 ) *Node {
 	node := Node{}
+	// Save starting harmony configuration
+	node.NodeHarmonyConfig = hc
 	node.unixTimeAtNodeStart = time.Now().Unix()
 	node.TransactionErrorSink = types.NewTransactionErrorSink()
 	// Get the node config that's created in the harmony.go program.
@@ -1290,4 +1296,8 @@ func (node *Node) GetAddresses(epoch *big.Int) map[string]common.Address {
 // IsRunningBeaconChain returns whether the node is running on beacon chain.
 func (node *Node) IsRunningBeaconChain() bool {
 	return node.NodeConfig.ShardID == shard.BeaconChainShardID
+}
+
+func (node *Node) GetHarmonyConfiguration() *config.HarmonyConfig {
+	return node.NodeHarmonyConfig
 }

--- a/node/node_handler_test.go
+++ b/node/node_handler_test.go
@@ -39,7 +39,7 @@ func TestAddNewBlock(t *testing.T) {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
 	nodeconfig.SetNetworkType(nodeconfig.Devnet)
-	node := New(host, consensus, testDBFactory, nil, nil)
+	node := New(host, consensus, testDBFactory, nil, nil, nil)
 
 	txs := make(map[common.Address]types.Transactions)
 	stks := staking.StakingTransactions{}
@@ -88,7 +88,7 @@ func TestVerifyNewBlock(t *testing.T) {
 	archiveMode := make(map[uint32]bool)
 	archiveMode[0] = true
 	archiveMode[1] = false
-	node := New(host, consensus, testDBFactory, nil, archiveMode)
+	node := New(host, consensus, testDBFactory, nil, archiveMode, nil)
 
 	txs := make(map[common.Address]types.Transactions)
 	stks := staking.StakingTransactions{}
@@ -134,7 +134,7 @@ func TestVerifyVRF(t *testing.T) {
 	archiveMode := make(map[uint32]bool)
 	archiveMode[0] = true
 	archiveMode[1] = false
-	node := New(host, consensus, testDBFactory, nil, archiveMode)
+	node := New(host, consensus, testDBFactory, nil, archiveMode, nil)
 
 	consensus.Blockchain = node.Blockchain()
 	txs := make(map[common.Address]types.Transactions)

--- a/node/node_newblock_test.go
+++ b/node/node_newblock_test.go
@@ -40,7 +40,7 @@ func TestFinalizeNewBlockAsync(t *testing.T) {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
 	var testDBFactory = &shardchain.MemDBFactory{}
-	node := New(host, consensus, testDBFactory, nil, nil)
+	node := New(host, consensus, testDBFactory, nil, nil, nil)
 
 	node.Worker.UpdateCurrent()
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -39,7 +39,7 @@ func TestNewNode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
-	node := New(host, consensus, testDBFactory, nil, nil)
+	node := New(host, consensus, testDBFactory, nil, nil, nil)
 	if node.Consensus == nil {
 		t.Error("Consensus is not initialized for the node")
 	}
@@ -216,7 +216,7 @@ func TestAddBeaconPeer(t *testing.T) {
 	archiveMode := make(map[uint32]bool)
 	archiveMode[0] = true
 	archiveMode[1] = false
-	node := New(host, consensus, testDBFactory, nil, archiveMode)
+	node := New(host, consensus, testDBFactory, nil, archiveMode, nil)
 	for _, p := range peers1 {
 		ret := node.AddBeaconPeer(p)
 		if ret {

--- a/rpc/harmony.go
+++ b/rpc/harmony.go
@@ -86,3 +86,11 @@ func (s *PublicHarmonyService) GetPeerInfo(
 	// Response output is the same for all versions
 	return NewStructuredResponse(s.hmy.GetPeerInfo())
 }
+
+// GetNodeHarmonyConfiguration produces the HarmonyConfiguration values that the node is using
+func (s *PublicHarmonyService) GetNodeHarmonyConfiguration(
+	ctx context.Context,
+) (StructuredResponse, error) {
+	// Response output is the same for all versions
+	return NewStructuredResponse(s.hmy.GetNodeHarmonyConfiguration())
+}


### PR DESCRIPTION
## Issue

https://github.com/harmony-one/bounties/issues/41

## Test

### Unit Test Coverage

Before:

```
ok  	github.com/harmony-one/harmony/cmd/harmony	0.132s	coverage: 47.8% of statements
ok  	github.com/harmony-one/harmony/node	        10.719s	coverage: 9.5% of statements
ok  	github.com/harmony-one/harmony/rpc	        0.061s	coverage: 1.2% of statements
?   	github.com/harmony-one/harmony/hmy	        [no test files]
```

After:

```log
ok  	github.com/harmony-one/harmony/cmd/harmony	0.093s	coverage: 47.5% of statements
ok  	github.com/harmony-one/harmony/node	        10.837s	coverage: 9.6% of statements
ok  	github.com/harmony-one/harmony/rpc	        0.099s	coverage: 1.2% of statements
?   	github.com/harmony-one/harmony/hmy	        [no test files]
```

### Test/Run Logs

New harmony flag: **./harmony --enable-config-logging**

```
Node Configuration:
Version = "2.0.0"

[BLSKeys]
KMSConfigFile = ""
KMSConfigSrcType = "shared"
KMSEnabled = false
KeyDir = "./.hmy/blskeys"
KeyFiles = []
MaxKeys = 10
PassEnabled = true
PassFile = ""
PassSrcType = "auto"
SavePassphrase = false

[DNSSync]
Client = true
LegacySyncing = false
Port = 6000
Server = true
ServerPort = 6000
Zone = ""

[General]
DataDir = "./"
IsArchival = false
IsBeaconArchival = false
IsOffline = false
NoStaking = false
NodeType = "validator"
ShardID = -1

[HTTP]
Enabled = true
IP = "127.0.0.1"
Port = 9500
RosettaEnabled = false
RosettaPort = 9700

[Log]
EnableConfigLogging = false
FileName = "harmony.log"
Folder = "./latest"
RotateSize = 100
Verbosity = 3

[Network]
BootNodes = []
NetworkType = "localnet"

[P2P]
IP = "0.0.0.0"
KeyFile = "./.hmykey"
Port = 9000

[Pprof]
Enabled = false
ListenAddr = "127.0.0.1:6060"

[RPCOpt]
DebugEnabled = false
RateLimterEnabled = true
RequestsPerSecond = 300

[Sync]
Concurrency = 4
DiscBatch = 8
DiscHardLowCap = 4
DiscHighCap = 1024
DiscSoftLowCap = 4
Downloader = false
Enabled = true
InitStreams = 4
MinPeers = 4

[TxPool]
BlacklistFile = "./.hmy/blacklist.txt"

[WS]
Enabled = true
IP = "127.0.0.1"
Port = 9800
```


New RPC method: **hmyv2_getNodeHarmonyConfiguration**
```json
curl -s --request POST 'http://127.0.0.1:9500/' --header 'Content-Type: application/json' --data-raw '{ "jsonrpc": "2.0", "method": "hmyv2_getNodeHarmonyConfiguration", "params": [], "id": 1}' | jq .
{
   "jsonrpc":"2.0",
   "id":1,
   "result":{
      "BLSKeys":{
         "KMSConfigFile":"",
         "KMSConfigSrcType":"shared",
         "KMSEnabled":false,
         "KeyDir":"./.hmy/blskeys",
         "KeyFiles":[
            "./test/../.hmy/65f55eb3052f9e9f632b2923be594ba77c55543f5c58ee1454b9cfd658d25e06373b0f7d42a19c84768139ea294f6204.key"
         ],
         "MaxKeys":10,
         "PassEnabled":true,
         "PassFile":"./test/../.hmy/blspass.txt",
         "PassSrcType":"file",
         "SavePassphrase":false
      },
      "Consensus":{
         "AggregateSig":true,
         "MinPeers":3
      },
      "DNSSync":{
         "Client":true,
         "LegacySyncing":true,
         "Port":6000,
         "Server":true,
         "ServerPort":6000,
         "Zone":""
      },
      "Devnet":null,
      "General":{
         "DataDir":"./test/../db-127.0.0.1-9000",
         "IsArchival":false,
         "IsBeaconArchival":false,
         "IsOffline":false,
         "NoStaking":true,
         "NodeType":"validator",
         "ShardID":-1
      },
      "HTTP":{
         "Enabled":true,
         "IP":"127.0.0.1",
         "Port":9500,
         "RosettaEnabled":false,
         "RosettaPort":9700
      },
      "Legacy":{
         "TPBroadcastInvalidTxn":false,
         "WebHookConfig":null
      },
      "Log":{
         "Context":{
            "IP":"127.0.0.1",
            "Port":9000
         },
         "FileName":"validator-127.0.0.1-9000.log",
         "Folder":"./test/../tmp_log/log-20210605-190227",
         "RotateSize":100,
         "Verbosity":3
      },
      "Network":{
         "BootNodes":[
            "/ip4/127.0.0.1/tcp/19876/p2p/Qmc1V6W7BwX8Ugb42Ti8RnXF1rY5PF7nnZ6bKBryCgi6cv"
         ],
         "NetworkType":"localnet"
      },
      "P2P":{
         "DHTDataStore":null,
         "IP":"0.0.0.0",
         "KeyFile":"/tmp/127.0.0.1-9000.key",
         "Port":9000
      },
      "Pprof":{
         "Enabled":false,
         "ListenAddr":"127.0.0.1:6060"
      },
      "Prometheus":{
         "EnablePush":false,
         "Enabled":true,
         "Gateway":"https://gateway.harmony.one",
         "IP":"0.0.0.0",
         "Port":9900
      },
      "RPCOpt":{
         "DebugEnabled":false,
         "RateLimterEnabled":true,
         "RequestsPerSecond":300
      },
      "Revert":null,
      "Sync":{
         "Concurrency":4,
         "DiscBatch":8,
         "DiscHardLowCap":4,
         "DiscHighCap":1024,
         "DiscSoftLowCap":4,
         "Downloader":false,
         "Enabled":true,
         "InitStreams":4,
         "MinPeers":4
      },
      "Sys":{
         "NtpServer":"1.pool.ntp.org"
      },
      "TxPool":{
         "BlacklistFile":"./.hmy/blacklist.txt"
      },
      "Version":"2.0.0",
      "WS":{
         "Enabled":true,
         "IP":"127.0.0.1",
         "Port":9800
      }
   }
}
```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

