### PR TITLE
[rpc] Optimized GetBlockByNumber with latest param

### DIFF
--- a/rpc/blockchain.go
+++ b/rpc/blockchain.go
@@ -173,8 +173,12 @@ func (s *PublicBlockchainService) GetBlockByNumber(
 	blockArgs.InclTx = true
 
 	blockNum := blockNumber.EthBlockNumber()
-	if blockNum != rpc.LatestBlockNumber && blockNum != rpc.PendingBlockNumber {
-		cacheKey := combineCacheKey(uint64(blockNum), s.version, blockArgs)
+	if blockNum != rpc.PendingBlockNumber {
+		realBlockNum := uint64(blockNum)
+		if blockNum == rpc.LatestBlockNumber {
+			realBlockNum = s.hmy.CurrentBlock().NumberU64()
+		}
+		cacheKey := combineCacheKey(realBlockNum, s.version, blockArgs)
 		if block, ok := s.blockCache.Get(cacheKey); ok {
 			return block.(StructuredResponse), nil
 		}


### PR DESCRIPTION
## issue

If the latest parameter is encountered as input, first get the real number of the latest block, and then look up the cache directly. Because a block comes out every two seconds, if a large number of requests for the latest parameter are accessed during this time period, the cache can be used directly

## test

have test it locally

add some debug log using printf to test:

```go
blockNum := blockNumber.EthBlockNumber()
	if blockNum != rpc.PendingBlockNumber {
		realBlockNum := uint64(blockNum)
		if blockNum == rpc.LatestBlockNumber {
			realBlockNum = s.hmy.CurrentBlock().NumberU64()
			fmt.Printf("real block number %d\n", realBlockNum)
		}
		cacheKey := combineCacheKey(realBlockNum, s.version, blockArgs)
		if block, ok := s.blockCache.Get(cacheKey); ok {
			fmt.Printf("get cached latest block number %d\n", realBlockNum)
			return block.(StructuredResponse), nil
		}
	}

```

just run first:

```bash
 curl -d '{ "jsonrpc":"2.0", "method":"hmy_getBlockByNumber", "params":[ "latest", true], "id":1 }' -H "Content-Type:application/json" -X POST "http://127.0.0.1:9500"
```

log as follws:

```txt
./harmony  --run=explorer  --run.offline   --run.shard=0 --rpc.ratelimit=1000 --db_dir=./
Started Explorer server at: 127.0.0.1:5000
Started RPC server at: 127.0.0.1:9500
Started WS server at: 127.0.0.1:9800
real block number 12237178
```

run second:

```bash
 curl -d '{ "jsonrpc":"2.0", "method":"hmy_getBlockByNumber", "params":[ "latest", true], "id":1 }' -H "Content-Type:application/json" -X POST "http://127.0.0.1:9500"
```

```txt
./harmony  --run=explorer  --run.offline   --run.shard=0 --rpc.ratelimit=1000 --db_dir=./
Started Explorer server at: 127.0.0.1:5000
Started RPC server at: 127.0.0.1:9500
Started WS server at: 127.0.0.1:9800
real block number 12237178
real block number 12237178
get cached latest block number 12237178
```



