### PR TITLE
P2p filterbeaconmsg

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -375,7 +375,7 @@ var (
 	errInvalidShard      = errors.New("invalid shard")
 )
 
-const beaconBlockHeightTolerance = 1
+const beaconBlockHeightTolerance = 2
 
 // validateNodeMessage validate node message
 func (node *Node) validateNodeMessage(ctx context.Context, payload []byte) (
@@ -416,7 +416,7 @@ func (node *Node) validateNodeMessage(ctx context.Context, payload []byte) (
 			curBeaconHeight := node.Beaconchain().CurrentBlock().NumberU64()
 			for _, block := range blocks {
 				// Ban blocks number that is smaller than tolerance
-				if block.NumberU64()+beaconBlockHeightTolerance < curBeaconHeight {
+				if block.NumberU64()+beaconBlockHeightTolerance <= curBeaconHeight {
 					return nil, 0, errors.New("beacon block height smaller than current height. Banned")
 				} else if block.NumberU64() <= curBeaconHeight {
 					return nil, 0, errIgnoreBeaconMsg

--- a/node/node.go
+++ b/node/node.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum/rlp"
+
 	"github.com/ethereum/go-ethereum/common"
 	protobuf "github.com/golang/protobuf/proto"
 	"github.com/harmony-one/abool"
@@ -373,6 +375,8 @@ var (
 	errInvalidShard      = errors.New("invalid shard")
 )
 
+const beaconBlockHeightTolerance = 1
+
 // validateNodeMessage validate node message
 func (node *Node) validateNodeMessage(ctx context.Context, payload []byte) (
 	[]byte, proto_node.MessageType, error) {
@@ -403,6 +407,22 @@ func (node *Node) validateNodeMessage(ctx context.Context, payload []byte) (
 			if node.Blockchain().ShardID() == shard.BeaconChainShardID {
 				return nil, 0, errIgnoreBeaconMsg
 			}
+			// checks whether the beacon block is larger than current block number
+			blocksPayload := payload[p2pNodeMsgPrefixSize+1:]
+			var blocks []*types.Block
+			if err := rlp.DecodeBytes(blocksPayload, &blocks); err != nil {
+				return nil, 0, errors.New("block rlp decode error")
+			}
+			curBeaconHeight := node.Beaconchain().CurrentBlock().NumberU64()
+			for _, block := range blocks {
+				// Ban blocks number that is smaller than tolerance
+				if block.NumberU64()+beaconBlockHeightTolerance < curBeaconHeight {
+					return nil, 0, errors.New("beacon block height smaller than current height. Banned")
+				} else if block.NumberU64() <= curBeaconHeight {
+					return nil, 0, errIgnoreBeaconMsg
+				}
+			}
+
 		case proto_node.SlashCandidate:
 			nodeNodeMessageCounterVec.With(prometheus.Labels{"type": "slash"}).Inc()
 			// only beacon chain node process slash candidate messages

--- a/node/node.go
+++ b/node/node.go
@@ -422,7 +422,7 @@ func (node *Node) validateNodeMessage(ctx context.Context, payload []byte) (
 					return nil, 0, errors.New("beacon block height smaller than current height beyond tolerance")
 				} else if block.NumberU64() <= curBeaconHeight {
 					utils.Logger().Info().Uint64("receivedNum", block.NumberU64()).
-						Uint64("currentNum", curBeaconHeight).Msg("beacon block sync message ginored")
+						Uint64("currentNum", curBeaconHeight).Msg("beacon block sync message ignored")
 					return nil, 0, errIgnoreBeaconMsg
 				}
 			}

--- a/node/node.go
+++ b/node/node.go
@@ -417,7 +417,7 @@ func (node *Node) validateNodeMessage(ctx context.Context, payload []byte) (
 			for _, block := range blocks {
 				// Ban blocks number that is smaller than tolerance
 				if block.NumberU64()+beaconBlockHeightTolerance <= curBeaconHeight {
-					return nil, 0, errors.New("beacon block height smaller than current height. Banned")
+					return nil, 0, errors.New("beacon block height smaller than current height beyond tolerance")
 				} else if block.NumberU64() <= curBeaconHeight {
 					return nil, 0, errIgnoreBeaconMsg
 				}


### PR DESCRIPTION
## Issue

Filter beacon block message that has block smaller than current block number.

This is just a current fix of flooding beacon block sync message. A more strict sanity check will be done later. This is the first of many PRs to prevent p2p spamming. 

## Test

Tested on shard 2 explorer. A bunch of following message is observed, meaning the flooding message is rejected.

```
{"level":"warn","receivedNum":14089918,"currentNum":14092588,"caller":"/home/yx/go/src/github.com/harmony-one/harmony/node/node.go:421","time":"2021-06-10T06:38:42.610431334Z","message":"beacon block sync message rejected"}
```

Need to test on mainnet to see whether this help reduce network load.