### PR TITLE
[p2p] Try to fix P2P memory issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/libp2p/go-libp2p-core v0.8.5
 	github.com/libp2p/go-libp2p-crypto v0.1.0
 	github.com/libp2p/go-libp2p-discovery v0.5.0
-	github.com/libp2p/go-libp2p-kad-dht v0.11.1
+	github.com/libp2p/go-libp2p-kad-dht v0.12.1
 	github.com/libp2p/go-libp2p-pubsub v0.4.0
 	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/multiformats/go-multiaddr-dns v0.3.1

--- a/go.mod
+++ b/go.mod
@@ -30,12 +30,12 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/ipfs/go-ds-badger v0.2.4
 	github.com/json-iterator/go v1.1.10
-	github.com/libp2p/go-libp2p v0.14.0
+	github.com/libp2p/go-libp2p v0.14.2
 	github.com/libp2p/go-libp2p-core v0.8.5
 	github.com/libp2p/go-libp2p-crypto v0.1.0
 	github.com/libp2p/go-libp2p-discovery v0.5.0
 	github.com/libp2p/go-libp2p-kad-dht v0.12.1
-	github.com/libp2p/go-libp2p-pubsub v0.4.0
+	github.com/libp2p/go-libp2p-pubsub v0.4.1
 	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/natefinch/lumberjack v2.0.0+incompatible

--- a/p2p/types/peerAddr.go
+++ b/p2p/types/peerAddr.go
@@ -86,7 +86,8 @@ func resolveMultiAddrString(addrStr string) ([]libp2p_peer.AddrInfo, error) {
 
 func resolveMultiAddr(raw ma.Multiaddr) ([]ma.Multiaddr, error) {
 	if madns.Matches(raw) {
-		ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 		mas, err := madns.Resolve(ctx, raw)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Issue

- orginal issue: https://github.com/harmony-one/harmony-ops-priv/issues/36
- go vet detected context leak:

```bash
# github.com/harmony-one/harmony/p2p/types
p2p/types/peerAddr.go:89:8: the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
```

- go-yamux memory leak issue https://github.com/libp2p/go-yamux/pull/30

Since this library is a dependency of libp2p-kad-dht, choose to upgrade and update libp2p-kad-dht

## Test

According to the [latest analysis and speculation](https://github.com/harmony-one/harmony-ops-priv/issues/36#issuecomment-864555047), there is no evidence that the DNS node memory issue is related to these Fixes, but there is some correlation.   So try to reproduce on my local https://github.com/harmony-one/harmony-ops-priv/issues/36#issuecomment-864986243, test is on going





