### PR TITLE
Public blockchain API performance optimization

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -69,8 +69,8 @@ var (
 )
 
 const (
-	bodyCacheLimit                     = 256
-	blockCacheLimit                    = 256
+	bodyCacheLimit                     = 2048
+	blockCacheLimit                    = 2048
 	receiptsCacheLimit                 = 32
 	maxFutureBlocks                    = 256
 	maxTimeFutureBlocks                = 30

--- a/rpc/common/block.go
+++ b/rpc/common/block.go
@@ -1,0 +1,19 @@
+package common
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/harmony-one/harmony/core/types"
+)
+
+// BlockFactory is the interface of factory for RPC block data
+type BlockFactory interface {
+	NewBlock(b *types.Block, args *BlockArgs) (interface{}, error)
+}
+
+// BlockDataProvider helps with providing data for RPC blocks
+type BlockDataProvider interface {
+	GetLeader(b *types.Block) string
+	GetSigners(b *types.Block) ([]string, error)
+	GetStakingTxs(b *types.Block) (interface{}, error)
+	GetStakingTxHashes(b *types.Block) []common.Hash
+}

--- a/rpc/eth/block.go
+++ b/rpc/eth/block.go
@@ -1,0 +1,71 @@
+package eth
+
+import (
+	"github.com/harmony-one/harmony/core/types"
+	internal_common "github.com/harmony-one/harmony/internal/common"
+	rpc_common "github.com/harmony-one/harmony/rpc/common"
+	"github.com/pkg/errors"
+)
+
+// BlockFactory is the factory for v1 rpc block
+type BlockFactory struct {
+	provider rpc_common.BlockDataProvider
+}
+
+// NewBlockFactory return the block factory with the given provider
+func NewBlockFactory(provider rpc_common.BlockDataProvider) *BlockFactory {
+	return &BlockFactory{provider}
+}
+
+// NewBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
+// returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
+// transaction hashes.
+func (fac *BlockFactory) NewBlock(b *types.Block, args *rpc_common.BlockArgs) (interface{}, error) {
+	if args.FullTx {
+		return fac.newBlockWithFullTx(b, args)
+	}
+	return fac.newBlockWithTxHash(b, args)
+}
+
+func (fac *BlockFactory) newBlockWithTxHash(b *types.Block, args *rpc_common.BlockArgs) (*BlockWithTxHash, error) {
+	blk := blockWithTxHashFromBlock(b)
+
+	leader := fac.provider.GetLeader(b)
+	ethLeader, err := internal_common.ParseAddr(leader)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse leader address")
+	}
+	blk.Block.Miner = ethLeader
+
+	if args.WithSigners {
+		signers, err := fac.provider.GetSigners(b)
+		if err != nil {
+			return nil, errors.Wrap(err, "GetSigners")
+		}
+		blk.Signers = signers
+	}
+	return blk, nil
+}
+
+func (fac *BlockFactory) newBlockWithFullTx(b *types.Block, args *rpc_common.BlockArgs) (*BlockWithFullTx, error) {
+	blk, err := blockWithFullTxFromBlock(b)
+	if err != nil {
+		return nil, errors.Wrap(err, "blockWithFullTxFromBlock")
+	}
+
+	leader := fac.provider.GetLeader(b)
+	ethLeader, err := internal_common.ParseAddr(leader)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse leader address")
+	}
+	blk.Block.Miner = ethLeader
+
+	if args.WithSigners {
+		signers, err := fac.provider.GetSigners(b)
+		if err != nil {
+			return nil, errors.Wrap(err, "GetSigners")
+		}
+		blk.Signers = signers
+	}
+	return blk, nil
+}

--- a/rpc/staking.go
+++ b/rpc/staking.go
@@ -51,7 +51,7 @@ func (s *PublicStakingService) getBalanceByBlockNumber(
 	return balance, nil
 }
 
