### PR TITLE
[DO NOT MERGE] [p2p] Reduce memory and CPU usage of libp2p

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/libp2p/go-libp2p-core v0.8.5
 	github.com/libp2p/go-libp2p-crypto v0.1.0
 	github.com/libp2p/go-libp2p-discovery v0.5.0
-	github.com/libp2p/go-libp2p-kad-dht v0.12.1
+	github.com/libp2p/go-libp2p-kad-dht v0.12.2
 	github.com/libp2p/go-libp2p-pubsub v0.4.1
 	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/multiformats/go-multiaddr-dns v0.3.1

--- a/p2p/discovery/option.go
+++ b/p2p/discovery/option.go
@@ -33,6 +33,7 @@ func (opt DHTConfig) getLibp2pRawOptions() ([]libp2p_dht.Option, error) {
 		opts = append(opts, dsOption)
 	}
 
+	opts = append(opts, libp2p_dht.Concurrency(1))
 	return opts, nil
 }
 

--- a/p2p/discovery/option_test.go
+++ b/p2p/discovery/option_test.go
@@ -40,14 +40,14 @@ func TestDHTOption_getLibp2pRawOptions(t *testing.T) {
 			opt: DHTConfig{
 				BootNodes: testAddrStr,
 			},
-			expLen: 1,
+			expLen: 2,
 		},
 		{
 			opt: DHTConfig{
 				BootNodes:     testAddrStr,
 				DataStoreFile: &validPath,
 			},
-			expLen: 2,
+			expLen: 3,
 		},
 		{
 			opt: DHTConfig{


### PR DESCRIPTION
## Issue

- https://github.com/harmony-one/harmony-ops-priv/issues/36
- https://github.com/harmony-one/harmony/issues/3709

According to the test and verification in issue https://github.com/harmony-one/harmony-ops-priv/issues/36, the OOM is indeed caused by the Discovery function of libp2p's pubsub, but this feature cannot be simply disable. Otherwise, it will cause missing feature. After reading the code implementation of libp2p's kad-dht(https://github.com/libp2p/go-libp2p-kad-dht/blob/7cf0c1e05fe3a69cba5d3747358a25b937fcad89/query.go#L282-L300   https://github.com/libp2p/go-libp2p-kad-dht/blob/7cf0c1e05fe3a69cba5d3747358a25b937fcad89/query.go#L344-L349), I found that some Option parameters can reduce the frequency of queryPeer calls and reduce the calls related to `go-yamux's Stream` function. After testing, the memory is currently performing very well.

### Why upgrade kad DHT? 

cause 0.12.2 reduced CPU usage by the FullRT DHT client during bulk providing https://github.com/libp2p/go-libp2p-kad-dht/pull/720 maybe this fix can solve hold high CPU usage for stream protocol made by @JackyWYX  ?

## Test

the node 105.44 Test Without Discovery,  running it for a few days, the memory behaved very well:

![](https://user-images.githubusercontent.com/8574915/123597574-148bdf80-d826-11eb-9f7e-dda971921d77.png)

the node 105.44 Test With concurrency is 1 and upgrade kad-dht, running for 7 hours the memory is smooth:

![图片](https://user-images.githubusercontent.com/8574915/124098930-97fc3980-da8f-11eb-8b8b-7fbd123df870.png)
