### PR TITLE
[p2p] Remove DiscConcurrency code

### DIFF
--- a/p2p/discovery/option.go
+++ b/p2p/discovery/option.go
@@ -34,12 +34,6 @@ func (opt DHTConfig) getLibp2pRawOptions() ([]libp2p_dht.Option, error) {
 		opts = append(opts, dsOption)
 	}
 
-	// if Concurrency <= 0, it uses default concurrency supplied from libp2p dht
-	// the concurrency num meaning you can see Section 2.3 in the KAD paper https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf
-	if opt.DiscConcurrency > 0 {
-		opts = append(opts, libp2p_dht.Concurrency(opt.DiscConcurrency))
-	}
-
 	return opts, nil
 }
 


### PR DESCRIPTION
## Issue

First remove the DiscConcurrency parameter setting code completely， `--p2p.disc,concurrency` flag does is No use for now. This is just a temporary quick fix


