### PR TITLE
[core] Do not save ValidatorWrapper state for every block

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1178,8 +1178,7 @@ func (bc *BlockChain) WriteBlockWithState(
 			root, err = bc.commitWithValidatorWrapper(state, block.Epoch())
 			bc.validatorBlkCnt = 0
 		} else {
-			stateCopy := state.Copy()
-			root, err = bc.commitWithoutValidatorWrapper(stateCopy, block.Epoch())
+			root, err = bc.commitWithoutValidatorWrapper(state.Copy(), block.Epoch())
 			bc.commitWithValidatorWrapper(state, block.Epoch())
 			bc.validatorBlkCnt++
 		}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1172,7 +1172,7 @@ func (bc *BlockChain) WriteBlockWithState(
 	// Commit state object changes to in-memory trie
 	var root common.Hash
 	if bc.cacheConfig.Disabled && !block.IsLastBlockInEpoch() {
-		if block.NumberU64()%triesInMemoryBlocksInterval == 0 {
+		if block.NumberU64()%triesInMemoryBlocksInterval != 0 {
 			root, err = bc.commitWithValidatorWrapper(state, block.Epoch())
 		} else {
 			root, err = bc.commitWithoutValidatorWrapper(state.Copy(), block.Epoch())

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -203,7 +203,7 @@ func GenerateChain(
 			}
 
 			// Write state changes to db
-			root, err := statedb.Commit(config.IsS3(b.header.Epoch()))
+			root, err := statedb.Commit(config.IsS3(b.header.Epoch()), true)
 			if err != nil {
 				panic(fmt.Sprintf("state write error: %v", err))
 			}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -269,7 +269,7 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 		ShardStateHash(g.ShardStateHash).
 		ShardState(shardStateBytes).
 		Header()
-	statedb.Commit(false)
+	statedb.Commit(false, true)
 	statedb.Database().TrieDB().Commit(root, true)
 
 	return types.NewBlock(head, nil, nil, nil, nil, nil)

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -97,6 +97,43 @@ func TestValidatorWrapperDump(t *testing.T) {
 		}
 	}
 
+	{
+		s := newStateTest()
+		addr := toAddr([]byte{0x01})
+		obj := s.state.GetOrNewStateObject(addr)
+
+		wrapper := &staking.ValidatorWrapper{}
+		wrapper.Delegations = []staking.Delegation{
+			staking.NewDelegation(toAddr([]byte{0x01, 0x55}), big.NewInt(66)),
+		}
+		wrapper.Counters.NumBlocksSigned = big.NewInt(2)
+		wrapper.Counters.NumBlocksToSign = big.NewInt(3)
+		wrapper.BlockReward = big.NewInt(7)
+
+		by, err := rlp.EncodeToBytes(wrapper)
+		if err != nil {
+			t.Errorf("rlp.EncodeToBytes failed: %s\n", err.Error())
+		}
+		obj.SetCode(crypto.Keccak256Hash(by), by)
+		s.state.SetValidatorFlag(addr)
+		s.state.Commit(false, false)
+
+		got := string(s.state.Dump(false, false, true))
+		got = removeAllMeanlessChars(got)
+		want := `{
+        "root": "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+        "accounts": {
+			
+		}
+    }`
+
+		want = removeAllMeanlessChars(want)
+
+		if got != want {
+			t.Errorf("validator wrapper dump mismatch:\ngot: %s\nwant: %s\n", got, want)
+		}
+	}
+
 }
 
 func TestDump(t *testing.T) {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -752,6 +752,7 @@ func (db *DB) clearJournalAndRefund() {
 
 // Commit writes the state to the underlying in-memory trie database.
 func (db *DB) Commit(deleteEmptyObjects bool, commitValidatorWrapper bool) (root common.Hash, err error) {
+
 	// Finalize any pending changes and merge everything into the tries
 	db.IntermediateRoot(deleteEmptyObjects)
 
@@ -761,6 +762,7 @@ func (db *DB) Commit(deleteEmptyObjects bool, commitValidatorWrapper bool) (root
 			// Write any contract code associated with the state object
 			if obj.code != nil && obj.dirtyCode {
 				if !commitValidatorWrapper && obj.IsValidator(db.db) {
+					db.deleteStateObject(obj)
 					continue
 				}
 				db.db.TrieDB().InsertBlob(common.BytesToHash(obj.CodeHash()), obj.code)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -763,6 +763,7 @@ func (db *DB) Commit(deleteEmptyObjects bool, commitValidatorWrapper bool) (root
 			if obj.code != nil && obj.dirtyCode {
 				if !commitValidatorWrapper && obj.IsValidator(db.db) {
 					db.deleteStateObject(obj)
+					obj.deleted = true
 					continue
 				}
 				db.db.TrieDB().InsertBlob(common.BytesToHash(obj.CodeHash()), obj.code)

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -103,7 +103,7 @@ func TestIntermediateLeaks(t *testing.T) {
 	}
 
 	// Commit and cross check the databases.
-	transRoot, err := transState.Commit(false)
+	transRoot, err := transState.Commit(false, true)
 	if err != nil {
 		t.Fatalf("failed to commit transition state: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestIntermediateLeaks(t *testing.T) {
 		t.Errorf("can not commit trie %v to persistent database", transRoot.Hex())
 	}
 
-	finalRoot, err := finalState.Commit(false)
+	finalRoot, err := finalState.Commit(false, true)
 	if err != nil {
 		t.Fatalf("failed to commit final state: %v", err)
 	}
@@ -460,7 +460,7 @@ func (test *snapshotTest) checkEqual(state, checkstate *DB) error {
 func TestTouchDelete(t *testing.T) {
 	s := newStateTest()
 	s.state.GetOrNewStateObject(common.Address{})
-	root, _ := s.state.Commit(false)
+	root, _ := s.state.Commit(false, true)
 	s.state.Reset(root)
 
 	snapshot := s.state.Snapshot()
@@ -533,7 +533,7 @@ func TestCopyCommitCopy(t *testing.T) {
 		t.Fatalf("first copy pre-commit committed storage slot mismatch: have %x, want %x", val, common.Hash{})
 	}
 
-	copyOne.Commit(false)
+	copyOne.Commit(false, true)
 	if balance := copyOne.GetBalance(addr); balance.Cmp(big.NewInt(42)) != 0 {
 		t.Fatalf("first copy post-commit balance mismatch: have %v, want %v", balance, 42)
 	}
@@ -618,7 +618,7 @@ func TestCopyCopyCommitCopy(t *testing.T) {
 	if val := copyTwo.GetCommittedState(addr, skey); val != (common.Hash{}) {
 		t.Fatalf("second copy pre-commit committed storage slot mismatch: have %x, want %x", val, common.Hash{})
 	}
-	copyTwo.Commit(false)
+	copyTwo.Commit(false, true)
 	if balance := copyTwo.GetBalance(addr); balance.Cmp(big.NewInt(42)) != 0 {
 		t.Fatalf("second copy post-commit balance mismatch: have %v, want %v", balance, 42)
 	}
@@ -662,7 +662,7 @@ func TestDeleteCreateRevert(t *testing.T) {
 	addr := toAddr([]byte("so"))
 	state.SetBalance(addr, big.NewInt(1))
 
-	root, _ := state.Commit(false)
+	root, _ := state.Commit(false, true)
 	state.Reset(root)
 
 	// Simulate self-destructing in one transaction, then create-reverting in another
@@ -674,7 +674,7 @@ func TestDeleteCreateRevert(t *testing.T) {
 	state.RevertToSnapshot(id)
 
 	// Commit the entire state and make sure we don't crash and have the correct state
-	root, _ = state.Commit(true)
+	root, _ = state.Commit(true, true)
 	state.Reset(root)
 
 	if state.getStateObject(addr) != nil {

--- a/hmy/tracer.go
+++ b/hmy/tracer.go
@@ -286,7 +286,7 @@ func (hmy *Harmony) TraceChain(ctx context.Context, start, end *types.Block, con
 				break
 			}
 			// Finalize the state so any modifications are written to the trie
-			root, err := statedb.Commit(true)
+			root, err := statedb.Commit(true, true)
 			if err != nil {
 				failed = err
 				break
@@ -679,7 +679,7 @@ func (hmy *Harmony) ComputeStateDB(block *types.Block, reexec uint64) (*state.DB
 			return nil, fmt.Errorf("processing block %d failed: %v", block.NumberU64(), err)
 		}
 		// Finalize the state so any modifications are written to the trie
-		root, err := statedb.Commit(true)
+		root, err := statedb.Commit(true, true)
 		if err != nil {
 			return nil, err
 		}

--- a/staking/slash/double-sign_test.go
+++ b/staking/slash/double-sign_test.go
@@ -627,7 +627,7 @@ func (tc *applyTestCase) makeData(t *testing.T) {
 		if err := tc.state.UpdateValidatorWrapper(tc.current.Address, tc.current); err != nil {
 			t.Error(err)
 		}
-		if _, err := tc.state.Commit(true); err != nil {
+		if _, err := tc.state.Commit(true, true); err != nil {
 			t.Error(err)
 		}
 	}


### PR DESCRIPTION
## Issue

https://github.com/harmony-one/harmony/issues/3843

Save ValidatorWrapper for every N blocks， In other words, in fact, in the archvial node is that not every block processed needs to be committed, which would cause an explosion of state

## Test

<del>have not passed unit test</del>

- [x] local test

1. use rclone to sync shard0  data 

```bash
rclone -P sync release:pub.harmony.one/mainnet.min/harmony_db_0 harmony_db_0
```

2. run harmony with archival:

```bash
 ./harmony --run=explorer --run.beacon-archive=true --run.archive=true --run.shard=0
Started Explorer server at: 0.0.0.0:5000
Started RPC server at: 127.0.0.1:9500
Started WS server at: 127.0.0.1:9800
```

3.  use hmy to check lastheaders of s0 comapred with explorer on mainnet

```bash
 ./hmy blockchain latest-headers
```
```json
{
  "id": "1",
  "jsonrpc": "2.0",
  "result": {
    "beacon-chain-header": {
      "difficulty": "0x0",
      "epoch": 672,
      "extraData": "0x",
      "gasLimit": "0x4c4b400",
      "gasUsed": "0x8ee371",
      "hash": "0x3a12b5ea8dbd4f0df728023e7be526837ffac17ed0ffebb1a4814c6c4b5be078",
      "logsBloom": "0x00000002000010008000000000000000001000000410003000000000000100000000000000000000000000000000000008080000400000000000000000000000000000000000100000000008400000010000000000000000000000000000200000000010820000000000000000000800000000000000000000000010000000100000000000000000002000000000000000000000000000040000000200040000000000000000000000000000000000000000000000004040000000001000000000000102000000010000000000000804000000000000000000080000240020000000000000010000000100080000000000000800400000000000000000000100",
      "miner": "0xe5dc9dbd0b93231e5d0bf998669463fe990a7211",
      "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
      "nonce": "0x0000000000000000",
      "number": "0xf9bb3b",
      "parentHash": "0xa5c498f08cbcb3a3ba9fe4daa9b860840caac8428cae529f477ff0296b7d1ca5",
      "receiptsRoot": "0xc7434bccf50e05d63a7539ee58325731eaf8ec759b50c0d28fb7ad2a669851a9",
      "sha3Uncles": "0x0000000000000000000000000000000000000000000000000000000000000000",
      "shardID": 0,
      "stateRoot": "0xf3b0707d83670df68952de20c1a3babf107364cc01c30a255a6a34bfbaf0adcd",
      "timestamp": "0x61245bf9",
      "transactionsRoot": "0xbadee2dcc97132c00efaeb45af8879e9ab35a7e1b82270a2387ed2cb5d571541",
      "viewID": 16366978
    },
    "shard-chain-header": {
      "difficulty": "0x0",
      "epoch": 672,
      "extraData": "0x",
      "gasLimit": "0x4c4b400",
      "gasUsed": "0x8ee371",
      "hash": "0x3a12b5ea8dbd4f0df728023e7be526837ffac17ed0ffebb1a4814c6c4b5be078",
      "logsBloom": "0x00000002000010008000000000000000001000000410003000000000000100000000000000000000000000000000000008080000400000000000000000000000000000000000100000000008400000010000000000000000000000000000200000000010820000000000000000000800000000000000000000000010000000100000000000000000002000000000000000000000000000040000000200040000000000000000000000000000000000000000000000004040000000001000000000000102000000010000000000000804000000000000000000080000240020000000000000010000000100080000000000000800400000000000000000000100",
      "miner": "0xe5dc9dbd0b93231e5d0bf998669463fe990a7211",
      "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
      "nonce": "0x0000000000000000",
      "number": "0xf9bb3b",
      "parentHash": "0xa5c498f08cbcb3a3ba9fe4daa9b860840caac8428cae529f477ff0296b7d1ca5",
      "receiptsRoot": "0xc7434bccf50e05d63a7539ee58325731eaf8ec759b50c0d28fb7ad2a669851a9",
      "sha3Uncles": "0x0000000000000000000000000000000000000000000000000000000000000000",
      "shardID": 0,
      "stateRoot": "0xf3b0707d83670df68952de20c1a3babf107364cc01c30a255a6a34bfbaf0adcd",
      "timestamp": "0x61245bf9",
      "transactionsRoot": "0xbadee2dcc97132c00efaeb45af8879e9ab35a7e1b82270a2387ed2cb5d571541",
      "viewID": 16366978
    }
  }
}
```


#### Test results

- local shard 0(number 16366406) catched up near latest block(number 16404268) shown on explorer https://explorer.harmony.one/

- `./hmy blockchain validator all-information-by-block-number 0 0xfa89d6` and `./hmy blockchain validator all-information-by-block-number 0 0xfa8a57` and ` ./hmy blockchain validator all-information-by-block-number 0 0xfa8ad8` can get the info related to Validator

[res-json.zip](https://github.com/harmony-one/harmony/files/7059397/res-json.zip)

In the history blocks, some of them can check the validator's information, and some of them can't, because not every bock is committed to Disk, now it is committing the state to Disk once every 128 blocks interval, and the latest state is kept in memory.

- `./hmy blockchain validator all-information-by-block-number 0 latest`

it can always get the info with last , the latest validatorwrapper state always keep in memory 

- storage test result:
 Storage growth rate of archived nodes is more than twice that of non-archived nodes, because other state change(exclude ValidatorWrapper) still commited into disk

run `./hmy blockchain latest-header && du -b ./harmony_db_0`


1. non-archival node (my PR)

|  height   |  bytes  |
|  ----  | ----  |
| 16472034     | 215361268349 |
| 16472084     | 215350751961 |
| 16472158     | 215372972324 |
| 16472835     | 215407678480 |
| 16473577     | 215451929641 |

from above result , summery as follows:

- block range 1543(height 16472034   to  16473577   ):  storage improved: 86MB 

- improved 0.05MB for every block

- improved 86MB for 51 minutes

2. archival node  (my PR)


|  height   |  bytes  |
|  ----  | ----  |
| 16473594        | 215430229194 |
| 16473771        | 215484376000 |
| 16474138        | 215530991142 |
| 16474450        | 215573004597 |
| 16475163        | 215634054394 |


from above result , summery as follows:

- block range 1569((height  16473594    to  16475163   ):  storage improved: 194MB 

- improved 0.12MB for every block

- improved 194MB for 52.3 minutes

3. archival node (main branch)

|  height   |  bytes  |
|  ----  | ----  |
| 16475787          | 215687030143 |
| 16475897          | 215971599919 |
| 16476250          | 216811970983 |
| 16476837        | 218224117296 |
| 16476890        | 218384751733 |
| 16477236        | 219204198410 |

from above result , summery as follows:

- block range 1449 (height 16477236 to 16475787): storage improved: 3354MB
- improved 2.31MB for every block
- improved 3354MB for 48.3 minutes

4. non-archive node (main branch)

|  height   |  bytes  |
|  ----  | ----  |
| 16477238          | 219179679116 |
| 16477849          | 219260393849 |
| 16477935          | 219271328497 |
| 16478138        |   219262309140|
| 16478294        |   219304492248 |
| 16478574        | 219349872133 |

from above result , summery as follows:

- block range 1336 (height 16477238 to 16478574): storage improved: 162MB
- improved 0.12MB for every block
- improved 162MB for 44.5 minutes