### PR TITLE
[metrics] Add crosslink messages to metrics

### DIFF
--- a/node/metrics.go
+++ b/node/metrics.go
@@ -56,6 +56,20 @@ var (
 			"type",
 		},
 	)
+
+	// nodeCrossLinkMessageCounterVec is used to keep track of node new/invalid/duplicate crosslink messages received
+	nodeCrossLinkMessageCounterVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "hmy",
+			Subsystem: "p2p",
+			Name:      "crosslink_msg",
+			Help:      "number of crosslink messages",
+		},
+		[]string{
+			"type",
+		},
+	)
+
 	onceMetrics sync.Once
 )
 
@@ -66,6 +80,7 @@ func initMetrics() {
 			nodeP2PMessageCounterVec,
 			nodeConsensusMessageCounterVec,
 			nodeNodeMessageCounterVec,
+			nodeCrossLinkMessageCounterVec,
 		)
 	})
 }

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -244,8 +244,7 @@ func (node *Node) doBeaconSyncing() {
 		}
 		if node.beaconSync.GetActivePeerNumber() == 0 {
 			utils.Logger().Info().Msg("no peers; bootstrapping beacon sync config")
-			// 0 means shardID=0 here
-			peers, err := node.SyncingPeerProvider.SyncingPeers(0)
+			peers, err := node.SyncingPeerProvider.SyncingPeers(shard.BeaconChainShardID)
 			if err != nil {
 				utils.Logger().Warn().
 					Err(err).


### PR DESCRIPTION
## Issue

- Add this issue: https://github.com/harmony-one/harmony/issues/3754
- Replace magic number `0` with constant `shard.BeaconChainShardID` when non-beacon chain exec `SyncLoop` syncing from Shard 0 for catching up beacon chain

## Test

Need to test it locally