### PR TITLE
[p2p] increase the max size of node message validation

### DIFF
--- a/core/types/tx_pool.go
+++ b/core/types/tx_pool.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	//MaxPoolTransactionDataSize is a 128KB heuristic data limit for DOS prevention
-	MaxPoolTransactionDataSize = 128 * 1024
+	//MaxPoolTransactionDataSize is a heuristic data limit for DOS prevention 1.25Mb
+	MaxPoolTransactionDataSize = 1280 * 1024
 	//MaxEncodedPoolTransactionSize is a heuristic raw/encoded data size limit. It has an additional 10KB for metadata
 	MaxEncodedPoolTransactionSize = MaxPoolTransactionDataSize + (10 * 1024)
 )


### PR DESCRIPTION
During the p2p message validation, the node will drop the node message if
the size is bigger than the MaxPoolTransactionDataSize.
The initial value was just a heuristic value set during the open staking testnet.
However, the valid node message becomes
bigger now due to the higher tx count in the mainnet. So we need to lift the
upper bound. We have observed the oversized node message from metrics.

Ex,
hmy_p2p_node_msg{type="invalid_oversized"} 3484

Signed-off-by: Leo Chen <leo@harmony.one>
