### PR TITLE
[RPC] General solution of prometheus metrics for all RPC methods

### DIFF
--- a/api/service/blockproposal/service.go
+++ b/api/service/blockproposal/service.go
@@ -3,7 +3,6 @@ package blockproposal
 import (
 	msg_pb "github.com/harmony-one/harmony/api/proto/message"
 	"github.com/harmony-one/harmony/consensus"
-	"github.com/harmony-one/harmony/eth/rpc"
 	"github.com/harmony-one/harmony/internal/utils"
 )
 
@@ -41,10 +40,5 @@ func (s *Service) Stop() error {
 	s.stopChan <- struct{}{}
 	<-s.stoppedChan
 	utils.Logger().Info().Msg("Role conversion stopped.")
-	return nil
-}
-
-// APIs for the services.
-func (s *Service) APIs() []rpc.API {
 	return nil
 }

--- a/api/service/consensus/service.go
+++ b/api/service/consensus/service.go
@@ -4,7 +4,6 @@ import (
 	msg_pb "github.com/harmony-one/harmony/api/proto/message"
 	"github.com/harmony-one/harmony/consensus"
 	"github.com/harmony-one/harmony/core/types"
-	"github.com/harmony-one/harmony/eth/rpc"
 	"github.com/harmony-one/harmony/internal/utils"
 )
 
@@ -40,9 +39,4 @@ func (s *Service) Stop() error {
 	<-s.stoppedChan
 	utils.Logger().Info().Msg("Consensus service stopped.")
 	return s.consensus.Close()
-}
-
-// APIs for the services.
-func (s *Service) APIs() []rpc.API {
-	return nil
 }

--- a/api/service/explorer/service.go
+++ b/api/service/explorer/service.go
@@ -17,7 +17,6 @@ import (
 	"github.com/gorilla/mux"
 	msg_pb "github.com/harmony-one/harmony/api/proto/message"
 	"github.com/harmony-one/harmony/core"
-	"github.com/harmony-one/harmony/eth/rpc"
 	"github.com/harmony-one/harmony/hmy"
 	"github.com/harmony-one/harmony/internal/chain"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
@@ -292,11 +291,6 @@ func (s *Service) NotifyService(params map[string]interface{}) {}
 // SetMessageChan sets up message channel to service.
 func (s *Service) SetMessageChan(messageChan chan *msg_pb.Message) {
 	s.messageChan = messageChan
-}
-
-// APIs for the services.
-func (s *Service) APIs() []rpc.API {
-	return nil
 }
 
 func defaultDBPath(ip, port string) string {

--- a/api/service/manager.go
+++ b/api/service/manager.go
@@ -3,7 +3,6 @@ package service
 import (
 	"fmt"
 
-	"github.com/harmony-one/harmony/eth/rpc"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -52,7 +51,6 @@ func (t Type) String() string {
 type Service interface {
 	Start() error
 	Stop() error
-	APIs() []rpc.API // the list of RPC descriptors the service provides
 }
 
 // Manager stores all services for service manager.

--- a/api/service/pprof/service.go
+++ b/api/service/pprof/service.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/harmony-one/harmony/eth/rpc"
 	"github.com/harmony-one/harmony/internal/utils"
 )
 
@@ -124,11 +123,6 @@ func (s *Service) Stop() error {
 			}
 		}
 	}
-	return nil
-}
-
-// APIs return all APIs of the service
-func (s *Service) APIs() []rpc.API {
 	return nil
 }
 

--- a/api/service/prometheus/service.go
+++ b/api/service/prometheus/service.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/harmony-one/harmony/eth/rpc"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -178,11 +177,6 @@ func (s *Service) Status() error {
 	if s.failStatus != nil {
 		return s.failStatus
 	}
-	return nil
-}
-
-// APIs returns the RPC apis of the prometheus service
-func (s *Service) APIs() []rpc.API {
 	return nil
 }
 

--- a/api/service/synchronize/service.go
+++ b/api/service/synchronize/service.go
@@ -2,7 +2,6 @@ package synchronize
 
 import (
 	"github.com/harmony-one/harmony/core"
-	"github.com/harmony-one/harmony/eth/rpc"
 	"github.com/harmony-one/harmony/hmy/downloader"
 	"github.com/harmony-one/harmony/p2p"
 )
