### PR TITLE
[core] Increase caching at HeaderChain

### DIFF
--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	headerCacheLimit    = 2048
+	headerCacheLimit    = 2048 // with 2s/block, 2048 headers is roughly block produced in 1 hour.
 	tdCacheLimit        = 1024
 	numberCacheLimit    = 4096
 	canonicalCacheLimit = 4096

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -78,7 +78,7 @@ func NewHeaderChain(chainDb ethdb.Database, config *params.ChainConfig, engine c
 	headerCache, _ := lru.New(headerCacheLimit)
 	tdCache, _ := lru.New(tdCacheLimit)
 	numberCache, _ := lru.New(numberCacheLimit)
-	indexCache, _ := lru.New(canonicalCacheLimit)
+	canonicalHash, _ := lru.New(canonicalCacheLimit)
 
 	// Seed a fast but crypto originating random generator
 	seed, err := crand.Int(crand.Reader, big.NewInt(math.MaxInt64))
@@ -92,7 +92,7 @@ func NewHeaderChain(chainDb ethdb.Database, config *params.ChainConfig, engine c
 		headerCache:    headerCache,
 		tdCache:        tdCache,
 		numberCache:    numberCache,
-		canonicalCache: indexCache,
+		canonicalCache: canonicalHash,
 		procInterrupt:  procInterrupt,
 		rand:           mrand.New(mrand.NewSource(seed.Int64())),
 		engine:         engine,


### PR DESCRIPTION
## Issue

According Pprof results, RPC `GetLogs` in calling `HeaderChain.GetHeaderByNumber` is causing intense CPU usage. Thus added a log to help query the canonical block number and increase the cache params in HeaderChain.

## Test

Passed local RPC tests. 