### PR TITLE
enable history vrf in mainnet at epoch 689

### DIFF
--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -52,7 +52,7 @@ var (
 		RedelegationEpoch:          big.NewInt(290),
 		NoEarlyUnlockEpoch:         big.NewInt(530), // Around Monday Apr 12th 2021, 22:30 UTC
 		VRFEpoch:                   big.NewInt(631), // Around Wed July 7th 2021
-		PrevVRFEpoch:               EpochTBD,
+		PrevVRFEpoch:               big.NewInt(689), // Around Wed Sept 15th 2021 with 3.5s block time
 		MinDelegation100Epoch:      big.NewInt(631), // Around Wed July 7th 2021
 		MinCommissionRateEpoch:     big.NewInt(631), // Around Wed July 7th 2021
 		MinCommissionPromoPeriod:   big.NewInt(100),


### PR DESCRIPTION
Fully tested in testnet. Ready to launch on mainnet at epoch 689