### PR TITLE
Implement pprof module extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ explorer_storage_*
 
 # local blskeys for testing
 .hmy/blskeys
+
+# pprof profiles
+profiles/*.pb.gz

--- a/api/service/manager.go
+++ b/api/service/manager.go
@@ -20,6 +20,7 @@ const (
 	Consensus
 	BlockProposal
 	NetworkInfo
+	Pprof
 	Prometheus
 	Synchronize
 )
@@ -36,6 +37,8 @@ func (t Type) String() string {
 		return "BlockProposal"
 	case NetworkInfo:
 		return "NetworkInfo"
+	case Pprof:
+		return "Pprof"
 	case Prometheus:
 		return "Prometheus"
 	case Synchronize:

--- a/api/service/pprof/service.go
+++ b/api/service/pprof/service.go
@@ -149,17 +149,17 @@ func scheduleProfile(profile Profile, dir string) {
 func saveProfile(profile Profile, dir string) error {
 	f, err := newTempFile(dir, profile.Name, ".pb.gz")
 	if err != nil {
-		utils.Logger().Error().Err(err).Msg(fmt.Sprintf("Could not save profile: %s", profile.Name))
+		utils.Logger().Error().Err(err).Msg(fmt.Sprintf("Could not save pprof profile: %s", profile.Name))
 		return err
 	}
 	defer f.Close()
 	if profile.ProfileRef != nil {
 		err = profile.ProfileRef.WriteTo(f, profile.Debug)
 		if err != nil {
-			utils.Logger().Error().Err(err).Msg(fmt.Sprintf("Could not write profile: %s", profile.Name))
+			utils.Logger().Error().Err(err).Msg(fmt.Sprintf("Could not write pprof profile: %s", profile.Name))
 			return err
 		}
-		utils.Logger().Info().Msg(fmt.Sprintf("Saved profile in: %s", f.Name()))
+		utils.Logger().Info().Msg(fmt.Sprintf("Saved pprof profile in: %s", f.Name()))
 	}
 	return nil
 }
@@ -170,9 +170,9 @@ func handleCpuProfile(profile Profile, dir string) {
 	f, err := newTempFile(dir, profile.Name, ".pb.gz")
 	if err == nil {
 		pprof.StartCPUProfile(f)
-		utils.Logger().Info().Msg(fmt.Sprintf("Saved CPU profile in: %s", f.Name()))
+		utils.Logger().Info().Msg(fmt.Sprintf("Saved pprof CPU profile in: %s", f.Name()))
 	} else {
-		utils.Logger().Error().Err(err).Msg("Could not start CPU profile")
+		utils.Logger().Error().Err(err).Msg("Could not start pprof CPU profile")
 	}
 }
 
@@ -203,7 +203,7 @@ func (config *Config) unpackProfilesIntoMap() (map[string]Profile, error) {
 		// Try set the profile reference
 		if profile.Name != CPU {
 			if p := pprof.Lookup(profile.Name); p == nil {
-				return nil, fmt.Errorf("Profile does not exist: %s", profile.Name)
+				return nil, fmt.Errorf("Pprof profile does not exist: %s", profile.Name)
 			} else {
 				profile.ProfileRef = p
 			}
@@ -219,7 +219,7 @@ func newTempFile(dir, name, suffix string) (*os.File, error) {
 	currentTime := time.Now().Unix()
 	f, err := os.OpenFile(filepath.Join(dir, fmt.Sprintf("%s%d%s", prefix, currentTime, suffix)), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
 	if err != nil {
-		return nil, fmt.Errorf("could not create file of the form %s%d%s", prefix, currentTime, suffix)
+		return nil, fmt.Errorf("Could not create file of the form %s%d%s", prefix, currentTime, suffix)
 	}
 	return f, nil
 }

--- a/api/service/pprof/service.go
+++ b/api/service/pprof/service.go
@@ -1,0 +1,225 @@
+package pprof
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime/pprof"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/harmony-one/harmony/internal/utils"
+)
+
+// Config is the config for the pprof service
+type Config struct {
+	Enabled            bool
+	ListenAddr         string
+	Folder             string
+	ProfileNames       []string
+	ProfileIntervals   []int
+	ProfileDebugValues []int
+}
+
+type Profile struct {
+	Name       string
+	Interval   int
+	Debug      int
+	ProfileRef *pprof.Profile
+}
+
+func (p Config) String() string {
+	return fmt.Sprintf("%v, %v, %v, %v/%v/%v", p.Enabled, p.ListenAddr, p.Folder, p.ProfileNames, p.ProfileIntervals, p.ProfileDebugValues)
+}
+
+// Constants for profile names
+const (
+	CPU = "cpu"
+)
+
+// Service provides access to pprof profiles via HTTP and can save them to local disk periodically as user settings.
+type Service struct {
+	config   Config
+	profiles map[string]Profile
+}
+
+var (
+	initOnce sync.Once
+	svc      = &Service{}
+)
+
+// NewService creates the new pprof service
+func NewService(cfg Config) *Service {
+	initOnce.Do(func() {
+		svc = newService(cfg)
+	})
+	return svc
+}
+
+func newService(cfg Config) *Service {
+	if !cfg.Enabled {
+		utils.Logger().Info().Msg("Pprof service disabled...")
+		return nil
+	}
+
+	utils.Logger().Debug().Str("cfg", cfg.String()).Msg("Pprof")
+	svc.config = cfg
+
+	if profiles, err := cfg.unpackProfilesIntoMap(); err != nil {
+		log.Fatal("Could not unpack pprof profiles into map")
+	} else {
+		svc.profiles = profiles
+	}
+
+	go func() {
+		utils.Logger().Info().Str("address", cfg.ListenAddr).Msg("Starting pprof HTTP service")
+		http.ListenAndServe(cfg.ListenAddr, nil)
+	}()
+
+	return svc
+}
+
+// Start start the service
+func (s *Service) Start() error {
+	dir, err := filepath.Abs(s.config.Folder)
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(dir, os.FileMode(0755))
+	if err != nil {
+		return err
+	}
+
+	if cpuProfile, ok := s.profiles[CPU]; ok {
+		go handleCpuProfile(cpuProfile, dir)
+	}
+
+	for _, profile := range s.profiles {
+		scheduleProfile(profile, dir)
+	}
+
+	return nil
+}
+
+// Stop stop the service
+func (s *Service) Stop() error {
+	dir, err := filepath.Abs(s.config.Folder)
+	if err != nil {
+		return err
+	}
+	for _, profile := range s.profiles {
+		if profile.Name == CPU {
+			pprof.StopCPUProfile()
+		} else {
+			saveProfile(profile, dir)
+		}
+	}
+	return nil
+}
+
+// APIs return all APIs of the service
+func (s *Service) APIs() []rpc.API {
+	return nil
+}
+
+// scheduleProfile schedules the provided profile based on the specified interval (e.g. saves the profile every x seconds)
+func scheduleProfile(profile Profile, dir string) {
+	go func() {
+		if profile.Interval > 0 {
+			ticker := time.NewTicker(time.Second * time.Duration(profile.Interval))
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					if profile.Name == CPU {
+						handleCpuProfile(profile, dir)
+					} else {
+						saveProfile(profile, dir)
+					}
+				}
+			}
+		}
+	}()
+}
+
+// saveProfile saves the provided profile in the specified directory
+func saveProfile(profile Profile, dir string) error {
+	f, err := newTempFile(dir, profile.Name, ".pb.gz")
+	if err != nil {
+		utils.Logger().Error().Err(err).Msg(fmt.Sprintf("Could not save profile: %s", profile.Name))
+		return err
+	}
+	defer f.Close()
+	if profile.ProfileRef != nil {
+		err = profile.ProfileRef.WriteTo(f, profile.Debug)
+		if err != nil {
+			utils.Logger().Error().Err(err).Msg(fmt.Sprintf("Could not write profile: %s", profile.Name))
+			return err
+		}
+		utils.Logger().Info().Msg(fmt.Sprintf("Saved profile in: %s", f.Name()))
+	}
+	return nil
+}
+
+// handleCpuProfile handles the provided CPU profile
+func handleCpuProfile(profile Profile, dir string) {
+	pprof.StopCPUProfile()
+	f, err := newTempFile(dir, profile.Name, ".pb.gz")
+	if err == nil {
+		pprof.StartCPUProfile(f)
+		utils.Logger().Info().Msg(fmt.Sprintf("Saved CPU profile in: %s", f.Name()))
+	} else {
+		utils.Logger().Error().Err(err).Msg("Could not start CPU profile")
+	}
+}
+
+// unpackProfilesIntoMap unpacks the profiles specified in the configuration into a map
+func (config *Config) unpackProfilesIntoMap() (map[string]Profile, error) {
+	result := make(map[string]Profile, len(config.ProfileNames))
+	if len(config.ProfileNames) == 0 {
+		return nil, nil
+	}
+	for index, name := range config.ProfileNames {
+		profile := Profile{
+			Name:     name,
+			Interval: 0,
+			Debug:    0,
+		}
+		// Try set interval value
+		if len(config.ProfileIntervals) == len(config.ProfileNames) {
+			profile.Interval = config.ProfileIntervals[index]
+		} else if len(config.ProfileIntervals) > 0 {
+			profile.Interval = config.ProfileIntervals[0]
+		}
+		// Try set debug value
+		if len(config.ProfileDebugValues) == len(config.ProfileNames) {
+			profile.Debug = config.ProfileDebugValues[index]
+		} else if len(config.ProfileDebugValues) > 0 {
+			profile.Debug = config.ProfileDebugValues[0]
+		}
+		// Try set the profile reference
+		if profile.Name != CPU {
+			if p := pprof.Lookup(profile.Name); p == nil {
+				return nil, fmt.Errorf("Profile does not exist: %s", profile.Name)
+			} else {
+				profile.ProfileRef = p
+			}
+		}
+		result[name] = profile
+	}
+	return result, nil
+}
+
+// newTempFile returns a new output file in dir with the provided prefix and suffix.
+func newTempFile(dir, name, suffix string) (*os.File, error) {
+	prefix := name + "."
+	currentTime := time.Now().Unix()
+	f, err := os.OpenFile(filepath.Join(dir, fmt.Sprintf("%s%d%s", prefix, currentTime, suffix)), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
+	if err != nil {
+		return nil, fmt.Errorf("could not create file of the form %s%d%s", prefix, currentTime, suffix)
+	}
+	return f, nil
+}

--- a/api/service/pprof/service.go
+++ b/api/service/pprof/service.go
@@ -50,7 +50,7 @@ var (
 	initOnce sync.Once
 	svc      = &Service{}
 	cpuFile  *os.File
-	lock     sync.Mutex
+	cpuLock  sync.Mutex
 )
 
 // NewService creates the new pprof service
@@ -178,8 +178,8 @@ func saveProfile(profile Profile, dir string) error {
 
 // restartCpuProfile stops the current CPU profile, if any and then starts a new CPU profile. While profiling in the background, the profile will be buffered and written to a file.
 func restartCpuProfile(dir string) error {
-	lock.Lock()
-	defer lock.Unlock()
+	cpuLock.Lock()
+	defer cpuLock.Unlock()
 	stopCpuProfile()
 	f, err := newTempFile(dir, CPU, ".pb.gz")
 	if err != nil {

--- a/api/service/pprof/service_test.go
+++ b/api/service/pprof/service_test.go
@@ -3,10 +3,14 @@ package pprof
 import (
 	"errors"
 	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
 	"reflect"
 	"runtime/pprof"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestUnpackProfilesIntoMap(t *testing.T) {
@@ -70,6 +74,29 @@ func TestUnpackProfilesIntoMap(t *testing.T) {
 			t.Errorf("Test %v: unexpected map\n\t%+v\n\t%+v", i, actual, test.expMap)
 		}
 	}
+}
+
+func TestStart(t *testing.T) {
+	input := &Config{
+		Enabled:          true,
+		Folder:           tempTestDir(),
+		ProfileNames:     []string{"cpu"},
+		ProfileIntervals: []int{1},
+	}
+	defer os.RemoveAll(input.Folder)
+	s := NewService(*input)
+	err := s.Start()
+	if assErr := assertError(err, nil); assErr != nil {
+		t.Fatal(assErr)
+	}
+	time.Sleep(1 * time.Second)
+}
+
+func tempTestDir() string {
+	tempDir := os.TempDir()
+	testDir := filepath.Join(tempDir, fmt.Sprintf("pprof-service-test-%d-%d", os.Getpid(), rand.Int()))
+	os.RemoveAll(testDir)
+	return testDir
 }
 
 func assertError(gotErr, expErr error) error {

--- a/api/service/pprof/service_test.go
+++ b/api/service/pprof/service_test.go
@@ -37,7 +37,7 @@ func TestUnpackProfilesIntoMap(t *testing.T) {
 				ProfileNames: []string{"test"},
 			},
 			expMap: nil,
-			expErr: errors.New("Pprof profile does not exist: test"),
+			expErr: errors.New("pprof profile does not exist: test"),
 		},
 		{
 			input: &Config{

--- a/api/service/pprof/service_test.go
+++ b/api/service/pprof/service_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"runtime/pprof"
 	"strings"
 	"testing"
 )
@@ -16,41 +17,46 @@ func TestUnpackProfilesIntoMap(t *testing.T) {
 	}{
 		{
 			input:  &Config{},
-			expMap: make(map[string]Profile),
+			expMap: nil,
 		},
 		{
 			input: &Config{
-				ProfileNames: []string{"test", "test"},
+				ProfileNames: []string{"cpu", "cpu"},
 			},
-			expMap: nil,
-			expErr: errors.New("Pprof profile names contains duplicate: test"),
+			expMap: map[string]Profile{
+				"cpu": {
+					Name:       "cpu",
+					Interval:   0,
+					Debug:      0,
+					ProfileRef: pprof.Lookup("cpu"),
+				},
+			},
 		},
 		{
 			input: &Config{
 				ProfileNames: []string{"test"},
 			},
-			expMap: map[string]Profile{
-				"test": {
-					Name: "test",
-				},
-			},
+			expMap: nil,
+			expErr: errors.New("Pprof profile does not exist: test"),
 		},
 		{
 			input: &Config{
-				ProfileNames:       []string{"test1", "test2"},
+				ProfileNames:       []string{"cpu", "heap"},
 				ProfileIntervals:   []int{0, 60},
 				ProfileDebugValues: []int{1},
 			},
 			expMap: map[string]Profile{
-				"test1": {
-					Name:     "test1",
-					Interval: 0,
-					Debug:    1,
+				"cpu": {
+					Name:       "cpu",
+					Interval:   0,
+					Debug:      1,
+					ProfileRef: pprof.Lookup("cpu"),
 				},
-				"test2": {
-					Name:     "test2",
-					Interval: 60,
-					Debug:    1,
+				"heap": {
+					Name:       "heap",
+					Interval:   60,
+					Debug:      1,
+					ProfileRef: pprof.Lookup("heap"),
 				},
 			},
 		},

--- a/api/service/pprof/service_test.go
+++ b/api/service/pprof/service_test.go
@@ -1,0 +1,80 @@
+package pprof
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestUnpackProfilesIntoMap(t *testing.T) {
+	tests := []struct {
+		input  *Config
+		expMap map[string]Profile
+		expErr error
+	}{
+		{
+			input:  &Config{},
+			expMap: make(map[string]Profile),
+		},
+		{
+			input: &Config{
+				ProfileNames: []string{"test", "test"},
+			},
+			expMap: nil,
+			expErr: errors.New("Pprof profile names contains duplicate: test"),
+		},
+		{
+			input: &Config{
+				ProfileNames: []string{"test"},
+			},
+			expMap: map[string]Profile{
+				"test": {
+					Name: "test",
+				},
+			},
+		},
+		{
+			input: &Config{
+				ProfileNames:       []string{"test1", "test2"},
+				ProfileIntervals:   []int{0, 60},
+				ProfileDebugValues: []int{1},
+			},
+			expMap: map[string]Profile{
+				"test1": {
+					Name:     "test1",
+					Interval: 0,
+					Debug:    1,
+				},
+				"test2": {
+					Name:     "test2",
+					Interval: 60,
+					Debug:    1,
+				},
+			},
+		},
+	}
+	for i, test := range tests {
+		actual, err := test.input.unpackProfilesIntoMap()
+		if assErr := assertError(err, test.expErr); assErr != nil {
+			t.Fatalf("Test %v: %v", i, assErr)
+		}
+		if !reflect.DeepEqual(actual, test.expMap) {
+			t.Errorf("Test %v: unexpected map\n\t%+v\n\t%+v", i, actual, test.expMap)
+		}
+	}
+}
+
+func assertError(gotErr, expErr error) error {
+	if (gotErr == nil) != (expErr == nil) {
+		return fmt.Errorf("error unexpected [%v] / [%v]", gotErr, expErr)
+	}
+	if gotErr == nil {
+		return nil
+	}
+	if !strings.Contains(gotErr.Error(), expErr.Error()) {
+		return fmt.Errorf("error unexpected [%v] / [%v]", gotErr, expErr)
+	}
+	return nil
+}

--- a/cmd/harmony/config_migrations.go
+++ b/cmd/harmony/config_migrations.go
@@ -177,13 +177,13 @@ func init() {
 			confTree.Set("Pprof.Folder", defaultConfig.Pprof.Folder)
 		}
 		if confTree.Get("Pprof.ProfileNames") == nil {
-			confTree.Set("Pprof.ProfileNames", []string{})
+			confTree.Set("Pprof.ProfileNames", make([]interface{}, 0))
 		}
 		if confTree.Get("Pprof.ProfileIntervals") == nil {
-			confTree.Set("Pprof.ProfileIntervals", []string{})
+			confTree.Set("Pprof.ProfileIntervals", make([]interface{}, 0))
 		}
 		if confTree.Get("Pprof.ProfileDebugValues") == nil {
-			confTree.Set("Pprof.ProfileDebugValues", []string{})
+			confTree.Set("Pprof.ProfileDebugValues", make([]interface{}, 0))
 		}
 
 		confTree.Set("Version", "2.2.0")

--- a/cmd/harmony/config_migrations.go
+++ b/cmd/harmony/config_migrations.go
@@ -167,4 +167,26 @@ func init() {
 		confTree.Set("Version", "2.1.0")
 		return confTree
 	}
+
+	migrations["2.1.0"] = func(confTree *toml.Tree) *toml.Tree {
+		// Legacy conf missing fields
+		if confTree.Get("Pprof.Enabled") == nil {
+			confTree.Set("Pprof.Enabled", true)
+		}
+		if confTree.Get("Pprof.Folder") == nil {
+			confTree.Set("Pprof.Folder", defaultConfig.Pprof.Folder)
+		}
+		if confTree.Get("Pprof.ProfileNames") == nil {
+			confTree.Set("Pprof.ProfileNames", "")
+		}
+		if confTree.Get("Pprof.ProfileIntervals") == nil {
+			confTree.Set("Pprof.ProfileIntervals", "")
+		}
+		if confTree.Get("Pprof.ProfileDebugValues") == nil {
+			confTree.Set("Pprof.ProfileDebugValues", "")
+		}
+
+		confTree.Set("Version", "2.2.0")
+		return confTree
+	}
 }

--- a/cmd/harmony/config_migrations.go
+++ b/cmd/harmony/config_migrations.go
@@ -177,13 +177,13 @@ func init() {
 			confTree.Set("Pprof.Folder", defaultConfig.Pprof.Folder)
 		}
 		if confTree.Get("Pprof.ProfileNames") == nil {
-			confTree.Set("Pprof.ProfileNames", make([]interface{}, 0))
+			confTree.Set("Pprof.ProfileNames", defaultConfig.Pprof.ProfileNames)
 		}
 		if confTree.Get("Pprof.ProfileIntervals") == nil {
-			confTree.Set("Pprof.ProfileIntervals", make([]interface{}, 0))
+			confTree.Set("Pprof.ProfileIntervals", defaultConfig.Pprof.ProfileIntervals)
 		}
 		if confTree.Get("Pprof.ProfileDebugValues") == nil {
-			confTree.Set("Pprof.ProfileDebugValues", make([]interface{}, 0))
+			confTree.Set("Pprof.ProfileDebugValues", defaultConfig.Pprof.ProfileDebugValues)
 		}
 
 		confTree.Set("Version", "2.2.0")

--- a/cmd/harmony/config_migrations.go
+++ b/cmd/harmony/config_migrations.go
@@ -177,13 +177,13 @@ func init() {
 			confTree.Set("Pprof.Folder", defaultConfig.Pprof.Folder)
 		}
 		if confTree.Get("Pprof.ProfileNames") == nil {
-			confTree.Set("Pprof.ProfileNames", "")
+			confTree.Set("Pprof.ProfileNames", []string{})
 		}
 		if confTree.Get("Pprof.ProfileIntervals") == nil {
-			confTree.Set("Pprof.ProfileIntervals", "")
+			confTree.Set("Pprof.ProfileIntervals", []string{})
 		}
 		if confTree.Get("Pprof.ProfileDebugValues") == nil {
-			confTree.Set("Pprof.ProfileDebugValues", "")
+			confTree.Set("Pprof.ProfileDebugValues", []string{})
 		}
 
 		confTree.Set("Version", "2.2.0")

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -5,7 +5,7 @@ import (
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 )
 
-const tomlConfigVersion = "2.1.0"
+const tomlConfigVersion = "2.2.0"
 
 const (
 	defNetworkType = nodeconfig.Mainnet

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -67,8 +67,8 @@ var defaultConfig = harmonyconfig.HarmonyConfig{
 		ListenAddr:         "127.0.0.1:6060",
 		Folder:             "./profiles",
 		ProfileNames:       []string{},
-		ProfileIntervals:   []int{},
-		ProfileDebugValues: []int{},
+		ProfileIntervals:   []int{600},
+		ProfileDebugValues: []int{0},
 	},
 	Log: harmonyconfig.LogConfig{
 		Folder:     "./latest",

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -63,8 +63,10 @@ var defaultConfig = harmonyconfig.HarmonyConfig{
 	},
 	Sync: getDefaultSyncConfig(defNetworkType),
 	Pprof: harmonyconfig.PprofConfig{
-		Enabled:    false,
-		ListenAddr: "127.0.0.1:6060",
+		Enabled:      false,
+		ListenAddr:   "127.0.0.1:6060",
+		Folder:       "./profiles",
+		ProfileNames: []string{},
 	},
 	Log: harmonyconfig.LogConfig{
 		Folder:     "./latest",

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -63,10 +63,12 @@ var defaultConfig = harmonyconfig.HarmonyConfig{
 	},
 	Sync: getDefaultSyncConfig(defNetworkType),
 	Pprof: harmonyconfig.PprofConfig{
-		Enabled:      false,
-		ListenAddr:   "127.0.0.1:6060",
-		Folder:       "./profiles",
-		ProfileNames: []string{},
+		Enabled:            false,
+		ListenAddr:         "127.0.0.1:6060",
+		Folder:             "./profiles",
+		ProfileNames:       []string{},
+		ProfileIntervals:   []int{},
+		ProfileDebugValues: []int{},
 	},
 	Log: harmonyconfig.LogConfig{
 		Folder:     "./latest",

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -986,7 +986,7 @@ var (
 	}
 	pprofProfileDebugFlag = cli.IntSliceFlag{
 		Name:     "pprof.profile.debug",
-		Usage:    "a list of pprof profile debug integer values (separated by ,) e.g. 0 writes the gzip-compressed protocol buffer and 1 writes the legacy text format",
+		Usage:    "a list of pprof profile debug integer values (separated by ,) e.g. 0 writes the gzip-compressed protocol buffer and 1 writes the legacy text format. Predefined profiles may assign meaning to other debug values: https://golang.org/pkg/runtime/pprof/",
 		DefValue: defaultConfig.Pprof.ProfileDebugValues,
 		Hidden:   true,
 	}

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -126,6 +126,10 @@ var (
 	pprofFlags = []cli.Flag{
 		pprofEnabledFlag,
 		pprofListenAddrFlag,
+		pprofFolderFlag,
+		pprofProfileNamesFlag,
+		pprofProfileIntervalFlag,
+		pprofProfileDebugFlag,
 	}
 
 	logFlags = []cli.Flag{
@@ -963,12 +967,51 @@ var (
 		Usage:    "listen address for pprof",
 		DefValue: defaultConfig.Pprof.ListenAddr,
 	}
+	pprofFolderFlag = cli.StringFlag{
+		Name:     "pprof.folder",
+		Usage:    "folder to put pprof profiles",
+		DefValue: defaultConfig.Pprof.Folder,
+		Hidden:   true,
+	}
+	pprofProfileNamesFlag = cli.StringSliceFlag{
+		Name:     "pprof.profile.names",
+		Usage:    "a list of pprof profile names (separated by ,) e.g. cpu,heap,goroutine",
+		DefValue: defaultConfig.Pprof.ProfileNames,
+	}
+	pprofProfileIntervalFlag = cli.IntSliceFlag{
+		Name:     "pprof.profile.intervals",
+		Usage:    "a list of pprof profile interval integer values (separated by ,) e.g. 30 saves all profiles every 30 seconds or 0,10 saves the first profile on shutdown and the second profile every 10 seconds",
+		DefValue: defaultConfig.Pprof.ProfileIntervals,
+		Hidden:   true,
+	}
+	pprofProfileDebugFlag = cli.IntSliceFlag{
+		Name:     "pprof.profile.debug",
+		Usage:    "a list of pprof profile debug integer values (separated by ,) e.g. 0 writes the gzip-compressed protocol buffer and 1 writes the legacy text format",
+		DefValue: defaultConfig.Pprof.ProfileDebugValues,
+		Hidden:   true,
+	}
 )
 
 func applyPprofFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	var pprofSet bool
 	if cli.IsFlagChanged(cmd, pprofListenAddrFlag) {
 		config.Pprof.ListenAddr = cli.GetStringFlagValue(cmd, pprofListenAddrFlag)
+		pprofSet = true
+	}
+	if cli.IsFlagChanged(cmd, pprofFolderFlag) {
+		config.Pprof.Folder = cli.GetStringFlagValue(cmd, pprofFolderFlag)
+		pprofSet = true
+	}
+	if cli.IsFlagChanged(cmd, pprofProfileNamesFlag) {
+		config.Pprof.ProfileNames = cli.GetStringSliceFlagValue(cmd, pprofProfileNamesFlag)
+		pprofSet = true
+	}
+	if cli.IsFlagChanged(cmd, pprofProfileIntervalFlag) {
+		config.Pprof.ProfileIntervals = cli.GetIntSliceFlagValue(cmd, pprofProfileIntervalFlag)
+		pprofSet = true
+	}
+	if cli.IsFlagChanged(cmd, pprofProfileDebugFlag) {
+		config.Pprof.ProfileDebugValues = cli.GetIntSliceFlagValue(cmd, pprofProfileDebugFlag)
 		pprofSet = true
 	}
 	if cli.IsFlagChanged(cmd, pprofEnabledFlag) {

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -98,8 +98,10 @@ func TestHarmonyFlags(t *testing.T) {
 					BlacklistFile: "./.hmy/blacklist.txt",
 				},
 				Pprof: harmonyconfig.PprofConfig{
-					Enabled:    false,
-					ListenAddr: "127.0.0.1:6060",
+					Enabled:      false,
+					ListenAddr:   "127.0.0.1:6060",
+					Folder:       "./profiles",
+					ProfileNames: []string{},
 				},
 				Log: harmonyconfig.LogConfig{
 					Folder:     "./latest",
@@ -773,22 +775,67 @@ func TestPprofFlags(t *testing.T) {
 		{
 			args: []string{"--pprof"},
 			expConfig: harmonyconfig.PprofConfig{
-				Enabled:    true,
-				ListenAddr: defaultConfig.Pprof.ListenAddr,
+				Enabled:            true,
+				ListenAddr:         defaultConfig.Pprof.ListenAddr,
+				Folder:             defaultConfig.Pprof.Folder,
+				ProfileNames:       defaultConfig.Pprof.ProfileNames,
+				ProfileIntervals:   defaultConfig.Pprof.ProfileIntervals,
+				ProfileDebugValues: defaultConfig.Pprof.ProfileDebugValues,
 			},
 		},
 		{
 			args: []string{"--pprof.addr", "8.8.8.8:9001"},
 			expConfig: harmonyconfig.PprofConfig{
-				Enabled:    true,
-				ListenAddr: "8.8.8.8:9001",
+				Enabled:            true,
+				ListenAddr:         "8.8.8.8:9001",
+				Folder:             defaultConfig.Pprof.Folder,
+				ProfileNames:       defaultConfig.Pprof.ProfileNames,
+				ProfileIntervals:   defaultConfig.Pprof.ProfileIntervals,
+				ProfileDebugValues: defaultConfig.Pprof.ProfileDebugValues,
 			},
 		},
 		{
 			args: []string{"--pprof=false", "--pprof.addr", "8.8.8.8:9001"},
 			expConfig: harmonyconfig.PprofConfig{
-				Enabled:    false,
-				ListenAddr: "8.8.8.8:9001",
+				Enabled:            false,
+				ListenAddr:         "8.8.8.8:9001",
+				Folder:             defaultConfig.Pprof.Folder,
+				ProfileNames:       defaultConfig.Pprof.ProfileNames,
+				ProfileIntervals:   defaultConfig.Pprof.ProfileIntervals,
+				ProfileDebugValues: defaultConfig.Pprof.ProfileDebugValues,
+			},
+		},
+		{
+			args: []string{"--pprof.profile.names", "cpu,heap,mutex"},
+			expConfig: harmonyconfig.PprofConfig{
+				Enabled:            true,
+				ListenAddr:         defaultConfig.Pprof.ListenAddr,
+				Folder:             defaultConfig.Pprof.Folder,
+				ProfileNames:       []string{"cpu", "heap", "mutex"},
+				ProfileIntervals:   defaultConfig.Pprof.ProfileIntervals,
+				ProfileDebugValues: defaultConfig.Pprof.ProfileDebugValues,
+			},
+		},
+		{
+			args: []string{"--pprof.profile.intervals", "0,1"},
+			expConfig: harmonyconfig.PprofConfig{
+				Enabled:            true,
+				ListenAddr:         defaultConfig.Pprof.ListenAddr,
+				Folder:             defaultConfig.Pprof.Folder,
+				ProfileNames:       defaultConfig.Pprof.ProfileNames,
+				ProfileIntervals:   []int{0, 1},
+				ProfileDebugValues: defaultConfig.Pprof.ProfileDebugValues,
+			},
+		},
+		{
+			args: []string{"--pprof.profile.debug", "0,1,0"},
+			expConfig: harmonyconfig.PprofConfig{
+				Enabled:            true,
+				ListenAddr:         defaultConfig.Pprof.ListenAddr,
+				Folder:             defaultConfig.Pprof.Folder,
+				ProfileNames:       defaultConfig.Pprof.ProfileNames,
+				ProfileIntervals:   defaultConfig.Pprof.ProfileIntervals,
+				ProfileDebugValues: []int{0, 1, 0},
 			},
 		},
 	}

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -102,8 +102,8 @@ func TestHarmonyFlags(t *testing.T) {
 					ListenAddr:         "127.0.0.1:6060",
 					Folder:             "./profiles",
 					ProfileNames:       []string{},
-					ProfileIntervals:   []int{},
-					ProfileDebugValues: []int{},
+					ProfileIntervals:   []int{600},
+					ProfileDebugValues: []int{0},
 				},
 				Log: harmonyconfig.LogConfig{
 					Folder:     "./latest",

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -98,10 +98,12 @@ func TestHarmonyFlags(t *testing.T) {
 					BlacklistFile: "./.hmy/blacklist.txt",
 				},
 				Pprof: harmonyconfig.PprofConfig{
-					Enabled:      false,
-					ListenAddr:   "127.0.0.1:6060",
-					Folder:       "./profiles",
-					ProfileNames: []string{},
+					Enabled:            false,
+					ListenAddr:         "127.0.0.1:6060",
+					Folder:             "./profiles",
+					ProfileNames:       []string{},
+					ProfileIntervals:   []int{},
+					ProfileDebugValues: []int{},
 				},
 				Log: harmonyconfig.LogConfig{
 					Folder:     "./latest",

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/pborman/uuid v1.2.0
-	github.com/pelletier/go-toml v1.2.0
+	github.com/pelletier/go-toml v1.9.3
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.8.0
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0

--- a/internal/cli/flag.go
+++ b/internal/cli/flag.go
@@ -79,6 +79,23 @@ func (f StringSliceFlag) RegisterTo(fs *pflag.FlagSet) error {
 	return markHiddenOrDeprecated(fs, f.Name, f.Deprecated, f.Hidden)
 }
 
+// IntSliceFlag is the flag with int slice value
+type IntSliceFlag struct {
+	Name       string
+	Shorthand  string
+	Usage      string
+	Deprecated string
+	Hidden     bool
+
+	DefValue []int
+}
+
+// RegisterTo register the string slice flag to FlagSet
+func (f IntSliceFlag) RegisterTo(fs *pflag.FlagSet) error {
+	fs.IntSliceP(f.Name, f.Shorthand, f.DefValue, f.Usage)
+	return markHiddenOrDeprecated(fs, f.Name, f.Deprecated, f.Hidden)
+}
+
 func markHiddenOrDeprecated(fs *pflag.FlagSet, name string, deprecated string, hidden bool) error {
 	if len(deprecated) != 0 {
 		// TODO: after totally removed node.sh, change MarkHidden to MarkDeprecated
@@ -102,6 +119,8 @@ func getFlagName(flag Flag) string {
 	case BoolFlag:
 		return f.Name
 	case StringSliceFlag:
+		return f.Name
+	case IntSliceFlag:
 		return f.Name
 	}
 	return ""

--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -105,6 +105,27 @@ func getStringSliceFlagValue(fs *pflag.FlagSet, flag StringSliceFlag) []string {
 	return val
 }
 
+// GetIntSliceFlagValue get the int slice value for the given IntSliceFlag from
+// the local flags of the cobra command.
+func GetIntSliceFlagValue(cmd *cobra.Command, flag IntSliceFlag) []int {
+	return getIntSliceFlagValue(cmd.Flags(), flag)
+}
+
+// GetIntSlicePersistentFlagValue get the int slice value for the given IntSliceFlag
+// from the persistent flags of the cobra command.
+func GetIntSlicePersistentFlagValue(cmd *cobra.Command, flag IntSliceFlag) []int {
+	return getIntSliceFlagValue(cmd.PersistentFlags(), flag)
+}
+
+func getIntSliceFlagValue(fs *pflag.FlagSet, flag IntSliceFlag) []int {
+	val, err := fs.GetIntSlice(flag.Name)
+	if err != nil {
+		handleParseError(err)
+		return nil
+	}
+	return val
+}
+
 // IsFlagChanged returns whether the flag has been changed in command
 func IsFlagChanged(cmd *cobra.Command, flag Flag) bool {
 	name := getFlagName(flag)

--- a/internal/configs/harmony/harmony.go
+++ b/internal/configs/harmony/harmony.go
@@ -91,8 +91,8 @@ type PprofConfig struct {
 	ListenAddr         string
 	Folder             string
 	ProfileNames       []string
-	ProfileIntervals   []int `toml:",omitempty"`
-	ProfileDebugValues []int `toml:",omitempty"`
+	ProfileIntervals   []int
+	ProfileDebugValues []int
 }
 
 type LogConfig struct {

--- a/internal/configs/harmony/harmony.go
+++ b/internal/configs/harmony/harmony.go
@@ -87,8 +87,12 @@ type TxPoolConfig struct {
 }
 
 type PprofConfig struct {
-	Enabled    bool
-	ListenAddr string
+	Enabled            bool
+	ListenAddr         string
+	Folder             string
+	ProfileNames       []string
+	ProfileIntervals   []int `toml:",omitempty"`
+	ProfileDebugValues []int `toml:",omitempty"`
 }
 
 type LogConfig struct {


### PR DESCRIPTION
## Issue
@JackyWYX 

[harmony-one/bounties#46](https://github.com/harmony-one/bounties/issues/46)

## Test
### Unit Test Coverage

`go test -cover ./cmd/harmony/`

Before:

```
ok  	github.com/harmony-one/harmony/cmd/harmony	0.266s	coverage: 47.8% of statements
```

After:

```
ok  	github.com/harmony-one/harmony/cmd/harmony	0.136s	coverage: 48.5% of statements
```

### Test/Run Logs
When running and stdin is terminal

```
./harmony -c config_1_0_4.toml 
Old config version detected 1.0.4
Do you want to update config to the latest version: [y/N]
y
Original config backed up to config_1_0_4.toml.backup
Successfully migrated config_1_0_4.toml from 1.0.4 to 2.1.0 
```

When stdin is piped

```
echo Y | ./harmony -c config_1_0_4.toml 
Old config version detected 1.0.4
Update saved config with `./harmony config update [config_file]`
```

## Operational Checklist
1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)
   **NO**
2. **Does this PR introduce backward-incompatible changes _NOT_ related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)
   **NO**

## Manual / cheatsheet

### pprof basics

pprof lets you collect CPU profiles, traces, and heap profiles. The normal way to use pprof is:

- Run `./harmony --pprof`
- Run `curl localhost:6060/debug/pprof/{profile_name} --output profile.pb.gz` to save a profile
- Use `go tool pprof profile.pb.gz` to analyze said profile

### pprof profiles

A Profile is a collection of stack traces showing the call sequences that led to instances of a particular event, such as allocation. Packages can create and maintain their own profiles; the most common use is for tracking resources that must be explicitly closed, such as files or network connections.

Each Profile has a unique name. A few profiles are predefined:

- goroutine    - stack traces of all current goroutines
- heap         - a sampling of memory allocations of live objects
- allocs       - a sampling of all past memory allocations
- threadcreate - stack traces that led to the creation of new OS threads
- block        - stack traces that led to blocking on synchronization primitives
- mutex        - stack traces of holders of contended mutexes

For more information see [runtime/pprof docs](https://golang.org/pkg/runtime/pprof)

A special profile accepted by `--pprof.profile.names`
- cpu          - profiles the current process

### pprof config

- --pprof                           enable pprof profiling
- --pprof.addr string               listen address for pprof (default "127.0.0.1:6060")
- --pprof.folder string             folder to put pprof profiles (default "./profiles")
- --pprof.profile.names strings     a list of pprof profile names (separated by ,) e.g. cpu,heap,goroutine
- --pprof.profile.intervals ints    a list of pprof profile interval integer values (separated by ,)
- --pprof.profile.debug ints        a list of pprof profile debug integer values (separated by ,)

**Example 1**

`./harmony --pprof.profile.names cpu,heap --pprof.profile.intervals 0,10`

Saves the cpu and heap profiles in the `./profiles` folder. The cpu profile will be saved on shutdown and the heap profile will be saved every 10 seconds.

**Example 2**

`./harmony --pprof.profile.names cpu,heap,goroutine --pprof.profile.intervals 10 --pprof.profile.debug 0,0,2`

Saves the cpu, heap and goroutine profiles in the `./profiles` folder. All profiles will be saved every 10 seconds. 
The goroutine profile will use debug=2 which means to print the goroutine stacks in the same form that a Go program uses when dying due to an unrecovered panic.