@@ -28,10 +27,5 @@ func (s *Service) Start() error {
 // Stop stop the service
 func (s *Service) Stop() error {
 	s.Downloaders.Close()
-	return nil
-}
-
-// APIs return all APIs of the service
-func (s *Service) APIs() []rpc.API {
 	return nil
 }

--- a/consensus/votepower/roster.go
+++ b/consensus/votepower/roster.go
@@ -103,7 +103,7 @@ type topLevelRegistry struct {
 type Roster struct {
 	Voters map[bls.SerializedPublicKey]*AccommodateHarmonyVote
 	topLevelRegistry
-	ShardID uint32
+	ShardID      uint32
 	OrderedSlots []bls.SerializedPublicKey
 }
 

--- a/eth/rpc/handler.go
+++ b/eth/rpc/handler.go
@@ -367,8 +367,12 @@ func (h *handler) handleSubscribe(cp *callProc, msg *jsonrpcMessage) *jsonrpcMes
 
 // runMethod runs the Go callback for an RPC method.
 func (h *handler) runMethod(ctx context.Context, msg *jsonrpcMessage, callb *callback, args []reflect.Value) *jsonrpcMessage {
+	timer := doMetricRequest(msg.Method)
+	defer doMetricDelayHist(timer)
+
 	result, err := callb.call(ctx, msg.Method, args)
 	if err != nil {
+		doMetricErroredRequest(msg.Method)
 		return msg.errorResponse(err)
 	}
 	return msg.response(result)

--- a/eth/rpc/metrics.go
+++ b/eth/rpc/metrics.go
@@ -17,7 +17,7 @@ var (
 	requestCounterVec = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "hmy",
-			Subsystem: "rpc_new",
+			Subsystem: "rpc2",
 			Name:      "request_count",
 			Help:      "counters for each RPC method",
 		},
@@ -27,7 +27,7 @@ var (
 	requestErroredCounterVec = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "hmy",
-			Subsystem: "rpc_new",
+			Subsystem: "rpc2",
 			Name:      "err_count",
 			Help:      "counters of errored RPC method",
 		},
@@ -37,7 +37,7 @@ var (
 	requestDurationHistVec = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "hmy",
-			Subsystem: "rpc_new",
+			Subsystem: "rpc2",
 			Name:      "delay_histogram",
 			Help:      "delays histogram in seconds",
 			// buckets: 50ms, 100ms, 200ms, 400ms, 800ms, 1600ms, 3200ms, +INF

--- a/eth/rpc/metrics.go
+++ b/eth/rpc/metrics.go
@@ -1,0 +1,68 @@
+package rpc
+
+import (
+	prom "github.com/harmony-one/harmony/api/service/prometheus"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func init() {
+	prom.PromRegistry().MustRegister(
+		requestCounterVec,
+		requestErroredCounterVec,
+		requestDurationHistVec,
+	)
+}
+
+var (
+	requestCounterVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "hmy",
+			Subsystem: "rpc_new",
+			Name:      "request_count",
+			Help:      "counters for each RPC method",
+		},
+		[]string{"method"},
+	)
+
+	requestErroredCounterVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "hmy",
+			Subsystem: "rpc_new",
+			Name:      "err_count",
+			Help:      "counters of errored RPC method",
+		},
+		[]string{"method"},
+	)
+
+	requestDurationHistVec = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "hmy",
+			Subsystem: "rpc_new",
+			Name:      "delay_histogram",
+			Help:      "delays histogram in seconds",
+			// buckets: 50ms, 100ms, 200ms, 400ms, 800ms, 1600ms, 3200ms, +INF
+			Buckets: prometheus.ExponentialBuckets(0.05, 2, 8),
+		},
+		[]string{"method"},
+	)
+)
+
+func doMetricRequest(method string) *prometheus.Timer {
+	pLabel := prometheus.Labels{
+		"method": method,
+	}
+	requestCounterVec.With(pLabel).Inc()
+	timer := prometheus.NewTimer(requestDurationHistVec.With(pLabel))
+	return timer
+}
+
+func doMetricErroredRequest(method string) {
+	pLabel := prometheus.Labels{
+		"method": method,
+	}
+	requestErroredCounterVec.With(pLabel).Inc()
+}
+
+func doMetricDelayHist(timer *prometheus.Timer) {
+	timer.ObserveDuration()
+}

--- a/node/api.go
+++ b/node/api.go
@@ -70,10 +70,6 @@ func (node *Node) StartRPC() error {
 	// Gather all the possible APIs to surface
 	apis := node.APIs(harmony)
 
-	for _, service := range node.serviceManager.GetServices() {
-		apis = append(apis, service.APIs()...)
-	}
-
 	return hmy_rpc.StartServers(harmony, apis, node.NodeConfig.RPCServer)
 }
 


### PR DESCRIPTION
## Issue

Previously we do not have the general solution for all RPC metrics. This PR add the general metric to all RPC methods.

The counters per method is now available at `hmy_rpc2_request_count` via `localhost:9900/metrics`

## Test

Tested locally. Example output for metrics result

```
curl localhost:9900
```

[Example output](https://gist.github.com/JackyWYX/874e571400d2362816e28afb5653dc09#file-metrics-txt)

## TODO:

1. Create the prometheus metric page at grafana using new metrics.
2. Retire the current prometheus RPC metric.
