### PR TITLE
remove unnecessary db writing for pending crosslinks

### DIFF
--- a/core/rawdb/accessors_offchain.go
+++ b/core/rawdb/accessors_offchain.go
@@ -75,7 +75,7 @@ func ReadPendingCrossLinks(db DatabaseReader) ([]byte, error) {
 	return db.Get(pendingCrosslinkKey)
 }
 
-// CachePendingCrossLinks stores last pending crosslinks into database.
+// WritePendingCrossLinks stores last pending crosslinks into database.
 func WritePendingCrossLinks(db DatabaseWriter, bytes []byte) error {
 	return db.Put(pendingCrosslinkKey, bytes)
 }

--- a/core/rawdb/accessors_offchain.go
+++ b/core/rawdb/accessors_offchain.go
@@ -75,7 +75,7 @@ func ReadPendingCrossLinks(db DatabaseReader) ([]byte, error) {
 	return db.Get(pendingCrosslinkKey)
 }
 
-// WritePendingCrossLinks stores last pending crosslinks into database.
+// CachePendingCrossLinks stores last pending crosslinks into database.
 func WritePendingCrossLinks(db DatabaseWriter, bytes []byte) error {
 	return db.Put(pendingCrosslinkKey, bytes)
 }

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -488,6 +488,10 @@ func (node *Node) CalculateResponse(request *downloader_pb.DownloaderRequest, in
 			}
 			payloadSize += len(encoded)
 			if payloadSize > getBlocksRequestHardCap {
+				utils.Logger().Warn().Err(err).
+					Int("req size", len(request.Hashes)).
+					Int("cur size", len(response.Payload)).
+					Msg("[SYNC] Max blocks response size reached, ignoring rest blocks")
 				break
 			}
 			response.Payload = append(response.Payload, encoded)

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -491,7 +491,7 @@ func (node *Node) CalculateResponse(request *downloader_pb.DownloaderRequest, in
 				utils.Logger().Warn().Err(err).
 					Int("req size", len(request.Hashes)).
 					Int("cur size", len(response.Payload)).
-					Msg("[SYNC] Max blocks response size reached, ignoring rest blocks")
+					Msg("[SYNC] Max blocks response size reached, ignoring the rest.")
 				break
 			}
 			response.Payload = append(response.Payload, encoded)


### PR DESCRIPTION
to avoid redundant serialization and deserialization of pending crosslinks.