### PR TITLE
Add logic to do aggregated reward distribution once every 64 blocks

### DIFF
--- a/consensus/reward/rewarder.go
+++ b/consensus/reward/rewarder.go
@@ -6,12 +6,10 @@ import (
 	"github.com/harmony-one/harmony/crypto/bls"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/harmony-one/harmony/shard"
 )
 
 // Payout ..
 type Payout struct {
-	ShardID     uint32
 	Addr        common.Address
 	NewlyEarned *big.Int
 	EarningKey  bls.SerializedPublicKey
@@ -27,5 +25,4 @@ type CompletedRound struct {
 // Reader ..
 type Reader interface {
 	ReadRoundResult() *CompletedRound
-	MissingSigners() shard.SlotList
 }

--- a/consensus/reward/rewarder.go
+++ b/consensus/reward/rewarder.go
@@ -17,9 +17,8 @@ type Payout struct {
 
 // CompletedRound ..
 type CompletedRound struct {
-	Total            *big.Int
-	BeaconchainAward []Payout
-	ShardChainAward  []Payout
+	Total   *big.Int
+	Payouts []Payout
 }
 
 // Reader ..

--- a/internal/chain/reward.go
+++ b/internal/chain/reward.go
@@ -218,8 +218,10 @@ func AccumulateRewardsAndCountSigs(
 			if blockNum%RewardFrequency != RewardFrequency-1 {
 				return network.EmptyPayout, nil
 			}
-			return distributeRewardAfterAggregateEpoch(bc, state, header, beaconChain, defaultReward)
 		} else {
+			if blockNum%RewardFrequency == RewardFrequency-1 {
+				distributeRewardAfterAggregateEpoch(bc, state, header, beaconChain, defaultReward)
+			}
 			return distributeRewardBeforeAggregateEpoch(bc, state, header, beaconChain, defaultReward, sigsReady)
 		}
 	}

--- a/internal/chain/reward.go
+++ b/internal/chain/reward.go
@@ -218,10 +218,8 @@ func AccumulateRewardsAndCountSigs(
 			if blockNum%RewardFrequency != RewardFrequency-1 {
 				return network.EmptyPayout, nil
 			}
+			return distributeRewardAfterAggregateEpoch(bc, state, header, beaconChain, defaultReward)
 		} else {
-			if blockNum%RewardFrequency == RewardFrequency-1 {
-				distributeRewardAfterAggregateEpoch(bc, state, header, beaconChain, defaultReward)
-			}
 			return distributeRewardBeforeAggregateEpoch(bc, state, header, beaconChain, defaultReward, sigsReady)
 		}
 	}

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -42,6 +42,7 @@ var (
 		EthCompatibleEpoch:         big.NewInt(442), // Around Thursday Feb 4th 2020, 10AM PST
 		CrossTxEpoch:               big.NewInt(28),
 		CrossLinkEpoch:             big.NewInt(186),
+		AggregatedRewardEpoch:      EpochTBD,
 		StakingEpoch:               big.NewInt(186),
 		PreStakingEpoch:            big.NewInt(185),
 		QuickUnlockEpoch:           big.NewInt(191),
@@ -69,6 +70,7 @@ var (
 		EthCompatibleEpoch:         big.NewInt(73290),
 		CrossTxEpoch:               big.NewInt(0),
 		CrossLinkEpoch:             big.NewInt(2),
+		AggregatedRewardEpoch:      EpochTBD,
 		StakingEpoch:               big.NewInt(2),
 		PreStakingEpoch:            big.NewInt(1),
 		QuickUnlockEpoch:           big.NewInt(0),
@@ -97,6 +99,7 @@ var (
 		EthCompatibleEpoch:         big.NewInt(0),
 		CrossTxEpoch:               big.NewInt(0),
 		CrossLinkEpoch:             big.NewInt(2),
+		AggregatedRewardEpoch:      big.NewInt(3),
 		StakingEpoch:               big.NewInt(2),
 		PreStakingEpoch:            big.NewInt(1),
 		QuickUnlockEpoch:           big.NewInt(0),
@@ -125,6 +128,7 @@ var (
 		EthCompatibleEpoch:         big.NewInt(0),
 		CrossTxEpoch:               big.NewInt(0),
 		CrossLinkEpoch:             big.NewInt(2),
+		AggregatedRewardEpoch:      big.NewInt(3),
 		StakingEpoch:               big.NewInt(2),
 		PreStakingEpoch:            big.NewInt(1),
 		QuickUnlockEpoch:           big.NewInt(0),
@@ -153,6 +157,7 @@ var (
 		EthCompatibleEpoch:         big.NewInt(0),
 		CrossTxEpoch:               big.NewInt(0),
 		CrossLinkEpoch:             big.NewInt(2),
+		AggregatedRewardEpoch:      big.NewInt(3),
 		StakingEpoch:               big.NewInt(2),
 		PreStakingEpoch:            big.NewInt(1),
 		QuickUnlockEpoch:           big.NewInt(0),
@@ -180,6 +185,7 @@ var (
 		EthCompatibleEpoch:         big.NewInt(0),
 		CrossTxEpoch:               big.NewInt(0),
 		CrossLinkEpoch:             big.NewInt(2),
+		AggregatedRewardEpoch:      big.NewInt(3),
 		StakingEpoch:               big.NewInt(2),
 		PreStakingEpoch:            big.NewInt(0),
 		QuickUnlockEpoch:           big.NewInt(0),
@@ -209,6 +215,7 @@ var (
 		big.NewInt(0),                      // EthCompatibleEpoch
 		big.NewInt(0),                      // CrossTxEpoch
 		big.NewInt(0),                      // CrossLinkEpoch
+		big.NewInt(0),                      // AggregatedRewardEpoch
 		big.NewInt(0),                      // StakingEpoch
 		big.NewInt(0),                      // PreStakingEpoch
 		big.NewInt(0),                      // QuickUnlockEpoch
@@ -238,6 +245,7 @@ var (
 		big.NewInt(0),        // EthCompatibleEpoch
 		big.NewInt(0),        // CrossTxEpoch
 		big.NewInt(0),        // CrossLinkEpoch
+		big.NewInt(0),        // AggregatedRewardEpoch
 		big.NewInt(0),        // StakingEpoch
 		big.NewInt(0),        // PreStakingEpoch
 		big.NewInt(0),        // QuickUnlockEpoch
@@ -299,6 +307,9 @@ type ChainConfig struct {
 	// CrossLinkEpoch is the epoch where beaconchain starts containing
 	// cross-shard links.
 	CrossLinkEpoch *big.Int `json:"cross-link-epoch,omitempty"`
+
+	// AggregatedRewardEpoch is the epoch when block rewards are distributed every 64 blocks
+	AggregatedRewardEpoch *big.Int `json:"aggregated-reward-epoch,omitempty"`
 
 	// StakingEpoch is the epoch when shard assign takes staking into account
 	StakingEpoch *big.Int `json:"staking-epoch,omitempty"`
@@ -397,6 +408,11 @@ func (c *ChainConfig) HasCrossTxFields(epoch *big.Int) bool {
 // IsEthCompatible determines whether it is ethereum compatible epoch
 func (c *ChainConfig) IsEthCompatible(epoch *big.Int) bool {
 	return isForked(c.EthCompatibleEpoch, epoch)
+}
+
+// IsAggregatedRewardEpoch determines whether it is the epoch when rewards are distributed every 64 blocks
+func (c *ChainConfig) IsAggregatedRewardEpoch(epoch *big.Int) bool {
+	return isForked(c.AggregatedRewardEpoch, epoch)
 }
 
 // IsStaking determines whether it is staking epoch

--- a/internal/utils/singleton.go
+++ b/internal/utils/singleton.go
@@ -45,7 +45,7 @@ func SetLogContext(_port, _ip string) {
 
 // SetLogVerbosity specifies the verbosity of global logger
 func SetLogVerbosity(verbosity log.Lvl) {
-	logVerbosity = verbosity
+	logVerbosity = 4
 	if glogger != nil {
 		glogger.Verbosity(logVerbosity)
 	}

--- a/internal/utils/singleton.go
+++ b/internal/utils/singleton.go
@@ -45,11 +45,11 @@ func SetLogContext(_port, _ip string) {
 
 // SetLogVerbosity specifies the verbosity of global logger
 func SetLogVerbosity(verbosity log.Lvl) {
-	logVerbosity = 4
+	logVerbosity = verbosity
 	if glogger != nil {
 		glogger.Verbosity(logVerbosity)
 	}
-	updateZeroLogLevel(int(verbosity))
+	updateZeroLogLevel(int(logVerbosity))
 }
 
 // AddLogFile creates a StreamHandler that outputs JSON logs

--- a/internal/utils/singleton.go
+++ b/internal/utils/singleton.go
@@ -45,7 +45,7 @@ func SetLogContext(_port, _ip string) {
 
 // SetLogVerbosity specifies the verbosity of global logger
 func SetLogVerbosity(verbosity log.Lvl) {
-	logVerbosity = 4
+	logVerbosity = verbosity
 	if glogger != nil {
 		glogger.Verbosity(logVerbosity)
 	}

--- a/staking/network/reward.go
+++ b/staking/network/reward.go
@@ -61,13 +61,11 @@ func (p *preStakingEra) ReadRoundResult() *reward.CompletedRound {
 
 type stakingEra struct {
 	reward.CompletedRound
-	missingSigners shard.SlotList
 }
 
 // NewStakingEraRewardForRound ..
 func NewStakingEraRewardForRound(
 	totalPayout *big.Int,
-	mia shard.SlotList,
 	beaconP, shardP []reward.Payout,
 ) reward.Reader {
 	return &stakingEra{
@@ -76,13 +74,7 @@ func NewStakingEraRewardForRound(
 			BeaconchainAward: beaconP,
 			ShardChainAward:  shardP,
 		},
-		missingSigners: mia,
 	}
-}
-
-// MissingSigners ..
-func (r *stakingEra) MissingSigners() shard.SlotList {
-	return r.missingSigners
 }
 
 // ReadRoundResult ..

--- a/staking/network/reward.go
+++ b/staking/network/reward.go
@@ -35,9 +35,8 @@ type noReward struct{ ignoreMissing }
 
 func (noReward) ReadRoundResult() *reward.CompletedRound {
 	return &reward.CompletedRound{
-		Total:            big.NewInt(0),
-		BeaconchainAward: []reward.Payout{},
-		ShardChainAward:  []reward.Payout{},
+		Total:   big.NewInt(0),
+		Payouts: []reward.Payout{},
 	}
 }
 
@@ -53,9 +52,8 @@ func NewPreStakingEraRewarded(totalAmount *big.Int) reward.Reader {
 
 func (p *preStakingEra) ReadRoundResult() *reward.CompletedRound {
 	return &reward.CompletedRound{
-		Total:            p.payout,
-		BeaconchainAward: []reward.Payout{},
-		ShardChainAward:  []reward.Payout{},
+		Total:   p.payout,
+		Payouts: []reward.Payout{},
 	}
 }
 
@@ -66,13 +64,12 @@ type stakingEra struct {
 // NewStakingEraRewardForRound ..
 func NewStakingEraRewardForRound(
 	totalPayout *big.Int,
-	beaconP, shardP []reward.Payout,
+	payouts []reward.Payout,
 ) reward.Reader {
 	return &stakingEra{
 		CompletedRound: reward.CompletedRound{
-			Total:            totalPayout,
-			BeaconchainAward: beaconP,
-			ShardChainAward:  shardP,
+			Total:   totalPayout,
+			Payouts: payouts,
 		},
 	}
 }


### PR DESCRIPTION
Implement the logic to aggregate the block reward distribution so it only happens every 64 blocks. After the fork epoch, for every 64 blocks, the first 63 blocks won't execute any block reward or signature counting logic, and at the 64th block, it will go back and process all the crosslinks/signatures for the previous 64 blocks (including itself). This way shard 0 block time can be reduced by an amortized time of around 0.5s. 

The new logic keeps the accounting of validator reward the same as before. The part that's improving performance is the delegator reward distribution where previously, for each block, the reward is distributed to all delegators, which is a huge computation cost as there are tens of thousands of delegators. Right now, for every 64 blocks, the reward for each validators are tallied and then distributed to their delegators only once, saving lots of computation.

Previously, it takes around 0.5-0.6 second to do the block reward distribution for every shard 0 block. Now, it takes similar amount of time but it only happens on the 64th block.

The reason for choosing 64 blocks is that the computation time is not significantly higher than the current situation (~0.5s). Following are some data points:

Doing reward distribution for 64 blocks takes around 0.5 second.
Doing reward distribution for 256 blocks takes around 1.8 second (which slows down the block time for too much).

Note: The old block reward logic is intact but only refactored on the crosslink processing logic.

Tested locally and also on mainnet node to see the old logic is compatible with current chain and new logic execute correctly.
