### PR TITLE
bump min gas price to 30 gwei

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -170,7 +170,7 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	Journal:   "transactions.rlp",
 	Rejournal: time.Hour,
 
-	PriceLimit: 1e9, // 1 Gwei/Nano
+	PriceLimit: 1e11, // 100 Gwei/Nano
 	PriceBump:  10,
 
 	AccountSlots: 16,

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -170,7 +170,7 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	Journal:   "transactions.rlp",
 	Rejournal: time.Hour,
 
-	PriceLimit: 5e10, // 100 Gwei/Nano
+	PriceLimit: 5e10, // 50 Gwei/Nano
 	PriceBump:  10,
 
 	AccountSlots: 16,

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -171,7 +171,7 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	Rejournal: time.Hour,
 
 	PriceLimit: 3e10, // 30 Gwei or Nano
-	PriceBump:  10,
+	PriceBump:  3,
 
 	AccountSlots: 16,
 	GlobalSlots:  4096,

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -170,7 +170,7 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	Journal:   "transactions.rlp",
 	Rejournal: time.Hour,
 
-	PriceLimit: 3e10, // 30 Gwei/Nano
+	PriceLimit: 3e10, // 30 Gwei or Nano
 	PriceBump:  10,
 
 	AccountSlots: 16,

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -170,7 +170,7 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	Journal:   "transactions.rlp",
 	Rejournal: time.Hour,
 
-	PriceLimit: 5e10, // 50 Gwei/Nano
+	PriceLimit: 3e10, // 30 Gwei/Nano
 	PriceBump:  10,
 
 	AccountSlots: 16,

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -170,7 +170,7 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	Journal:   "transactions.rlp",
 	Rejournal: time.Hour,
 
