### PR TITLE
[sync] changed param to support low network bandwidth against large block

### DIFF
--- a/api/service/legacysync/downloader/client.go
+++ b/api/service/legacysync/downloader/client.go
@@ -93,7 +93,7 @@ func (client *Client) GetBlocks(hashes [][]byte) *pb.DownloaderResponse {
 
 // GetBlocksAndSigs get blockWithSig in serialization byte array by calling a grpc request
 func (client *Client) GetBlocksAndSigs(hashes [][]byte) *pb.DownloaderResponse {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
 	defer cancel()
 	request := &pb.DownloaderRequest{Type: pb.DownloaderRequest_BLOCK, GetBlocksWithSig: true}
 	request.Hashes = make([][]byte, len(hashes))

--- a/api/service/legacysync/syncing.go
+++ b/api/service/legacysync/syncing.go
@@ -32,9 +32,9 @@ const (
 	downloadBlocksRetryLimit        = 5 // downloadBlocks service retry limit
 	RegistrationNumber              = 3
 	SyncingPortDifference           = 3000
-	inSyncThreshold                 = 0    // when peerBlockHeight - myBlockHeight <= inSyncThreshold, it's ready to join consensus
-	SyncLoopBatchSize        uint32 = 1000 // maximum size for one query of block hashes
-	verifyHeaderBatchSize    uint64 = 100  // block chain header verification batch size
+	inSyncThreshold                 = 0   // when peerBlockHeight - myBlockHeight <= inSyncThreshold, it's ready to join consensus
+	SyncLoopBatchSize        uint32 = 30  // maximum size for one query of block hashes
+	verifyHeaderBatchSize    uint64 = 100 // block chain header verification batch size (not used for now)
 	LastMileBlocksSize              = 50
 
 	// after cutting off a number of connected peers, the result number of peers
@@ -42,7 +42,7 @@ const (
 	NumPeersLowBound  = 3
 	numPeersHighBound = 5
 
-	downloadTaskBatch = 15
+	downloadTaskBatch = 5
 )
 
 // SyncPeerConfig is peer config to sync.

--- a/api/service/legacysync/syncing.go
+++ b/api/service/legacysync/syncing.go
@@ -29,7 +29,7 @@ import (
 
 // Constants for syncing.
 const (
-	downloadBlocksRetryLimit        = 5 // downloadBlocks service retry limit
+	downloadBlocksRetryLimit        = 10 // downloadBlocks service retry limit
 	RegistrationNumber              = 3
 	SyncingPortDifference           = 3000
 	inSyncThreshold                 = 0   // when peerBlockHeight - myBlockHeight <= inSyncThreshold, it's ready to join consensus


### PR DESCRIPTION
## Issue

Changed parameters for nodes that have low network bandwidth at DNS service.

During the spamming attack, the spammer also spammed transaction with large data which make the block size to be huge. It is possible that a block reaches a size of 1.5M per block, thus causing some of the DNS client failed to download blocks within time out.

From a contabo node at Europe for testing, it is observed that the downloading 4MB block batch data requires ~55s which is way beyond the current timeout, which is only 10s before.

Thus this PR is changing the following parameters:

1. Changed GetBlocks request timeout to 300s.
2. Further reduce the number of blocks per request: 15 -> 5
3. Reduce the number of blocks per process loop: 1000 -> 30
4. Increase the client retry times from 5 -> 10 per process loop so that client have the chance to fill up all holes in previous failed download requests.

Given the current processing time per block is around 400~500ms, the new parameters are more reasonable for the current network condition. 

## Test

Tested on contabo node, the node can now sync gradually.