### PR TITLE
Do not process txns if node out of sync

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -195,6 +195,12 @@ func (node *Node) tryBroadcastStaking(stakingTx *staking.StakingTransaction) {
 
 // Add new transactions to the pending transaction list.
 func (node *Node) addPendingTransactions(newTxs types.Transactions) []error {
+	if inSync, _, _ := node.SyncStatus(node.Blockchain().ShardID()); !inSync {
+		utils.Logger().Debug().
+			Int("length of newTxs", len(newTxs)).
+			Msg("[addPendingTransactions] Node out of sync, ignoring transactions")
+		return nil
+	}
 	poolTxs := types.PoolTransactions{}
 	errs := []error{}
 	acceptCx := node.Blockchain().Config().AcceptsCrossTx(node.Blockchain().CurrentHeader().Epoch())

--- a/node/node.go
+++ b/node/node.go
@@ -195,7 +195,7 @@ func (node *Node) tryBroadcastStaking(stakingTx *staking.StakingTransaction) {
 
 // Add new transactions to the pending transaction list.
 func (node *Node) addPendingTransactions(newTxs types.Transactions) []error {
-	if inSync, _, _ := node.SyncStatus(node.Blockchain().ShardID()); !inSync {
+	if inSync, _, _ := node.SyncStatus(node.Blockchain().ShardID()); !inSync && node.NodeConfig.GetNetworkType() == nodeconfig.Mainnet {
 		utils.Logger().Debug().
 			Int("length of newTxs", len(newTxs)).
 			Msg("[addPendingTransactions] Node out of sync, ignoring transactions")


### PR DESCRIPTION
We are experiencing high transaction volumes all the time on mainnet. Each node is accepting hundreds of txns per second and adding them to txns pools. Even though these txns are not included in the blocks yet. The node still need to process them in order to decide whether it's valid or not. This causes lots of resource consumption for the node, making other services slow and malfunciton.

Specifically, we've seen nodes sync'ing very slowly and fail to catch up to latest block for a long time. Digging in the log, it takes the node 1-2 second or more to sync one block, while there is a huge number of incoming txns being processed by the node at the same time. This is clearly an evidence that the incoming txn processing delayed the sync speed because each block should only takes ~400 ms to process in a healthy node.

The solution here is to avoid processing incoming txns while the node is out of sync. The reasoning is that out of sync node doesn't have the latest state to correctly validate the incoming txns, so the node shouldn't do that when out of sync. This will make the node sync to latest state faster and being able to correctly validate txns ealier.

Note the incoming txns are still relayed to other nodes via p2p even the out of sync node doesn't process them.