-// getAllValidatorInformation getHelper function to get all validator information for a given eth block number
+// getAllValidatorInformation is the helper function to get all validator information for a given eth block number
 func (s *PublicStakingService) getAllValidatorInformation(
 	ctx context.Context, page int, blockNum rpc.BlockNumber,
 ) ([]StructuredResponse, error) {

--- a/rpc/staking.go
+++ b/rpc/staking.go
@@ -51,7 +51,7 @@ func (s *PublicStakingService) getBalanceByBlockNumber(
 	return balance, nil
 }
 
-// getAllValidatorInformation helper function to get all validator information for a given eth block number
+// getAllValidatorInformation getHelper function to get all validator information for a given eth block number
 func (s *PublicStakingService) getAllValidatorInformation(
 	ctx context.Context, page int, blockNum rpc.BlockNumber,
 ) ([]StructuredResponse, error) {

--- a/rpc/transaction.go
+++ b/rpc/transaction.go
@@ -820,7 +820,7 @@ func EstimateGas(ctx context.Context, hmy *hmy.Harmony, args CallArgs, gasCap *b
 	}
 	cap = hi
 
-	// Create a getHelper to check if a gas allowance results in an executable transaction
+	// Create a helper to check if a gas allowance results in an executable transaction
 	executable := func(gas uint64) (bool, *core.ExecutionResult, error) {
 		args.Gas = (*hexutil.Uint64)(&gas)
 

--- a/rpc/transaction.go
+++ b/rpc/transaction.go
@@ -820,7 +820,7 @@ func EstimateGas(ctx context.Context, hmy *hmy.Harmony, args CallArgs, gasCap *b
 	}
 	cap = hi
 
-	// Create a helper to check if a gas allowance results in an executable transaction
+	// Create a getHelper to check if a gas allowance results in an executable transaction
 	executable := func(gas uint64) (bool, *core.ExecutionResult, error) {
 		args.Gas = (*hexutil.Uint64)(&gas)
 

--- a/rpc/v1/block.go
+++ b/rpc/v1/block.go
@@ -1,0 +1,68 @@
+package v1
+
+import (
+	"github.com/harmony-one/harmony/core/types"
+	rpc_common "github.com/harmony-one/harmony/rpc/common"
+	"github.com/pkg/errors"
+)
+
+// BlockFactory is the factory for v1 rpc block
+type BlockFactory struct {
+	provider rpc_common.BlockDataProvider
+}
+
+// NewBlockFactory return the block factory with the given provider
+func NewBlockFactory(provider rpc_common.BlockDataProvider) *BlockFactory {
+	return &BlockFactory{provider}
+}
+
+// NewBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
+// returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
+// transaction hashes.
+func (fac *BlockFactory) NewBlock(b *types.Block, args *rpc_common.BlockArgs) (interface{}, error) {
+	if args.FullTx {
+		return fac.newBlockWithFullTx(b, args)
+	}
+	return fac.newBlockWithTxHash(b, args)
+}
+
+func (fac *BlockFactory) newBlockWithTxHash(b *types.Block, args *rpc_common.BlockArgs) (*BlockWithTxHash, error) {
+	blk := blockWithTxHashFromBlock(b)
+
+	blk.Miner = fac.provider.GetLeader(b)
+	if args.InclStaking {
+		blk.StakingTxs = fac.provider.GetStakingTxHashes(b)
+	}
+	if args.WithSigners {
+		signers, err := fac.provider.GetSigners(b)
+		if err != nil {
+			return nil, errors.Wrap(err, "GetSigners")
+		}
+		blk.Signers = signers
+	}
+	return blk, nil
+}
+
+func (fac *BlockFactory) newBlockWithFullTx(b *types.Block, args *rpc_common.BlockArgs) (*BlockWithFullTx, error) {
+	blk, err := blockWithFullTxFromBlock(b)
+	if err != nil {
+		return nil, errors.Wrap(err, "blockWithFullTxFromBlock")
+	}
+
+	blk.Miner = fac.provider.GetLeader(b)
+	if args.InclStaking {
+		txs, err := fac.provider.GetStakingTxs(b)
+		if err != nil {
+			return nil, errors.Wrap(err, "GetStakingTxs")
+		}
+		blk.StakingTxs = txs.([]*StakingTransaction)
+	}
+	if args.WithSigners {
+		signers, err := fac.provider.GetSigners(b)
+		if err != nil {
+			return nil, errors.Wrap(err, "GetSigners")
+		}
+		blk.Signers = signers
+	}
+	return blk, nil
+}

--- a/rpc/v2/block.go
+++ b/rpc/v2/block.go
@@ -1,0 +1,68 @@
+package v2
+
+import (
+	"github.com/harmony-one/harmony/core/types"
+	rpc_common "github.com/harmony-one/harmony/rpc/common"
+	"github.com/pkg/errors"
+)
+
+// BlockFactory is the factory for v1 rpc block
+type BlockFactory struct {
+	provider rpc_common.BlockDataProvider
+}
+
+// NewBlockFactory return the block factory with the given provider
+func NewBlockFactory(provider rpc_common.BlockDataProvider) *BlockFactory {
+	return &BlockFactory{provider}
+}
+
+// NewBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
+// returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
+// transaction hashes.
+func (fac *BlockFactory) NewBlock(b *types.Block, args *rpc_common.BlockArgs) (interface{}, error) {
+	if args.FullTx {
+		return fac.newBlockWithFullTx(b, args)
+	}
+	return fac.newBlockWithTxHash(b, args)
+}
+
+func (fac *BlockFactory) newBlockWithTxHash(b *types.Block, args *rpc_common.BlockArgs) (*BlockWithTxHash, error) {
+	blk := blockWithTxHashFromBlock(b)
+
+	blk.Miner = fac.provider.GetLeader(b)
+	if args.InclStaking {
+		blk.StakingTxs = fac.provider.GetStakingTxHashes(b)
+	}
+	if args.WithSigners {
+		signers, err := fac.provider.GetSigners(b)
+		if err != nil {
+			return nil, errors.Wrap(err, "GetSigners")
+		}
+		blk.Signers = signers
+	}
+	return blk, nil
+}
+
+func (fac *BlockFactory) newBlockWithFullTx(b *types.Block, args *rpc_common.BlockArgs) (*BlockWithFullTx, error) {
+	blk, err := blockWithFullTxFromBlock(b)
+	if err != nil {
+		return nil, errors.Wrap(err, "blockWithFullTxFromBlock")
+	}
+
+	blk.Miner = fac.provider.GetLeader(b)
+	if args.InclStaking {
+		txs, err := fac.provider.GetStakingTxs(b)
+		if err != nil {
+			return nil, errors.Wrap(err, "GetStakingTxs")
+		}
+		blk.StakingTxs = txs.([]*StakingTransaction)
+	}
+	if args.WithSigners {
+		signers, err := fac.provider.GetSigners(b)
+		if err != nil {
+			return nil, errors.Wrap(err, "GetSigners")
+		}
+		blk.Signers = signers
+	}
+	return blk, nil
+}

--- a/rpc/v2/types.go
+++ b/rpc/v2/types.go
@@ -13,7 +13,6 @@ import (
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/crypto/bls"
 	internal_common "github.com/harmony-one/harmony/internal/common"
-	rpc_common "github.com/harmony-one/harmony/rpc/common"
 	staking "github.com/harmony-one/harmony/staking/types"
 )
 
@@ -589,24 +588,8 @@ func NewStakingTransaction(
 	return result, nil
 }
 
-// NewBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
-// returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
-// transaction hashes.
-func NewBlock(b *types.Block, blockArgs *rpc_common.BlockArgs, leader string) (interface{}, error) {
-	if blockArgs.FullTx {
-		return NewBlockWithFullTx(b, blockArgs, leader)
-	}
-	return NewBlockWithTxHash(b, blockArgs, leader)
-}
-
-// NewBlockWithTxHash return a block with only the transaction hash that will serialize to the RPC representation
-func NewBlockWithTxHash(
-	b *types.Block, blockArgs *rpc_common.BlockArgs, leader string,
-) (*BlockWithTxHash, error) {
-	if blockArgs.FullTx {
-		return nil, fmt.Errorf("block args specifies full tx, but requested RPC block with only tx hash")
-	}
-
+// blockWithTxHashFromBlock return a block with only the transaction hash that will serialize to the RPC representation
+func blockWithTxHashFromBlock(b *types.Block) *BlockWithTxHash {
 	head := b.Header()
 
 	vrfAndProof := head.Vrf()
@@ -626,7 +609,6 @@ func NewBlockWithTxHash(
 		MixHash:          head.MixDigest(),
 		LogsBloom:        head.Bloom(),
 		StateRoot:        head.Root(),
-		Miner:            leader,
 		Difficulty:       0, // Remove this because we don't have it in our header
 		ExtraData:        hexutil.Bytes(head.Extra()),
 		Size:             uint64(b.Size()),
@@ -648,26 +630,11 @@ func NewBlockWithTxHash(
 		blk.EthTransactions = append(blk.EthTransactions, tx.ConvertToEth().Hash())
 	}
 
-	if blockArgs.InclStaking {
-		for _, stx := range b.StakingTransactions() {
-			blk.StakingTxs = append(blk.StakingTxs, stx.Hash())
-		}
-	}
-
-	if blockArgs.WithSigners {
-		blk.Signers = blockArgs.Signers
-	}
-	return blk, nil
+	return blk
 }
 
 // NewBlockWithFullTx return a block with the transaction that will serialize to the RPC representation
-func NewBlockWithFullTx(
-	b *types.Block, blockArgs *rpc_common.BlockArgs, leader string,
-) (*BlockWithFullTx, error) {
-	if !blockArgs.FullTx {
-		return nil, fmt.Errorf("block args specifies NO full tx, but requested RPC block with full tx")
-	}
-
+func blockWithFullTxFromBlock(b *types.Block) (*BlockWithFullTx, error) {
 	head := b.Header()
 
 	vrfAndProof := head.Vrf()
@@ -687,7 +654,6 @@ func NewBlockWithFullTx(
 		MixHash:          head.MixDigest(),
 		LogsBloom:        head.Bloom(),
 		StateRoot:        head.Root(),
-		Miner:            leader,
 		Difficulty:       0, // Remove this because we don't have it in our header
 		ExtraData:        hexutil.Bytes(head.Extra()),
 		Size:             uint64(b.Size()),
@@ -709,20 +675,6 @@ func NewBlockWithFullTx(
 			return nil, err
 		}
 		blk.Transactions = append(blk.Transactions, fmtTx)
-	}
-
-	if blockArgs.InclStaking {
-		for _, stx := range b.StakingTransactions() {
-			fmtStx, err := NewStakingTransactionFromBlockHash(b, stx.Hash())
-			if err != nil {
-				return nil, err
-			}
-			blk.StakingTxs = append(blk.StakingTxs, fmtStx)
-		}
-	}
-
-	if blockArgs.WithSigners {
-		blk.Signers = blockArgs.Signers
 	}
 	return blk, nil
 }
@@ -746,6 +698,20 @@ func NewTransactionFromBlockIndex(b *types.Block, index uint64) (*Transaction, e
 		)
 	}
 	return NewTransaction(txs[index], b.Hash(), b.NumberU64(), b.Time().Uint64(), index)
+}
+
+// StakingTransactionsFromBlock return rpc staking transactions from a block
+func StakingTransactionsFromBlock(b *types.Block) ([]*StakingTransaction, error) {
+	rawStakings := b.StakingTransactions()
+	rpcStakings := make([]*StakingTransaction, 0, len(rawStakings))
+	for idx, raw := range rawStakings {
+		rpcStk, err := NewStakingTransaction(raw, b.Hash(), b.NumberU64(), b.Time().Uint64(), uint64(idx), true)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse staking transaction %v", raw.Hash())
+		}
+		rpcStakings = append(rpcStakings, rpcStk)
+	}
+	return rpcStakings, nil
 }
 
 // NewStakingTransactionFromBlockHash returns a staking transaction that will serialize to the RPC representation.


### PR DESCRIPTION
## Issue

Refactor and optimized public blockchain API requests. Effected APIs:

1. GetBlockByNumber
2. GetBlockByHash
3. GetBlocks
4. GetBlockSigners
5. GetBlockSignerKeys
6. IsBlockSigner
7. GetSignedBlocks
8. GetLeader
Also changed some parameters in caching.

## Test

Passed local test.

Did a stress test on AWS medium machine. Stress test scripts:

```
#!/bin/bash
COUNTER=0
while true;
do
    curl -d '{
      "jsonrpc":"2.0",
      "method":"hmy_getBlocks",
      "params":[
        15524096,15524097,{"withSigners": true, "fullTx": true, "inclStaking": true}
      ],
      "id":1
    }' -H 'Content-Type:application/json' -X POST 'localhost:9500' > /dev/null;
    COUNTER=$((COUNTER+1));
    echo $COUNTER;
done;
```

Metrics compared with main branch. Both cases will hit cache.

1. Main branch: 230 requests / 30s
2. After the fix: 1120 requests / 30

More metrics (cpu, memory) shall be collected on mainnet machine. @sophoah 
