### PR TITLE
[Explorer] Fix explorer constantly lagging behind

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -80,8 +80,8 @@ type Consensus struct {
 	ShardID uint32
 	// IgnoreViewIDCheck determines whether to ignore viewID check
 	IgnoreViewIDCheck *abool.AtomicBool
-	// consensus mutex
-	mutex sync.Mutex
+	// consensus Mutex
+	Mutex sync.Mutex
 	// ViewChange struct
 	vc *viewChange
 	// Signal channel for proposing a new block and start new consensus

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -354,7 +354,7 @@ func (consensus *Consensus) Start(
 			// TODO: Refactor this piece of code to consensus/downloader.go after DNS legacy sync is removed
 			case <-consensus.syncReadyChan:
 				consensus.getLogger().Info().Msg("[ConsensusMainLoop] syncReadyChan")
-				consensus.mutex.Lock()
+				consensus.Mutex.Lock()
 				if consensus.blockNum < consensus.Blockchain.CurrentHeader().Number().Uint64()+1 {
 					consensus.SetBlockNum(consensus.Blockchain.CurrentHeader().Number().Uint64() + 1)
 					consensus.SetViewIDs(consensus.Blockchain.CurrentHeader().ViewID().Uint64() + 1)
@@ -373,7 +373,7 @@ func (consensus *Consensus) Start(
 					consensus.consensusTimeout[timeoutConsensus].Start()
 					consensusSyncCounterVec.With(prometheus.Labels{"consensus": "in_sync"}).Inc()
 				}
-				consensus.mutex.Unlock()
+				consensus.Mutex.Unlock()
 
 			// TODO: Refactor this piece of code to consensus/downloader.go after DNS legacy sync is removed
 			case <-consensus.syncNotReadyChan:
@@ -461,13 +461,13 @@ type LastMileBlockIter struct {
 
 // GetLastMileBlockIter get the iterator of the last mile blocks starting from number bnStart
 func (consensus *Consensus) GetLastMileBlockIter(bnStart uint64) (*LastMileBlockIter, error) {
-	consensus.mutex.Lock()
-	defer consensus.mutex.Unlock()
+	consensus.Mutex.Lock()
+	defer consensus.Mutex.Unlock()
 
 	if consensus.BlockVerifier == nil {
 		return nil, errors.New("consensus haven't initialized yet")
 	}
-	blocks, _, err := consensus.getLastMileBlocksAndMsg(bnStart)
+	blocks, _, err := consensus.GetLastMileBlocksAndMsg(bnStart)
 	if err != nil {
 		return nil, err
 	}
@@ -498,7 +498,8 @@ func (iter *LastMileBlockIter) Next() *types.Block {
 	return block
 }
 
-func (consensus *Consensus) getLastMileBlocksAndMsg(bnStart uint64) ([]*types.Block, []*FBFTMessage, error) {
+// GetLastMileBlocksAndMsg get last mile blocks and messages
+func (consensus *Consensus) GetLastMileBlocksAndMsg(bnStart uint64) ([]*types.Block, []*FBFTMessage, error) {
 	var (
 		blocks []*types.Block
 		msgs   []*FBFTMessage
@@ -616,7 +617,7 @@ func (consensus *Consensus) tryCatchup() error {
 	initBN := consensus.blockNum
 	defer consensus.postCatchup(initBN)
 
-	blks, msgs, err := consensus.getLastMileBlocksAndMsg(initBN)
+	blks, msgs, err := consensus.GetLastMileBlocksAndMsg(initBN)
 	if err != nil {
 		return errors.Wrapf(err, "[TryCatchup] Failed to get last mile blocks: %v", err)
 	}

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -27,10 +27,10 @@ func (consensus *Consensus) announce(block *types.Block) {
 	}
 
 	//// Lock Write - Start
-	consensus.mutex.Lock()
+	consensus.Mutex.Lock()
 	copy(consensus.blockHash[:], blockHash[:])
 	consensus.block = encodedBlock
-	consensus.mutex.Unlock()
+	consensus.Mutex.Unlock()
 	//// Lock Write - End
 
 	key, err := consensus.GetConsensusLeaderPrivateKey()
@@ -108,8 +108,8 @@ func (consensus *Consensus) onPrepare(recvMsg *FBFTMessage) {
 	}
 
 	//// Read - Start
-	consensus.mutex.Lock()
-	defer consensus.mutex.Unlock()
+	consensus.Mutex.Lock()
+	defer consensus.Mutex.Unlock()
 
 	if !consensus.isRightBlockNumAndViewID(recvMsg) {
 		return
@@ -193,8 +193,8 @@ func (consensus *Consensus) onPrepare(recvMsg *FBFTMessage) {
 }
 
 func (consensus *Consensus) onCommit(recvMsg *FBFTMessage) {
-	consensus.mutex.Lock()
-	defer consensus.mutex.Unlock()
+	consensus.Mutex.Lock()
+	defer consensus.Mutex.Unlock()
 	//// Read - Start
 	if !consensus.isRightBlockNumAndViewID(recvMsg) {
 		return
@@ -314,8 +314,8 @@ func (consensus *Consensus) onCommit(recvMsg *FBFTMessage) {
 			time.Sleep(waitTime)
 			logger.Info().Msg("[OnCommit] Commit Grace Period Ended")
 
-			consensus.mutex.Lock()
-			defer consensus.mutex.Unlock()
+			consensus.Mutex.Lock()
+			defer consensus.Mutex.Unlock()
 			if viewID == consensus.GetCurBlockViewID() {
 				consensus.finalCommit()
 			}

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -36,8 +36,8 @@ func (consensus *Consensus) onAnnounce(msg *msg_pb.Message) {
 		Uint64("MsgBlockNum", recvMsg.BlockNum).
 		Msg("[OnAnnounce] Announce message Added")
 	consensus.FBFTLog.AddVerifiedMessage(recvMsg)
-	consensus.mutex.Lock()
-	defer consensus.mutex.Unlock()
+	consensus.Mutex.Lock()
+	defer consensus.Mutex.Unlock()
 	consensus.blockHash = recvMsg.BlockHash
 	// we have already added message and block, skip check viewID
 	// and send prepare message if is in ViewChanging mode
@@ -98,8 +98,8 @@ func (consensus *Consensus) sendCommitMessages(blockObj *types.Block) {
 // if onPrepared accepts the prepared message from the leader, then
 // it will send a COMMIT message for the leader to receive on the network.
 func (consensus *Consensus) onPrepared(recvMsg *FBFTMessage) {
-	consensus.mutex.Lock()
-	defer consensus.mutex.Unlock()
+	consensus.Mutex.Lock()
+	defer consensus.Mutex.Unlock()
 
 	consensus.getLogger().Info().
 		Uint64("MsgBlockNum", recvMsg.BlockNum).
@@ -228,8 +228,8 @@ func (consensus *Consensus) onPrepared(recvMsg *FBFTMessage) {
 }
 
 func (consensus *Consensus) onCommitted(recvMsg *FBFTMessage) {
-	consensus.mutex.Lock()
-	defer consensus.mutex.Unlock()
+	consensus.Mutex.Lock()
+	defer consensus.Mutex.Unlock()
 
 	consensus.getLogger().Info().
 		Uint64("MsgBlockNum", recvMsg.BlockNum).

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -232,8 +232,8 @@ func (consensus *Consensus) startViewChange() {
 	if consensus.disableViewChange {
 		return
 	}
-	consensus.mutex.Lock()
-	defer consensus.mutex.Unlock()
+	consensus.Mutex.Lock()
+	defer consensus.Mutex.Unlock()
 
 	consensus.consensusTimeout[timeoutConsensus].Stop()
 	consensus.consensusTimeout[timeoutBootstrap].Stop()
@@ -344,8 +344,8 @@ func (consensus *Consensus) startNewView(viewID uint64, newLeaderPriKey *bls.Pri
 
 // onViewChange is called when the view change message is received.
 func (consensus *Consensus) onViewChange(recvMsg *FBFTMessage) {
-	consensus.mutex.Lock()
-	defer consensus.mutex.Unlock()
+	consensus.Mutex.Lock()
+	defer consensus.Mutex.Unlock()
 
 	consensus.getLogger().Info().
 		Uint64("viewID", recvMsg.ViewID).
@@ -443,8 +443,8 @@ func (consensus *Consensus) onViewChange(recvMsg *FBFTMessage) {
 // Or the validator will enter announce phase to wait for the new block proposed
 // from the new leader
 func (consensus *Consensus) onNewView(recvMsg *FBFTMessage) {
-	consensus.mutex.Lock()
-	consensus.mutex.Unlock()
+	consensus.Mutex.Lock()
+	consensus.Mutex.Unlock()
 
 	consensus.getLogger().Info().
 		Uint64("viewID", recvMsg.ViewID).

--- a/node/node.go
+++ b/node/node.go
@@ -122,6 +122,8 @@ type Node struct {
 	IsInSync      *abool.AtomicBool
 	proposedBlock map[uint64]*types.Block
 
+	explorerHelper *explorerHelper
+
 	deciderCache   *lru.Cache
 	committeeCache *lru.Cache
 
@@ -1042,6 +1044,7 @@ func New(
 	nodeStringCounterVec.WithLabelValues("version", nodeconfig.GetVersion()).Inc()
 
 	node.serviceManager = service.NewManager()
+	node.explorerHelper = newExplorerHelper(&node)
 
 	return &node
 }

--- a/node/node_explorer.go
+++ b/node/node_explorer.go
@@ -35,12 +35,12 @@ var (
 
 // explorerMessageHandler passes received message in node_handler to explorer service
 func (node *Node) explorerMessageHandler(ctx context.Context, msg *msg_pb.Message) error {
-	parsedMsg, err := node.Consensus.ParseFBFTMessage(msg)
-	if err != nil {
-		return errors.New("failed to parse FBFT message")
-	}
-
 	if msg.Type == msg_pb.MessageType_COMMITTED {
+		parsedMsg, err := node.Consensus.ParseFBFTMessage(msg)
+		if err != nil {
+			return errors.New("failed to parse FBFT message")
+		}
+
 		node.Consensus.Mutex.Lock()
 		defer node.Consensus.Mutex.Unlock()
 
@@ -57,6 +57,11 @@ func (node *Node) explorerMessageHandler(ctx context.Context, msg *msg_pb.Messag
 			return errors.Wrap(err, "failed to catchup for explorer")
 		}
 	} else if msg.Type == msg_pb.MessageType_PREPARED {
+		parsedMsg, err := node.Consensus.ParseFBFTMessage(msg)
+		if err != nil {
+			return errors.New("failed to parse FBFT message")
+		}
+
 		node.Consensus.Mutex.Lock()
 		defer node.Consensus.Mutex.Unlock()
 


### PR DESCRIPTION
## Issue

A fix to https://github.com/harmony-one/harmony/issues/3740. The explorer node seems to be lagging behind quite frequent. This is because the explorer node does not have a cache for block insertion. So if the consensus message does not come in order, the explorer node is messed up.

In this PR, the caching logic for explorer is implemented which is very similiar to normal validator node handling consensus message logic. Active DNS sync logic is also added to ensure the explorer node will actively fetch block from DNS node when it realize itself is lagging behind. 

We shall consider refactor explorer node to consensus later.

## Test

Local tests passed. But still need to test it out on mainnet. Will do later.