### PR TITLE
[sync] extend the expiration for sync status cache for non-validator nodes

### DIFF
--- a/api/service/legacysync/syncing_test.go
+++ b/api/service/legacysync/syncing_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/api/service/legacysync/downloader"
 	"github.com/harmony-one/harmony/block"
@@ -100,7 +102,7 @@ func TestCompareSyncPeerConfigByblockHashes(t *testing.T) {
 }
 
 func TestCreateStateSync(t *testing.T) {
-	stateSync := CreateStateSync(nil, "127.0.0.1", "8000", [20]byte{}, false)
+	stateSync := CreateStateSync(nil, "127.0.0.1", "8000", [20]byte{}, false, nodeconfig.Validator)
 
 	if stateSync == nil {
 		t.Error("Unable to create stateSync")

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -104,8 +104,9 @@ func (node *Node) createStateSync(bc *core.BlockChain) *legacysync.StateSync {
 		mySyncPort = nodeconfig.DefaultDNSPort
 	}
 	mutatedPort := strconv.Itoa(mySyncPort + legacysync.SyncingPortDifference)
+	role := node.NodeConfig.Role()
 	return legacysync.CreateStateSync(bc, node.SelfPeer.IP, mutatedPort,
-		node.GetSyncID(), node.NodeConfig.Role() == nodeconfig.ExplorerNode)
+		node.GetSyncID(), node.NodeConfig.Role() == nodeconfig.ExplorerNode, role)
 }
 
 // SyncingPeerProvider is an interface for getting the peers in the given shard.


### PR DESCRIPTION
## Issue

Extend the sync status cache expiration from 6s to 12s to reduce some loads at DNS server.
