### PR TITLE
Order super committe slots list by bitmap order

### DIFF
--- a/consensus/quorum/one-node-staked-vote.go
+++ b/consensus/quorum/one-node-staked-vote.go
@@ -268,7 +268,9 @@ func (v *stakedVoteWeight) MarshalJSON() ([]byte, error) {
 	i, externalCount := 0, 0
 
 	totalRaw := numeric.ZeroDec()
-	for identity, voter := range v.roster.Voters {
+	for _, slot := range v.roster.OrderedSlots {
+		identity := slot
+		voter := v.roster.Voters[slot]
 		member := u{
 			voter.IsHarmonyNode,
 			common2.MustAddressToBech32(voter.EarningAccount),

--- a/consensus/votepower/roster.go
+++ b/consensus/votepower/roster.go
@@ -104,6 +104,7 @@ type Roster struct {
 	Voters map[bls.SerializedPublicKey]*AccommodateHarmonyVote
 	topLevelRegistry
 	ShardID uint32
+	OrderedSlots []bls.SerializedPublicKey
 }
 
 func (r Roster) String() string {
@@ -245,6 +246,9 @@ func Compute(subComm *shard.Committee, epoch *big.Int) (*Roster, error) {
 
 	roster.OurVotingPowerTotalPercentage = ourPercentage
 	roster.TheirVotingPowerTotalPercentage = theirPercentage
+	for _, slot := range subComm.Slots {
+		roster.OrderedSlots = append(roster.OrderedSlots, slot.BLSPublicKey)
+	}
 	return roster, nil
 }
 


### PR DESCRIPTION
Order the validator slot list in rpc  getSuperCommittees according to the onchain slot list in the signer bitmap.

Tested locally.