### PR TITLE
[rpc] add limitation on GetBlocks and GetLogs. Also some other small changes

### DIFF
--- a/rpc/common/types.go
+++ b/rpc/common/types.go
@@ -13,9 +13,8 @@ import (
 // BlockArgs is struct to include optional block formatting params.
 type BlockArgs struct {
 	WithSigners bool     `json:"withSigners"`
-	InclTx      bool     `json:"inclTx"`
 	FullTx      bool     `json:"fullTx"`
-	Signers     []string `json:"signers"`
+	Signers     []string `json:"-"`
 	InclStaking bool     `json:"inclStaking"`
 }
 

--- a/rpc/filters/api.go
+++ b/rpc/filters/api.go
@@ -18,6 +18,10 @@ var (
 	deadline = 5 * time.Minute // consider a filter inactive if it has not been polled for within deadline
 )
 
+const (
+	rpcGetLogsLimit = 1024
+)
+
 // filter is a helper struct that holds meta information over the filter type
 // and associated subscription in the event system.
 type filter struct {
@@ -378,6 +382,10 @@ func (api *PublicFilterAPI) GetLogs(ctx context.Context, crit FilterCriteria) ([
 		if crit.ToBlock != nil {
 			end = crit.ToBlock.Int64()
 		}
+		if end >= begin && end-begin > rpcGetLogsLimit {
+			return nil, fmt.Errorf("GetLogs query must be smaller than size %v", rpcGetLogsLimit)
+		}
+
 		// Construct the range filter
 		filter = NewRangeFilter(api.backend, begin, end, crit.Addresses, crit.Topics, api.isEth())
 	}

--- a/rpc/filters/filter.go
+++ b/rpc/filters/filter.go
@@ -220,6 +220,11 @@ func (f *Filter) unindexedLogs(ctx context.Context, end uint64) ([]*types.Log, e
 	var logs []*types.Log
 
 	for ; f.begin <= int64(end); f.begin++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
 		header, err := f.backend.HeaderByNumber(ctx, rpc.BlockNumber(f.begin))
 		if header == nil || err != nil {
 			return logs, err

--- a/rpc/v2/types.go
+++ b/rpc/v2/types.go
@@ -704,7 +704,7 @@ func NewBlockWithFullTx(
 	}
 
 	for _, tx := range b.Transactions() {
-		fmtTx, err := NewTransactionFromBlockHash(b, tx.Hash())
+		fmtTx, err := NewTransactionFromHash(b, tx.Hash())
 		if err != nil {
 			return nil, err
 		}
@@ -727,8 +727,8 @@ func NewBlockWithFullTx(
 	return blk, nil
 }
 
-// NewTransactionFromBlockHash returns a transaction that will serialize to the RPC representation.
-func NewTransactionFromBlockHash(b *types.Block, hash common.Hash) (*Transaction, error) {
+// NewTransactionFromHash returns a transaction that will serialize to the RPC representation.
+func NewTransactionFromHash(b *types.Block, hash common.Hash) (*Transaction, error) {
 	for idx, tx := range b.Transactions() {
 		if tx.Hash() == hash {
 			return NewTransactionFromBlockIndex(b, uint64(idx))


### PR DESCRIPTION
## Issue

Add limitation to GetBlocks and GetLogs.

## Test

### Unit Test Coverage

Passed local tests.

Passed mainnet RPC tests.

```
curl -s --request POST 'http://localhost:9500/' --header 'Content-Type: application/json' --data-raw '{ "jsonrpc": "2.0", "method": "hmyv2_getBlocks", "params": [1, 1025, {"withSigners": false, "fullTx": false,"inclStaking": false}], "id": 1}'
> .... # Some data

curl -s --request POST 'http://localhost:9500/' --header 'Content-Type: application/json' --data-raw '{ "jsonrpc": "2.0", "method": "hmyv2_getBlocks", "params": [1, 1026, {"withSigners": false, "fullTx": false,"inclStaking": false}], "id": 1}'
{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"GetBlocks query must be smaller than size 1024"}}
```