### PR TITLE
Resolve harmony-one/bounties#90: Add revert mechanism for UpdateValidatorWrapper

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2312,7 +2312,7 @@ func (bc *BlockChain) ReadValidatorInformationAtState(
 	if state == nil {
 		return nil, errors.New("empty state")
 	}
-	wrapper, err := state.ValidatorWrapper(addr)
+	wrapper, err := state.ValidatorWrapper(addr, true, false)
 	if err != nil {
 		return nil, err
 	}
@@ -2408,7 +2408,7 @@ func (bc *BlockChain) UpdateValidatorVotingPower(
 			}
 			// This means it's already in staking epoch
 			if currentEpochSuperCommittee.Epoch != nil {
-				wrapper, err := state.ValidatorWrapper(currentValidator)
+				wrapper, err := state.ValidatorWrapper(currentValidator, true, false)
 				if err != nil {
 					return nil, err
 				}
@@ -2489,7 +2489,7 @@ func (bc *BlockChain) UpdateValidatorVotingPower(
 		// compute APR for validators in current committee only
 		if currentEpochSuperCommittee.Epoch != nil {
 			if _, ok := existing.LookupSet[key]; ok {
-				wrapper, err := state.ValidatorWrapper(key)
+				wrapper, err := state.ValidatorWrapper(key, true, false)
 				if err != nil {
 					return nil, err
 				}
@@ -2555,7 +2555,7 @@ func (bc *BlockChain) UpdateValidatorSnapshots(
 	// Read all validator's current data and snapshot them
 	for i := range allValidators {
 		// The snapshot will be captured in the state after the last epoch block is finalized
-		validator, err := state.ValidatorWrapper(allValidators[i])
+		validator, err := state.ValidatorWrapper(allValidators[i], true, false)
 		if err != nil {
 			return err
 		}
@@ -2701,7 +2701,7 @@ func (bc *BlockChain) UpdateStakingMetaData(
 			}
 
 			// Update validator snapshot for the new validator
-			validator, err := state.ValidatorWrapper(addr)
+			validator, err := state.ValidatorWrapper(addr, true, false)
 			if err != nil {
 				return newValidators, err
 			}
@@ -2868,7 +2868,7 @@ func (bc *BlockChain) addDelegationIndex(
 
 	// Found the delegation from state and add the delegation index
 	// Note this should read from the state of current block in concern
-	wrapper, err := state.ValidatorWrapper(validatorAddress)
+	wrapper, err := state.ValidatorWrapper(validatorAddress, true, false)
 	if err != nil {
 		return delegations, err
 	}

--- a/core/staking_verifier.go
+++ b/core/staking_verifier.go
@@ -46,7 +46,7 @@ func checkDuplicateFields(
 
 	for _, addr := range addrs {
 		if !bytes.Equal(validator.Bytes(), addr.Bytes()) {
-			wrapper, err := state.ValidatorWrapperCopy(addr)
+			wrapper, err := state.ValidatorWrapper(addr, true, false)
 
 			if err != nil {
 				return err
@@ -156,7 +156,8 @@ func VerifyAndEditValidatorFromMsg(
 		newBlsKeys); err != nil {
 		return nil, err
 	}
-	wrapper, err := stateDB.ValidatorWrapperCopy(msg.ValidatorAddress)
+	// request a copy, but delegations are not being changed so do not deep copy them
+	wrapper, err := stateDB.ValidatorWrapper(msg.ValidatorAddress, false, false)
 	if err != nil {
 		return nil, err
 	}
@@ -245,7 +246,8 @@ func VerifyAndDelegateFromMsg(
 		// Check if we can use tokens in undelegation to delegate (redelegate)
 		for i := range delegations {
 			delegationIndex := &delegations[i]
-			wrapper, err := stateDB.ValidatorWrapperCopy(delegationIndex.ValidatorAddress)
+			// request a copy, and since delegations will be changed, copy them too
+			wrapper, err := stateDB.ValidatorWrapper(delegationIndex.ValidatorAddress, false, true)
 			if err != nil {
 				return nil, nil, nil, err
 			}
@@ -296,7 +298,8 @@ func VerifyAndDelegateFromMsg(
 
 	if delegateeWrapper == nil {
 		var err error
-		delegateeWrapper, err = stateDB.ValidatorWrapperCopy(msg.ValidatorAddress)
+		// request a copy, and since delegations will be changed, copy them too
+		delegateeWrapper, err = stateDB.ValidatorWrapper(msg.ValidatorAddress, false, true)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -367,7 +370,7 @@ func VerifyAndUndelegateFromMsg(
 		return nil, errValidatorNotExist
 	}
 
-	wrapper, err := stateDB.ValidatorWrapperCopy(msg.ValidatorAddress)
+	wrapper, err := stateDB.ValidatorWrapper(msg.ValidatorAddress, false, true)
 	if err != nil {
 		return nil, err
 	}
@@ -408,7 +411,8 @@ func VerifyAndCollectRewardsFromDelegation(
 	totalRewards := big.NewInt(0)
 	for i := range delegations {
 		delegation := &delegations[i]
-		wrapper, err := stateDB.ValidatorWrapperCopy(delegation.ValidatorAddress)
+		// request a copy, and since delegations will be changed (.Reward.Set), copy them too
+		wrapper, err := stateDB.ValidatorWrapper(delegation.ValidatorAddress, false, true)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/core/staking_verifier_test.go
+++ b/core/staking_verifier_test.go
@@ -134,7 +134,7 @@ func TestCheckDuplicateFields(t *testing.T) {
 			bc: makeFakeChainContextForStake(),
 			sdb: func(t *testing.T) *state.DB {
 				sdb := makeStateDBForStake(t)
-				vw, err := sdb.ValidatorWrapper(makeTestAddr(0))
+				vw, err := sdb.ValidatorWrapper(makeTestAddr(0), false, true)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -640,7 +640,7 @@ func TestVerifyAndEditValidatorFromMsg(t *testing.T) {
 			// 13: cannot update a banned validator
 			sdb: func(t *testing.T) *state.DB {
 				sdb := makeStateDBForStake(t)
-				vw, err := sdb.ValidatorWrapper(validatorAddr)
+				vw, err := sdb.ValidatorWrapper(validatorAddr, false, true)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -1140,7 +1140,7 @@ func makeStateForRedelegate(t *testing.T) *state.DB {
 }
 
 func addStateUndelegationForAddr(sdb *state.DB, addr common.Address, epoch *big.Int) error {
-	w, err := sdb.ValidatorWrapper(addr)
+	w, err := sdb.ValidatorWrapper(addr, false, true)
 	if err != nil {
 		return err
 	}
@@ -1253,7 +1253,7 @@ func TestVerifyAndUndelegateFromMsg(t *testing.T) {
 			// 4: Extract tokens from banned validator
 			sdb: func(t *testing.T) *state.DB {
 				sdb := makeDefaultStateForUndelegate(t)
-				w, err := sdb.ValidatorWrapper(validatorAddr)
+				w, err := sdb.ValidatorWrapper(validatorAddr, false, true)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -1574,7 +1574,7 @@ func makeStateForReward(t *testing.T) *state.DB {
 }
 
 func addStateRewardForAddr(sdb *state.DB, addr common.Address, rewards []*big.Int) error {
-	w, err := sdb.ValidatorWrapper(addr)
+	w, err := sdb.ValidatorWrapper(addr, false, true)
 	if err != nil {
 		return err
 	}

--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	stk "github.com/harmony-one/harmony/staking/types"
 )
 
 // journalEntry is a modification entry in the state change journal that can be
@@ -115,6 +116,10 @@ type (
 		account            *common.Address
 		prevcode, prevhash []byte
 	}
+	validatorWrapperChange struct {
+		address *common.Address
+		prev    *stk.ValidatorWrapper
+	}
 
 	// Changes to other state values.
 	refundChange struct {
@@ -191,6 +196,14 @@ func (ch codeChange) revert(s *DB) {
 
 func (ch codeChange) dirtied() *common.Address {
 	return ch.account
+}
+
+func (ch validatorWrapperChange) revert(s *DB) {
+	s.stateValidators.Add(ch.address.Hex(), ch.prev)
+}
+
+func (ch validatorWrapperChange) dirtied() *common.Address {
+	return ch.address
 }
 
 func (ch storageChange) revert(s *DB) {

--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -199,7 +199,7 @@ func (ch codeChange) dirtied() *common.Address {
 }
 
 func (ch validatorWrapperChange) revert(s *DB) {
-	s.stateValidators.Add(ch.address.Hex(), ch.prev)
+	s.stateValidators[*(ch.address)] = ch.prev
 }
 
 func (ch validatorWrapperChange) dirtied() *common.Address {

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -989,71 +989,239 @@ func makeBLSPubSigPair() blsPubSigPair {
 	return blsPubSigPair{shardPub, shardSig}
 }
 
-func TestValidatorRevert(t *testing.T) {
-	// initialize empty state
-	state, _ := New(common.Hash{}, NewDatabase(rawdb.NewMemoryDatabase()))
-	snapshot := state.Snapshot()
-	key, _ := crypto.GenerateKey()
-	wrapper := makeValidValidatorWrapper(crypto.PubkeyToAddress(key.PublicKey))
-	// add it
-	if err := state.UpdateValidatorWrapperWithRevert(wrapper.Address, &wrapper); err != nil {
-		t.Error(err)
-	}
-	// check that it is stored
-	loadedWrapper, _ := state.ValidatorWrapper(wrapper.Address, true, false)
-	if err := staketest.CheckValidatorWrapperEqual(wrapper, *loadedWrapper); err != nil {
-		t.Errorf("Loaded wrapper not equal to saved wrapper")
-	}
-	// now revert
-	state.RevertToSnapshot(snapshot)
-	loadedWrapper, _ = state.ValidatorWrapper(wrapper.Address, true, false)
-	if loadedWrapper != nil {
-		fmt.Printf("Wrapper: %v\n", wrapper)
-		fmt.Printf("LoadedWrapper: %v\n", loadedWrapper)
-		t.Errorf("Loaded wrapper not empty after revert")
-	}
-	// do a check against empty state and this state
-	emptyState, _ := New(common.Hash{}, NewDatabase(rawdb.NewMemoryDatabase()))
-	st := &snapshotTest{addrs: []common.Address{wrapper.Address}}
-	if err := st.checkEqual(state, emptyState); err != nil {
-		t.Error(err)
-		t.Errorf("State is not empty after revert")
+func updateAndCheckValidator(t *testing.T, state *DB, wrapper stk.ValidatorWrapper) {
+	// do not modify / link the original into the state object
+	copied := staketest.CopyValidatorWrapper(wrapper)
+	if err := state.UpdateValidatorWrapperWithRevert(copied.Address, &copied); err != nil {
+		t.Fatalf("Could not update wrapper with revert %v\n", err)
 	}
 
-	// add back the validator
-	state.UpdateValidatorWrapperWithRevert(wrapper.Address, &wrapper)
-	snapshot = state.Snapshot()
-	stateWithValidatorAndNoDelegation := state.Copy()
-	// add a delegation
-	delegatorKey, _ := crypto.GenerateKey()
+	// load a copy here to be safe
+	loadedWrapper, err := state.ValidatorWrapper(copied.Address, false, true)
+	if err != nil {
+		t.Fatalf("Could not load wrapper %v\n", err)
+	}
+
+	if err := staketest.CheckValidatorWrapperEqual(wrapper, *loadedWrapper); err != nil {
+		t.Fatalf("Wrappers are unequal %v\n", err)
+	}
+}
+
+func verifyValidatorWrapperRevert(
+	t *testing.T,
+	state *DB,
+	snapshot int,
+	wrapperAddress common.Address, // if expectedWrapper is nil, this is needed
+	allowErrAddressNotPresent bool,
+	expectedWrapper *stk.ValidatorWrapper,
+	stateToCompare *DB,
+	modifiedAddresses []common.Address,
+) {
+	state.RevertToSnapshot(snapshot)
+	loadedWrapper, err := state.ValidatorWrapper(wrapperAddress, true, false)
+	if err != nil && !(err == errAddressNotPresent && allowErrAddressNotPresent) {
+		t.Fatalf("Could not load wrapper %v\n", err)
+	}
+	if expectedWrapper != nil {
+		if err := staketest.CheckValidatorWrapperEqual(*expectedWrapper, *loadedWrapper); err != nil {
+			fmt.Printf("ExpectWrapper: %v\n", expectedWrapper)
+			fmt.Printf("LoadedWrapper: %v\n", loadedWrapper)
+			fmt.Printf("ExpectCounters: %v\n", expectedWrapper.Counters)
+			fmt.Printf("LoadedCounters: %v\n", loadedWrapper.Counters)
+			t.Fatalf("Loaded wrapper not equal to expected wrapper after revert %v\n", err)
+		}
+	} else if loadedWrapper != nil {
+		t.Fatalf("Expected wrapper is nil but got loaded wrapper %v\n", loadedWrapper)
+	}
+
+	st := &snapshotTest{addrs: modifiedAddresses}
+	if err := st.checkEqual(state, stateToCompare); err != nil {
+		t.Fatalf("State not as expected after revert %v\n", err)
+	}
+}
+
+func TestValidatorCreationRevert(t *testing.T) {
+	state, err := New(common.Hash{}, NewDatabase(rawdb.NewMemoryDatabase()))
+	emptyState := state.Copy()
+	if err != nil {
+		t.Fatalf("Could not instantiate state %v\n", err)
+	}
+	snapshot := state.Snapshot()
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("Could not generate key %v\n", err)
+	}
+	wrapper := makeValidValidatorWrapper(crypto.PubkeyToAddress(key.PublicKey))
+	// step 1 is adding the validator, and checking that is it successfully added
+	updateAndCheckValidator(t, state, wrapper)
+	// step 2 is the revert check, the meat of the test
+	verifyValidatorWrapperRevert(t,
+		state,
+		snapshot,
+		wrapper.Address,
+		true,
+		nil,
+		emptyState,
+		[]common.Address{wrapper.Address},
+	)
+}
+
+func TestValidatorAddDelegationRevert(t *testing.T) {
+	state, err := New(common.Hash{}, NewDatabase(rawdb.NewMemoryDatabase()))
+	if err != nil {
+		t.Fatalf("Could not instantiate state %v\n", err)
+	}
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("Could not generate key %v\n", err)
+	}
+	delegatorKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("Could not generate key %v\n", err)
+	}
+	wrapper := makeValidValidatorWrapper(crypto.PubkeyToAddress(key.PublicKey))
+	// always, step 1 is adding the validator, and checking that is it successfully added
+	updateAndCheckValidator(t, state, wrapper)
+	wrapperWithoutDelegation := staketest.CopyValidatorWrapper(wrapper) // for comparison later
+	stateWithoutDelegation := state.Copy()
+	// we will revert to the state without the delegation
+	snapshot := state.Snapshot()
+	// which is added here
 	wrapper.Delegations = append(wrapper.Delegations, stk.NewDelegation(
 		crypto.PubkeyToAddress(delegatorKey.PublicKey),
 		new(big.Int).Mul(big.NewInt(denominations.One), big.NewInt(100))),
 	)
-	if err := state.UpdateValidatorWrapperWithRevert(wrapper.Address, &wrapper); err != nil {
-		t.Error(err)
+	// again, add and make sure added == sent
+	updateAndCheckValidator(t, state, wrapper)
+	// now the meat of the test
+	verifyValidatorWrapperRevert(t,
+		state,
+		snapshot,
+		wrapper.Address,
+		false,
+		&wrapperWithoutDelegation,
+		stateWithoutDelegation,
+		[]common.Address{wrapper.Address, wrapper.Delegations[1].DelegatorAddress},
+	)
+}
+
+type expectedRevertItem struct {
+	snapshot                   int
+	expectedWrapperAfterRevert *stk.ValidatorWrapper
+	expectedStateAfterRevert   *DB
+	modifiedAddresses          []common.Address
+}
+
+func makeExpectedRevertItem(state *DB,
+	wrapper *stk.ValidatorWrapper,
+	modifiedAddresses []common.Address,
+) expectedRevertItem {
+	x := expectedRevertItem{
+		snapshot:                 state.Snapshot(),
+		expectedStateAfterRevert: state.Copy(),
+		modifiedAddresses:        modifiedAddresses,
 	}
-	// check that it is stored
-	loadedWrapper, _ = state.ValidatorWrapper(wrapper.Address, true, false)
+	if wrapper != nil {
+		copied := staketest.CopyValidatorWrapper(*wrapper)
+		x.expectedWrapperAfterRevert = &copied
+	}
+	return x
+}
+
+func TestValidatorMultipleReverts(t *testing.T) {
+	var expectedRevertItems []expectedRevertItem
+
+	state, err := New(common.Hash{}, NewDatabase(rawdb.NewMemoryDatabase()))
+	if err != nil {
+		t.Fatalf("Could not instantiate state %v\n", err)
+	}
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("Could not generate key %v\n", err)
+	}
+	delegatorKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("Could not generate key %v\n", err)
+	}
+	validatorAddress := crypto.PubkeyToAddress(key.PublicKey)
+	delegatorAddress := crypto.PubkeyToAddress(delegatorKey.PublicKey)
+	modifiedAddresses := []common.Address{validatorAddress, delegatorAddress}
+	// first we add a validator
+	expectedRevertItems = append(expectedRevertItems,
+		makeExpectedRevertItem(state, nil, modifiedAddresses))
+	wrapper := makeValidValidatorWrapper(crypto.PubkeyToAddress(key.PublicKey))
+	updateAndCheckValidator(t, state, wrapper)
+	// then we add a delegation
+	expectedRevertItems = append(expectedRevertItems,
+		makeExpectedRevertItem(state, &wrapper, modifiedAddresses))
+	wrapper.Delegations = append(wrapper.Delegations, stk.NewDelegation(
+		crypto.PubkeyToAddress(delegatorKey.PublicKey),
+		new(big.Int).Mul(big.NewInt(denominations.One), big.NewInt(100))),
+	)
+	updateAndCheckValidator(t, state, wrapper)
+	// then we have it sign blocks
+	wrapper.Counters.NumBlocksToSign.Add(
+		wrapper.Counters.NumBlocksToSign, common.Big1,
+	)
+	wrapper.Counters.NumBlocksSigned.Add(
+		wrapper.Counters.NumBlocksSigned, common.Big1,
+	)
+	updateAndCheckValidator(t, state, wrapper)
+	// then modify the name and the block reward
+	expectedRevertItems = append(expectedRevertItems,
+		makeExpectedRevertItem(state, &wrapper, modifiedAddresses))
+	wrapper.BlockReward.SetInt64(1)
+	wrapper.Validator.Description.Name = "Name"
+	for i := len(expectedRevertItems) - 1; i >= 0; i-- {
+		item := expectedRevertItems[i]
+		verifyValidatorWrapperRevert(t,
+			state,
+			item.snapshot,
+			wrapper.Address,
+			i == 0,
+			item.expectedWrapperAfterRevert,
+			item.expectedStateAfterRevert,
+			[]common.Address{wrapper.Address},
+		)
+	}
+}
+
+func TestValidatorWrapperPanic(t *testing.T) {
+	defer func() { recover() }()
+
+	state, err := New(common.Hash{}, NewDatabase(rawdb.NewMemoryDatabase()))
+	if err != nil {
+		t.Fatalf("Could not instantiate state %v\n", err)
+	}
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("Could not generate key %v\n", err)
+	}
+	validatorAddress := crypto.PubkeyToAddress(key.PublicKey)
+	// will panic because we are asking for Original with copy of delegations
+	_, _ = state.ValidatorWrapper(validatorAddress, true, true)
+	t.Fatalf("Did not panic")
+}
+
+func TestValidatorWrapperGetCode(t *testing.T) {
+	state, err := New(common.Hash{}, NewDatabase(rawdb.NewMemoryDatabase()))
+	if err != nil {
+		t.Fatalf("Could not instantiate state %v\n", err)
+	}
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("Could not generate key %v\n", err)
+	}
+	wrapper := makeValidValidatorWrapper(crypto.PubkeyToAddress(key.PublicKey))
+	updateAndCheckValidator(t, state, wrapper)
+	// delete it from the cache so we can force it to use GetCode
+	delete(state.stateValidators, wrapper.Address)
+	loadedWrapper, err := state.ValidatorWrapper(wrapper.Address, false, false)
 	if err := staketest.CheckValidatorWrapperEqual(wrapper, *loadedWrapper); err != nil {
-		fmt.Printf("Wrapper: %v\n", wrapper)
+		fmt.Printf("ExpectWrapper: %v\n", wrapper)
 		fmt.Printf("LoadedWrapper: %v\n", loadedWrapper)
-		t.Errorf("Loaded wrapper not equal to saved wrapper")
-	}
-	// now revert
-	state.RevertToSnapshot(snapshot)
-	// drop the new delegation
-	wrapper.Delegations = wrapper.Delegations[:1]
-	loadedWrapper, _ = state.ValidatorWrapper(wrapper.Address, true, false)
-	if err := staketest.CheckValidatorWrapperEqual(wrapper, *loadedWrapper); err != nil {
-		fmt.Printf("Wrapper: %v\n", wrapper)
-		fmt.Printf("LoadedWrapper: %v\n", loadedWrapper)
-		t.Errorf("Loaded wrapper not equal to wrapper without delegation")
-	}
-	// make sure to add the delegation address to snapshotTest
-	st = &snapshotTest{addrs: []common.Address{wrapper.Address, crypto.PubkeyToAddress(delegatorKey.PublicKey)}}
-	if err := st.checkEqual(state, stateWithValidatorAndNoDelegation); err != nil {
-		t.Error(err)
-		t.Errorf("State does not match after delegation revert")
+		fmt.Printf("ExpectCounters: %v\n", wrapper.Counters)
+		fmt.Printf("LoadedCounters: %v\n", loadedWrapper.Counters)
+		t.Fatalf("Loaded wrapper not equal to expected wrapper%v\n", err)
 	}
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -432,6 +432,9 @@ func (st *StateTransition) verifyAndApplyCreateValidatorTx(
 	if err != nil {
 		return err
 	}
+	// since createValidator is not accessible to smart contracts
+	// it should not be reversible (to save resources)
+	// but it would be trivial to enable it later
 	if err := st.state.UpdateValidatorWrapper(wrapper.Address, wrapper); err != nil {
 		return err
 	}
@@ -449,6 +452,9 @@ func (st *StateTransition) verifyAndApplyEditValidatorTx(
 	if err != nil {
 		return err
 	}
+	// since editValidator is not accessible to smart contracts
+	// it should not be reversible (to save resources)
+	// but it would be trivial to enable it later
 	return st.state.UpdateValidatorWrapper(wrapper.Address, wrapper)
 }
 
@@ -464,7 +470,7 @@ func (st *StateTransition) verifyAndApplyDelegateTx(delegate *staking.Delegate) 
 	}
 
 	for _, wrapper := range updatedValidatorWrappers {
-		if err := st.state.UpdateValidatorWrapper(wrapper.Address, wrapper); err != nil {
+		if err := st.state.UpdateValidatorWrapperWithRevert(wrapper.Address, wrapper); err != nil {
 			return err
 		}
 	}
@@ -510,7 +516,7 @@ func (st *StateTransition) verifyAndApplyUndelegateTx(
 	if err != nil {
 		return err
 	}
-	return st.state.UpdateValidatorWrapper(wrapper.Address, wrapper)
+	return st.state.UpdateValidatorWrapperWithRevert(wrapper.Address, wrapper)
 }
 
 func (st *StateTransition) verifyAndApplyCollectRewards(collectRewards *staking.CollectRewards) (*big.Int, error) {
@@ -528,7 +534,7 @@ func (st *StateTransition) verifyAndApplyCollectRewards(collectRewards *staking.
 		return stakingReward.None, err
 	}
 	for _, wrapper := range updatedValidatorWrappers {
-		if err := st.state.UpdateValidatorWrapper(wrapper.Address, wrapper); err != nil {
+		if err := st.state.UpdateValidatorWrapperWithRevert(wrapper.Address, wrapper); err != nil {
 			return stakingReward.None, err
 		}
 	}

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -42,8 +42,9 @@ type StateDB interface {
 	SetCode(common.Address, []byte)
 	GetCodeSize(common.Address) int
 
-	ValidatorWrapperCopy(common.Address) (*staking.ValidatorWrapper, error)
+	ValidatorWrapper(common.Address, bool, bool) (*staking.ValidatorWrapper, error)
 	UpdateValidatorWrapper(common.Address, *staking.ValidatorWrapper) error
+	UpdateValidatorWrapperWithRevert(common.Address, *staking.ValidatorWrapper) error
 	SetValidatorFlag(common.Address)
 	UnsetValidatorFlag(common.Address)
 	IsValidator(common.Address) bool

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -367,7 +367,7 @@ func payoutUndelegations(
 	lockPeriod := GetLockPeriodInEpoch(chain, header.Epoch())
 	noEarlyUnlock := chain.Config().IsNoEarlyUnlock(header.Epoch())
 	for _, validator := range validators {
-		wrapper, err := state.ValidatorWrapper(validator)
+		wrapper, err := state.ValidatorWrapper(validator, true, false)
 		if err != nil {
 			return errors.New(
 				"[Finalize] failed to get validator from state to finalize",
@@ -409,7 +409,7 @@ func setElectionEpochAndMinFee(header *block.Header, state *state.DB, config *pa
 		return errors.New(msg)
 	}
 	for _, addr := range newShardState.StakedValidators().Addrs {
-		wrapper, err := state.ValidatorWrapper(addr)
+		wrapper, err := state.ValidatorWrapper(addr, true, false)
 		if err != nil {
 			return errors.New(
 				"[Finalize] failed to get validator from state to finalize",

--- a/staking/availability/interface.go
+++ b/staking/availability/interface.go
@@ -23,6 +23,6 @@ type RoundHeader interface {
 
 // ValidatorState is the interface of state.DB
 type ValidatorState interface {
-	ValidatorWrapper(common.Address) (*staking.ValidatorWrapper, error)
+	ValidatorWrapper(common.Address, bool, bool) (*staking.ValidatorWrapper, error)
 	UpdateValidatorWrapper(common.Address, *staking.ValidatorWrapper) error
 }

--- a/staking/availability/measure.go
+++ b/staking/availability/measure.go
@@ -96,7 +96,7 @@ func bumpCount(
 				continue
 			}
 
-			wrapper, err := state.ValidatorWrapper(addr)
+			wrapper, err := state.ValidatorWrapper(addr, true, false)
 			if err != nil {
 				return err
 			}
@@ -183,7 +183,7 @@ func ComputeAndMutateEPOSStatus(
 ) error {
 	utils.Logger().Info().Msg("begin compute for availability")
 
-	wrapper, err := state.ValidatorWrapper(addr)
+	wrapper, err := state.ValidatorWrapper(addr, true, false)
 	if err != nil {
 		return err
 	}
@@ -231,7 +231,7 @@ func UpdateMinimumCommissionFee(
 ) error {
 	utils.Logger().Info().Msg("begin update min commission fee")
 
-	wrapper, err := state.ValidatorWrapper(addr)
+	wrapper, err := state.ValidatorWrapper(addr, true, false)
 	if err != nil {
 		return err
 	}

--- a/staking/availability/measure_test.go
+++ b/staking/availability/measure_test.go
@@ -447,11 +447,11 @@ func (ctx *incStateTestCtx) checkHmyNodeStateChangeByAddr(addr common.Address) e
 func (ctx *incStateTestCtx) checkWrapperChangeByAddr(addr common.Address,
 	f func(w1, w2 *staking.ValidatorWrapper) bool) error {
 
-	snapWrapper, err := ctx.snapState.ValidatorWrapper(addr)
+	snapWrapper, err := ctx.snapState.ValidatorWrapper(addr, true, false)
 	if err != nil {
 		return err
 	}
-	curWrapper, err := ctx.state.ValidatorWrapper(addr)
+	curWrapper, err := ctx.state.ValidatorWrapper(addr, true, false)
 	if err != nil {
 		return err
 	}
@@ -517,7 +517,7 @@ func (ctx *computeEPOSTestCtx) makeStateAndReader() {
 }
 
 func (ctx *computeEPOSTestCtx) checkWrapperStatus(expStatus effective.Eligibility) error {
-	wrapper, err := ctx.state.ValidatorWrapper(ctx.addr)
+	wrapper, err := ctx.state.ValidatorWrapper(ctx.addr, true, false)
 	if err != nil {
 		return err
 	}
@@ -605,7 +605,7 @@ func (state testStateDB) snapshot() testStateDB {
 	return res
 }
 
-func (state testStateDB) ValidatorWrapper(addr common.Address) (*staking.ValidatorWrapper, error) {
+func (state testStateDB) ValidatorWrapper(addr common.Address, readOnly bool, copyDelegations bool) (*staking.ValidatorWrapper, error) {
 	wrapper, ok := state[addr]
 	if !ok {
 		return nil, fmt.Errorf("addr not exist in validator wrapper: %v", addr.String())

--- a/staking/slash/double-sign.go
+++ b/staking/slash/double-sign.go
@@ -151,7 +151,7 @@ func Verify(
 	state *state.DB,
 	candidate *Record,
 ) error {
-	wrapper, err := state.ValidatorWrapper(candidate.Evidence.Offender)
+	wrapper, err := state.ValidatorWrapper(candidate.Evidence.Offender, true, false)
 	if err != nil {
 		return err
 	}
@@ -492,7 +492,7 @@ func Apply(
 			)
 		}
 
-		current, err := state.ValidatorWrapper(slash.Evidence.Offender)
+		current, err := state.ValidatorWrapper(slash.Evidence.Offender, true, false)
 		if err != nil {
 			return nil, errors.Wrapf(
 				errValidatorNotFoundDuringSlash, " %s ", err.Error(),

--- a/staking/slash/double-sign_test.go
+++ b/staking/slash/double-sign_test.go
@@ -662,7 +662,7 @@ func (tc *applyTestCase) checkResult() error {
 // checkState checks whether the state has been banned and whether the delegations
 // are different from the original
 func (tc *applyTestCase) checkState() error {
-	vw, err := tc.state.ValidatorWrapper(offAddr)
+	vw, err := tc.state.ValidatorWrapper(offAddr, true, false)
 	if err != nil {
 		return err
 	}
@@ -670,7 +670,7 @@ func (tc *applyTestCase) checkState() error {
 		return fmt.Errorf("status not banned")
 	}
 
-	vwSnap, err := tc.stateSnap.ValidatorWrapperCopy(offAddr)
+	vwSnap, err := tc.stateSnap.ValidatorWrapper(offAddr, true, false)
 	if err != nil {
 		return err
 	}

--- a/staking/types/test/copy.go
+++ b/staking/types/test/copy.go
@@ -10,9 +10,25 @@ import (
 
 // CopyValidatorWrapper deep copies staking.ValidatorWrapper
 func CopyValidatorWrapper(w staking.ValidatorWrapper) staking.ValidatorWrapper {
+	return copyValidatorWrapper(w, true)
+}
+
+// CopyValidatorWrapperNoDelegations deep copies staking.ValidatorWrapper, excluding Delegations
+// With the heap pprof turned on, we see that copying validator wrapper is an expensive operation
+// of which the most expensive part is copyng the delegations
+// this function can be used when delegations are not expected to be changed by the caller
+func CopyValidatorWrapperNoDelegations(w staking.ValidatorWrapper) staking.ValidatorWrapper {
+	return copyValidatorWrapper(w, false)
+}
+
+func copyValidatorWrapper(w staking.ValidatorWrapper, copyDelegations bool) staking.ValidatorWrapper {
 	cp := staking.ValidatorWrapper{
-		Validator:   CopyValidator(w.Validator),
-		Delegations: CopyDelegations(w.Delegations),
+		Validator: CopyValidator(w.Validator),
+	}
+	if copyDelegations {
+		cp.Delegations = CopyDelegations(w.Delegations)
+	} else {
+		cp.Delegations = w.Delegations
 	}
 	if w.Counters.NumBlocksSigned != nil {
 		cp.Counters.NumBlocksSigned = new(big.Int).Set(w.Counters.NumBlocksSigned)

--- a/test/chain/reward/main.go
+++ b/test/chain/reward/main.go
@@ -131,7 +131,7 @@ func main() {
 	statedb.UpdateValidatorWrapper(msg.ValidatorAddress, validator)
 
 	startTime := time.Now()
-	validator, _ = statedb.ValidatorWrapper(msg.ValidatorAddress)
+	validator, _ = statedb.ValidatorWrapper(msg.ValidatorAddress, true, false)
 	endTime := time.Now()
 	fmt.Printf("Time required to read validator: %f seconds\n", endTime.Sub(startTime).Seconds())
 


### PR DESCRIPTION
1. Merge ValidatorWrapper and ValidatorWrapperCopy to let callers ask for either a copy, or a pointer to the cached object. Additionally, give callers the option to not deep copy delegations (which is a heavy process). Copies need to be explicitly committed (and thus can be reverted), while the pointers are (auto-)committed when Finalise is called.
1. Add a UpdateValidatorWrapperWithRevert function, which is used by staking txs `Delegate`, `Undelegate`, and `CollectRewards`. Other 2 types of staking txs and `db.Finalize` continue to use UpdateValidateWrapper without revert, again, to save memory
1. Add unit tests which check
   1. Revert goes through
   1. Wrapper is as expected after revert
   1. State is as expected after revert

## Issue
harmony-one/bounties#90

## Test

### Unit Test Coverage

Before:

```
core/state: 70.0%
```

After:

```
core/state: 71.9%
```

### Test/Run Logs
```golang
$ go test -run TestValidatorRevert
=== Testing validator wrapper revert ===
=== Creating new validator and wrapper ===
=== Writing validator and wrapper to state ===
=== Validator successfully written to state ===
=== Reverting validator to None ===
=== Revert successful, according to ValidatorWrapper ===
=== Revert successful, according to checkEqual ===
=== Adding delegation to validator in stateDB ===
=== Writing validator with delegation to state ===
=== Validator successfully written to state ===
=== Reverting delegation from validator ===
=== Revert successful, according to ValidatorWrapper ===
=== Revert successful, according to checkEqual ===
PASS
ok  	github.com/harmony-one/harmony/core/state	0.024s
```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)
No.

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)
No.

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**
No. See [comment](https://github.com/harmony-one/harmony/pull/3939#issuecomment-985894599).