### PR TITLE
[cmd] stop broadcasting invalid transaction

### DIFF
--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -157,7 +157,7 @@ var (
 )
 
 const (
-	defaultBroadcastInvalidTx = true
+	defaultBroadcastInvalidTx = false
 )
 
 func getDefaultHmyConfigCopy(nt nodeconfig.NetworkType) harmonyConfig {


### PR DESCRIPTION
## Issue

As discussed [here](https://github.com/harmony-one/harmony/pull/3666#issuecomment-857211586). Disable broadcasting invalid transactions.

## Test

No tests done yet. Shall be confirmed at mainnet deployment.