### PR TITLE
[metrics] Change wrong metrics discription

### DIFF
--- a/p2p/stream/common/streammanager/metric.go
+++ b/p2p/stream/common/streammanager/metric.go
@@ -62,7 +62,7 @@ var (
 			Namespace: "hmy",
 			Subsystem: "stream",
 			Name:      "setup_stream_duration",
-			Help:      "duration in seconds of setting up connection to a discovered peer",
+			Help:      "duration in milliseconds of setting up connection to a discovered peer",
 			// buckets: 20ms, 40ms, 80ms, 160ms, 320ms, 640ms, 1280ms, +INF
 			Buckets: prometheus.ExponentialBuckets(0.02, 2, 8),
 		},

--- a/p2p/stream/protocols/sync/metric.go
+++ b/p2p/stream/protocols/sync/metric.go
@@ -40,7 +40,7 @@ var (
 			Namespace: "hmy",
 			Subsystem: "stream_sync",
 			Name:      "client_request_delay",
-			Help:      "delay in seconds to do sync requests as a client",
+			Help:      "delay in milliseconds to do sync requests as a client",
 			// buckets: 20ms, 40ms, 80ms, 160ms, 320ms, 640ms, 1280ms, +INF
 			Buckets: prometheus.ExponentialBuckets(0.02, 2, 8),
 		},

--- a/rpc/metrics.go
+++ b/rpc/metrics.go
@@ -111,7 +111,7 @@ var (
 			Namespace: "hmy",
 			Subsystem: "rpc",
 			Name:      "rpc_request_delay",
-			Help:      "delay in seconds to do rpc requests",
+			Help:      "delay in milliseconds to do rpc requests",
 			// buckets: 20ms, 40ms, 80ms, 160ms, 320ms, 640ms, 1280ms, +INF
 			Buckets: prometheus.ExponentialBuckets(0.02, 2, 8),
 		},


### PR DESCRIPTION
Just discussed with @sophoah , it must be milliseconds in metrics description. 

The changes here are related to the stream_sync metrics, which @JackyWYX  can also look at