### PR TITLE
Add Rosetta Indexer

### DIFF
--- a/rosetta/rosetta.go
+++ b/rosetta/rosetta.go
@@ -85,6 +85,8 @@ func getRouter(asserter *asserter.Asserter, hmy *hmy.Harmony, limiterEnable bool
 		server.NewNetworkAPIController(services.NewNetworkAPI(hmy), asserter),
 		server.NewConstructionAPIController(services.NewConstructionAPI(hmy), asserter),
 		server.NewCallAPIController(services.NewCallAPIService(hmy, limiterEnable, rateLimit), asserter),
+		server.NewEventsAPIController(services.NewEventAPI(hmy), asserter),
+		server.NewSearchAPIController(services.NewSearchAPI(hmy), asserter),
 	)
 }
 

--- a/rosetta/services/event.go
+++ b/rosetta/services/event.go
@@ -1,0 +1,67 @@
+package services
+
+import (
+	"context"
+	"github.com/coinbase/rosetta-sdk-go/types"
+	hmyTypes "github.com/harmony-one/harmony/core/types"
+	"github.com/harmony-one/harmony/hmy"
+)
+
+// EventAPI implements the server.EventsAPIServicer interface.
+type EventAPI struct {
+	hmy *hmy.Harmony
+}
+
+func NewEventAPI(hmy *hmy.Harmony) *EventAPI {
+	return &EventAPI{hmy: hmy}
+}
+
+// EventsBlocks implements the /events/blocks endpoint
+func (e *EventAPI) EventsBlocks(ctx context.Context, request *types.EventsBlocksRequest) (*types.EventsBlocksResponse, *types.Error) {
+	if err := assertValidNetworkIdentifier(request.NetworkIdentifier, e.hmy.ShardID); err != nil {
+		return nil, err
+	}
+
+	var offset, limit int64
+
+	if request.Limit == nil {
+		limit = 10
+	} else {
+		limit = *request.Limit
+		if limit > 1000 {
+			limit = 1000
+		}
+	}
+
+	if request.Offset == nil {
+		offset = 0
+	} else {
+		offset = *request.Offset
+	}
+
+	resp := &types.EventsBlocksResponse{
+		MaxSequence: e.hmy.BlockChain.CurrentHeader().Number().Int64(),
+	}
+
+	for i := offset; i < offset+limit; i++ {
+		block := e.hmy.BlockChain.GetBlockByNumber(uint64(i))
+		if block == nil {
+			break
+		}
+
+		resp.Events = append(resp.Events, buildFromBlock(block))
+	}
+
+	return resp, nil
+}
+
+func buildFromBlock(block *hmyTypes.Block) *types.BlockEvent {
+	return &types.BlockEvent{
+		Sequence: block.Number().Int64(),
+		BlockIdentifier: &types.BlockIdentifier{
+			Index: block.Number().Int64(),
+			Hash:  block.Hash().Hex(),
+		},
+		Type: types.ADDED,
+	}
+}

