### PR TITLE
add limit on block size

### DIFF
--- a/node/worker/worker.go
+++ b/node/worker/worker.go
@@ -63,6 +63,7 @@ func (w *Worker) CommitSortedTransactions(
 	txs *types.TransactionsByPriceAndNonce,
 	coinbase common.Address,
 ) {
+	counter := 0
 	for {
 		// If we don't have enough gas for any further transactions then we're done
 		if w.current.gasPool.Gas() < params.TxGas {
@@ -125,6 +126,11 @@ func (w *Worker) CommitSortedTransactions(
 			// nonce-too-high clause will prevent us from executing in vain).
 			utils.Logger().Info().Str("hash", tx.Hash().Hex()).AnErr("err", err).Msg("Transaction failed, account skipped")
 			txs.Shift()
+		}
+		counter++
+		if counter >= 50 {
+			// Limit the number of txn per block as a temporary solution to spams.
+			break
 		}
 	}
 }


### PR DESCRIPTION
Temporary solution to recover consensus which is broken due to block size that's too large.