### PR TITLE
add correct auth api

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -94,7 +94,7 @@ func StartServers(hmy *hmy.Harmony, apis []rpc.API, config nodeconfig.RPCServerC
 		}
 
 		wsAuthEndpoint = fmt.Sprintf("%v:%v", config.WSIp, config.WSAuthPort)
-		if err := startAuthWS(apis); err != nil {
+		if err := startAuthWS(authApis); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Issue

#3931 was the original issue #3932 added the ws auth api port but was missing the correct auth api method

## Test
```
wscat -c ws://localhost:9801/ -x '{"method":"trace_block","params":["0x10E5117"],"id":1,"jsonrpc":"2.0"}'
{"jsonrpc":"2.0","id":1,"result":[{"blockNumber":17715479,"blockHash":"0x4da0178a2576976ecb8facb6b531a5405377d350a00b9cc9bf9e9b87e0db163f","transactionHash":"0xef47582f7b216b7cad548cc9294fa93af309f1b30467482412b1b2befd123930","transactionPosition":0,"subtraces":0,"traceAddress":[],"type":"call","action":{"callType":"call","value":"0x0","to":"0xbc744eca05d23694687a3a16cd26661dfb5570bf","gas":"0x73d18","from":"0x2580e45606271b656a933f6305e02b6c5259c369","input":"0xc9807539000000___Truncated___cec82b3275d54b362fc7dc96e01310e8d9b3ac15dfa3"},"result":{"output":"0x","gasUsed":"0x275ea"}}]}
```
Before:
```
wscat -c ws://localhost:9801/ -x '{"method":"trace_block","params":["0x10E5117"],"id":1,"jsonrpc":"2.0"}'
{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"the method trace_block does not exist/is not available"}}
```
