### PR TITLE
add rate limit on PendingTransactions, Call, and GetDelegationsByValidator rpc

### DIFF
--- a/rpc/contract.go
+++ b/rpc/contract.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"reflect"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/time/rate"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -26,6 +30,8 @@ const (
 type PublicContractService struct {
 	hmy     *hmy.Harmony
 	version Version
+	// TEMP SOLUTION to rpc node spamming issue
+	limiterCall *rate.Limiter
 }
 
 // NewPublicContractAPI creates a new API for the RPC interface
@@ -33,9 +39,25 @@ func NewPublicContractAPI(hmy *hmy.Harmony, version Version) rpc.API {
 	return rpc.API{
 		Namespace: version.Namespace(),
 		Version:   APIVersion,
-		Service:   &PublicContractService{hmy, version},
+		Service:   &PublicContractService{hmy, version, rate.NewLimiter(100, 1000)},
 		Public:    true,
 	}
+}
+
+func (s *PublicContractService) wait(limiter *rate.Limiter, ctx context.Context) error {
+	if limiter != nil {
+		deadlineCtx, cancel := context.WithTimeout(ctx, DefaultRateLimiterWaitTimeout)
+		defer cancel()
+		if !limiter.Allow() {
+			name := reflect.TypeOf(limiter).Elem().Name()
+			rpcRateLimitCounterVec.With(prometheus.Labels{
+				"limiter_name": name,
+			}).Inc()
+		}
+
+		return limiter.Wait(deadlineCtx)
+	}
+	return nil
 }
 
 // Call executes the given transaction on the state for the given block number.
