### PR TITLE
turn on aggregated reward on mainnet

### DIFF
--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -42,8 +42,8 @@ var (
 		EthCompatibleEpoch:         big.NewInt(442), // Around Thursday Feb 4th 2020, 10AM PST
 		CrossTxEpoch:               big.NewInt(28),
 		CrossLinkEpoch:             big.NewInt(186),
-		AggregatedRewardEpoch:      EpochTBD,
-		StakingEpoch:               big.NewInt(186),
+		AggregatedRewardEpoch:      big.NewInt(689), // Around Wed Sept 15th 2021 with 3.5s block time
+		StakingEpoch:               big.NewInt(186), 
 		PreStakingEpoch:            big.NewInt(185),
 		QuickUnlockEpoch:           big.NewInt(191),
 		FiveSecondsEpoch:           big.NewInt(230),


### PR DESCRIPTION
At mainnet epoch 689 which is supposed to happen around sept 15 2021 with a s0 3.5s block time