### PR TITLE
Add vrf and proof in header and block rpc

### DIFF
--- a/rpc/eth/types.go
+++ b/rpc/eth/types.go
@@ -29,6 +29,8 @@ type Block struct {
 	Size             hexutil.Uint64      `json:"size"`
 	GasLimit         hexutil.Uint64      `json:"gasLimit"`
 	GasUsed          hexutil.Uint64      `json:"gasUsed"`
+	VRF              common.Hash         `json:"vrf"`
+	VRFProof         hexutil.Bytes       `json:"vrfProof"`
 	Timestamp        hexutil.Uint64      `json:"timestamp"`
 	TransactionsRoot common.Hash         `json:"transactionsRoot"`
 	ReceiptsRoot     common.Hash         `json:"receiptsRoot"`
@@ -173,6 +175,13 @@ func NewBlock(b *types.Block, blockArgs *rpc_common.BlockArgs, leaderAddress str
 func newBlock(b *types.Block, leader common.Address) *Block {
 	head := b.Header()
 
+	vrfAndProof := head.Vrf()
+	vrf := common.Hash{}
+	vrfProof := []byte{}
+	if len(vrfAndProof) == 32+96 {
+		copy(vrf[:], vrfAndProof[:32])
+		vrfProof = vrfAndProof[32:]
+	}
 	return &Block{
 		Number:           (*hexutil.Big)(head.Number()),
 		Hash:             b.Hash(),
@@ -188,6 +197,8 @@ func newBlock(b *types.Block, leader common.Address) *Block {
 		Size:             hexutil.Uint64(b.Size()),
 		GasLimit:         hexutil.Uint64(head.GasLimit()),
 		GasUsed:          hexutil.Uint64(head.GasUsed()),
+		VRF:              vrf,
+		VRFProof:         vrfProof,
 		Timestamp:        hexutil.Uint64(head.Time().Uint64()),
 		TransactionsRoot: head.TxHash(),
 		ReceiptsRoot:     head.ReceiptHash(),

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -214,6 +214,8 @@ type HeaderInformation struct {
 	UnixTime         uint64            `json:"unixtime"`
 	LastCommitSig    string            `json:"lastCommitSig"`
 	LastCommitBitmap string            `json:"lastCommitBitmap"`
+	VRF              string            `json:"vrf"`
+	VRFProof         string            `json:"vrfProof"`
 	CrossLinks       *types.CrossLinks `json:"crossLinks,omitempty"`
 }
 
@@ -223,6 +225,13 @@ func NewHeaderInformation(header *block.Header, leader string) *HeaderInformatio
 		return nil
 	}
 
+	vrfAndProof := header.Vrf()
+	vrf := common.Hash{}
+	vrfProof := []byte{}
+	if len(vrfAndProof) == 32+96 {
+		copy(vrf[:], vrfAndProof[:32])
+		vrfProof = vrfAndProof[32:]
+	}
 	result := &HeaderInformation{
 		BlockHash:        header.Hash(),
 		BlockNumber:      header.Number().Uint64(),
@@ -233,6 +242,8 @@ func NewHeaderInformation(header *block.Header, leader string) *HeaderInformatio
 		UnixTime:         header.Time().Uint64(),
 		Timestamp:        time.Unix(header.Time().Int64(), 0).UTC().String(),
 		LastCommitBitmap: hex.EncodeToString(header.LastCommitBitmap()),
+		VRF:              hex.EncodeToString(vrf[:]),
+		VRFProof:         hex.EncodeToString(vrfProof),
 	}
 
 	sig := header.LastCommitSignature()

--- a/rpc/v1/types.go
+++ b/rpc/v1/types.go
@@ -33,6 +33,8 @@ type BlockWithTxHash struct {
 	Size             hexutil.Uint64 `json:"size"`
 	GasLimit         hexutil.Uint64 `json:"gasLimit"`
 	GasUsed          hexutil.Uint64 `json:"gasUsed"`
+	VRF              common.Hash    `json:"vrf"`
+	VRFProof         hexutil.Bytes  `json:"vrfProof"`
 	Timestamp        hexutil.Uint64 `json:"timestamp"`
 	TransactionsRoot common.Hash    `json:"transactionsRoot"`
 	ReceiptsRoot     common.Hash    `json:"receiptsRoot"`
@@ -61,6 +63,8 @@ type BlockWithFullTx struct {
 	Size             hexutil.Uint64        `json:"size"`
 	GasLimit         hexutil.Uint64        `json:"gasLimit"`
 	GasUsed          hexutil.Uint64        `json:"gasUsed"`
+	VRF              common.Hash           `json:"vrf"`
+	VRFProof         hexutil.Bytes         `json:"vrfProof"`
 	Timestamp        hexutil.Uint64        `json:"timestamp"`
 	TransactionsRoot common.Hash           `json:"transactionsRoot"`
 	ReceiptsRoot     common.Hash           `json:"receiptsRoot"`
@@ -588,6 +592,14 @@ func NewBlockWithTxHash(
 	}
 
 	head := b.Header()
+
+	vrfAndProof := head.Vrf()
+	vrf := common.Hash{}
+	vrfProof := []byte{}
+	if len(vrfAndProof) == 32+96 {
+		copy(vrf[:], vrfAndProof[:32])
+		vrfProof = vrfAndProof[32:]
+	}
 	blk := &BlockWithTxHash{
 		Number:           (*hexutil.Big)(head.Number()),
 		ViewID:           (*hexutil.Big)(head.ViewID()),
@@ -604,6 +616,8 @@ func NewBlockWithTxHash(
 		Size:             hexutil.Uint64(b.Size()),
 		GasLimit:         hexutil.Uint64(head.GasLimit()),
 		GasUsed:          hexutil.Uint64(head.GasUsed()),
+		VRF:              vrf,
+		VRFProof:         vrfProof,
 		Timestamp:        hexutil.Uint64(head.Time().Uint64()),
 		TransactionsRoot: head.TxHash(),
 		ReceiptsRoot:     head.ReceiptHash(),
@@ -639,6 +653,14 @@ func NewBlockWithFullTx(
 	}
 
 	head := b.Header()
+
+	vrfAndProof := head.Vrf()
+	vrf := common.Hash{}
+	vrfProof := []byte{}
+	if len(vrfAndProof) == 32+96 {
+		copy(vrf[:], vrfAndProof[:32])
+		vrfProof = vrfAndProof[32:]
+	}
 	blk := &BlockWithFullTx{
 		Number:           (*hexutil.Big)(head.Number()),
 		ViewID:           (*hexutil.Big)(head.ViewID()),
@@ -655,6 +677,8 @@ func NewBlockWithFullTx(
 		Size:             hexutil.Uint64(b.Size()),
 		GasLimit:         hexutil.Uint64(head.GasLimit()),
 		GasUsed:          hexutil.Uint64(head.GasUsed()),
+		VRF:              vrf,
+		VRFProof:         vrfProof,
 		Timestamp:        hexutil.Uint64(head.Time().Uint64()),
 		TransactionsRoot: head.TxHash(),
 		ReceiptsRoot:     head.ReceiptHash(),

--- a/rpc/v2/types.go
+++ b/rpc/v2/types.go
@@ -35,6 +35,8 @@ type BlockWithTxHash struct {
 	Size             uint64         `json:"size"`
 	GasLimit         uint64         `json:"gasLimit"`
 	GasUsed          uint64         `json:"gasUsed"`
+	VRF              common.Hash    `json:"vrf"`
+	VRFProof         hexutil.Bytes  `json:"vrfProof"`
 	Timestamp        *big.Int       `json:"timestamp"`
 	TransactionsRoot common.Hash    `json:"transactionsRoot"`
 	ReceiptsRoot     common.Hash    `json:"receiptsRoot"`
@@ -63,6 +65,8 @@ type BlockWithFullTx struct {
 	Size             uint64                `json:"size"`
 	GasLimit         uint64                `json:"gasLimit"`
 	GasUsed          uint64                `json:"gasUsed"`
+	VRF              common.Hash           `json:"vrf"`
+	VRFProof         hexutil.Bytes         `json:"vrfProof"`
 	Timestamp        *big.Int              `json:"timestamp"`
 	TransactionsRoot common.Hash           `json:"transactionsRoot"`
 	ReceiptsRoot     common.Hash           `json:"receiptsRoot"`
@@ -604,6 +608,14 @@ func NewBlockWithTxHash(
 	}
 
 	head := b.Header()
+
+	vrfAndProof := head.Vrf()
+	vrf := common.Hash{}
+	vrfProof := []byte{}
+	if len(vrfAndProof) == 32+96 {
+		copy(vrf[:], vrfAndProof[:32])
+		vrfProof = vrfAndProof[32:]
+	}
 	blk := &BlockWithTxHash{
 		Number:           head.Number(),
 		ViewID:           head.ViewID(),
@@ -620,6 +632,8 @@ func NewBlockWithTxHash(
 		Size:             uint64(b.Size()),
 		GasLimit:         head.GasLimit(),
 		GasUsed:          head.GasUsed(),
+		VRF:              vrf,
+		VRFProof:         vrfProof,
 		Timestamp:        head.Time(),
 		TransactionsRoot: head.TxHash(),
 		ReceiptsRoot:     head.ReceiptHash(),
@@ -655,6 +669,14 @@ func NewBlockWithFullTx(
 	}
 
 	head := b.Header()
+
+	vrfAndProof := head.Vrf()
+	vrf := common.Hash{}
+	vrfProof := []byte{}
+	if len(vrfAndProof) == 32+96 {
+		copy(vrf[:], vrfAndProof[:32])
+		vrfProof = vrfAndProof[32:]
+	}
 	blk := &BlockWithFullTx{
 		Number:           head.Number(),
 		ViewID:           head.ViewID(),
@@ -671,6 +693,8 @@ func NewBlockWithFullTx(
 		Size:             uint64(b.Size()),
 		GasLimit:         head.GasLimit(),
 		GasUsed:          head.GasUsed(),
+		VRF:              vrf,
+		VRFProof:         vrfProof,
 		Timestamp:        head.Time(),
 		TransactionsRoot: head.TxHash(),
 		ReceiptsRoot:     head.ReceiptHash(),


### PR DESCRIPTION
Add VRF and VRFProof field in block and header rpc.

Test result:

```
"result": {
        "difficulty": 0,
        "epoch": "0x0",
        "extraData": "0x",
        "gasLimit": "0x4c4b400",
        "gasUsed": "0x0",
        "hash": "0xb911aa8dc72e82add0821b603410e9aede6f592222a72de0b435245c1f538e95",
        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
        "miner": "one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy",
        "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
        "nonce": 0,
        "number": "0x1",
        "parentHash": "0xd4323aad207d6b427e489e933777a7ef3a158d31655511422f313102aef4eaa0",
        "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
        "size": "0x31e",
        "stakingTransactions": [],
        "stateRoot": "0x0fd45a16d7b29584880824530746a3ef42864c9c42c3c8301e239584d3c8efb9",
        "timestamp": "0x60e88983",
        "transactions": [],
        "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
        "uncles": [],
        "viewID": "0x1",
        "vrf": "0xbeffd3285073e5cb4436b755c8c22f4f859ad28d87a9f0b8a12ce4b7770a4c21",
        "vrfProof": "0x69e406a61856e2024fb0048ff7c3921a49069553f0838713e77a97b43e505b1322b996ac55edfac7140d9328e63d94076197eba3cb3d5ff9bca01332016ad879f97794009a36c1d486149ebfd02bffef0758dd0a8f046f9afaf505853c63c607"
    }
```