### PR TITLE
Fix circulating supply

### DIFF
--- a/api/service/explorer/service.go
+++ b/api/service/explorer/service.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"net"
 	"net/http"
 	"path"
@@ -21,7 +20,6 @@ import (
 	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/hmy"
 	"github.com/harmony-one/harmony/internal/chain"
-	"github.com/harmony-one/harmony/internal/common"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/numeric"
@@ -202,14 +200,6 @@ func (s *Service) IsAvailable() bool {
 	return s.storage.available.IsSet()
 }
 
-var (
-	// InaccessibleAddresses are a list of known eth addresses that cannot spend ONE tokens.
-	InaccessibleAddresses = []ethCommon.Address{
-		// one10000000000000000000000000000dead5shlag
-		ethCommon.HexToAddress("0x7bDeF7Bdef7BDeF7BDEf7bDef7bdef7bdeF6E7AD"),
-	}
-)
-
 // InaccessibleAddressInfo ..
 type InaccessibleAddressInfo struct {
 	EthAddress ethCommon.Address `json:"eth-address"`
@@ -220,36 +210,20 @@ type InaccessibleAddressInfo struct {
 
 // getAllInaccessibleAddresses information according to InaccessibleAddresses
 func (s *Service) getAllInaccessibleAddresses() ([]*InaccessibleAddressInfo, error) {
-	state, err := s.blockchain.StateAt(s.blockchain.CurrentHeader().Root())
+	ais, err := chain.GetInaccessibleAddressInfo(s.blockchain)
 	if err != nil {
 		return nil, err
 	}
-
-	accs := []*InaccessibleAddressInfo{}
-	for _, addr := range InaccessibleAddresses {
+	accs := make([]*InaccessibleAddressInfo, 0, len(ais))
+	for _, ai := range ais {
 		accs = append(accs, &InaccessibleAddressInfo{
-			EthAddress: addr,
-			Address:    common.MustAddressToBech32(addr),
-			Balance:    numeric.NewDecFromBigIntWithPrec(state.GetBalance(addr), 18),
-			Nonce:      state.GetNonce(addr),
+			EthAddress: ai.EthAddress,
+			Address:    ai.Address,
+			Balance:    ai.Balance,
+			Nonce:      ai.Nonce,
 		})
 	}
-
 	return accs, nil
-}
-
-// getTotalInaccessibleTokens in ONE at the latest header.
-func (s *Service) getTotalInaccessibleTokens() (numeric.Dec, error) {
-	addrInfos, err := s.getAllInaccessibleAddresses()
-	if err != nil {
-		return numeric.Dec{}, err
-	}
-
-	total := numeric.NewDecFromBigIntWithPrec(big.NewInt(0), 18)
-	for _, addr := range addrInfos {
-		total = total.Add(addr.Balance)
-	}
-	return total, nil
 }
 
 // GetInaccessibleAddressInfo serves /burn-addresses end-point.
@@ -270,17 +244,12 @@ func (s *Service) GetInaccessibleAddressInfo(w http.ResponseWriter, r *http.Requ
 // Note that known InaccessibleAddresses have their funds removed from the supply for this endpoint.
 func (s *Service) GetCirculatingSupply(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	circulatingSupply, err := chain.GetCirculatingSupply(context.Background(), s.blockchain)
+	cs, err := chain.GetCirculatingSupply(s.blockchain)
 	if err != nil {
-		utils.Logger().Warn().Err(err).Msg("unable to fetch circulating supply")
+		utils.Logger().Warn().Msg("Failed to get circulating supply")
 		w.WriteHeader(http.StatusInternalServerError)
 	}
-	totalInaccessible, err := s.getTotalInaccessibleTokens()
-	if err != nil {
-		utils.Logger().Warn().Err(err).Msg("unable to fetch inaccessible tokens")
-		w.WriteHeader(http.StatusInternalServerError)
-	}
-	if err := json.NewEncoder(w).Encode(circulatingSupply.Sub(totalInaccessible)); err != nil {
+	if err := json.NewEncoder(w).Encode(cs); err != nil {
 		utils.Logger().Warn().Msg("cannot JSON-encode circulating supply")
 		w.WriteHeader(http.StatusInternalServerError)
 	}
@@ -295,7 +264,7 @@ func (s *Service) GetTotalSupply(w http.ResponseWriter, r *http.Request) {
 		utils.Logger().Warn().Err(err).Msg("unable to fetch total supply")
 		w.WriteHeader(http.StatusInternalServerError)
 	}
-	totalInaccessible, err := s.getTotalInaccessibleTokens()
+	totalInaccessible, err := chain.GetInaccessibleTokens(s.blockchain)
 	if err != nil {
 		utils.Logger().Warn().Err(err).Msg("unable to fetch inaccessible tokens")
 		w.WriteHeader(http.StatusInternalServerError)

--- a/api/service/explorer/service.go
+++ b/api/service/explorer/service.go
@@ -208,28 +208,10 @@ type InaccessibleAddressInfo struct {
 	Nonce      uint64            `json:"nonce"`
 }
 
-// getAllInaccessibleAddresses information according to InaccessibleAddresses
-func (s *Service) getAllInaccessibleAddresses() ([]*InaccessibleAddressInfo, error) {
-	ais, err := chain.GetInaccessibleAddressInfo(s.blockchain)
-	if err != nil {
-		return nil, err
-	}
-	accs := make([]*InaccessibleAddressInfo, 0, len(ais))
-	for _, ai := range ais {
-		accs = append(accs, &InaccessibleAddressInfo{
-			EthAddress: ai.EthAddress,
-			Address:    ai.Address,
-			Balance:    ai.Balance,
-			Nonce:      ai.Nonce,
-		})
-	}
-	return accs, nil
-}
-
 // GetInaccessibleAddressInfo serves /burn-addresses end-point.
 func (s *Service) GetInaccessibleAddressInfo(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	accInfos, err := s.getAllInaccessibleAddresses()
+	accInfos, err := chain.GetInaccessibleTokens(s.blockchain)
 	if err != nil {
 		utils.Logger().Warn().Err(err).Msg("unable to fetch inaccessible addresses")
 		w.WriteHeader(http.StatusInternalServerError)

--- a/api/service/explorer/service.go
+++ b/api/service/explorer/service.go
@@ -211,10 +211,19 @@ type InaccessibleAddressInfo struct {
 // GetInaccessibleAddressInfo serves /burn-addresses end-point.
 func (s *Service) GetInaccessibleAddressInfo(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	accInfos, err := chain.GetInaccessibleTokens(s.blockchain)
+	accInfos, err := chain.GetInaccessibleAddressInfo(s.blockchain)
 	if err != nil {
 		utils.Logger().Warn().Err(err).Msg("unable to fetch inaccessible addresses")
 		w.WriteHeader(http.StatusInternalServerError)
+	}
+	display := make([]*InaccessibleAddressInfo, 0, len(accInfos))
+	for _, acc := range accInfos {
+		display = append(display, &InaccessibleAddressInfo{
+			EthAddress: acc.EthAddress,
+			Address:    acc.Address,
+			Balance:    acc.Balance,
+			Nonce:      acc.Nonce,
+		})
 	}
 	if err := json.NewEncoder(w).Encode(accInfos); err != nil {
 		utils.Logger().Warn().Msg("cannot JSON-encode inaccessible account info")

--- a/internal/chain/supply.go
+++ b/internal/chain/supply.go
@@ -104,7 +104,7 @@ func getAllInaccessibleTokens(chain engine.ChainReader) (numeric.Dec, error) {
 }
 
 func getAllInaccessibleAddresses(chain engine.ChainReader) ([]*InaccessibleAddressInfo, error) {
-	state, err := chain.StateAt(chain.CurrentHeader().Hash())
+	state, err := chain.StateAt(chain.CurrentHeader().Root())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/chain/supply.go
+++ b/internal/chain/supply.go
@@ -1,29 +1,75 @@
 package chain
 
 import (
-	"context"
 	"math/big"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/consensus/engine"
 	"github.com/harmony-one/harmony/consensus/reward"
+	common2 "github.com/harmony-one/harmony/internal/common"
 	"github.com/harmony-one/harmony/numeric"
 	"github.com/harmony-one/harmony/shard"
 	stakingReward "github.com/harmony-one/harmony/staking/reward"
+	"github.com/pkg/errors"
 )
 
-// GetCirculatingSupply using the following formula:
+// Circulating supply calculation
+var (
+	// InaccessibleAddresses are a list of known eth addresses that cannot spend ONE tokens.
+	InaccessibleAddresses = []common.Address{
+		// one10000000000000000000000000000dead5shlag
+		common.HexToAddress("0x7bDeF7Bdef7BDeF7BDEf7bDef7bdef7bdeF6E7AD"),
+	}
+)
+
+// InaccessibleAddressInfo is the structure for inaccessible addresses
+type InaccessibleAddressInfo struct {
+	EthAddress common.Address
+	Address    string // One address
+	Balance    numeric.Dec
+	Nonce      uint64
+}
+
+// GetCirculatingSupply get the circulating supply.
+// The value is the total circulating supply sub the tokens burnt at
+// inaccessible addresses.
+// WARNING: only works on beacon chain if in staking era.
+func GetCirculatingSupply(chain engine.ChainReader) (numeric.Dec, error) {
+	total, err := getTotalCirculatingSupply(chain)
+	if err != nil {
+		return numeric.Dec{}, err
+	}
+	invalid, err := getAllInaccessibleTokens(chain)
+	if err != nil {
+		return numeric.Dec{}, err
+	}
+	if total.LT(invalid) {
+		return numeric.Dec{}, errors.New("FATAL: negative circulating supply")
+	}
+	return total.Sub(invalid), nil
+}
+
+// GetInaccessibleAddressInfo return the information of all inaccessible
+// addresses.
+func GetInaccessibleAddressInfo(chain engine.ChainReader) ([]*InaccessibleAddressInfo, error) {
+	return getAllInaccessibleAddresses(chain)
+}
+
+// GetInaccessibleTokens get the total inaccessible tokens.
+// The amount is the sum of balance at all inaccessible addresses.
+func GetInaccessibleTokens(chain engine.ChainReader) (numeric.Dec, error) {
+	return getAllInaccessibleTokens(chain)
+}
+
+// getTotalCirculatingSupply using the following formula:
 // (TotalInitialTokens * percentReleased) + PreStakingBlockRewards + StakingBlockRewards
 //
 // Note that PreStakingBlockRewards is set to the amount of rewards given out by the
 // LAST BLOCK of the pre-staking era regardless of what the current block height is
 // if network is in the pre-staking era. This is for implementation reasons, reference
 // stakingReward.GetTotalPreStakingTokens for more details.
-//
-// WARNING: only works on beaconchain if in staking era.
-func GetCirculatingSupply(
-	ctx context.Context, chain engine.ChainReader,
-) (ret numeric.Dec, err error) {
+func getTotalCirculatingSupply(chain engine.ChainReader) (ret numeric.Dec, err error) {
 	currHeader, timestamp := chain.CurrentHeader(), time.Now().Unix()
 	stakingBlockRewards := big.NewInt(0)
 
@@ -43,4 +89,37 @@ func GetCirculatingSupply(
 	return releasedInitSupply.Add(preStakingBlockRewards).Add(
 		numeric.NewDecFromBigIntWithPrec(stakingBlockRewards, 18),
 	), nil
+}
+
+func getAllInaccessibleTokens(chain engine.ChainReader) (numeric.Dec, error) {
+	ais, err := getAllInaccessibleAddresses(chain)
+	if err != nil {
+		return numeric.Dec{}, err
+	}
+	total := numeric.NewDecFromBigIntWithPrec(big.NewInt(0), numeric.Precision)
+	for _, ai := range ais {
+		total = total.Add(ai.Balance)
+	}
+	return total, nil
+}
+
+func getAllInaccessibleAddresses(chain engine.ChainReader) ([]*InaccessibleAddressInfo, error) {
+	state, err := chain.StateAt(chain.CurrentHeader().Hash())
+	if err != nil {
+		return nil, err
+	}
+
+	accs := make([]*InaccessibleAddressInfo, 0, len(InaccessibleAddresses))
+	for _, addr := range InaccessibleAddresses {
+		nonce := state.GetNonce(addr)
+		oneAddr, _ := common2.AddressToBech32(addr)
+		balance := state.GetBalance(addr)
+		accs = append(accs, &InaccessibleAddressInfo{
+			EthAddress: addr,
+			Address:    oneAddr,
+			Balance:    numeric.NewDecFromBigIntWithPrec(balance, numeric.Precision),
+			Nonce:      nonce,
+		})
+	}
+	return accs, nil
 }

--- a/rpc/blockchain.go
+++ b/rpc/blockchain.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/harmony-one/harmony/internal/chain"
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -15,7 +17,6 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/harmony-one/harmony/hmy"
-	"github.com/harmony-one/harmony/internal/chain"
 	internal_common "github.com/harmony-one/harmony/internal/common"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
@@ -767,7 +768,7 @@ func (s *PublicBlockchainService) GetTotalSupply(
 func (s *PublicBlockchainService) GetCirculatingSupply(
 	ctx context.Context,
 ) (numeric.Dec, error) {
-	return chain.GetCirculatingSupply(ctx, s.hmy.BlockChain)
+	return chain.GetCirculatingSupply(s.hmy.BlockChain)
 }
 
 // GetStakingNetworkInfo ..


### PR DESCRIPTION
## Issue

Fixing https://github.com/harmony-one/harmony/issues/3800.

Sub the inaccessible tokens when calculating chain supply at RPC endpoints

## Test

Tested on localnode on mainnet. Result:

```
> curl localhost:5000/circulating-supply;
"10208016410.793122399090366864"

> curl -ls --request POST 'http://localhost:9500' --header 'Content-Type: application/json' --data-raw '{
>     "jsonrpc": "2.0",
>     "id": 1,
>     "method": "hmy_getCirculatingSupply",
>     "params": []
> }';
{"jsonrpc":"2.0","id":1,"result":"10208016410.793122399090366864"}

> curl localhost:5000/total-supply
"13078958823.793138999090362468"

> curl localhost:5000/burn-addresses
[{"EthAddress":"0x7bdef7bdef7bdef7bdef7bdef7bdef7bdef6e7ad","Address":"one10000000000000000000000000000dead5shlag","Balance":"319237512.206861000000000000","Nonce":0}]
```

