### PR TITLE
[sync] release one rlock and change default value at getMaxPeerHeight

### DIFF
--- a/rosetta/services/network.go
+++ b/rosetta/services/network.go
@@ -118,7 +118,7 @@ func (s *NetworkAPI) NetworkStatus(
 		}
 	}
 	targetInt := int64(targetHeight)
-	if targetHeight == math.MaxInt64 {
+	if targetHeight == math.MaxUint64 {
 		targetInt = 0
 	}
 	currentIndex := currentHeader.Number().Int64()

--- a/rosetta/services/network.go
+++ b/rosetta/services/network.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common/math"
+
 	"github.com/coinbase/rosetta-sdk-go/server"
 	"github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -115,8 +117,10 @@ func (s *NetworkAPI) NetworkStatus(
 			}
 		}
 	}
-
 	targetInt := int64(targetHeight)
+	if targetHeight == math.MaxInt64 {
+		targetInt = 0
+	}
 	currentIndex := currentHeader.Number().Int64()
 	ss := &types.SyncStatus{
 		CurrentIndex: &currentIndex,


### PR DESCRIPTION
## Issue

Release one rlock when iterating peers in sync. And change the default return result of getMaxPeerHeight as max uint64

## Test

Passed local tests.