### PR TITLE
[DO NOT MERGE][pprof] added mutex pprof

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -248,6 +248,8 @@ func setupNodeLog(config harmonyconfig.HarmonyConfig) {
 func setupPprof(config harmonyconfig.HarmonyConfig) {
 	enabled := config.Pprof.Enabled
 	addr := config.Pprof.ListenAddr
+	// Set mutex matrix. This might have an impact on the performance.
+	runtime.SetMutexProfileFraction(2)
 
 	if enabled {
 		go func() {


### PR DESCRIPTION
## Issue

Add the mutex runtime parameter change to enable pprof on mutex. This is the temporary fix to help explorer the archival node out of sync issue.

This PR shall not be merged to main branch since the impact of the parameter is unknown.