--- a/rosetta/services/search.go
+++ b/rosetta/services/search.go
@@ -1,0 +1,184 @@
+package services
+
+import (
+	"context"
+	"github.com/coinbase/rosetta-sdk-go/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/harmony-one/harmony/core/rawdb"
+	hmyTypes "github.com/harmony-one/harmony/core/types"
+	"github.com/harmony-one/harmony/hmy"
+	internal_common "github.com/harmony-one/harmony/internal/common"
+	rosetta_common "github.com/harmony-one/harmony/rosetta/common"
+)
+
+// SearchAPI implements the server.SearchAPIServicer interface.
+type SearchAPI struct {
+	hmy *hmy.Harmony
+}
+
+func NewSearchAPI(hmy *hmy.Harmony) *SearchAPI {
+	return &SearchAPI{hmy: hmy}
+}
+
+// SearchTransactions implements the /search/transactions endpoint
+func (s *SearchAPI) SearchTransactions(ctx context.Context, request *types.SearchTransactionsRequest) (*types.SearchTransactionsResponse, *types.Error) {
+	if err := assertValidNetworkIdentifier(request.NetworkIdentifier, s.hmy.ShardID); err != nil {
+		return nil, err
+	}
+
+	var offset, limit int64
+	if request.Limit == nil {
+		limit = 10
+	} else {
+		limit = *request.Limit
+		if limit > 1000 {
+			limit = 1000
+		}
+	}
+
+	var filteredHash, rangeHash []common.Hash
+
+	filteredType := ""
+	if request.Type != nil {
+		filteredType = *request.Type
+	}
+
+	if request.AccountIdentifier != nil {
+		ddr, err := internal_common.ParseAddr(request.AccountIdentifier.Address)
+		if err != nil {
+			return nil, &rosetta_common.ErrCallParametersInvalid
+		}
+
+		address, err := internal_common.AddressToBech32(ddr)
+		if err != nil {
+			return nil, &rosetta_common.ErrCallParametersInvalid
+		}
+
+		histories, err := s.hmy.GetTransactionsHistory(address, filteredType, "")
+		if err != nil {
+			return nil, rosetta_common.NewError(rosetta_common.CatchAllError, map[string]interface{}{
+				"message": err.Error(),
+			})
+		}
+
+		filteredHash = histories
+	}
+
+	if request.TransactionIdentifier != nil {
+		hash := common.HexToHash(request.TransactionIdentifier.Hash)
+		filteredHash = operatorFilter(request.Operator, filteredHash, []common.Hash{hash})
+	}
+
+	resp := &types.SearchTransactionsResponse{}
+	if int64(len(filteredHash)) < offset {
+		return resp, nil
+	} else if int64(len(filteredHash)) < offset+limit {
+		rangeHash = filteredHash[offset:]
+	} else {
+		rangeHash = filteredHash[offset : offset+limit]
+	}
+
+	for _, hash := range rangeHash {
+		tx, blockHash, blockNumber, index := rawdb.ReadTransaction(s.hmy.ChainDb(), hash)
+		if tx == nil {
+			return nil, rosetta_common.NewError(rosetta_common.CatchAllError, map[string]interface{}{
+				"message": "can not get tx info by hash",
+			})
+		}
+
+		info, err := buildFromTXInfo(tx, blockHash, blockNumber, index)
+		if err != nil {
+			return nil, err
+		}
+
+		resp.Transactions = append(resp.Transactions, info)
+	}
+
+	resp.TotalCount = int64(len(resp.Transactions))
+	if offset+limit < int64(len(filteredHash)) {
+		resp.NextOffset = &resp.TotalCount
+	}
+
+	return resp, nil
+}
+
+func buildFromTXInfo(tx *hmyTypes.Transaction, blockHash common.Hash, blockNumber uint64, index uint64) (*types.BlockTransaction, *types.Error) {
+	receiverAccountID, rosettaError := newAccountIdentifier(*tx.To())
+	if rosettaError != nil {
+		return nil, rosettaError
+	}
+
+	var typ string
+	if tx.To() == nil {
+		typ = rosetta_common.ContractCreationOperation
+	} else if tx.ShardID() != tx.ToShardID() {
+		typ = rosetta_common.NativeCrossShardTransferOperation
+	} else {
+		typ = rosetta_common.NativeTransferOperation
+	}
+
+	return &types.BlockTransaction{
+		BlockIdentifier: &types.BlockIdentifier{
+			Index: int64(blockNumber),
+			Hash:  blockHash.Hex(),
+		},
+		Transaction: &types.Transaction{
+			TransactionIdentifier: &types.TransactionIdentifier{
+				Hash: tx.Hash().String(),
+			},
+			Operations: []*types.Operation{
+				{
+					OperationIdentifier: &types.OperationIdentifier{
+						Index: int64(index),
+					},
+					Status:  &rosetta_common.SuccessOperationStatus.Status,
+					Type:    typ,
+					Account: receiverAccountID,
+					Amount: &types.Amount{
+						Value:    tx.Value().String(),
+						Currency: &rosetta_common.NativeCurrency,
+					},
+				},
+			},
+			Metadata: map[string]interface{}{
+				"index": index,
+				"size":  tx.Size().String(),
+			},
+		},
+	}, nil
+}
+
+func operatorFilter(operator *types.Operator, hashesArr ...[]common.Hash) (ret []common.Hash) {
+	if len(hashesArr) == 0 {
+		return ret
+	}
+
+	if operator == nil || *operator == types.AND { // operator is and
+		filterMap := make(map[string]common.Hash)
+		for _, hash := range hashesArr[0] {
+			filterMap[hash.Hex()] = hash
+		}
+
+		for _, hashes := range hashesArr[1:] {
+			filteredMap := make(map[string]common.Hash)
+
+			for _, hash := range hashes {
+				if _, ok := filterMap[hash.Hex()]; ok {
+					filteredMap[hash.Hex()] = hash
+				}
+			}
+
+			filterMap = filteredMap
+		}
+
+		for _, hash := range filterMap {
+			ret = append(ret, hash)
+		}
+	} else { // operator is or
+		for _, hashes := range hashesArr {
+			ret = append(ret, hashes...)
+		}
+	}
+
+	return ret
+}


