### PR TITLE
Set Sync to false when explorer service unavailable

### DIFF
--- a/api/service/explorer/service.go
+++ b/api/service/explorer/service.go
@@ -192,8 +192,14 @@ func (s *Service) DumpNewBlock(b *types.Block) {
 	s.storage.DumpNewBlock(b)
 }
 
+// DumpCatchupBlock instruct the explorer storage to dump a catch up block in explorer DB
 func (s *Service) DumpCatchupBlock(b *types.Block) {
 	s.storage.DumpCatchupBlock(b)
+}
+
+// IsAvailable return whether the explorer db is available for now.
+func (s *Service) IsAvailable() bool {
+	return s.storage.available.IsSet()
 }
 
 var (


### PR DESCRIPTION
## Issue

During the explorer DB migration, the explorer service is unavailable. Thus, set InSync RPC result to false when migration on going.

## Test

Tested on mainnet explorer machine with following command

```
curl localhost:5000/node-sync
false
```