### PR TITLE
[metrics] Add metrics for RPCs

### DIFF
--- a/rpc/filters/api.go
+++ b/rpc/filters/api.go
@@ -361,6 +361,9 @@ func (api *PublicFilterAPI) NewFilter(crit FilterCriteria) (rpc.ID, error) {
 //
 // https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getlogs
 func (api *PublicFilterAPI) GetLogs(ctx context.Context, crit FilterCriteria) ([]*types.Log, error) {
+	timer := hmy_rpc.DoMetricRPCRequest(hmy_rpc.GetLogs)
+	defer timer.ObserveDuration()
+
 	var filter *Filter
 	if crit.BlockHash != nil {
 		// Block filter requested, construct a single-shot filter
@@ -381,6 +384,7 @@ func (api *PublicFilterAPI) GetLogs(ctx context.Context, crit FilterCriteria) ([
 	// Run the filter and return all the logs
 	logs, err := filter.Logs(ctx)
 	if err != nil {
+		hmy_rpc.DoMetricRPCQueryInfo(hmy_rpc.GetLogs, hmy_rpc.FailedNumber)
 		return nil, err
 	}
 	return returnLogs(logs), err
@@ -390,6 +394,9 @@ func (api *PublicFilterAPI) GetLogs(ctx context.Context, crit FilterCriteria) ([
 //
 // https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_uninstallfilter
 func (api *PublicFilterAPI) UninstallFilter(id rpc.ID) bool {
+	timer := hmy_rpc.DoMetricRPCRequest(hmy_rpc.UninstallFilter)
+	defer timer.ObserveDuration()
+
 	api.filtersMu.Lock()
 	f, found := api.filters[id]
 	if found {
@@ -408,6 +415,9 @@ func (api *PublicFilterAPI) UninstallFilter(id rpc.ID) bool {
 //
 // https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getfilterlogs
 func (api *PublicFilterAPI) GetFilterLogs(ctx context.Context, id rpc.ID) ([]*types.Log, error) {
+	timer := hmy_rpc.DoMetricRPCRequest(hmy_rpc.GetFilterLogs)
+	defer timer.ObserveDuration()
+
 	api.filtersMu.Lock()
 	f, found := api.filters[id]
 	api.filtersMu.Unlock()
@@ -436,6 +446,7 @@ func (api *PublicFilterAPI) GetFilterLogs(ctx context.Context, id rpc.ID) ([]*ty
 	// Run the filter and return all the logs
 	logs, err := filter.Logs(ctx)
 	if err != nil {
+		hmy_rpc.DoMetricRPCQueryInfo(hmy_rpc.GetFilterLogs, hmy_rpc.FailedNumber)
 		return nil, err
 	}
 	return returnLogs(logs), nil

--- a/rpc/metrics.go
+++ b/rpc/metrics.go
@@ -5,9 +5,83 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// rpc name const
+const (
+	// blockchain
+	GetBlockByNumberNew      = "GetBlockByNumberNew"
+	GetBlockByNumber         = "GetBlockByNumber"
+	GetBlockByHashNew        = "GetBlockByHashNew"
+	GetBlockByHash           = "GetBlockByHash"
+	GetBlocks                = "GetBlocks"
+	GetShardingStructure     = "GetShardingStructure"
+	GetBalanceByBlockNumber  = "GetBalanceByBlockNumber"
+	LatestHeader             = "LatestHeader"
+	GetLatestChainHeaders    = "GetLatestChainHeaders"
+	GetLastCrossLinks        = "GetLastCrossLinks"
+	GetHeaderByNumber        = "GetHeaderByNumber"
+	GetCurrentUtilityMetrics = "GetCurrentUtilityMetrics"
+	GetSuperCommittees       = "GetSuperCommittees"
+	GetCurrentBadBlocks      = "GetCurrentBadBlocks"
+	GetStakingNetworkInfo    = "GetStakingNetworkInfo"
+
+	// contract
+	GetCode      = "GetCode"
+	GetStorageAt = "GetStorageAt"
+	DoEvmCall    = "DoEVMCall"
+
+	// net
+	PeerCount = "PeerCount"
+
+	// pool
+	SendRawTransaction             = "SendRawTransaction"
+	SendRawStakingTransaction      = "SendRawStakingTransaction"
+	GetPoolStats                   = "GetPoolStats"
+	PendingTransactions            = "PendingTransactions"
+	PendingStakingTransactions     = "PendingStakingTransactions"
+	GetCurrentTransactionErrorSink = "GetCurrentTransactionErrorSink"
+	GetCurrentStakingErrorSink     = "GetCurrentStakingErrorSink"
+	GetPendingCXReceipts           = "GetPendingCXReceipts"
+
+	// staking
+	GetAllValidatorInformation              = "GetAllValidatorInformation"
+	GetAllValidatorInformationByBlockNumber = "GetAllValidatorInformationByBlockNumber"
+	GetValidatorInformation                 = "GetValidatorInformation"
+	GetValidatorInformationByBlockNumber    = "GetValidatorInformationByBlockNumber"
+	GetAllDelegationInformation             = "GetAllDelegationInformation"
+	GetDelegationsByDelegator               = "GetDelegationsByDelegator"
+	GetDelegationsByValidator               = "GetDelegationsByValidator"
+	GetDelegationByDelegatorAndValidator    = "GetDelegationByDelegatorAndValidator"
+
+	// tracer
+	TraceBlockByNumber = "TraceBlockByNumber"
+	TraceBlockByHash   = "TraceBlockByHash"
+	TraceBlock         = "TraceBlock"
+	TraceTransaction   = "TraceTransaction"
+	TraceCall          = "TraceCall"
+
+	// transaction
+	GetTransactionByHash          = "GetTransactionByHash"
+	GetStakingTransactionByHash   = "GetStakingTransactionByHash"
+	GetTransactionsHistory        = "GetTransactionsHistory"
+	GetStakingTransactionsHistory = "GetStakingTransactionsHistory"
+
+	// filters
+	GetLogs         = "GetLogs"
+	UninstallFilter = "UninstallFilter"
+	GetFilterLogs   = "GetFilterLogs"
+)
+
+// info type const
+const (
+	QueryNumber  = "query_number"
+	FailedNumber = "failed_number"
+)
+
 func init() {
 	prom.PromRegistry().MustRegister(
 		rpcRateLimitCounterVec,
+		rpcQueryInfoCounterVec,
+		rpcRequestDurationVec,
 	)
 }
 
@@ -19,5 +93,53 @@ var (
 			Name:      "over_ratelimit",
 			Help:      "number of times triggered rpc rate limit",
 		},
-		[]string{"rate_limit"})
+		[]string{"rate_limit"},
+	)
+
+	rpcQueryInfoCounterVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "hmy",
+			Subsystem: "rpc",
+			Name:      "query_info",
+			Help:      "different types of RPC query information",
+		},
+		[]string{"rpc_name", "info_type"},
+	)
+
+	rpcRequestDurationVec = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "hmy",
+			Subsystem: "rpc",
+			Name:      "rpc_request_delay",
+			Help:      "delay in seconds to do rpc requests",
+			// buckets: 20ms, 40ms, 80ms, 160ms, 320ms, 640ms, 1280ms, +INF
+			Buckets: prometheus.ExponentialBuckets(0.02, 2, 8),
+		},
+		[]string{"rpc_name"},
+	)
 )
+
+func DoMetricRPCRequest(rpcName string) *prometheus.Timer {
+	DoMetricRPCQueryInfo(rpcName, QueryNumber)
+	pLabel := getRPCDurationPromLabel(rpcName)
+	timer := prometheus.NewTimer(rpcRequestDurationVec.With(pLabel))
+	return timer
+}
+
+func DoMetricRPCQueryInfo(rpcName string, infoType string) {
+	pLabel := getRPCQueryInfoPromLabel(rpcName, infoType)
+	rpcQueryInfoCounterVec.With(pLabel).Inc()
+}
+
+func getRPCDurationPromLabel(rpcName string) prometheus.Labels {
+	return prometheus.Labels{
+		"rpc_name": rpcName,
+	}
+}
+
+func getRPCQueryInfoPromLabel(rpcName string, infoType string) prometheus.Labels {
+	return prometheus.Labels{
+		"rpc_name":  rpcName,
+		"info_type": infoType,
+	}
+}

--- a/rpc/net.go
+++ b/rpc/net.go
@@ -45,6 +45,8 @@ func NewPublicNetAPI(net p2p.Host, chainID uint64, version Version) rpc.API {
 // PeerCount returns the number of connected peers
 // Note that the return type is an interface to account for the different versions
 func (s *PublicNetService) PeerCount(ctx context.Context) (interface{}, error) {
+	timer := DoMetricRPCRequest(PeerCount)
+	defer timer.ObserveDuration()
 	// Format response according to version
 	switch s.version {
 	case V1, Eth:

--- a/rpc/pool.go
+++ b/rpc/pool.go
@@ -44,6 +44,9 @@ func NewPublicPoolAPI(hmy *hmy.Harmony, version Version) rpc.API {
 func (s *PublicPoolService) SendRawTransaction(
 	ctx context.Context, encodedTx hexutil.Bytes,
 ) (common.Hash, error) {
+	timer := DoMetricRPCRequest(SendRawTransaction)
+	defer timer.ObserveDuration()
+
 	// DOS prevention
 	if len(encodedTx) >= types.MaxEncodedPoolTransactionSize {
 		err := errors.Wrapf(core.ErrOversizedData, "encoded tx size: %d", len(encodedTx))
@@ -128,6 +131,9 @@ func (s *PublicPoolService) verifyChainID(tx *types.Transaction) error {
 func (s *PublicPoolService) SendRawStakingTransaction(
 	ctx context.Context, encodedTx hexutil.Bytes,
 ) (common.Hash, error) {
+	timer := DoMetricRPCRequest(SendRawStakingTransaction)
+	defer timer.ObserveDuration()
+
 	// DOS prevention
 	if len(encodedTx) >= types.MaxEncodedPoolTransactionSize {
 		err := errors.Wrapf(core.ErrOversizedData, "encoded tx size: %d", len(encodedTx))
@@ -165,6 +171,9 @@ func (s *PublicPoolService) SendRawStakingTransaction(
 func (s *PublicPoolService) GetPoolStats(
 	ctx context.Context,
 ) (StructuredResponse, error) {
+	timer := DoMetricRPCRequest(GetPoolStats)
+	defer timer.ObserveDuration()
+
 	pendingCount, queuedCount := s.hmy.GetPoolStats()
 
 	// Response output is the same for all versions
@@ -178,9 +187,13 @@ func (s *PublicPoolService) GetPoolStats(
 func (s *PublicPoolService) PendingTransactions(
 	ctx context.Context,
 ) ([]StructuredResponse, error) {
+	timer := DoMetricRPCRequest(PendingTransactions)
+	defer timer.ObserveDuration()
+
 	// Fetch all pending transactions (stx & plain tx)
 	pending, err := s.hmy.GetPoolTransactions()
 	if err != nil {
+		DoMetricRPCQueryInfo(PendingTransactions, FailedNumber)
 		return nil, err
 	}
 
@@ -239,9 +252,13 @@ func (s *PublicPoolService) PendingTransactions(
 func (s *PublicPoolService) PendingStakingTransactions(
 	ctx context.Context,
 ) ([]StructuredResponse, error) {
+	timer := DoMetricRPCRequest(PendingStakingTransactions)
+	defer timer.ObserveDuration()
+
 	// Fetch all pending transactions (stx & plain tx)
 	pending, err := s.hmy.GetPoolTransactions()
 	if err != nil {
+		DoMetricRPCQueryInfo(PendingStakingTransactions, FailedNumber)
 		return nil, err
 	}
 
@@ -292,11 +309,15 @@ func (s *PublicPoolService) PendingStakingTransactions(
 func (s *PublicPoolService) GetCurrentTransactionErrorSink(
 	ctx context.Context,
 ) ([]StructuredResponse, error) {
+	timer := DoMetricRPCRequest(GetCurrentTransactionErrorSink)
+	defer timer.ObserveDuration()
+
 	// For each transaction error in the error sink, format the response (same format for all versions)
 	formattedErrors := []StructuredResponse{}
 	for _, txError := range s.hmy.GetCurrentTransactionErrorSink() {
 		formattedErr, err := NewStructuredResponse(txError)
 		if err != nil {
+			DoMetricRPCQueryInfo(GetCurrentTransactionErrorSink, FailedNumber)
 			return nil, err
 		}
 		formattedErrors = append(formattedErrors, formattedErr)
@@ -308,11 +329,15 @@ func (s *PublicPoolService) GetCurrentTransactionErrorSink(
 func (s *PublicPoolService) GetCurrentStakingErrorSink(
 	ctx context.Context,
 ) ([]StructuredResponse, error) {
+	timer := DoMetricRPCRequest(GetCurrentStakingErrorSink)
+	defer timer.ObserveDuration()
+
 	// For each staking tx error in the error sink, format the response (same format for all versions)
 	formattedErrors := []StructuredResponse{}
 	for _, txErr := range s.hmy.GetCurrentStakingErrorSink() {
 		formattedErr, err := NewStructuredResponse(txErr)
 		if err != nil {
+			DoMetricRPCQueryInfo(GetCurrentStakingErrorSink, FailedNumber)
 			return nil, err
 		}
 		formattedErrors = append(formattedErrors, formattedErr)
@@ -324,11 +349,15 @@ func (s *PublicPoolService) GetCurrentStakingErrorSink(
 func (s *PublicPoolService) GetPendingCXReceipts(
 	ctx context.Context,
 ) ([]StructuredResponse, error) {
+	timer := DoMetricRPCRequest(GetPendingCXReceipts)
+	defer timer.ObserveDuration()
+
 	// For each cx receipt, format the response (same format for all versions)
 	formattedReceipts := []StructuredResponse{}
 	for _, receipts := range s.hmy.GetPendingCXReceipts() {
 		formattedReceipt, err := NewStructuredResponse(receipts)
 		if err != nil {
+			DoMetricRPCQueryInfo(GetPendingCXReceipts, FailedNumber)
 			return nil, err
 		}
 		formattedReceipts = append(formattedReceipts, formattedReceipt)

--- a/rpc/staking.go
+++ b/rpc/staking.go
@@ -242,7 +242,11 @@ func (s *PublicStakingService) GetValidatorKeys(
 func (s *PublicStakingService) GetAllValidatorInformation(
 	ctx context.Context, page int,
 ) ([]StructuredResponse, error) {
+	timer := DoMetricRPCRequest(GetAllValidatorInformation)
+	defer timer.ObserveDuration()
+
 	if !isBeaconShard(s.hmy) {
+		DoMetricRPCQueryInfo(GetAllValidatorInformation, FailedNumber)
 		return nil, ErrNotBeaconShard
 	}
 
@@ -262,6 +266,7 @@ func (s *PublicStakingService) GetAllValidatorInformation(
 		},
 	)
 	if err != nil {
+		DoMetricRPCQueryInfo(GetAllValidatorInformation, FailedNumber)
 		return nil, err
 	}
 
@@ -274,13 +279,18 @@ func (s *PublicStakingService) GetAllValidatorInformation(
 func (s *PublicStakingService) GetAllValidatorInformationByBlockNumber(
 	ctx context.Context, page int, blockNumber BlockNumber,
 ) ([]StructuredResponse, error) {
+	timer := DoMetricRPCRequest(GetAllValidatorInformationByBlockNumber)
+	defer timer.ObserveDuration()
+
 	// Process number based on version
 	blockNum := blockNumber.EthBlockNumber()
 
 	if !isBeaconShard(s.hmy) {
+		DoMetricRPCQueryInfo(GetAllValidatorInformationByBlockNumber, FailedNumber)
 		return nil, ErrNotBeaconShard
 	}
 	if isBlockGreaterThanLatest(s.hmy, blockNum) {
+		DoMetricRPCQueryInfo(GetAllValidatorInformationByBlockNumber, FailedNumber)
 		return nil, ErrRequestedBlockTooHigh
 	}
 
@@ -292,23 +302,30 @@ func (s *PublicStakingService) GetAllValidatorInformationByBlockNumber(
 func (s *PublicStakingService) GetValidatorInformation(
 	ctx context.Context, address string,
 ) (StructuredResponse, error) {
+	timer := DoMetricRPCRequest(GetValidatorInformation)
+	defer timer.ObserveDuration()
+
 	if !isBeaconShard(s.hmy) {
+		DoMetricRPCQueryInfo(GetValidatorInformation, FailedNumber)
 		return nil, ErrNotBeaconShard
 	}
 
 	// Fetch latest block
 	blk, err := s.hmy.BlockByNumber(ctx, rpc.LatestBlockNumber)
 	if err != nil {
+		DoMetricRPCQueryInfo(GetValidatorInformation, FailedNumber)
 		return nil, errors.Wrapf(err, "could not retrieve the latest blk information")
 	}
 
 	// Fetch validator information
 	addr, err := internal_common.ParseAddr(address)
 	if err != nil {
+		DoMetricRPCQueryInfo(GetValidatorInformation, FailedNumber)
 		return nil, err
 	}
 	validatorInfo, err := s.hmy.GetValidatorInformation(addr, blk)
 	if err != nil {
+		DoMetricRPCQueryInfo(GetValidatorInformation, FailedNumber)
 		return nil, err
 	}
 
@@ -320,28 +337,36 @@ func (s *PublicStakingService) GetValidatorInformation(
 func (s *PublicStakingService) GetValidatorInformationByBlockNumber(
 	ctx context.Context, address string, blockNumber BlockNumber,
 ) (StructuredResponse, error) {
+	timer := DoMetricRPCRequest(GetValidatorInformationByBlockNumber)
+	defer timer.ObserveDuration()
+
 	// Process number based on version
 	blockNum := blockNumber.EthBlockNumber()
 
 	// Fetch block
 	if !isBeaconShard(s.hmy) {
+		DoMetricRPCQueryInfo(GetValidatorInformationByBlockNumber, FailedNumber)
 		return nil, ErrNotBeaconShard
 	}
 	if isBlockGreaterThanLatest(s.hmy, blockNum) {
+		DoMetricRPCQueryInfo(GetValidatorInformationByBlockNumber, FailedNumber)
 		return nil, ErrRequestedBlockTooHigh
 	}
 	blk, err := s.hmy.BlockByNumber(ctx, blockNum)
 	if err != nil {
+		DoMetricRPCQueryInfo(GetValidatorInformationByBlockNumber, FailedNumber)
 		return nil, errors.Wrapf(err, "could not retrieve the blk information for blk number: %d", blockNum)
 	}
 
 	// Fetch validator info
 	addr, err := internal_common.ParseAddr(address)
 	if err != nil {
+		DoMetricRPCQueryInfo(GetValidatorInformationByBlockNumber, FailedNumber)
 		return nil, err
 	}
 	validatorInfo, err := s.hmy.GetValidatorInformation(addr, blk)
 	if err != nil {
+		DoMetricRPCQueryInfo(GetValidatorInformationByBlockNumber, FailedNumber)
 		return nil, err
 	}
 
@@ -414,7 +439,11 @@ func (s *PublicStakingService) GetValidatorTotalDelegation(
 func (s *PublicStakingService) GetAllDelegationInformation(
 	ctx context.Context, page int,
 ) ([][]StructuredResponse, error) {
+	timer := DoMetricRPCRequest(GetAllDelegationInformation)
+	defer timer.ObserveDuration()
+
 	if !isBeaconShard(s.hmy) {
+		DoMetricRPCQueryInfo(GetAllDelegationInformation, FailedNumber)
 		return nil, ErrNotBeaconShard
 	}
 	if page < -1 {
@@ -446,6 +475,7 @@ func (s *PublicStakingService) GetAllDelegationInformation(
 	for i := start; i < start+validatorsNum; i++ {
 		validators[i-start], err = s.GetDelegationsByValidator(ctx, addresses[i].String())
 		if err != nil {
+			DoMetricRPCQueryInfo(GetAllDelegationInformation, FailedNumber)
 			return nil, err
 		}
 	}
@@ -458,13 +488,18 @@ func (s *PublicStakingService) GetAllDelegationInformation(
 func (s *PublicStakingService) GetDelegationsByDelegator(
 	ctx context.Context, address string,
 ) ([]StructuredResponse, error) {
+	timer := DoMetricRPCRequest(GetDelegationsByDelegator)
+	defer timer.ObserveDuration()
+
 	if !isBeaconShard(s.hmy) {
+		DoMetricRPCQueryInfo(GetDelegationsByDelegator, FailedNumber)
 		return nil, ErrNotBeaconShard
 	}
 
 	// Fetch delegation
 	delegatorAddress, err := internal_common.ParseAddr(address)
 	if err != nil {
+		DoMetricRPCQueryInfo(GetDelegationsByDelegator, FailedNumber)
 		return nil, err
 	}
 	validators, delegations := s.hmy.GetDelegationsByDelegator(delegatorAddress)
@@ -493,6 +528,7 @@ func (s *PublicStakingService) GetDelegationsByDelegator(
 			Undelegations:    undelegations,
 		})
 		if err != nil {
+			DoMetricRPCQueryInfo(GetDelegationsByDelegator, FailedNumber)
 			return nil, err
 		}
 		result = append(result, del)
@@ -574,7 +610,11 @@ func (s *PublicStakingService) parseGetDelegationsByDelegatorResp(
 func (s *PublicStakingService) GetDelegationsByValidator(
 	ctx context.Context, address string,
 ) ([]StructuredResponse, error) {
+	timer := DoMetricRPCRequest(GetDelegationsByValidator)
+	defer timer.ObserveDuration()
+
 	if !isBeaconShard(s.hmy) {
+		DoMetricRPCQueryInfo(GetDelegationsByValidator, FailedNumber)
 		return nil, ErrNotBeaconShard
 	}
 
@@ -614,6 +654,7 @@ func (s *PublicStakingService) GetDelegationsByValidator(
 			Undelegations:    undelegations,
 		})
 		if err != nil {
+			DoMetricRPCQueryInfo(GetDelegationsByValidator, FailedNumber)
 			return nil, err
 		}
 		result = append(result, del)
@@ -625,17 +666,23 @@ func (s *PublicStakingService) GetDelegationsByValidator(
 func (s *PublicStakingService) GetDelegationByDelegatorAndValidator(
 	ctx context.Context, address string, validator string,
 ) (StructuredResponse, error) {
+	timer := DoMetricRPCRequest(GetDelegationByDelegatorAndValidator)
+	defer timer.ObserveDuration()
+
 	if !isBeaconShard(s.hmy) {
+		DoMetricRPCQueryInfo(GetDelegationByDelegatorAndValidator, FailedNumber)
 		return nil, ErrNotBeaconShard
 	}
 
 	// Fetch delegations
 	delegatorAddress, err := internal_common.ParseAddr(address)
 	if err != nil {
+		DoMetricRPCQueryInfo(GetDelegationByDelegatorAndValidator, FailedNumber)
 		return nil, err
 	}
 	validatorAddress, err := internal_common.ParseAddr(validator)
 	if err != nil {
+		DoMetricRPCQueryInfo(GetDelegationByDelegatorAndValidator, FailedNumber)
 		return nil, err
 	}
 	validators, delegations := s.hmy.GetDelegationsByDelegator(delegatorAddress)

--- a/rpc/tracer.go
+++ b/rpc/tracer.go
@@ -98,6 +98,9 @@ func (s *PublicTracerService) TraceChain(ctx context.Context, start, end rpc.Blo
 // TraceBlockByNumber returns the structured logs created during the execution of
 // EVM and returns them as a JSON object.
 func (s *PublicTracerService) TraceBlockByNumber(ctx context.Context, number rpc.BlockNumber, config *hmy.TraceConfig) ([]*hmy.TxTraceResult, error) {
+	timer := DoMetricRPCRequest(TraceBlockByNumber)
+	defer timer.ObserveDuration()
+
 	// Fetch the block that we want to trace
 	block := s.hmy.BlockChain.GetBlockByNumber(uint64(number))
 
@@ -107,8 +110,12 @@ func (s *PublicTracerService) TraceBlockByNumber(ctx context.Context, number rpc
 // TraceBlockByHash returns the structured logs created during the execution of
 // EVM and returns them as a JSON object.
 func (s *PublicTracerService) TraceBlockByHash(ctx context.Context, hash common.Hash, config *hmy.TraceConfig) ([]*hmy.TxTraceResult, error) {
+	timer := DoMetricRPCRequest(TraceBlockByHash)
+	defer timer.ObserveDuration()
+
 	block := s.hmy.BlockChain.GetBlockByHash(hash)
 	if block == nil {
+		DoMetricRPCQueryInfo(TraceBlockByHash, FailedNumber)
 		return nil, fmt.Errorf("block %#x not found", hash)
 	}
 	return s.hmy.TraceBlock(ctx, block, config)
@@ -117,8 +124,12 @@ func (s *PublicTracerService) TraceBlockByHash(ctx context.Context, hash common.
 // TraceBlock returns the structured logs created during the execution of EVM
 // and returns them as a JSON object.
 func (s *PublicTracerService) TraceBlock(ctx context.Context, blob []byte, config *hmy.TraceConfig) ([]*hmy.TxTraceResult, error) {
+	timer := DoMetricRPCRequest(TraceBlock)
+	defer timer.ObserveDuration()
+
 	block := new(types.Block)
 	if err := rlp.Decode(bytes.NewReader(blob), block); err != nil {
+		DoMetricRPCQueryInfo(TraceBlock, FailedNumber)
 		return nil, fmt.Errorf("could not decode block: %v", err)
 	}
 	return s.hmy.TraceBlock(ctx, block, config)
@@ -127,9 +138,13 @@ func (s *PublicTracerService) TraceBlock(ctx context.Context, blob []byte, confi
 // TraceTransaction returns the structured logs created during the execution of EVM
 // and returns them as a JSON object.
 func (s *PublicTracerService) TraceTransaction(ctx context.Context, hash common.Hash, config *hmy.TraceConfig) (interface{}, error) {
+	timer := DoMetricRPCRequest(TraceTransaction)
+	defer timer.ObserveDuration()
+
 	// Retrieve the transaction and assemble its EVM context
 	tx, blockHash, _, index := rawdb.ReadTransaction(s.hmy.ChainDb(), hash)
 	if tx == nil {
+		DoMetricRPCQueryInfo(TraceTransaction, FailedNumber)
 		return nil, fmt.Errorf("transaction %#x not found", hash)
 	}
 	reexec := defaultTraceReexec
@@ -139,10 +154,12 @@ func (s *PublicTracerService) TraceTransaction(ctx context.Context, hash common.
 	// Retrieve the block
 	block := s.hmy.BlockChain.GetBlockByHash(blockHash)
 	if block == nil {
+		DoMetricRPCQueryInfo(TraceTransaction, FailedNumber)
 		return nil, fmt.Errorf("block %#x not found", blockHash)
 	}
 	msg, vmctx, statedb, err := s.hmy.ComputeTxEnv(block, int(index), reexec)
 	if err != nil {
+		DoMetricRPCQueryInfo(TraceTransaction, FailedNumber)
 		return nil, err
 	}
 	// Trace the transaction and return
@@ -154,12 +171,16 @@ func (s *PublicTracerService) TraceTransaction(ctx context.Context, hash common.
 // You can provide -2 as a block number to trace on top of the pending block.
 // NOTE: Our version only supports block number as an input
 func (s *PublicTracerService) TraceCall(ctx context.Context, args CallArgs, blockNr rpc.BlockNumber, config *hmy.TraceConfig) (interface{}, error) {
+	timer := DoMetricRPCRequest(TraceCall)
+	defer timer.ObserveDuration()
+
 	// First try to retrieve the state
 	statedb, header, err := s.hmy.StateAndHeaderByNumber(ctx, blockNr)
 	if err != nil {
 		// Try to retrieve the specified block
 		block := s.hmy.BlockChain.GetBlockByNumber(uint64(blockNr))
 		if block == nil {
+			DoMetricRPCQueryInfo(TraceCall, FailedNumber)
 			return nil, fmt.Errorf("block %v not found: %v", blockNr, err)
 		}
 		// try to recompute the state
@@ -169,6 +190,7 @@ func (s *PublicTracerService) TraceCall(ctx context.Context, args CallArgs, bloc
 		}
 		_, _, statedb, err = s.hmy.ComputeTxEnv(block, 0, reexec)
 		if err != nil {
+			DoMetricRPCQueryInfo(TraceCall, FailedNumber)
 			return nil, err
 		}
 	}


### PR DESCRIPTION
## Issue

Add metircs for RPCs, Need to make sure if RPC is  the culprit for OUT OF SYNC or not.

## Test

use ` curl  http://127.0.0.1:9900/metrics | grep ^hmy_rpc`: 

```txt
 % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
1hmy_rpc_over_ratelimit{rate_limit="1000"} 302
00 hmy_rpc_query_info{info_type="failed_number",rpc_name="GetBlockByNumber"} 1
 524hmy_rpc_query_info{info_type="query_number",rpc_name="GetBlockByNumber"} 3
7    hmy_rpc_query_info{info_type="query_number",rpc_name="GetShardingStructure"} 3
0  52hmy_rpc_rpc_request_delay_bucket{rpc_name="GetBlockByNumber",le="0.02"} 0
47hmy_rpc_rpc_request_delay_bucket{rpc_name="GetBlockByNumber",le="0.04"} 0
 hmy_rpc_rpc_request_delay_bucket{rpc_name="GetBlockByNumber",le="0.08"} 0
  hmy_rpc_rpc_request_delay_bucket{rpc_name="GetBlockByNumber",le="0.16"} 0
 0hmy_rpc_rpc_request_delay_bucket{rpc_name="GetBlockByNumber",le="0.32"} 0
    hmy_rpc_rpc_request_delay_bucket{rpc_name="GetBlockByNumber",le="0.64"} 0
 hmy_rpc_rpc_request_delay_bucket{rpc_name="GetBlockByNumber",le="1.28"} 0
0  hmy_rpc_rpc_request_delay_bucket{rpc_name="GetBlockByNumber",le="2.56"} 3
12hmy_rpc_rpc_request_delay_bucket{rpc_name="GetBlockByNumber",le="+Inf"} 3
81hmy_rpc_rpc_request_delay_sum{rpc_name="GetBlockByNumber"} 6.0036811
k hmy_rpc_rpc_request_delay_count{rpc_name="GetBlockByNumber"} 3
  hmy_rpc_rpc_request_delay_bucket{rpc_name="GetShardingStructure",le="0.02"} 3
  hmy_rpc_rpc_request_delay_bucket{rpc_name="GetShardingStructure",le="0.04"} 3
 hmy_rpc_rpc_request_delay_bucket{rpc_name="GetShardingStructure",le="0.08"} 3
0 hmy_rpc_rpc_request_delay_bucket{rpc_name="GetShardingStructure",le="0.16"} 3
--:--hmy_rpc_rpc_request_delay_bucket{rpc_name="GetShardingStructure",le="0.32"} 3
:-hmy_rpc_rpc_request_delay_bucket{rpc_name="GetShardingStructure",le="0.64"} 3
- hmy_rpc_rpc_request_delay_bucket{rpc_name="GetShardingStructure",le="1.28"} 3
--:--hmy_rpc_rpc_request_delay_bucket{rpc_name="GetShardingStructure",le="2.56"} 3
:-hmy_rpc_rpc_request_delay_bucket{rpc_name="GetShardingStructure",le="+Inf"} 3
- hmy_rpc_rpc_request_delay_sum{rpc_name="GetShardingStructure"} 0.0027276
--hmy_rpc_rpc_request_delay_count{rpc_name="GetShardingStructure"} 3

```