### PR TITLE
[rpc] disable trace api in rpc

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -129,8 +129,8 @@ func StopServers() error {
 
 func getAuthAPIs(hmy *hmy.Harmony, debugEnable bool, rateLimiterEnable bool, ratelimit int) []rpc.API {
 	return []rpc.API{
-		NewPublicTraceAPI(hmy, Debug), // Debug version means geth trace rpc
-		NewPublicTraceAPI(hmy, Trace), // Trace version means parity trace rpc
+		//NewPublicTraceAPI(hmy, Debug), // Debug version means geth trace rpc
+		//NewPublicTraceAPI(hmy, Trace), // Trace version means parity trace rpc
 	}
 }
 
@@ -157,8 +157,8 @@ func getAPIs(hmy *hmy.Harmony, debugEnable bool, rateLimiterEnable bool, ratelim
 		NewPublicStakingAPI(hmy, V2),
 		NewPublicDebugAPI(hmy, V1),
 		NewPublicDebugAPI(hmy, V2),
-		NewPublicTraceAPI(hmy, Debug), // Debug version means geth trace rpc
-		NewPublicTraceAPI(hmy, Trace), // Trace version means parity trace rpc
+		//NewPublicTraceAPI(hmy, Debug), // Debug version means geth trace rpc
+		//NewPublicTraceAPI(hmy, Trace), // Trace version means parity trace rpc
 		// Legacy methods (subject to removal)
 		v1.NewPublicLegacyAPI(hmy, "hmy"),
 		eth.NewPublicEthService(hmy, "eth"),


### PR DESCRIPTION
## Issue

Trace APIs are heavy RPCs. Currently, the backend nodes are receiving a large amount of these RPC method calls,  causing bad RPC service performance.

We will disable the Trace methods for now, meanwhile it will effect the explorer contract code verification. We will enable the methods in private methods later.

## Test

Tested locally.

```
curl --location --request POST 'localhost:9500' \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "hmyv2_traceTransaction",
    "params": []
}'
{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"the method hmyv2_traceTransaction does not exist/is not available"}}
```

@LeoHChen  Please verify the result before deployment. Thanks.