### PR TITLE
WIP: Get previous block vrf on chain for secure random number generation

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -42,6 +42,9 @@ type (
 	// GetHashFunc returns the nth block hash in the blockchain
 	// and is used by the BLOCKHASH EVM op code.
 	GetHashFunc func(uint64) common.Hash
+	// GetVRFFunc returns the nth block vrf in the blockchain
+	// and is used by the precompile VRF contract.
+	GetVRFFunc func(uint64) common.Hash
 )
 
 // run runs the given contract and takes care of running precompiles with a fallback to the byte code interpreter.
@@ -59,8 +62,18 @@ func run(evm *EVM, contract *Contract, input []byte, readOnly bool) ([]byte, err
 		}
 		if p := precompiles[*contract.CodeAddr]; p != nil {
 			if _, ok := p.(*vrf); ok {
-				// Override the input with vrf data of the current block so it can be returned to the contract program.
-				input = evm.Context.VRF.Bytes()
+				var Int *big.Int
+				requestedBlockNum := Int.SetBytes(input)
+				minBlockNum := Int.Sub(evm.BlockNumber, common.Big257)
+
+				// Override the input with vrf data of block's VRF so it can be returned to the contract program.
+				if requestedBlockNum.Cmp(minBlockNum) > 0 && requestedBlockNum.Cmp(evm.BlockNumber) <= 0 {
+					// requested block number is in range
+					input = evm.GetVRF(requestedBlockNum.Uint64()).Bytes()
+				} else {
+					//requested block number not in range, return current block VRF
+					input = evm.GetVRF(evm.BlockNumber.Uint64()).Bytes()
+				}
 			}
 			return RunPrecompiledContract(p, input, contract)
 		}
@@ -93,6 +106,9 @@ type Context struct {
 	// GetHash returns the hash corresponding to n
 	GetHash GetHashFunc
 
+	// GetVRF returns the VRF corresponding to n
+	GetVRF GetVRFFunc
+
 	// IsValidator determines whether the address corresponds to a validator or a smart contract
 	// true: is a validator address; false: is smart contract address
 	IsValidator IsValidatorFunc
@@ -107,7 +123,6 @@ type Context struct {
 	BlockNumber *big.Int       // Provides information for NUMBER
 	EpochNumber *big.Int       // Provides information for EPOCH
 	Time        *big.Int       // Provides information for TIME
-	VRF         common.Hash    // Provides information for VRF
 
 	TxType types.TransactionType
 }

--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -29,12 +29,12 @@ func NewEnv(cfg *Config) *vm.EVM {
 		Transfer:    core.Transfer,
 		IsValidator: core.IsValidator,
 		GetHash:     func(uint64) common.Hash { return common.Hash{} },
+		GetVRF:      func(uint64) common.Hash { return common.Hash{} },
 
 		Origin:      cfg.Origin,
 		Coinbase:    cfg.Coinbase,
 		BlockNumber: cfg.BlockNumber,
 		EpochNumber: cfg.EpochNumber,
-		VRF:         cfg.VRF,
 		Time:        cfg.Time,
 		GasLimit:    cfg.GasLimit,
 		GasPrice:    cfg.GasPrice,


### PR DESCRIPTION
## Issue

#3846

My implementation fixing #3846 is based on t how the blockhash() opcode is resolved by creating and using the Context's `GetHash` function. 

**Please note**: I'm not familiar with golang, and am unsure of this implementation. However, this PR is mainly meant as an attachment to #3846 to demonstrate how the issue could possibly be resolved. 

I would very much appreciate assistance with this PR to make it up to spec with the rest of harmony's codebase!

As per the optimization concerns mentioned in #3846 I have put the constraint of requiring the block number to be within 256 blocks, this is subject to change and I would appreciate feedback from someone who more so understands the implications on the operational cost of fetching long-ago blocks.

## Test

**TODO**

### Unit Test Coverage

**TODO**

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

**TODO**

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

*TODO*

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
