### PR TITLE
Add gas price suggestion on GasPrice rpc

### DIFF
--- a/hmy/gasprice.go
+++ b/hmy/gasprice.go
@@ -19,12 +19,13 @@ package hmy
 import (
 	"context"
 	"fmt"
-	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/harmony-one/harmony/block"
-	"github.com/harmony-one/harmony/internal/utils"
 	"math/big"
 	"sort"
 	"sync"
+
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/harmony-one/harmony/block"
+	"github.com/harmony-one/harmony/internal/utils"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"

--- a/hmy/gasprice.go
+++ b/hmy/gasprice.go
@@ -1,0 +1,224 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package hmy
+
+import (
+	"context"
+	"fmt"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/harmony-one/harmony/block"
+	"github.com/harmony-one/harmony/internal/utils"
+	"math/big"
+	"sort"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/harmony-one/harmony/core/types"
+)
+
+const sampleNumber = 3 // Number of transactions sampled in a block
+
+var DefaultMaxPrice = big.NewInt(1 * params.Ether)
+
+type GasPriceConfig struct {
+	Blocks     int
+	Percentile int
+	Default    *big.Int `toml:",omitempty"`
+	MaxPrice   *big.Int `toml:",omitempty"`
+}
+
+// OracleBackend includes all necessary background APIs for oracle.
+type OracleBackend interface {
+	HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*block.Header, error)
+	BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error)
+	ChainConfig() *params.ChainConfig
+}
+
+// Oracle recommends gas prices based on the content of recent
+// blocks. Suitable for both light and full clients.
+type Oracle struct {
+	backend   *Harmony
+	lastHead  common.Hash
+	lastPrice *big.Int
+	maxPrice  *big.Int
+	cacheLock sync.RWMutex
+	fetchLock sync.Mutex
+
+	checkBlocks int
+	percentile  int
+}
+
+// NewOracle returns a new gasprice oracle which can recommend suitable
+// gasprice for newly created transaction.
+func NewOracle(backend *Harmony, params GasPriceConfig) *Oracle {
+	blocks := params.Blocks
+	if blocks < 1 {
+		blocks = 1
+		utils.Logger().Warn().Msg(fmt.Sprint("Sanitizing invalid gasprice oracle sample blocks", "provided", params.Blocks, "updated", blocks))
+	}
+	percent := params.Percentile
+	if percent < 0 {
+		percent = 0
+		utils.Logger().Warn().Msg(fmt.Sprint("Sanitizing invalid gasprice oracle sample percentile", "provided", params.Percentile, "updated", percent))
+	}
+	if percent > 100 {
+		percent = 100
+		utils.Logger().Warn().Msg(fmt.Sprint("Sanitizing invalid gasprice oracle sample percentile", "provided", params.Percentile, "updated", percent))
+	}
+	maxPrice := params.MaxPrice
+	if maxPrice == nil || maxPrice.Int64() <= 0 {
+		maxPrice = DefaultMaxPrice
+		utils.Logger().Warn().Msg(fmt.Sprint("Sanitizing invalid gasprice oracle price cap", "provided", params.MaxPrice, "updated", maxPrice))
+	}
+	return &Oracle{
+		backend:     backend,
+		lastPrice:   params.Default,
+		maxPrice:    maxPrice,
+		checkBlocks: blocks,
+		percentile:  percent,
+	}
+}
+
+// SuggestPrice returns a gasprice so that newly created transaction can
+// have a very high chance to be included in the following blocks.
+func (gpo *Oracle) SuggestPrice(ctx context.Context) (*big.Int, error) {
+	head, _ := gpo.backend.HeaderByNumber(ctx, rpc.LatestBlockNumber)
+	headHash := head.Hash()
+
+	// If the latest gasprice is still available, return it.
+	gpo.cacheLock.RLock()
+	lastHead, lastPrice := gpo.lastHead, gpo.lastPrice
+	gpo.cacheLock.RUnlock()
+	if headHash == lastHead {
+		return lastPrice, nil
+	}
+	gpo.fetchLock.Lock()
+	defer gpo.fetchLock.Unlock()
+
+	// Try checking the cache again, maybe the last fetch fetched what we need
+	gpo.cacheLock.RLock()
+	lastHead, lastPrice = gpo.lastHead, gpo.lastPrice
+	gpo.cacheLock.RUnlock()
+	if headHash == lastHead {
+		return lastPrice, nil
+	}
+	var (
+		sent, exp int
+		number    = head.Number().Uint64()
+		result    = make(chan getBlockPricesResult, gpo.checkBlocks)
+		quit      = make(chan struct{})
+		txPrices  []*big.Int
+	)
+	for sent < gpo.checkBlocks && number > 0 {
+		go gpo.getBlockPrices(ctx, types.MakeSigner(gpo.backend.ChainConfig(), big.NewInt(int64(number))), number, sampleNumber, result, quit)
+		sent++
+		exp++
+		number--
+	}
+	for exp > 0 {
+		res := <-result
+		if res.err != nil {
+			close(quit)
+			return lastPrice, res.err
+		}
+		exp--
+		// Nothing returned. There are two special cases here:
+		// - The block is empty
+		// - All the transactions included are sent by the miner itself.
+		// In these cases, use the latest calculated price for samping.
+		if len(res.prices) == 0 {
+			res.prices = []*big.Int{lastPrice}
+		}
+		// Besides, in order to collect enough data for sampling, if nothing
+		// meaningful returned, try to query more blocks. But the maximum
+		// is 2*checkBlocks.
+		if len(res.prices) == 1 && len(txPrices)+1+exp < gpo.checkBlocks*2 && number > 0 {
+			go gpo.getBlockPrices(ctx, types.MakeSigner(gpo.backend.ChainConfig(), big.NewInt(int64(number))), number, sampleNumber, result, quit)
+			sent++
+			exp++
+			number--
+		}
+		txPrices = append(txPrices, res.prices...)
+	}
+	price := lastPrice
+	if len(txPrices) > 0 {
+		sort.Sort(bigIntArray(txPrices))
+		price = txPrices[(len(txPrices)-1)*gpo.percentile/100]
+	}
+	if price.Cmp(gpo.maxPrice) > 0 {
+		price = new(big.Int).Set(gpo.maxPrice)
+	}
+	gpo.cacheLock.Lock()
+	gpo.lastHead = headHash
+	gpo.lastPrice = price
+	gpo.cacheLock.Unlock()
+	return price, nil
+}
+
+type getBlockPricesResult struct {
+	prices []*big.Int
+	err    error
+}
+
+type transactionsByGasPrice []*types.Transaction
+
+func (t transactionsByGasPrice) Len() int      { return len(t) }
+func (t transactionsByGasPrice) Swap(i, j int) { t[i], t[j] = t[j], t[i] }
+func (t transactionsByGasPrice) Less(i, j int) bool {
+	return t[i].GasPrice().Cmp(t[j].GasPrice()) < 0
+}
+
+// getBlockPrices calculates the lowest transaction gas price in a given block
+// and sends it to the result channel. If the block is empty or all transactions
+// are sent by the miner itself(it doesn't make any sense to include this kind of
+// transaction prices for sampling), nil gasprice is returned.
+func (gpo *Oracle) getBlockPrices(ctx context.Context, signer types.Signer, blockNum uint64, limit int, result chan getBlockPricesResult, quit chan struct{}) {
+	block, err := gpo.backend.BlockByNumber(ctx, rpc.BlockNumber(blockNum))
+	if block == nil {
+		select {
+		case result <- getBlockPricesResult{nil, err}:
+		case <-quit:
+		}
+		return
+	}
+	blockTxs := block.Transactions()
+	txs := make([]*types.Transaction, len(blockTxs))
+	copy(txs, blockTxs)
+	sort.Sort(transactionsByGasPrice(txs))
+
+	var prices []*big.Int
+	for _, tx := range txs {
+		sender, err := types.Sender(signer, tx)
+		if err == nil && sender != block.Coinbase() {
+			prices = append(prices, tx.GasPrice())
+			if len(prices) >= limit {
+				break
+			}
+		}
+	}
+	select {
+	case result <- getBlockPricesResult{prices, nil}:
+	case <-quit:
+	}
+}
+
+type bigIntArray []*big.Int
+
+func (s bigIntArray) Len() int           { return len(s) }
+func (s bigIntArray) Less(i, j int) bool { return s[i].Cmp(s[j]) < 0 }
+func (s bigIntArray) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }

