### PR TITLE
Turn pprof default on with local saved files

### DIFF
--- a/cmd/harmony/config_migrations_test.go
+++ b/cmd/harmony/config_migrations_test.go
@@ -266,7 +266,7 @@ Version = "1.0.4"
   Port = 9000
 
 [Pprof]
-  Enabled = false
+  Enabled = true
   ListenAddr = "127.0.0.1:6060"
 
 [RPCOpt]

--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -76,7 +76,7 @@ Version = "1.0.4"
   Port = 9000
 
 [Pprof]
-  Enabled = false
+  Enabled = true
   ListenAddr = "127.0.0.1:6060"
 
 [TxPool]

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -65,10 +65,10 @@ var defaultConfig = harmonyconfig.HarmonyConfig{
 	},
 	Sync: getDefaultSyncConfig(defNetworkType),
 	Pprof: harmonyconfig.PprofConfig{
-		Enabled:            false,
+		Enabled:            true,
 		ListenAddr:         "127.0.0.1:6060",
 		Folder:             "./profiles",
-		ProfileNames:       []string{},
+		ProfileNames:       []string{"cpu", "heap", "goroutine"},
 		ProfileIntervals:   []int{600},
 		ProfileDebugValues: []int{0},
 	},

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -69,7 +69,7 @@ var defaultConfig = harmonyconfig.HarmonyConfig{
 		ListenAddr:         "127.0.0.1:6060",
 		Folder:             "./profiles",
 		ProfileNames:       []string{"cpu", "heap", "goroutine"},
-		ProfileIntervals:   []int{600},
+		ProfileIntervals:   []int{3600},
 		ProfileDebugValues: []int{0},
 	},
 	Log: harmonyconfig.LogConfig{

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -104,7 +104,7 @@ func TestHarmonyFlags(t *testing.T) {
 					ListenAddr:         "127.0.0.1:6060",
 					Folder:             "./profiles",
 					ProfileNames:       []string{"cpu", "heap", "goroutine"},
-					ProfileIntervals:   []int{600},
+					ProfileIntervals:   []int{3600},
 					ProfileDebugValues: []int{0},
 				},
 				Log: harmonyconfig.LogConfig{

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -100,10 +100,10 @@ func TestHarmonyFlags(t *testing.T) {
 					BlacklistFile: "./.hmy/blacklist.txt",
 				},
 				Pprof: harmonyconfig.PprofConfig{
-					Enabled:            false,
+					Enabled:            true,
 					ListenAddr:         "127.0.0.1:6060",
 					Folder:             "./profiles",
-					ProfileNames:       []string{},
+					ProfileNames:       []string{"cpu", "heap", "goroutine"},
 					ProfileIntervals:   []int{600},
 					ProfileDebugValues: []int{0},
 				},
@@ -802,9 +802,9 @@ func TestPprofFlags(t *testing.T) {
 			expConfig: defaultConfig.Pprof,
 		},
 		{
-			args: []string{"--pprof"},
+			args: []string{"--pprof=false"},
 			expConfig: harmonyconfig.PprofConfig{
-				Enabled:            true,
+				Enabled:            false,
 				ListenAddr:         defaultConfig.Pprof.ListenAddr,
 				Folder:             defaultConfig.Pprof.Folder,
 				ProfileNames:       defaultConfig.Pprof.ProfileNames,


### PR DESCRIPTION
## Issue

Currently, the pprof module is default off. Need to turn it on by default to enable history pprof data persisting on disk.

For `harmony.conf`, it would be better to have `ProfileNames` set to `[]string{"cpu", "heap", "goroutine"}` so that the specified profiles will be persisted into disk.

## Test

Tested and run locally.
