### PR TITLE
[rpc]  Add New RPC GetReceiptsByBlockHash for quering all receipts of the block in bulk

### DIFF
--- a/rpc/v1/types.go
+++ b/rpc/v1/types.go
@@ -171,6 +171,12 @@ type UndelegateMsg struct {
 	Amount           *hexutil.Big `json:"amount"`
 }
 
+// BlockReceipts represents a block all receipts that will serialize to the RPC representation.
+type BlockReceipts struct {
+	TxReceipts        []*TxReceipt        `json:"txReceipts"`
+	StakingTxReceipts []*StakingTxReceipt `json:"stakingTxReceipts"`
+}
+
 // TxReceipt represents a transaction receipt that will serialize to the RPC representation.
 type TxReceipt struct {
 	BlockHash         common.Hash    `json:"blockHash"`
@@ -315,6 +321,40 @@ func NewReceipt(
 		return NewStakingTxReceipt(stakingTx, blockHash, blockNumber, blockIndex, receipt)
 	}
 	return nil, fmt.Errorf("unknown transaction type for RPC receipt")
+}
+
+// NewReceipts returns all receipts of the block that will serialize to the RPC representation
+func NewReceipts(txn []interface{}, blockHash common.Hash, blockNumber uint64, receipts types.Receipts) (interface{}, error) {
+
+	blockReceipts := &BlockReceipts{
+		TxReceipts:        []*TxReceipt{},
+		StakingTxReceipts: []*StakingTxReceipt{},
+	}
+
+	for index, receipt := range receipts {
+		plainTx, ok := txn[index].(*types.Transaction)
+		if ok {
+			tx, err := NewTxReceipt(plainTx, blockHash, blockNumber, uint64(index), receipt)
+			if err != nil {
+				return nil, err
+			}
+			blockReceipts.TxReceipts = append(blockReceipts.TxReceipts, tx)
+			continue
+		}
+		stakingTx, ok := txn[index].(*staking.StakingTransaction)
+		if ok {
+			stx, err := NewStakingTxReceipt(stakingTx, blockHash, blockNumber, uint64(index), receipt)
+			if err != nil {
+				return nil, err
+			}
+			blockReceipts.StakingTxReceipts = append(blockReceipts.StakingTxReceipts, stx)
+			continue
+		}
+
+		return nil, fmt.Errorf("unknown transaction type for RPC receipt")
+	}
+
+	return blockReceipts, nil
 }
 
 // NewTxReceipt returns a transaction receipt that will serialize to the RPC representation


### PR DESCRIPTION
## Issue

https://github.com/harmony-one/harmony/issues/3821

## Test


No test with @hypnagonia 

### Local Test

- [x] tested hmy
- [x] tested hmyv2
- [x] tested eth

Use RPC to comapre reponse data for same blockHash and TxHash is consistent:

`curl -d '{ "jsonrpc":"2.0", "method":"hmy_getBlockByHash", "params":[ "0x73852a261acd91e6ee0b72e4b39eb3ee42ec31cfb13a5b1b0fdb676e9dbc358c", true], "id":1 }' -H "Content-Type:application/json" -X POST http://127.0.0.1:9500`

response data:

[data.zip](https://github.com/harmony-one/harmony/files/6839998/data.zip)

`curl -d '{ "jsonrpc":"2.0", "method":"hmy_getReceiptsByBlockHash", "params":["0x73852a261acd91e6ee0b72e4b39eb3ee42ec31cfb13a5b1b0fdb676e9dbc358c"], "id":1 }' -H "Content-Type:application/json"
 -X POST http://127.0.0.1:9500`

reponse data:

[bb.zip](https://github.com/harmony-one/harmony/files/6840012/bb.zip)


`curl -d '{ "jsonrpc": "2.0", "method": "hmy_getTransactionReceipt", "params": [ "0xcd2634fdaaff70ab8c538e99b8cbf44ee56fd2073f54ceeeeeb9962b447691a8"], "id": 1}' -H "Content-Type:application/json" -X POST http: //127.0.0.1:9500`

reponse data:

[uu.zip](https://github.com/harmony-one/harmony/files/6840026/uu.zip)
