### PR TITLE
Statedb Copy(): Use Staking/Tests Deep Copy of ValidatorWrapper

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -37,6 +37,7 @@ import (
 	"github.com/harmony-one/harmony/staking"
 	"github.com/harmony-one/harmony/staking/effective"
 	stk "github.com/harmony-one/harmony/staking/types"
+	staketest "github.com/harmony-one/harmony/staking/types/test"
 	"github.com/pkg/errors"
 )
 
@@ -632,6 +633,10 @@ func (db *DB) Copy() *DB {
 			state.stateObjects[addr] = db.stateObjects[addr].deepCopy(state)
 		}
 		state.stateObjectsDirty[addr] = struct{}{}
+	}
+	for addr := range db.stateValidators {
+		validatorWrapper := staketest.CopyValidatorWrapper(*db.stateValidators[addr])
+		state.stateValidators[addr] = &validatorWrapper
 	}
 	for hash, logs := range db.logs {
 		cpy := make([]*types.Log, len(logs))


### PR DESCRIPTION
## Issue

Copy function in statedb.go does not deeply copy stateValidators.

This push uses implementation of validatorDeepCopy from /staking/test and tests correctness of these deep copies in the 

## Test

Tests were built matching the structure for existing testCopy tests:

A generic []validatorWrapper was built and stored in state.
State was copied using statedb.Copy() into variable copy.
The copy was copied again into ccopy.
Each *big.Int field in each value of []validatorWrapper in original, copy, and ccopy were modified and tested for expected values.

### Unit Test Coverage

Before:

```
~/go/src/github.com/harmony-one/harmony/core/state# go test -cover
PASS
coverage: 68.3% of statements
ok      github.com/harmony-one/harmony/core/state       9.996s
```

After:

```
~/go/src/github.com/harmony-one/harmony/core/state# go test -cover
PASS
coverage: 70.0% of statements
ok      github.com/harmony-one/harmony/core/state       10.259s
```

## Operational Checklist

Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?. (If no, skip to question 8.)

NO

Does this PR introduce backward-incompatible changes NOT related to on-disk data structure and/or over-the-wire protocol? (If no, continue to question 11.)

NO

Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?

NO