### PR TITLE
Optimize the `getAllValidatorInformation` rpc method

### DIFF
--- a/rpc/types.go
+++ b/rpc/types.go
@@ -123,6 +123,14 @@ func NewStructuredResponse(input interface{}) (StructuredResponse, error) {
 // BlockNumber ..
 type BlockNumber rpc.BlockNumber
 
+const (
+	// LatestBlockNumber is the alias to rpc latest block number
+	LatestBlockNumber BlockNumber = rpc.LatestBlockNumber
+
+	// PendingBlockNumber is the alias to rpc pending block number
+	PendingBlockNumber BlockNumber = rpc.PendingBlockNumber
+)
+
 // UnmarshalJSON converts a hex string or integer to a block number
 func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 	baseBn := rpc.BlockNumber(0)

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -125,10 +125,10 @@ type BlockNumber rpc.BlockNumber
 
 const (
 	// LatestBlockNumber is the alias to rpc latest block number
-	LatestBlockNumber BlockNumber = rpc.LatestBlockNumber
+	LatestBlockNumber = BlockNumber(rpc.LatestBlockNumber)
 
 	// PendingBlockNumber is the alias to rpc pending block number
-	PendingBlockNumber BlockNumber = rpc.PendingBlockNumber
+	PendingBlockNumber = BlockNumber(rpc.PendingBlockNumber)
 )
 
 // UnmarshalJSON converts a hex string or integer to a block number


### PR DESCRIPTION
## Issue

Because of the complexity of RPC method of `GetAllValidatorInformation`, the RPC is expected to take some time to return the result. This PR is trying to do some optimization of the RPC method. 
1. Remove one unnecessary serialization/deserialization to save CPU and memory resources. 
2. Replace the usage of single flight with caching to mitigate the possible memory leak.

The heavy RPC was once a temporary solution to serve our explorer node. But now the method seems way too bloated that one single RPC request may return 36MB data on mainnet. This shall be mitigated by deprecating this RPC method with a number of small requests.

## Test

1. Passed local test.
2. Manual test with command:
```
curl --location --request POST 'http://localhost:9500' \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "hmyv2_getAllValidatorInformation",
    "params": [-1]
}'

curl --location --request POST 'http://localhost:9500' \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "hmyv2_getAllValidatorInformationByBlockNumber",
    "params": [-1, 15]
}'
```