### PR TITLE
update brew install in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ sudo yum install glibc-static gmp-devel gmp-static openssl-libs openssl-static g
 
 On macOS: 
 ```bash
-brew cask install docker
+brew install --cask docker
 open /Applications/Docker.app
 ```
 On Linux, reference official documentation [here](https://docs.docker.com/engine/install/).


### PR DESCRIPTION
Updating README because cask is no longer supported brew command. Should use `brew install --cask` instead.