### PR TITLE
[docker][rosetta] fix docker image build error

### DIFF
--- a/rosetta/infra/Dockerfile
+++ b/rosetta/infra/Dockerfile
@@ -20,6 +20,8 @@ WORKDIR $HMY_PATH/harmony
 
 RUN go mod download
 
+RUN go mod tidy
+
 RUN make linux_static && \
     cp ./bin/harmony /root/harmony && \
     cp ./rosetta/infra/run.sh /root/run.sh


### PR DESCRIPTION
To address errors in https://jenkins.harmony.one/job/docker-explorer-release/542/console
multiple similar error
```
20:25:03 internal/utils/utils.go:17:2: missing go.sum entry for module providing package github.com/ethereum/go-ethereum/common (imported by github.com/harmony-one/harmony/internal/utils); to add:
20:25:03 	go get github.com/harmony-one/harmony/internal/utils
```