--- a/hmy/hmy.go
+++ b/hmy/hmy.go
@@ -2,7 +2,6 @@ package hmy
 
 import (
 	"context"
-	"github.com/harmony-one/harmony/hmy/gasprice"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -17,11 +16,11 @@ import (
 	"github.com/harmony-one/harmony/core/state"
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/core/vm"
-	"github.com/harmony-one/harmony/internal/configs/node"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	commonRPC "github.com/harmony-one/harmony/rpc/common"
 	"github.com/harmony-one/harmony/shard"
 	staking "github.com/harmony-one/harmony/staking/types"
-	"github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/singleflight"
@@ -63,7 +62,7 @@ type Harmony struct {
 	ShardID   uint32
 
 	// Gas price suggestion oracle
-	gpo *gasprice.Oracle
+	gpo *Oracle
 
 	// Internals
 	eventMux *event.TypeMux

--- a/hmy/pool.go
+++ b/hmy/pool.go
@@ -2,6 +2,7 @@ package hmy
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/core/types"
@@ -45,4 +46,8 @@ func (hmy *Harmony) GetPoolTransactions() (types.PoolTransactions, error) {
 		txs = append(txs, batch...)
 	}
 	return txs, nil
+}
+
+func (hmy *Harmony) SuggestPrice(ctx context.Context) (*big.Int, error) {
+	return hmy.gpo.SuggestPrice(ctx)
 }

--- a/hmy/staking.go
+++ b/hmy/staking.go
@@ -357,7 +357,7 @@ func (hmy *Harmony) GetValidatorInformation(
 	// b.apiCache.Forget(prevKey)
 
 	// calculate last APRHistoryLength epochs for averaging APR
-	// epochFrom := bc.Config().StakingEpoch
+	// epochFrom := bc.GasPriceConfig().StakingEpoch
 	// nowMinus := big.NewInt(0).Sub(now, big.NewInt(staking.APRHistoryLength))
 	// if nowMinus.Cmp(epochFrom) > 0 {
 	// 	epochFrom = nowMinus

--- a/rpc/harmony.go
+++ b/rpc/harmony.go
@@ -59,13 +59,16 @@ func (s *PublicHarmonyService) Syncing(
 // GasPrice returns a suggestion for a gas price.
 // Note that the return type is an interface to account for the different versions
 func (s *PublicHarmonyService) GasPrice(ctx context.Context) (interface{}, error) {
-	// TODO(dm): add SuggestPrice API
+	price, err := s.hmy.SuggestPrice(ctx)
+	if err != nil || price.Cmp(big.NewInt(1e10)) < 0 {
+		price = big.NewInt(1e10)
+	}
 	// Format response according to version
 	switch s.version {
 	case V1, Eth:
-		return (*hexutil.Big)(big.NewInt(1e10)), nil
+		return (*hexutil.Big)(price), nil
 	case V2:
-		return 1e10, nil
+		return price.Uint64(), nil
 	default:
 		return nil, ErrUnknownRPCVersion
 	}


### PR DESCRIPTION
Previously our GasPrice rpc returns a fixed number of 10Gwei as suggested gas price.

Now we are adding a more reasonable gas suggestion logic based on transactions in recent blocks. The main logic are exactly following ethereum's gas suggestion mechanism but with a minimum suggested gas price of 10Gwei.