-	PriceLimit: 1e11, // 100 Gwei/Nano
+	PriceLimit: 5e10, // 100 Gwei/Nano
 	PriceBump:  10,
 
 	AccountSlots: 16,

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -977,7 +977,7 @@ func testTransactionQueueGlobalLimiting(t *testing.T, nolocals bool) {
 	keys := make([]*ecdsa.PrivateKey, 5)
 	for i := 0; i < len(keys); i++ {
 		keys[i], _ = crypto.GenerateKey()
-		pool.currentState.AddBalance(crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(1000000000000000))
+		pool.currentState.AddBalance(crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(30000000000000000))
 	}
 	local := keys[len(keys)-1]
 

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -710,7 +710,7 @@ func TestTransactionDropping(t *testing.T) {
 	defer pool.Stop()
 
 	account, _ := deriveSender(transaction(0, 0, 0, key))
-	pool.currentState.AddBalance(account, big.NewInt(100000000000000))
+	pool.currentState.AddBalance(account, big.NewInt(30000000000000))
 
 	// Add some pending and some queued transactions
 	var (
@@ -749,7 +749,7 @@ func TestTransactionDropping(t *testing.T) {
 		t.Errorf("total transaction mismatch: have %d, want %d", pool.all.Count(), 6)
 	}
 	// Reduce the balance of the account, and check that invalidated transactions are dropped
-	pool.currentState.AddBalance(account, big.NewInt(-650000000000))
+	pool.currentState.AddBalance(account, big.NewInt(-19500000000000))
 	pool.lockedReset(nil, nil)
 
 	if _, ok := pool.pending[account].txs.items[tx0.Nonce()]; !ok {
@@ -858,7 +858,7 @@ func TestTransactionPostponing(t *testing.T) {
 	}
 	// Reduce the balance of the account, and check that transactions are reorganised
 	for _, addr := range accs {
-		pool.currentState.AddBalance(addr, big.NewInt(-1))
+		pool.currentState.AddBalance(addr, big.NewInt(-30))
 	}
 	pool.lockedReset(nil, nil)
 

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -52,7 +52,7 @@ var (
 	testBLSPubKey    = "30b2c38b1316da91e068ac3bd8751c0901ef6c02a1d58bc712104918302c6ed03d5894671d0c816dad2b4d303320f202"
 	testBLSPrvKey    = "c6d7603520311f7a4e6aac0b26701fc433b75b38df504cd416ef2b900cd66205"
 
-	gasPrice       = big.NewInt(1e9)
+	gasPrice       = big.NewInt(3e10)
 	gasLimit       = big.NewInt(int64(params.TxGasValidatorCreation))
 	cost           = big.NewInt(1).Mul(gasPrice, gasLimit)
 	dummyErrorSink = types.NewTransactionErrorSink()
@@ -439,7 +439,7 @@ func TestMixedTransactions(t *testing.T) {
 	goodFromKey, _ := crypto.GenerateKey()
 	tx := transaction(0, 0, 25000, goodFromKey)
 	txAddr, _ := deriveSender(tx)
-	pool.currentState.AddBalance(txAddr, big.NewInt(50100000000000))
+	pool.currentState.AddBalance(txAddr, big.NewInt(1503000000000000))
 
 	errs := pool.AddRemotes(types.PoolTransactions{stx, tx})
 	for _, err := range errs {
@@ -472,8 +472,8 @@ func TestBlacklistedTransactions(t *testing.T) {
 	goodFromAcc, _ := deriveSender(goodTx)
 
 	// Fund from accounts
-	pool.currentState.AddBalance(bannedFromAcc, big.NewInt(50100000000000))
-	pool.currentState.AddBalance(goodFromAcc, big.NewInt(50100000000000))
+	pool.currentState.AddBalance(bannedFromAcc, big.NewInt(1503000000000000))
+	pool.currentState.AddBalance(goodFromAcc, big.NewInt(1503000000000000))
 
 	DefaultTxPoolConfig.Blacklist[bannedToAcc] = struct{}{}
 	err := pool.AddRemotes(types.PoolTransactions{badTx})
@@ -506,7 +506,7 @@ func TestTransactionQueue(t *testing.T) {
 
 	tx := transaction(0, 0, 100, key)
 	from, _ := deriveSender(tx)
-	pool.currentState.AddBalance(from, big.NewInt(1000000000000))
+	pool.currentState.AddBalance(from, big.NewInt(30000000000000))
 	pool.lockedReset(nil, nil)
 	pool.enqueueTx(tx)
 
@@ -535,7 +535,7 @@ func TestTransactionQueue(t *testing.T) {
 	tx2 := transaction(0, 10, 100, key)
 	tx3 := transaction(0, 11, 100, key)
 	from, _ = deriveSender(tx1)
-	pool.currentState.AddBalance(from, big.NewInt(1000000000000))
+	pool.currentState.AddBalance(from, big.NewInt(30000000000000))
 	pool.lockedReset(nil, nil)
 
 	pool.enqueueTx(tx1)
@@ -577,7 +577,7 @@ func TestTransactionChainFork(t *testing.T) {
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 	resetState := func() {
 		statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()))
-		statedb.AddBalance(addr, big.NewInt(9000000000000000))
+		statedb.AddBalance(addr, big.NewInt(90000000000000000000))
 
 		pool.chain = &testBlockChain{statedb, 1000000, new(event.Feed)}
 		pool.lockedReset(nil, nil)
@@ -606,7 +606,7 @@ func TestTransactionDoubleNonce(t *testing.T) {
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 	resetState := func() {
 		statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()))
-		statedb.AddBalance(addr, big.NewInt(100000000000000000))
+		statedb.AddBalance(addr, big.NewInt(10000000000000000000))
 
 		pool.chain = &testBlockChain{statedb, 1000000, new(event.Feed)}
 		pool.lockedReset(nil, nil)
@@ -660,7 +660,7 @@ func TestTransactionMissingNonce(t *testing.T) {
 	defer pool.Stop()
 
 	addr := crypto.PubkeyToAddress(key.PublicKey)
-	pool.currentState.AddBalance(addr, big.NewInt(100100000000000))
+	pool.currentState.AddBalance(addr, big.NewInt(3003000000000000))
 	tx := transaction(0, 1, 100000, key)
 	if _, err := pool.add(tx, false); err != nil {
 		t.Error("didn't expect error", err)
@@ -685,7 +685,7 @@ func TestTransactionNonceRecovery(t *testing.T) {
 
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 	pool.currentState.SetNonce(addr, n)
-	pool.currentState.AddBalance(addr, big.NewInt(100100000000000))
+	pool.currentState.AddBalance(addr, big.NewInt(3003000000000000))
 	pool.lockedReset(nil, nil)
 
 	tx := transaction(0, n, 100000, key)
@@ -710,7 +710,7 @@ func TestTransactionDropping(t *testing.T) {
 	defer pool.Stop()
 
 	account, _ := deriveSender(transaction(0, 0, 0, key))
-	pool.currentState.AddBalance(account, big.NewInt(1000000000000))
+	pool.currentState.AddBalance(account, big.NewInt(100000000000000))
 
 	// Add some pending and some queued transactions
 	var (
@@ -815,7 +815,7 @@ func TestTransactionPostponing(t *testing.T) {
 		keys[i], _ = crypto.GenerateKey()
 		accs[i] = crypto.PubkeyToAddress(keys[i].PublicKey)
 
-		pool.currentState.AddBalance(crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(50100000000000))
+		pool.currentState.AddBalance(crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(1503000000000000))
 	}
 	// Add a batch consecutive pending transactions for validation
 	txs := types.PoolTransactions{}
@@ -922,7 +922,7 @@ func TestTransactionQueueAccountLimiting(t *testing.T) {
 	defer pool.Stop()
 
 	account, _ := deriveSender(transaction(0, 0, 0, key))
-	pool.currentState.AddBalance(account, big.NewInt(900000000000000))
+	pool.currentState.AddBalance(account, big.NewInt(9000000000000000000))
 
 	// Keep queuing up transactions and make sure all above a limit are dropped
 	for i := uint64(1); i <= testTxPoolConfig.AccountQueue+5; i++ {
@@ -1067,8 +1067,8 @@ func testTransactionQueueTimeLimiting(t *testing.T, nolocals bool) {
 	local, _ := crypto.GenerateKey()
 	remote, _ := crypto.GenerateKey()
 
-	pool.currentState.AddBalance(crypto.PubkeyToAddress(local.PublicKey), big.NewInt(900000000000000))
-	pool.currentState.AddBalance(crypto.PubkeyToAddress(remote.PublicKey), big.NewInt(900000000000000))
+	pool.currentState.AddBalance(crypto.PubkeyToAddress(local.PublicKey), big.NewInt(9000000000000000000))
+	pool.currentState.AddBalance(crypto.PubkeyToAddress(remote.PublicKey), big.NewInt(9000000000000000000))
 
 	// Add the two transactions and ensure they both are queued up
 	if err := pool.AddLocal(pricedTransaction(0, 1, 100000, big.NewInt(100000000000), local)); err != nil {
@@ -1123,7 +1123,7 @@ func testTransactionLimitingEquivalency(t *testing.T, origin uint64) {
 	defer pool1.Stop()
 
 	account1, _ := deriveSender(transaction(0, 0, 0, key1))
-	pool1.currentState.AddBalance(account1, big.NewInt(9000000000000000))
+	pool1.currentState.AddBalance(account1, big.NewInt(90000000000000000000))
 
 	for i := uint64(0); i < testTxPoolConfig.AccountQueue+5; i++ {
 		if err := pool1.AddRemote(transaction(0, origin+i, 100000, key1)); err != nil {
@@ -1135,7 +1135,7 @@ func testTransactionLimitingEquivalency(t *testing.T, origin uint64) {
 	defer pool2.Stop()
 
 	account2, _ := deriveSender(transaction(0, 0, 0, key2))
-	pool2.currentState.AddBalance(account2, big.NewInt(9000000000000000))
+	pool2.currentState.AddBalance(account2, big.NewInt(90000000000000000000))
 
 	txs := types.PoolTransactions{}
 	for i := uint64(0); i < testTxPoolConfig.AccountQueue+5; i++ {
@@ -1381,8 +1381,8 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 	local, _ := crypto.GenerateKey()
 	remote, _ := crypto.GenerateKey()
 
-	pool.currentState.AddBalance(crypto.PubkeyToAddress(local.PublicKey), big.NewInt(900000000000000))
-	pool.currentState.AddBalance(crypto.PubkeyToAddress(remote.PublicKey), big.NewInt(900000000000000))
+	pool.currentState.AddBalance(crypto.PubkeyToAddress(local.PublicKey), big.NewInt(9000000000000000000))
+	pool.currentState.AddBalance(crypto.PubkeyToAddress(remote.PublicKey), big.NewInt(9000000000000000000))
 
 	// Add three local and a remote transactions and ensure they are queued up
 	if err := pool.AddLocal(pricedTransaction(0, 0, 100000, big.NewInt(1000000000), local)); err != nil {
@@ -1475,7 +1475,7 @@ func TestTransactionStatusCheck(t *testing.T) {
 	keys := make([]*ecdsa.PrivateKey, 3)
 	for i := 0; i < len(keys); i++ {
 		keys[i], _ = crypto.GenerateKey()
-		pool.currentState.AddBalance(crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(9000000000000000))
+		pool.currentState.AddBalance(crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(90000000000000000000))
 	}
 	// Generate and queue a batch of transactions, both pending and queued
 	txs := types.PoolTransactions{}

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -749,26 +749,26 @@ func TestTransactionDropping(t *testing.T) {
 		t.Errorf("total transaction mismatch: have %d, want %d", pool.all.Count(), 6)
 	}
 	// Reduce the balance of the account, and check that invalidated transactions are dropped
-	pool.currentState.AddBalance(account, big.NewInt(-19500000000000))
+	pool.currentState.AddBalance(account, big.NewInt(-23000000000000))
 	pool.lockedReset(nil, nil)
 
 	if _, ok := pool.pending[account].txs.items[tx0.Nonce()]; !ok {
 		t.Errorf("funded pending transaction missing: %v", tx0)
 	}
 	if _, ok := pool.pending[account].txs.items[tx1.Nonce()]; !ok {
-		t.Errorf("funded pending transaction missing: %v", tx0)
+		t.Errorf("funded pending transaction missing: %v", tx1)
 	}
 	if _, ok := pool.pending[account].txs.items[tx2.Nonce()]; ok {
-		t.Errorf("out-of-fund pending transaction present: %v", tx1)
+		t.Errorf("out-of-fund pending transaction present: %v", tx2)
 	}
 	if _, ok := pool.queue[account].txs.items[tx10.Nonce()]; !ok {
 		t.Errorf("funded queued transaction missing: %v", tx10)
 	}
 	if _, ok := pool.queue[account].txs.items[tx11.Nonce()]; !ok {
-		t.Errorf("funded queued transaction missing: %v", tx10)
+		t.Errorf("funded queued transaction missing: %v", tx11)
 	}
 	if _, ok := pool.queue[account].txs.items[tx12.Nonce()]; ok {
-		t.Errorf("out-of-fund queued transaction present: %v", tx11)
+		t.Errorf("out-of-fund queued transaction present: %v", tx12)
 	}
 	if pool.all.Count() != 4 {
 		t.Errorf("total transaction mismatch: have %d, want %d", pool.all.Count(), 4)
@@ -815,7 +815,7 @@ func TestTransactionPostponing(t *testing.T) {
 		keys[i], _ = crypto.GenerateKey()
 		accs[i] = crypto.PubkeyToAddress(keys[i].PublicKey)
 
-		pool.currentState.AddBalance(crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(1503000000000000))
+		pool.currentState.AddBalance(crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(1500100000000000))
 	}
 	// Add a batch consecutive pending transactions for validation
 	txs := types.PoolTransactions{}

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -577,7 +577,7 @@ func TestTransactionChainFork(t *testing.T) {
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 	resetState := func() {
 		statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()))
-		statedb.AddBalance(addr, big.NewInt(90000000000000000000))
+		statedb.AddBalance(addr, big.NewInt(9000000000000000000))
 
 		pool.chain = &testBlockChain{statedb, 1000000, new(event.Feed)}
 		pool.lockedReset(nil, nil)
@@ -606,7 +606,7 @@ func TestTransactionDoubleNonce(t *testing.T) {
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 	resetState := func() {
 		statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()))
-		statedb.AddBalance(addr, big.NewInt(10000000000000000000))
+		statedb.AddBalance(addr, big.NewInt(1000000000000000000))
 
 		pool.chain = &testBlockChain{statedb, 1000000, new(event.Feed)}
 		pool.lockedReset(nil, nil)
@@ -1123,7 +1123,7 @@ func testTransactionLimitingEquivalency(t *testing.T, origin uint64) {
 	defer pool1.Stop()
 
 	account1, _ := deriveSender(transaction(0, 0, 0, key1))
-	pool1.currentState.AddBalance(account1, big.NewInt(90000000000000000000))
+	pool1.currentState.AddBalance(account1, big.NewInt(9000000000000000000))
 
 	for i := uint64(0); i < testTxPoolConfig.AccountQueue+5; i++ {
 		if err := pool1.AddRemote(transaction(0, origin+i, 100000, key1)); err != nil {
@@ -1135,7 +1135,7 @@ func testTransactionLimitingEquivalency(t *testing.T, origin uint64) {
 	defer pool2.Stop()
 
 	account2, _ := deriveSender(transaction(0, 0, 0, key2))
-	pool2.currentState.AddBalance(account2, big.NewInt(90000000000000000000))
+	pool2.currentState.AddBalance(account2, big.NewInt(9000000000000000000))
 
 	txs := types.PoolTransactions{}
 	for i := uint64(0); i < testTxPoolConfig.AccountQueue+5; i++ {
@@ -1475,7 +1475,7 @@ func TestTransactionStatusCheck(t *testing.T) {
 	keys := make([]*ecdsa.PrivateKey, 3)
 	for i := 0; i < len(keys); i++ {
 		keys[i], _ = crypto.GenerateKey()
-		pool.currentState.AddBalance(crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(90000000000000000000))
+		pool.currentState.AddBalance(crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(9000000000000000000))
 	}
 	// Generate and queue a batch of transactions, both pending and queued
 	txs := types.PoolTransactions{}

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -127,13 +127,13 @@ func stakingCreateValidatorTransaction(key *ecdsa.PrivateKey) (*staking.StakingT
 		}
 	}
 
-	gasPrice := big.NewInt(1000000000)
+	gasPrice := big.NewInt(100000000000)
 	tx, _ := staking.NewStakingTransaction(0, 1e10, gasPrice, stakePayloadMaker)
 	return staking.Sign(tx, staking.NewEIP155Signer(tx.ChainID()), key)
 }
 
 func transaction(shardID uint32, nonce uint64, gaslimit uint64, key *ecdsa.PrivateKey) types.PoolTransaction {
-	return pricedTransaction(shardID, nonce, gaslimit, big.NewInt(1000000000), key)
+	return pricedTransaction(shardID, nonce, gaslimit, big.NewInt(100000000000), key)
 }
 
 func pricedTransaction(shardID uint32, nonce uint64, gaslimit uint64, gasprice *big.Int, key *ecdsa.PrivateKey) types.PoolTransaction {
@@ -1071,10 +1071,10 @@ func testTransactionQueueTimeLimiting(t *testing.T, nolocals bool) {
 	pool.currentState.AddBalance(crypto.PubkeyToAddress(remote.PublicKey), big.NewInt(900000000000000))
 
 	// Add the two transactions and ensure they both are queued up
-	if err := pool.AddLocal(pricedTransaction(0, 1, 100000, big.NewInt(1000000000), local)); err != nil {
+	if err := pool.AddLocal(pricedTransaction(0, 1, 100000, big.NewInt(100000000000), local)); err != nil {
 		t.Fatalf("failed to add local transaction: %v", err)
 	}
-	if err := pool.AddRemote(pricedTransaction(0, 1, 100000, big.NewInt(1000000000), remote)); err != nil {
+	if err := pool.AddRemote(pricedTransaction(0, 1, 100000, big.NewInt(100000000000), remote)); err != nil {
 		t.Fatalf("failed to add remote transaction: %v", err)
 	}
 	pending, queued := pool.Stats()

--- a/hmy/hmy.go
+++ b/hmy/hmy.go
@@ -153,7 +153,7 @@ func New(
 	gpoParams := GasPriceConfig{
 		Blocks:     20,
 		Percentile: 60,
-		Default:    big.NewInt(1e10),
+		Default:    big.NewInt(1e11),
 	}
 	gpo := NewOracle(backend, gpoParams)
 	backend.gpo = gpo

--- a/hmy/hmy.go
+++ b/hmy/hmy.go
@@ -153,7 +153,7 @@ func New(
 	gpoParams := GasPriceConfig{
 		Blocks:     20,
 		Percentile: 60,
-		Default:    big.NewInt(1e11),
+		Default:    big.NewInt(5e10),
 	}
 	gpo := NewOracle(backend, gpoParams)
 	backend.gpo = gpo

--- a/hmy/hmy.go
+++ b/hmy/hmy.go
@@ -153,7 +153,7 @@ func New(
 	gpoParams := GasPriceConfig{
 		Blocks:     20,
 		Percentile: 60,
-		Default:    big.NewInt(5e10),
+		Default:    big.NewInt(3e10),
 	}
 	gpo := NewOracle(backend, gpoParams)
 	backend.gpo = gpo

--- a/node/node.go
+++ b/node/node.go
@@ -1007,6 +1007,13 @@ func New(
 		node.ConfirmedBlockChannel = make(chan *types.Block)
 		node.BeaconBlockChannel = make(chan *types.Block)
 		txPoolConfig := core.DefaultTxPoolConfig
+
+		// Temporarily not updating other networks to make the rpc tests pass
+		if node.NodeConfig.GetNetworkType() != nodeconfig.Mainnet {
+			txPoolConfig.PriceLimit = 1e9
+			txPoolConfig.PriceBump = 10
+		}
+
 		txPoolConfig.Blacklist = blacklist
 		txPoolConfig.Journal = fmt.Sprintf("%v/%v", node.NodeConfig.DBDir, txPoolConfig.Journal)
 		node.TxPool = core.NewTxPool(txPoolConfig, node.Blockchain().Config(), blockchain, node.TransactionErrorSink)

--- a/node/node.go
+++ b/node/node.go
@@ -1009,7 +1009,7 @@ func New(
 		txPoolConfig := core.DefaultTxPoolConfig
 
 		// Temporarily not updating other networks to make the rpc tests pass
-		if node.NodeConfig.GetNetworkType() != nodeconfig.Mainnet {
+		if node.NodeConfig.GetNetworkType() != nodeconfig.Mainnet && node.NodeConfig.GetNetworkType() != nodeconfig.Testnet {
 			txPoolConfig.PriceLimit = 1e9
 			txPoolConfig.PriceBump = 10
 		}

--- a/rpc/harmony.go
+++ b/rpc/harmony.go
@@ -60,8 +60,8 @@ func (s *PublicHarmonyService) Syncing(
 // Note that the return type is an interface to account for the different versions
 func (s *PublicHarmonyService) GasPrice(ctx context.Context) (interface{}, error) {
 	price, err := s.hmy.SuggestPrice(ctx)
-	if err != nil || price.Cmp(big.NewInt(1e11)) < 0 {
-		price = big.NewInt(1e11)
+	if err != nil || price.Cmp(big.NewInt(5e10)) < 0 {
+		price = big.NewInt(5e10)
 	}
 	// Format response according to version
 	switch s.version {

--- a/rpc/harmony.go
+++ b/rpc/harmony.go
@@ -60,8 +60,8 @@ func (s *PublicHarmonyService) Syncing(
 // Note that the return type is an interface to account for the different versions
 func (s *PublicHarmonyService) GasPrice(ctx context.Context) (interface{}, error) {
 	price, err := s.hmy.SuggestPrice(ctx)
-	if err != nil || price.Cmp(big.NewInt(1e10)) < 0 {
-		price = big.NewInt(1e10)
+	if err != nil || price.Cmp(big.NewInt(1e11)) < 0 {
+		price = big.NewInt(1e11)
 	}
 	// Format response according to version
 	switch s.version {

--- a/rpc/harmony.go
+++ b/rpc/harmony.go
@@ -60,8 +60,8 @@ func (s *PublicHarmonyService) Syncing(
 // Note that the return type is an interface to account for the different versions
 func (s *PublicHarmonyService) GasPrice(ctx context.Context) (interface{}, error) {
 	price, err := s.hmy.SuggestPrice(ctx)
-	if err != nil || price.Cmp(big.NewInt(5e10)) < 0 {
-		price = big.NewInt(5e10)
+	if err != nil || price.Cmp(big.NewInt(3e10)) < 0 {
+		price = big.NewInt(3e10)
 	}
 	// Format response according to version
 	switch s.version {


### PR DESCRIPTION
A refresh of the original PR: https://github.com/harmony-one/harmony/pull/3960

Bump min gas price to 30 gwei to deter spamming.

Currently the min gas price is 1 gwei and suggested gas price is 10 gwei. The spamming txns in mainnet blocks are using gas price randomly but mostly close to 1 gwei.

Assuming on average, the attackers gas price is 2 gwei. With a mainnet block with 100 txns (https://explorer.harmony.one/block/0x41ce7ec54ee61607f959cd891bceead274cb4efc1136cec6cb7cf6c217f43670), 16852987 gas is used, which is 16852987 * 0.000000002 ONE ~ = 0.034 ONE (~ $0.0067). So the cost to spam one block is $0.0067 and the cost to spam for a whole day is 24 * 1800 * 0.0067 = $289.44.

By changing the min gas price to 30 gwei, the cost of spamming our network for 1 day will be $289.44 * (30/2) = $4341.6.

Let's assume normal users are using 10 gwei as gas price since it's suggested by the network, a normal txn interacting with Dex (e.g. https://explorer.harmony.one/tx/0x8001d74c0b6269f69e2aa2b577ed748fb961dfe7a0390f76dca30c69045d6364) would pay 0.0019 ONE ($0.00095). With the update to min gas price of 30 gwei, the gas fee will be $0.00095 * (30/10) = $0.00285. It's still very cheap (still 100x cheaper than ethereum) to use Harmony to interact with Dapps frequently as a normal user.