### PR DESCRIPTION
This PR implements Rosetta's Indexer API, currently support `Events` and `Search` Endpoints


## Test

Events Endpoints:

```
POST /events/blocks HTTP/1.1
Content-Type: application/json

{
    "network_identifier": {
        "blockchain": "Harmony",
        "network": "Testnet",
        "sub_network_identifier": {
            "network": "shard 0",
            "metadata": {
               "is_beacon": true
            }
        }
    },
    "offset": 1000,
    "limit": 5
}

---

HTTP/1.1 200 OK

{
    "max_sequence": 19020,
    "events": [
        {
            "sequence": 1000,
            "block_identifier": {
                "index": 1000,
                "hash": "0x7698a5a502089ecb37580897e3798f1c2425c07511fdde164f385d1e99252bf5"
            },
            "type": "block_added"
        },
        {
            "sequence": 1001,
            "block_identifier": {
                "index": 1001,
                "hash": "0xe086efe7374e3b43d4b50a2c9c88942f86539ff9f9f6bc82e84d5eeab4fce454"
            },
            "type": "block_added"
        },
        {
            "sequence": 1002,
            "block_identifier": {
                "index": 1002,
                "hash": "0xbebc5649ff1a6bb75c38da881fdff35796d8369b59831729d6cd29045ff70c02"
            },
            "type": "block_added"
        },
        {
            "sequence": 1003,
            "block_identifier": {
                "index": 1003,
                "hash": "0xdc068a9535201626dc602e4feccea32d4f1df9de044e1986b06a3e8fc413c7b2"
            },
            "type": "block_added"
        },
        {
            "sequence": 1004,
            "block_identifier": {
                "index": 1004,
                "hash": "0x6818d0326cfdc30b47172877010bc55251601bf79dbb3a83d6ba15258b231099"
            },
            "type": "block_added"
        }
    ]
}
```

Search Endpoints:

```
POST /search/transactions HTTP/1.1
Content-Type: application/json

{
    "network_identifier": {
        "blockchain": "Harmony",
        "network": "Testnet",
        "sub_network_identifier": {
            "network": "shard 0",
            "metadata": {
                "is_beacon": true
            }
        }
    },
    "operator": "or",
    "max_block": 5,
    "offset": 5,
    "limit": 5,
    "transaction_identifier": {
        "hash": "0x51207385e8327cc1405adc43049975557d1b07f205feebc89f4a2975df7819f4"
    }
}

---

HTTP/1.1 200 OK

{
    "transactions": [
        {
            "block_identifier": {
                "index": 9996,
                "hash": "0x7a863597cad374895c8aad5e1b09bc54ffa76097cb963cf8ad7c9dadb99865e7"
            },
            "transaction": {
                "transaction_identifier": {
                    "hash": "0x4573e600fc7ebf3d42116f89877edd751447bdb64f387070768118557748b409"
                },
                "operations": [
                    {
                        "operation_identifier": {
                            "index": 0
                        },
                        "type": "NativeTransfer",
                        "status": "success",
                        "account": {
                            "address": "one1l70tcs2u02ft54p4dupvunjcny54ry2wqzdmyu",
                            "metadata": {
                                "hex_address": "0xff9eBc415C7a92ba54356f02CE4E58992951914e"
                            }
                        },
                        "amount": {
                            "value": "10000000000000000000",
                            "currency": {
                                "symbol": "ONE",
                                "decimals": 18
                            }
                        }
                    }
                ],
                "metadata": {
                    "index": 0,
                    "size": "182.00 B"
                }
            }
        }
    ],
    "total_count": 1
}
```