### PR TITLE
[sync] half the batch size of downloading a block

### DIFF
--- a/api/service/legacysync/syncing.go
+++ b/api/service/legacysync/syncing.go
@@ -42,7 +42,7 @@ const (
 	NumPeersLowBound  = 3
 	numPeersHighBound = 5
 
-	downloadTaskBatch = 30
+	downloadTaskBatch = 15
 )
 
 // SyncPeerConfig is peer config to sync.


### PR DESCRIPTION
## Issue

Half the gRPC getBlockAndSigs batch size. Since the block size is growing, the replied message with 30 block is exceeding gRPC default max message size as 4MB. This is a temporary fix and need to be investigated later.

## Test

This is a simple parameter tuning. It need to be tested on mainnet.

