### PR TITLE
[core] fix cache introduced by getHashByNumber

### DIFF
--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -454,7 +454,9 @@ func (hc *HeaderChain) getHashByNumber(number uint64) common.Hash {
 		return hash.(common.Hash)
 	}
 	hash := rawdb.ReadCanonicalHash(hc.chainDb, number)
-	hc.canonicalCache.Add(number, hash)
+	if hash != (common.Hash{}) {
+		hc.canonicalCache.Add(number, hash)
+	}
 	return hash
 }
 


### PR DESCRIPTION
## Issue

Fix an error introduced at https://github.com/harmony-one/harmony/pull/3813.

## Test

Tested locally