### PR TITLE
[misc] add a general purpose rate limiter

### DIFF
--- a/internal/rate/config.go
+++ b/internal/rate/config.go
@@ -1,0 +1,57 @@
+package rate
+
+import (
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+const (
+	defCheckInt    = 1 * time.Minute // Check and evict every 1 minute
+	defMinEvictDur = 3 * time.Minute // limiter evicted must be inactive for 3 minutes
+	defCapacity    = 100             // Evict old IPs if size of IP list grows larger than 100
+)
+
+type (
+	// Config is the config for Limiter
+	Config struct {
+		Capacity    *int
+		CheckInt    *time.Duration
+		MinEvictDur *time.Duration
+		Whitelist   []string
+	}
+
+	// internal config
+	configInt struct {
+		limit       rate.Limit
+		burst       int
+		capacity    int
+		checkInt    time.Duration
+		minEvictDur time.Duration
+		whitelist   map[string]struct{}
+	}
+)
+
+func toConfigInt(limit rate.Limit, burst int, c *Config) configInt {
+	ci := configInt{
+		limit:       limit,
+		burst:       burst,
+		capacity:    defCapacity,
+		checkInt:    defCheckInt,
+		minEvictDur: defMinEvictDur,
+		whitelist:   make(map[string]struct{}),
+	}
+	if c == nil {
+		return ci
+	}
+	if c.Capacity != nil && *c.Capacity > 0 {
+		ci.capacity = *c.Capacity
+	}
+	if c.CheckInt != nil {
+		ci.checkInt = *c.CheckInt
+	}
+	if c.MinEvictDur != nil {
+		ci.minEvictDur = *c.MinEvictDur
+	}
+	return ci
+}

--- a/internal/rate/interface.go
+++ b/internal/rate/interface.go
@@ -1,0 +1,26 @@
+package rate
+
+import (
+	"context"
+	"time"
+)
+
+// IDLimiter is the limiter interface to limit incoming traffics per ID
+type IDLimiter interface {
+	AllowN(id string, n int) bool
+	WaitN(ctx context.Context, id string, n int) error
+}
+
+// timer is the interface of time used for testing
+type timer interface {
+	now() time.Time
+	since(time.Time) time.Duration
+	newTicker(time.Duration) *time.Ticker
+}
+
+// timerImpl is the timer for production. Use package time directly
+type timerImpl struct{}
+
+func (t timerImpl) now() time.Time                         { return time.Now() }
+func (t timerImpl) since(t2 time.Time) time.Duration       { return time.Since(t2) }
+func (t timerImpl) newTicker(d time.Duration) *time.Ticker { return time.NewTicker(d) }

--- a/internal/rate/limiter.go
+++ b/internal/rate/limiter.go
@@ -1,0 +1,114 @@
+package rate
+
+import (
+	"container/list"
+	"context"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+type (
+	limiterPerID struct {
+		evictList *list.List
+		items     map[string]*list.Element
+
+		lock sync.Mutex
+		t    timer
+		c    configInt
+	}
+
+	entry struct {
+		id       string
+		limiter  *rate.Limiter
+		lastCall time.Time
+	}
+)
+
+// NewLimiterPerID creates a limit limiter based on ID
+func NewLimiterPerID(rate rate.Limit, burst int, c *Config) *limiterPerID {
+	lpi := &limiterPerID{
+		evictList: list.New(),
+		items:     make(map[string]*list.Element),
+		t:         timerImpl{},
+		c:         toConfigInt(rate, burst, c),
+	}
+	go lpi.maintainLoop()
+	return lpi
+}
+
+// AllowN return whether a request of size n is allowed by IP
+func (lpi *limiterPerID) AllowN(id string, n int) bool {
+	if lpi.isWhitelisted(id) {
+		return true
+	}
+	lmt := lpi.getLimiterByID(id)
+	return lmt.AllowN(lpi.t.now(), n)
+}
+
+// WaitN waits until the n token is granted by IP
+func (lpi *limiterPerID) WaitN(ctx context.Context, id string, n int) error {
+	if lpi.isWhitelisted(id) {
+		return nil
+	}
+	lmt := lpi.getLimiterByID(id)
+	return lmt.WaitN(ctx, n)
+}
+
+func (lpi *limiterPerID) getLimiterByID(id string) *rate.Limiter {
+	lpi.lock.Lock()
+	defer lpi.lock.Unlock()
+
+	elem, ok := lpi.items[id]
+	if !ok || elem == nil {
+		lmt := rate.NewLimiter(lpi.c.limit, lpi.c.burst)
+		ent := &entry{id: id, limiter: lmt, lastCall: lpi.t.now()}
+		elem := lpi.evictList.PushFront(ent)
+		lpi.items[id] = elem
+		return lmt
+	}
+	ent := elem.Value.(*entry)
+	lpi.evictList.MoveToFront(elem)
+	ent.lastCall = lpi.t.now()
+	return ent.limiter
+}
+
+func (lpi *limiterPerID) maintainLoop() {
+	t := lpi.t.newTicker(lpi.c.checkInt)
+	defer t.Stop()
+
+	for range t.C {
+		lpi.maintain()
+	}
+}
+
+func (lpi *limiterPerID) maintain() {
+	lpi.lock.Lock()
+	defer lpi.lock.Unlock()
+
+	for lpi.evictList.Len() > lpi.c.capacity {
+		evicted := lpi.evictLast(func(ent *entry) bool {
+			return lpi.t.since(ent.lastCall) > lpi.c.minEvictDur
+		})
+		if !evicted {
+			break
+		}
+	}
+}
+
+func (lpi *limiterPerID) evictLast(isEvict func(ent *entry) bool) bool {
+	elem := lpi.evictList.Back()
+	evict := elem.Value.(*entry) // not nil ensured
+	if isEvict(evict) {
+		delete(lpi.items, evict.id)
+		lpi.evictList.Remove(elem)
+		return true
+	}
+	return false
+}
+
+func (lpi *limiterPerID) isWhitelisted(id string) bool {
+	_, ok := lpi.c.whitelist[id]
+	return ok
+}

--- a/internal/rate/limiter_test.go
+++ b/internal/rate/limiter_test.go
@@ -1,0 +1,157 @@
+package rate
+
+import (
+	"container/list"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+var (
+	id1 = "id1"
+	id2 = "id2"
+)
+
+func TestLimiterPerID_AllowN(t *testing.T) {
+	tests := []struct {
+		steps []testStep
+	}{
+		{
+			steps: []testStep{
+				{id1, 1, true},
+				{id1, 1, true},
+				{id1, 1, false},
+			},
+		},
+		{
+			steps: []testStep{
+				{id1, 1, true},
+				{id2, 1, true},
+				{id1, 1, true},
+				{id1, 1, false},
+				{id2, 1, true},
+			},
+		},
+		{
+			steps: []testStep{
+				{id1, 2, true},
+				{id1, 1, false},
+			},
+		},
+		{
+			steps: []testStep{
+				{id1, 3, false},
+				{id1, 3, false},
+			},
+		},
+	}
+	for i, test := range tests {
+		lpi := newTestLimiter()
+		steps := test.steps
+		for j, step := range steps {
+			res := lpi.AllowN(step.id, step.n)
+			if res != step.exp {
+				t.Errorf("Test %v/%v unexpected %v/%v", i, j, res, step.exp)
+			}
+			lpi.t.(*testTimer).tick()
+		}
+	}
+}
+
+func TestLimiterPerID_maintain(t *testing.T) {
+	lpi := newTestLimiter()
+	lpi.c.capacity = 0
+	lpi.AllowN(id1, 2)
+	lpi.t.(*testTimer).tick()
+	lpi.AllowN(id2, 2)
+	lpi.t.(*testTimer).tick()
+
+	lpi.maintain()
+	if lpi.evictList.Len() != 1 || len(lpi.items) != 1 {
+		t.Errorf("unexpected number. Expect 1")
+	}
+	for id := range lpi.items {
+		if id != id2 {
+			t.Errorf("unexpected id. Expect id2")
+		}
+	}
+	lpi.t.(*testTimer).tick()
+	lpi.maintain()
+	if lpi.evictList.Len() != 0 || len(lpi.items) != 0 {
+		t.Errorf("unexpected number. Expect 0")
+	}
+}
+
+func TestLimiterPerID_maintain_largeCap(t *testing.T) {
+	lpi := newTestLimiter()
+	lpi.c.capacity = 10
+	lpi.AllowN(id1, 2)
+	lpi.t.(*testTimer).tick()
+	lpi.AllowN(id2, 2)
+	lpi.t.(*testTimer).tick()
+	lpi.maintain()
+
+	if lpi.evictList.Len() != 2 || len(lpi.items) != 2 {
+		t.Errorf("unexpected number")
+	}
+}
+
+func TestLimiterPerID_maintain_largeMinDur(t *testing.T) {
+	lpi := newTestLimiter()
+	lpi.c.minEvictDur = 5 * time.Second
+	lpi.AllowN(id1, 2)
+	lpi.t.(*testTimer).tick()
+	lpi.AllowN(id2, 2)
+	lpi.t.(*testTimer).tick()
+	lpi.maintain()
+
+	if lpi.evictList.Len() != 2 || len(lpi.items) != 2 {
+		t.Errorf("unexpected number")
+	}
+}
+
+type testStep struct {
+	id  string
+	n   int
+	exp bool
+}
+
+func newTestLimiter() *limiterPerID {
+	return &limiterPerID{
+		evictList: list.New(),
+		items:     make(map[string]*list.Element),
+		t:         &testTimer{time.Now()},
+		c:         testConfig,
+	}
+}
+
+var testConfig = configInt{
+	limit:       rate.Every(100 * time.Second),
+	burst:       2,
+	capacity:    1,
+	checkInt:    time.Second,
+	minEvictDur: 1 * time.Second,
+	whitelist:   make(map[string]struct{}),
+}
+
+// testTimer will increment 1 sec per call
+type testTimer struct {
+	c time.Time
+}
+
+func (t *testTimer) now() time.Time {
+	return t.c
+}
+
+func (t *testTimer) tick() {
+	t.c = t.c.Add(time.Second)
+}
+
+func (t *testTimer) since(t2 time.Time) time.Duration {
+	return t.c.Sub(t2)
+}
+
+func (t *testTimer) newTicker(d time.Duration) *time.Ticker {
+	return time.NewTicker(time.Nanosecond)
+}


### PR DESCRIPTION
## Issue

Add a general purpose rate limiter to be used by RPC and SYNC module. Here are the features of the module:

1. Provide limit by ID (IP).
2. Self maintained loops to remove inactive IPs to avoid memory leak.

Note: This was part of the PR https://github.com/harmony-one/harmony/pull/3938/files. Handle sync rate limit later.

## Test

Implemented unit test case.