### PR TITLE
[cmd] default Log.VerbosePrints.Config to true

### DIFF
--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -72,7 +72,7 @@ var defaultConfig = harmonyconfig.HarmonyConfig{
 		RotateSize: 100,
 		Verbosity:  3,
 		VerbosePrints: harmonyconfig.LogVerbosePrints{
-			Config: false,
+			Config: true,
 		},
 	},
 	DNSSync: getDefaultDNSSyncConfig(defNetworkType),

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -999,7 +999,7 @@ var (
 	logVerbosePrintsFlag = cli.StringSliceFlag{
 		Name:     "log.verbose-prints",
 		Usage:    "debugging feature. to print verbose internal objects as JSON in log file. available internal objects: config",
-		DefValue: []string{},
+		DefValue: []string{"config"},
 	}
 	// TODO: remove context (this shall not be in the log)
 	logContextIPFlag = cli.StringFlag{

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -110,6 +110,9 @@ func TestHarmonyFlags(t *testing.T) {
 						IP:   "8.8.8.8",
 						Port: 9000,
 					},
+					VerbosePrints: harmonyconfig.LogVerbosePrints{
+						Config: true,
+					},
 				},
 				Sys: &harmonyconfig.SysConfig{
 					NtpServer: defaultSysConfig.NtpServer,


### PR DESCRIPTION
## Issue

#3781

## Test

### Unit Test Coverage

Before:

```
PASS
coverage: 48.1% of statements
ok  	github.com/harmony-one/harmony/cmd/harmony	0.040s
```

After:

```
PASS
coverage: 48.1% of statements
ok  	github.com/harmony-one/harmony/cmd/harmony	0.075s
```

### Test/Run Logs

```shell
➜  bin git:(fix-3781) ✗ ./harmony --config ./1_0_4.config                                                                                                                                                  [1:19:35]
Old config version detected 1.0.4
Do you want to update config to the latest version: [y/N]
y
Original config backed up to ./1_0_4.config.backup
Successfully migrated ./1_0_4.config from 1.0.4 to 2.1.0 
```

migrated config file
https://gist.github.com/touhonoob/e5b0a2239376e1bce42f6c64c0d1c401

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

NO

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

NO

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

NO
