### PR TITLE
enable sha3-256 fork on mainnet and testnet

### DIFF
--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -62,7 +62,7 @@ var (
 		DataCopyFixEpoch:           big.NewInt(689), // Around Wed Sept 15th 2021 with 3.5s block time
 		IstanbulEpoch:              big.NewInt(314),
 		ReceiptLogEpoch:            big.NewInt(101),
-		SHA3Epoch:                  EpochTBD,        //EpochTBD
+		SHA3Epoch:                  big.NewInt(725), // Around Mon Oct 11 2021, 19:00 UTC
 		HIP6And8Epoch:              big.NewInt(725), // Around Mon Oct 11 2021, 19:00 UTC
 	}
 
@@ -94,7 +94,7 @@ var (
 		DataCopyFixEpoch:           big.NewInt(74412),
 		IstanbulEpoch:              big.NewInt(43800),
 		ReceiptLogEpoch:            big.NewInt(0),
-		SHA3Epoch:                  EpochTBD, //EpochTBD
+		SHA3Epoch:                  big.NewInt(74590),
 		HIP6And8Epoch:              big.NewInt(74590),
 	}
 

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -94,8 +94,8 @@ var (
 		DataCopyFixEpoch:           big.NewInt(74412),
 		IstanbulEpoch:              big.NewInt(43800),
 		ReceiptLogEpoch:            big.NewInt(0),
-		SHA3Epoch:                  big.NewInt(74590),
-		HIP6And8Epoch:              big.NewInt(74590),
+		SHA3Epoch:                  big.NewInt(74570),
+		HIP6And8Epoch:              big.NewInt(74570),
 	}
 
 	// PangaeaChainConfig contains the chain parameters for the Pangaea network.


### PR DESCRIPTION
enable sha3-256 precompile at epoch 725 Around Mon Oct 11 2021, 19:00 UTC for mainnet.