### PR TITLE
Added metrics for dns server for sync service

### DIFF
--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -8,6 +8,9 @@ import (
 	"sync"
 	"time"
 
+	prom "github.com/harmony-one/harmony/api/service/prometheus"
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
 	lru "github.com/hashicorp/golang-lru"
@@ -427,6 +430,7 @@ func (node *Node) CalculateResponse(request *downloader_pb.DownloaderRequest, in
 
 	switch request.Type {
 	case downloader_pb.DownloaderRequest_BLOCKHASH:
+		dnsServerRequestCounterVec.With(dnsReqMetricLabel("block_hash")).Inc()
 		if request.BlockHash == nil {
 			return response, fmt.Errorf("[SYNC] GetBlockHashes Request BlockHash is NIL")
 		}
@@ -464,6 +468,7 @@ func (node *Node) CalculateResponse(request *downloader_pb.DownloaderRequest, in
 		}
 
 	case downloader_pb.DownloaderRequest_BLOCKHEADER:
+		dnsServerRequestCounterVec.With(dnsReqMetricLabel("block_header")).Inc()
 		var hash common.Hash
 		for _, bytes := range request.Hashes {
 			hash.SetBytes(bytes)
@@ -475,6 +480,7 @@ func (node *Node) CalculateResponse(request *downloader_pb.DownloaderRequest, in
 		}
 
 	case downloader_pb.DownloaderRequest_BLOCK:
+		dnsServerRequestCounterVec.With(dnsReqMetricLabel("block")).Inc()
 		var hash common.Hash
 
 		payloadSize := 0
@@ -505,10 +511,12 @@ func (node *Node) CalculateResponse(request *downloader_pb.DownloaderRequest, in
 		}
 
 	case downloader_pb.DownloaderRequest_BLOCKHEIGHT:
+		dnsServerRequestCounterVec.With(dnsReqMetricLabel("block height")).Inc()
 		response.BlockHeight = node.Blockchain().CurrentBlock().NumberU64()
 
 	// this is the out of sync node acts as grpc server side
 	case downloader_pb.DownloaderRequest_NEWBLOCK:
+		dnsServerRequestCounterVec.With(dnsReqMetricLabel("new block")).Inc()
 		if node.IsInSync.IsSet() {
 			response.Type = downloader_pb.DownloaderResponse_INSYNC
 			return response, nil
@@ -572,6 +580,30 @@ func (node *Node) CalculateResponse(request *downloader_pb.DownloaderRequest, in
 	}
 
 	return response, nil
+}
+
+func init() {
+	prom.PromRegistry().MustRegister(
+		dnsServerRequestCounterVec,
+	)
+}
+
+var (
+	dnsServerRequestCounterVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "hmy",
+			Subsystem: "dns_server",
+			Name:      "request_count",
+			Help:      "request count for each dns request",
+		},
+		[]string{"method"},
+	)
+)
+
+func dnsReqMetricLabel(method string) prometheus.Labels {
+	return prometheus.Labels{
+		"method": method,
+	}
 }
 
 const (

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -511,7 +511,7 @@ func (node *Node) CalculateResponse(request *downloader_pb.DownloaderRequest, in
 		}
 
 	case downloader_pb.DownloaderRequest_BLOCKHEIGHT:
-		dnsServerRequestCounterVec.With(dnsReqMetricLabel("block height")).Inc()
+		dnsServerRequestCounterVec.With(dnsReqMetricLabel("block_height")).Inc()
 		response.BlockHeight = node.Blockchain().CurrentBlock().NumberU64()
 
 	// this is the out of sync node acts as grpc server side


### PR DESCRIPTION
## Issue

Added metrics for DNS sync service for counting the request count per SYNC request

The new added metrics will be available through `$IP:9900/metrics`

Example:

```
# HELP hmy_dns_server_request_count request count for each dns request
# TYPE hmy_dns_server_request_count counter
hmy_dns_server_request_count{method="block_height"} 1
```

The code may be deployed to DNS server nodes to see the sync traffics.