@@ -45,6 +67,12 @@ func (s *PublicContractService) Call(
 ) (hexutil.Bytes, error) {
 	// Process number based on version
 	blockNum := blockNumber.EthBlockNumber()
+
+	err := s.wait(s.limiterCall, ctx)
+	if err != nil {
+		DoMetricRPCQueryInfo(Call, RateLimitedNumber)
+		return nil, err
+	}
 
 	// Execute call
 	result, err := DoEVMCall(ctx, s.hmy, args, blockNum, CallTimeout)

--- a/rpc/metrics.go
+++ b/rpc/metrics.go
@@ -29,6 +29,7 @@ const (
 	// contract
 	GetCode      = "GetCode"
 	GetStorageAt = "GetStorageAt"
+	Call         = "Call"
 	DoEvmCall    = "DoEVMCall"
 
 	// net
@@ -75,8 +76,9 @@ const (
 
 // info type const
 const (
-	QueryNumber  = "query_number"
-	FailedNumber = "failed_number"
+	QueryNumber       = "query_number"
+	FailedNumber      = "failed_number"
+	RateLimitedNumber = "rate_limited_number"
 )
 
 func init() {
@@ -96,7 +98,7 @@ var (
 			Name:      "over_ratelimit",
 			Help:      "number of times triggered rpc rate limit",
 		},
-		[]string{"rate_limit"},
+		[]string{"limiter_name"},
 	)
 
 	rpcQueryInfoCounterVec = prometheus.NewCounterVec(

--- a/rpc/pool.go
+++ b/rpc/pool.go
@@ -3,9 +3,10 @@ package rpc
 import (
 	"context"
 	"fmt"
+	"reflect"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/time/rate"
-	"reflect"
 
 	"github.com/pkg/errors"
 

--- a/rpc/pool.go
+++ b/rpc/pool.go
@@ -41,7 +41,7 @@ func NewPublicPoolAPI(hmy *hmy.Harmony, version Version) rpc.API {
 	return rpc.API{
 		Namespace: version.Namespace(),
 		Version:   APIVersion,
-		Service:   &PublicPoolService{hmy, version, rate.NewLimiter(5, 10)},
+		Service:   &PublicPoolService{hmy, version, rate.NewLimiter(2, 5)},
 		Public:    true,
 	}
 }

--- a/rpc/pool.go
+++ b/rpc/pool.go
@@ -2,7 +2,6 @@ package rpc
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -52,10 +51,9 @@ func (s *PublicPoolService) wait(limiter *rate.Limiter, ctx context.Context) err
 		deadlineCtx, cancel := context.WithTimeout(ctx, DefaultRateLimiterWaitTimeout)
 		defer cancel()
 		if !limiter.Allow() {
-			strLimit := fmt.Sprintf("%d", int64(limiter.Limit()))
 			name := reflect.TypeOf(limiter).Elem().Name()
 			rpcRateLimitCounterVec.With(prometheus.Labels{
-				name: strLimit,
+				"limiter_name": name,
 			}).Inc()
 		}
 
@@ -217,7 +215,7 @@ func (s *PublicPoolService) PendingTransactions(
 
 	err := s.wait(s.limiterPendingTransactions, ctx)
 	if err != nil {
-		DoMetricRPCQueryInfo(PendingTransactions, FailedNumber)
+		DoMetricRPCQueryInfo(PendingTransactions, RateLimitedNumber)
 		return nil, err
 	}
 

--- a/rpc/staking.go
+++ b/rpc/staking.go
@@ -2,7 +2,6 @@ package rpc
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 	"reflect"
 
@@ -63,11 +62,9 @@ func (s *PublicStakingService) wait(limiter *rate.Limiter, ctx context.Context) 
 		deadlineCtx, cancel := context.WithTimeout(ctx, DefaultRateLimiterWaitTimeout)
 		defer cancel()
 		if !limiter.Allow() {
-			strLimit := fmt.Sprintf("%d", int64(limiter.Limit()))
-
 			name := reflect.TypeOf(limiter).Elem().Name()
 			rpcRateLimitCounterVec.With(prometheus.Labels{
-				name: strLimit,
+				"limiter_name": name,
 			}).Inc()
 		}
 
@@ -240,7 +237,7 @@ func (s *PublicStakingService) GetAllValidatorInformation(
 
 	err := s.wait(s.limiterGetAllValidatorInformation, ctx)
 	if err != nil {
-		DoMetricRPCQueryInfo(GetAllValidatorInformation, FailedNumber)
+		DoMetricRPCQueryInfo(GetAllValidatorInformation, RateLimitedNumber)
 		return nil, err
 	}
 
@@ -269,7 +266,7 @@ func (s *PublicStakingService) GetAllValidatorInformationByBlockNumber(
 
 	err := s.wait(s.limiterGetAllValidatorInformation, ctx)
 	if err != nil {
-		DoMetricRPCQueryInfo(GetAllValidatorInformationByBlockNumber, FailedNumber)
+		DoMetricRPCQueryInfo(GetAllValidatorInformationByBlockNumber, RateLimitedNumber)
 		return nil, err
 	}
 
@@ -510,7 +507,7 @@ func (s *PublicStakingService) GetAllDelegationInformation(
 
 	err := s.wait(s.limiterGetAllDelegationInformation, ctx)
 	if err != nil {
-		DoMetricRPCQueryInfo(GetAllDelegationInformation, FailedNumber)
+		DoMetricRPCQueryInfo(GetAllDelegationInformation, RateLimitedNumber)
 		return nil, err
 	}
 
@@ -691,7 +688,7 @@ func (s *PublicStakingService) GetDelegationsByValidator(
 
 	err := s.wait(s.limiterGetDelegationsByValidator, ctx)
 	if err != nil {
-		DoMetricRPCQueryInfo(GetDelegationsByValidator, FailedNumber)
+		DoMetricRPCQueryInfo(GetDelegationsByValidator, RateLimitedNumber)
 		return nil, err
 	}
 	return s.getDelegationByValidatorHelper(address)


### PR DESCRIPTION
With more digging, there are more costly rpcs that's dragging nodes down. One of them is PendingTransactions:
![image](https://user-images.githubusercontent.com/1042540/148287474-762196a3-0437-4aa7-b47a-0908e560928d.png)

this node got out of memory at the same time:
![image](https://user-images.githubusercontent.com/1042540/148287532-afd3df94-b140-45c9-a949-e5bae8f60c9d.png)

during that time, the pending txns in the node is "totalPending:3820". That pendingTransaction rpc is returning all of 3820 txns in each call...
Similarly GetDelegationsByValidator is also called extensively, and it could be costly if the validator has thousands of delegators.
![image](https://user-images.githubusercontent.com/1042540/148287544-ee824af8-0ed6-4ea6-9fc0-663107a80f85.png)