### PR TITLE
Add flag to allow configuring log rotation via lumberjack

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -93,6 +93,8 @@ func main() {
 	port := flag.String("port", "9876", "port of the node.")
 	logFolder := flag.String("log_folder", "latest", "the folder collecting the logs of this execution")
 	logMaxSize := flag.Int("log_max_size", 100, "the max size in megabytes of the log file before it gets rotated")
+	logRotateCount := flag.Int("log_rotate_count", 0, "the number of rotated logs to keep. If set to 0 rotation is disabled")
+	logRotateMaxAge := flag.Int("log_rotate_max_age", 0, "the maximum number of days to retain old logs. If set to 0 rotation is disabled")
 	keyFile := flag.String("key", "./.bnkey", "the private key file of the bootnode")
 	versionFlag := flag.Bool("version", false, "Output version info")
 	verbosity := flag.Int("verbosity", 5, "Logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail (default: 5)")
@@ -107,7 +109,7 @@ func main() {
 	// Logging setup
 	utils.SetLogContext(*port, *ip)
 	utils.SetLogVerbosity(log.Lvl(*verbosity))
-	utils.AddLogFile(fmt.Sprintf("%v/bootnode-%v-%v.log", *logFolder, *ip, *port), *logMaxSize)
+	utils.AddLogFile(fmt.Sprintf("%v/bootnode-%v-%v.log", *logFolder, *ip, *port), *logMaxSize, *logRotateCount, *logRotateMaxAge)
 
 	privKey, _, err := utils.LoadKeyFromFile(*keyFile)
 	if err != nil {

--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -62,6 +62,8 @@ Version = "1.0.4"
   FileName = "harmony.log"
   Folder = "./latest"
   RotateSize = 100
+  RotateCount = 50
+  RotateMaxAge = 0
   Verbosity = 3
 
 [Network]

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -73,10 +73,11 @@ var defaultConfig = harmonyconfig.HarmonyConfig{
 		ProfileDebugValues: []int{0},
 	},
 	Log: harmonyconfig.LogConfig{
-		Folder:     "./latest",
-		FileName:   "harmony.log",
-		RotateSize: 100,
-		Verbosity:  3,
+		Folder:      "./latest",
+		FileName:    "harmony.log",
+		RotateSize:  100,
+		RotateCount: 10,
+		Verbosity:   3,
 		VerbosePrints: harmonyconfig.LogVerbosePrints{
 			Config: true,
 		},

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -136,6 +136,8 @@ var (
 	logFlags = []cli.Flag{
 		logFolderFlag,
 		logRotateSizeFlag,
+		logRotateCountFlag,
+		logRotateMaxAgeFlag,
 		logFileNameFlag,
 		logContextIPFlag,
 		logContextPortFlag,
@@ -1053,6 +1055,16 @@ var (
 		Usage:    "rotation log size in megabytes",
 		DefValue: defaultConfig.Log.RotateSize,
 	}
+	logRotateCountFlag = cli.IntFlag{
+		Name:     "log.rotate-count",
+		Usage:    "maximum number of old log files to retain",
+		DefValue: defaultConfig.Log.RotateCount,
+	}
+	logRotateMaxAgeFlag = cli.IntFlag{
+		Name:     "log.rotate-max-age",
+		Usage:    "maximum number of days to retain old log files",
+		DefValue: defaultConfig.Log.RotateCount,
+	}
 	logFileNameFlag = cli.StringFlag{
 		Name:     "log.name",
 		Usage:    "log file name (e.g. harmony.log)",
@@ -1113,6 +1125,14 @@ func applyLogFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 		config.Log.RotateSize = cli.GetIntFlagValue(cmd, logRotateSizeFlag)
 	} else if cli.IsFlagChanged(cmd, legacyLogRotateSizeFlag) {
 		config.Log.RotateSize = cli.GetIntFlagValue(cmd, legacyLogRotateSizeFlag)
+	}
+
+	if cli.IsFlagChanged(cmd, logRotateCountFlag) {
+		config.Log.RotateCount = cli.GetIntFlagValue(cmd, logRotateCountFlag)
+	}
+
+	if cli.IsFlagChanged(cmd, logRotateMaxAgeFlag) {
+		config.Log.RotateMaxAge = cli.GetIntFlagValue(cmd, logRotateMaxAgeFlag)
 	}
 
 	if cli.IsFlagChanged(cmd, logFileNameFlag) {

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -896,13 +896,16 @@ func TestLogFlags(t *testing.T) {
 			expConfig: defaultConfig.Log,
 		},
 		{
-			args: []string{"--log.dir", "latest_log", "--log.max-size", "10", "--log.name", "harmony.log",
-				"--log.verb", "5", "--log.verbose-prints", "config"},
+			args: []string{"--log.dir", "latest_log", "--log.max-size", "10", "--log.rotate-count", "3",
+				"--log.rotate-max-age", "0", "--log.name", "harmony.log", "--log.verb", "5",
+				"--log.verbose-prints", "config"},
 			expConfig: harmonyconfig.LogConfig{
-				Folder:     "latest_log",
-				FileName:   "harmony.log",
-				RotateSize: 10,
-				Verbosity:  5,
+				Folder:       "latest_log",
+				FileName:     "harmony.log",
+				RotateSize:   10,
+				RotateCount:  3,
+				RotateMaxAge: 0,
+				Verbosity:    5,
 				VerbosePrints: harmonyconfig.LogVerbosePrints{
 					Config: true,
 				},
@@ -915,6 +918,8 @@ func TestLogFlags(t *testing.T) {
 				Folder:        defaultConfig.Log.Folder,
 				FileName:      defaultConfig.Log.FileName,
 				RotateSize:    defaultConfig.Log.RotateSize,
+				RotateCount:   defaultConfig.Log.RotateCount,
+				RotateMaxAge:  defaultConfig.Log.RotateMaxAge,
 				Verbosity:     defaultConfig.Log.Verbosity,
 				VerbosePrints: defaultConfig.Log.VerbosePrints,
 				Context: &harmonyconfig.LogContext{

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -233,9 +233,11 @@ func applyRootFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 func setupNodeLog(config harmonyconfig.HarmonyConfig) {
 	logPath := filepath.Join(config.Log.Folder, config.Log.FileName)
 	rotateSize := config.Log.RotateSize
+	rotateCount := config.Log.RotateCount
+	rotateMaxAge := config.Log.RotateMaxAge
 	verbosity := config.Log.Verbosity
 
-	utils.AddLogFile(logPath, rotateSize)
+	utils.AddLogFile(logPath, rotateSize, rotateCount, rotateMaxAge)
 	utils.SetLogVerbosity(log.Lvl(verbosity))
 	if config.Log.Context != nil {
 		ip := config.Log.Context.IP

--- a/internal/configs/harmony/harmony.go
+++ b/internal/configs/harmony/harmony.go
@@ -100,6 +100,8 @@ type LogConfig struct {
 	Folder        string
 	FileName      string
 	RotateSize    int
+	RotateCount   int
+	RotateMaxAge  int
 	Verbosity     int
 	VerbosePrints LogVerbosePrints
 	Context       *LogContext `toml:",omitempty"`

--- a/internal/utils/singleton.go
+++ b/internal/utils/singleton.go
@@ -53,9 +53,10 @@ func SetLogVerbosity(verbosity log.Lvl) {
 }
 
 // AddLogFile creates a StreamHandler that outputs JSON logs
-// into rotating files with specified max file size
-func AddLogFile(filepath string, maxSize int) {
-	setZeroLoggerFileOutput(filepath, maxSize)
+// into rotating files with specified max file size and storing at
+// max rotateCount files
+func AddLogFile(filepath string, maxSize int, rotateCount int, rotateMaxAge int) {
+	setZeroLoggerFileOutput(filepath, maxSize, rotateCount, rotateMaxAge)
 }
 
 // AddLogHandler add a log handler
@@ -97,7 +98,7 @@ func setZeroLogContext(port string, ip string) {
 
 // SetZeroLoggerFileOutput sets zeroLogger's output stream
 // to destinated filepath with log file rotation.
-func setZeroLoggerFileOutput(filepath string, maxSize int) error {
+func setZeroLoggerFileOutput(filepath string, maxSize int, rotateCount int, rotateMaxAge int) error {
 	dir := path.Dir(filepath)
 	filename := path.Base(filepath)
 
@@ -105,9 +106,11 @@ func setZeroLoggerFileOutput(filepath string, maxSize int) error {
 	// TODO: zerolog filename prefix can be removed once all loggers
 	// has been replaced
 	childLogger := Logger().Output(&lumberjack.Logger{
-		Filename: fmt.Sprintf("%s/zerolog-%s", dir, filename),
-		MaxSize:  maxSize,
-		Compress: true,
+		Filename:   fmt.Sprintf("%s/zerolog-%s", dir, filename),
+		MaxSize:    maxSize,
+		MaxBackups: rotateCount,
+		MaxAge:     rotateMaxAge,
+		Compress:   true,
 	})
 	zeroLogger = &childLogger
 


### PR DESCRIPTION
## Issue

https://github.com/harmony-one/harmony/issues/3888

## Test

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**

## TODO
