### PR TITLE
[RPC] Add a general RPC rate limiter per IP

### DIFF
--- a/eth/rpc/client.go
+++ b/eth/rpc/client.go
@@ -113,7 +113,7 @@ type clientConn struct {
 
 func (c *Client) newClientConn(conn ServerCodec) *clientConn {
 	ctx := context.WithValue(context.Background(), clientContextKey{}, c)
-	handler := newHandler(ctx, conn, c.idgen, c.services)
+	handler := newHandler(ctx, conn, c.idgen, c.services, nil)
 	return &clientConn{conn, handler}
 }
 
@@ -199,7 +199,7 @@ func newClient(initctx context.Context, connect reconnectFunc) (*Client, error) 
 	if err != nil {
 		return nil, err
 	}
-	c := initClient(conn, randomIDGenerator(), new(serviceRegistry))
+	c := initClient(conn, randomIDGenerator(), new(serviceRegistry), nil)
 	c.reconnectFunc = connect
 	return c, nil
 }

--- a/eth/rpc/errors.go
+++ b/eth/rpc/errors.go
@@ -67,6 +67,6 @@ func (e *invalidParamsError) Error() string { return e.message }
 // hit the rate limiter
 type rateLimitedError struct{ e error }
 
-func (e *rateLimitedError) eErrorCode() int { return -32700 }
+func (e *rateLimitedError) ErrorCode() int { return -32700 }
 
 func (e *rateLimitedError) Error() string { return e.e.Error() }

--- a/eth/rpc/errors.go
+++ b/eth/rpc/errors.go
@@ -65,7 +65,7 @@ func (e *invalidParamsError) ErrorCode() int { return -32602 }
 func (e *invalidParamsError) Error() string { return e.message }
 
 // hit the rate limiter
-type rateLimitedError struct{ e Error }
+type rateLimitedError struct{ e error }
 
 func (e *rateLimitedError) eErrorCode() int { return -32700 }
 

--- a/eth/rpc/errors.go
+++ b/eth/rpc/errors.go
@@ -63,3 +63,10 @@ type invalidParamsError struct{ message string }
 func (e *invalidParamsError) ErrorCode() int { return -32602 }
 
 func (e *invalidParamsError) Error() string { return e.message }
+
+// hit the rate limiter
+type rateLimitedError struct{ e Error }
+
+func (e *rateLimitedError) eErrorCode() int { return -32700 }
+
+func (e *rateLimitedError) Error() string { return e.e.Error() }

--- a/eth/rpc/errors.go
+++ b/eth/rpc/errors.go
@@ -70,3 +70,8 @@ type rateLimitedError struct{ e error }
 func (e *rateLimitedError) ErrorCode() int { return -32700 }
 
 func (e *rateLimitedError) Error() string { return e.e.Error() }
+
+// Rate limiter is hit
+type tooManyRequestsError struct{}
+
+func (e *tooManyRequestsError) Error() string { return "too many requests" }

--- a/eth/rpc/handler.go
+++ b/eth/rpc/handler.go
@@ -32,7 +32,7 @@ import (
 
 // handleCallLimitTimeOut is the timeout duration for rate limit.
 // If user hit the timeout at rate limiter, a too many request error will be returned
-const handleCallLimitTimeout = 2 * time.Second
+const handleCallLimitTimeout = 5 * time.Second
 
 // handler handles JSON-RPC messages. There is one handler per connection. Note that
 // handler is not safe for concurrent use. Message handling never blocks indefinitely

--- a/eth/rpc/handler.go
+++ b/eth/rpc/handler.go
@@ -305,7 +305,7 @@ func (h *handler) handleCallMsg(ctx *callProc, msg *jsonrpcMessage) *jsonrpcMess
 			}
 			if isContextExpiredError(err) {
 				rateLimiterHitCounter.Inc()
-				utils.Logger().Info().Str("ip", ip).Msg("[RPC] rate limited")
+				utils.Logger().Debug().Str("ip", ip).Msg("[RPC] rate limited")
 				err = &tooManyRequestsError{}
 			}
 			return msg.errorResponse(&rateLimitedError{e: err})

--- a/eth/rpc/handler.go
+++ b/eth/rpc/handler.go
@@ -297,7 +297,6 @@ func (h *handler) handleCallMsg(ctx *callProc, msg *jsonrpcMessage) *jsonrpcMess
 			if err != context.Canceled && err != context.DeadlineExceeded {
 				utils.Logger().Error().Err(err).Msg("RPC handleCallMsg")
 			}
-			limiterHitCounter.Inc()
 			return msg.errorResponse(&rateLimitedError{e: err})
 		}
 	}

--- a/eth/rpc/handler.go
+++ b/eth/rpc/handler.go
@@ -305,7 +305,7 @@ func (h *handler) handleCallMsg(ctx *callProc, msg *jsonrpcMessage) *jsonrpcMess
 			}
 			if isContextExpiredError(err) {
 				rateLimiterHitCounter.Inc()
-				utils.Logger().Error().Str("ip", ip).Msg("[RPC] rate limited")
+				utils.Logger().Info().Str("ip", ip).Msg("[RPC] rate limited")
 				err = &tooManyRequestsError{}
 			}
 			return msg.errorResponse(&rateLimitedError{e: err})

--- a/eth/rpc/http.go
+++ b/eth/rpc/http.go
@@ -263,6 +263,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if origin := r.Header.Get("Origin"); origin != "" {
 		ctx = context.WithValue(ctx, "Origin", origin)
 	}
+	if xForwardedFor := r.Header.Get("X-Forwarded-For"); xForwardedFor != "" {
+		ctx = context.WithValue(ctx, "X-Forwarded-For", xForwardedFor)
+	}
 
 	w.Header().Set("content-type", contentType)
 	codec := newHTTPServerConn(r, w)

--- a/eth/rpc/inproc.go
+++ b/eth/rpc/inproc.go
@@ -26,7 +26,7 @@ func DialInProc(handler *Server) *Client {
 	initctx := context.Background()
 	c, _ := newClient(initctx, func(context.Context) (ServerCodec, error) {
 		p1, p2 := net.Pipe()
-		go handler.ServeCodec(NewCodec(p1), 0)
+		go handler.ServeCodec(NewCodec(p1), 0, false)
 		return NewCodec(p2), nil
 	})
 	return c

--- a/eth/rpc/ipc.go
+++ b/eth/rpc/ipc.go
@@ -35,7 +35,7 @@ func (s *Server) ServeListener(l net.Listener) error {
 			return err
 		}
 		log.Trace("Accepted RPC connection", "conn", conn.RemoteAddr())
-		go s.ServeCodec(NewCodec(conn), 0)
+		go s.ServeCodec(NewCodec(conn), 0, false)
 	}
 }
 

--- a/eth/rpc/limit.go
+++ b/eth/rpc/limit.go
@@ -29,11 +29,11 @@ func newRateLimiter() *rateLimiter {
 	}
 }
 
-func (rl *rateLimiter) waitN(ctx context.Context) error {
+func (rl *rateLimiter) waitN(ctx context.Context) (string, error) {
 	hostPort := ctx.Value("remote").(string)
 	ip, _, err := net.SplitHostPort(hostPort)
 	if err != nil {
-		return err
+		return ip, err
 	}
-	return rl.il.WaitN(ctx, ip, weightPerRequest)
+	return ip, rl.il.WaitN(ctx, ip, weightPerRequest)
 }

--- a/eth/rpc/limit.go
+++ b/eth/rpc/limit.go
@@ -1,0 +1,26 @@
+package rpc
+
+import (
+	"context"
+
+	"github.com/harmony-one/harmony/internal/rate"
+)
+
+const (
+	defaultRate      = 100  // 100 requests per second
+	defaultBurst     = 1000 // Burst to 1000 request
+	weightPerRequest = 1
+)
+
+type limiter interface {
+	WaitN(ctx context.Context, n int) error
+}
+
+// httpServerLimiter is a wrapper of rate.IDLimiter which serves as the limiter for handling
+// single RPC requests. The IP field is obtainable from ctx
+// in the module
+type httpServerLimiter rate.IDLimiter
+
+func (*httpServerLimiter) WaitN(ctx context.Context, n int) error {
+	remote := 
+}

--- a/eth/rpc/limit.go
+++ b/eth/rpc/limit.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	defaultRate      rate.Limit = 100  // 100 requests per second
-	defaultBurst                = 1000 // Burst to 1000 request
+	defaultRate      rate.Limit = 10  // 100 requests per second
+	defaultBurst                = 100 // Burst to 1000 request
 	weightPerRequest            = 1
 )
 

--- a/eth/rpc/limit.go
+++ b/eth/rpc/limit.go
@@ -2,25 +2,37 @@ package rpc
 
 import (
 	"context"
+	"net"
 
 	"github.com/harmony-one/harmony/internal/rate"
 )
 
 const (
-	defaultRate      = 100  // 100 requests per second
-	defaultBurst     = 1000 // Burst to 1000 request
-	weightPerRequest = 1
+	defaultRate      rate.Limit = 100  // 100 requests per second
+	defaultBurst                = 1000 // Burst to 1000 request
+	weightPerRequest            = 1
 )
 
-type limiter interface {
-	WaitN(ctx context.Context, n int) error
+// rateLimiter is a wrapper of rate.IDLimiter which serves as the limiter for handling
+// RPC requests. The IP field can be obtained from ctx in the module.
+type rateLimiter struct {
+	il rate.IDLimiter
 }
 
-// httpServerLimiter is a wrapper of rate.IDLimiter which serves as the limiter for handling
-// single RPC requests. The IP field is obtainable from ctx
-// in the module
-type httpServerLimiter rate.IDLimiter
+func newRateLimiter() *rateLimiter {
+	config := &rate.Config{
+		Whitelist: []string{"127.0.0.1", "localhost"},
+	}
+	return &rateLimiter{
+		il: rate.NewLimiterPerID(defaultRate, defaultBurst, config), // use default IDRateLimiter settings
+	}
+}
 
-func (*httpServerLimiter) WaitN(ctx context.Context, n int) error {
-	remote := 
+func (rl *rateLimiter) waitN(ctx context.Context) error {
+	hostPort := ctx.Value("remote").(string)
+	ip, _, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		return err
+	}
+	return rl.il.WaitN(ctx, ip, weightPerRequest)
 }

--- a/eth/rpc/limit.go
+++ b/eth/rpc/limit.go
@@ -8,8 +8,9 @@ import (
 )
 
 const (
-	defaultRate      rate.Limit = 10  // 100 requests per second
-	defaultBurst                = 100 // Burst to 1000 request
+	// TODO: decide these parameters
+	defaultRate      rate.Limit = 2  // 2 requests per second
+	defaultBurst                = 10 // Burst to 10 request
 	weightPerRequest            = 1
 )
 

--- a/eth/rpc/limit.go
+++ b/eth/rpc/limit.go
@@ -30,7 +30,7 @@ func newRateLimiter() *rateLimiter {
 }
 
 func (rl *rateLimiter) waitN(ctx context.Context) (string, error) {
-	hostPort := ctx.Value("remote").(string)
+	hostPort := ctx.Value("X-Forwarded-For").(string)
 	ip, _, err := net.SplitHostPort(hostPort)
 	if err != nil {
 		return ip, err

--- a/eth/rpc/limit.go
+++ b/eth/rpc/limit.go
@@ -9,8 +9,8 @@ import (
 
 const (
 	// TODO: decide these parameters
-	defaultRate      rate.Limit = 2  // 2 requests per second
-	defaultBurst                = 10 // Burst to 10 request
+	defaultRate      rate.Limit = 5  // 2 requests per second
+	defaultBurst                = 50 // Burst to 10 request
 	weightPerRequest            = 1
 )
 

--- a/eth/rpc/limit.go
+++ b/eth/rpc/limit.go
@@ -9,8 +9,8 @@ import (
 
 const (
 	// TODO: decide these parameters
-	defaultRate      rate.Limit = 5  // 2 requests per second
-	defaultBurst                = 50 // Burst to 10 request
+	defaultRate      rate.Limit = 0.5
+	defaultBurst                = 50
 	weightPerRequest            = 1
 )
 

--- a/eth/rpc/limit.go
+++ b/eth/rpc/limit.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net"
 
+	"github.com/harmony-one/harmony/internal/utils"
+
 	"github.com/harmony-one/harmony/internal/rate"
 )
 
@@ -31,6 +33,7 @@ func newRateLimiter() *rateLimiter {
 
 func (rl *rateLimiter) waitN(ctx context.Context) (string, error) {
 	hostPort := ctx.Value("X-Forwarded-For").(string)
+	utils.Logger().Info().Str("host", hostPort).Msg("x forwarded for")
 	ip, _, err := net.SplitHostPort(hostPort)
 	if err != nil {
 		return ip, err

--- a/eth/rpc/limit.go
+++ b/eth/rpc/limit.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"net"
 
-	"github.com/harmony-one/harmony/internal/utils"
-
 	"github.com/harmony-one/harmony/internal/rate"
 )
 
@@ -32,8 +30,11 @@ func newRateLimiter() *rateLimiter {
 }
 
 func (rl *rateLimiter) waitN(ctx context.Context) (string, error) {
-	hostPort := ctx.Value("X-Forwarded-For").(string)
-	utils.Logger().Info().Str("host", hostPort).Msg("x forwarded for")
+	hostPortObj := ctx.Value("X-Forwarded-For")
+	if hostPortObj == nil {
+		hostPortObj = ctx.Value("remote")
+	}
+	hostPort := hostPortObj.(string)
 	ip, _, err := net.SplitHostPort(hostPort)
 	if err != nil {
 		return ip, err

--- a/eth/rpc/limit_test.go
+++ b/eth/rpc/limit_test.go
@@ -1,0 +1,17 @@
+package rpc
+
+import "github.com/harmony-one/harmony/internal/rate"
+
+const (
+	testRate  rate.Limit = 1000000
+	testBurst            = 100000
+)
+
+func getTestRateLimiter() *rateLimiter {
+	config := &rate.Config{
+		Whitelist: []string{"127.0.0.1", "localhost"},
+	}
+	return &rateLimiter{
+		il: rate.NewLimiterPerID(testRate, testBurst, config), // use default IDRateLimiter settings
+	}
+}

--- a/eth/rpc/metrics.go
+++ b/eth/rpc/metrics.go
@@ -10,6 +10,7 @@ func init() {
 		requestCounterVec,
 		requestErroredCounterVec,
 		requestDurationHistVec,
+		limiterHitCounter,
 	)
 }
 
@@ -44,6 +45,15 @@ var (
 			Buckets: prometheus.ExponentialBuckets(0.05, 2, 8),
 		},
 		[]string{"method"},
+	)
+
+	limiterHitCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "hmy",
+			Subsystem: "rpc2",
+			Name:      "limiter_hit",
+			Help:      "counter of limiter being hit",
+		},
 	)
 )
 

--- a/eth/rpc/metrics.go
+++ b/eth/rpc/metrics.go
@@ -10,7 +10,6 @@ func init() {
 		requestCounterVec,
 		requestErroredCounterVec,
 		requestDurationHistVec,
-		limiterHitCounter,
 	)
 }
 
@@ -45,15 +44,6 @@ var (
 			Buckets: prometheus.ExponentialBuckets(0.05, 2, 8),
 		},
 		[]string{"method"},
-	)
-
-	limiterHitCounter = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: "hmy",
-			Subsystem: "rpc2",
-			Name:      "limiter_hit",
-			Help:      "counter of limiter being hit",
-		},
 	)
 )
 

--- a/eth/rpc/metrics.go
+++ b/eth/rpc/metrics.go
@@ -10,6 +10,7 @@ func init() {
 		requestCounterVec,
 		requestErroredCounterVec,
 		requestDurationHistVec,
+		rateLimiterHitCounter,
 	)
 }
 
@@ -44,6 +45,15 @@ var (
 			Buckets: prometheus.ExponentialBuckets(0.05, 2, 8),
 		},
 		[]string{"method"},
+	)
+
+	rateLimiterHitCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "hmy",
+			Subsystem: "rpc2",
+			Name:      "rate_limited",
+			Help:      "Number of request being rate limited",
+		},
 	)
 )
 

--- a/eth/rpc/server_test.go
+++ b/eth/rpc/server_test.go
@@ -77,7 +77,7 @@ func runTestScript(t *testing.T, file string) {
 
 	clientConn, serverConn := net.Pipe()
 	defer clientConn.Close()
-	go server.ServeCodec(NewCodec(serverConn), 0)
+	go server.ServeCodec(NewCodec(serverConn), 0, false)
 	readbuf := bufio.NewReader(clientConn)
 	for _, line := range strings.Split(string(content), "\n") {
 		line = strings.TrimSpace(line)

--- a/eth/rpc/subscription_test.go
+++ b/eth/rpc/subscription_test.go
@@ -68,7 +68,7 @@ func TestSubscriptions(t *testing.T) {
 			t.Fatalf("unable to register test service %v", err)
 		}
 	}
-	go server.ServeCodec(NewCodec(serverConn), 0)
+	go server.ServeCodec(NewCodec(serverConn), 0, false)
 	defer server.Stop()
 
 	// wait for message and write them to the given channels
@@ -130,7 +130,7 @@ func TestServerUnsubscribe(t *testing.T) {
 	service := &notificationTestService{unsubscribed: make(chan string)}
 	server.RegisterName("nftest2", service)
 	p1, p2 := net.Pipe()
-	go server.ServeCodec(NewCodec(p1), 0)
+	go server.ServeCodec(NewCodec(p1), 0, false)
 
 	p2.SetDeadline(time.Now().Add(10 * time.Second))
 

--- a/eth/rpc/testservice_test.go
+++ b/eth/rpc/testservice_test.go
@@ -26,6 +26,7 @@ import (
 
 func newTestServer() *Server {
 	server := NewServer()
+	server.limiter = getTestRateLimiter()
 	server.idgen = sequentialIDGenerator()
 	if err := server.RegisterName("test", new(testService)); err != nil {
 		panic(err)

--- a/eth/rpc/types.go
+++ b/eth/rpc/types.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/goccy/go-json"
 )
 
 // API describes the set of methods offered over the RPC interface

--- a/eth/rpc/types.go
+++ b/eth/rpc/types.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/goccy/go-json"
 )
 
 // API describes the set of methods offered over the RPC interface

--- a/eth/rpc/websocket.go
+++ b/eth/rpc/websocket.go
@@ -63,7 +63,7 @@ func (s *Server) WebsocketHandler(allowedOrigins []string) http.Handler {
 			return
 		}
 		codec := newWebsocketCodec(conn)
-		s.ServeCodec(codec, 0)
+		s.ServeCodec(codec, 0, true)
 	})
 }
 

--- a/internal/rate/config.go
+++ b/internal/rate/config.go
@@ -51,5 +51,10 @@ func toConfigInt(limit Limit, burst int, c *Config) configInt {
 	if c.MinEvictDur != nil {
 		ci.minEvictDur = *c.MinEvictDur
 	}
+	if c.Whitelist != nil {
+		for _, ip := range c.Whitelist {
+			ci.whitelist[ip] = struct{}{}
+		}
+	}
 	return ci
 }

--- a/internal/rate/config.go
+++ b/internal/rate/config.go
@@ -2,8 +2,6 @@ package rate
 
 import (
 	"time"
-
-	"golang.org/x/time/rate"
 )
 
 const (
@@ -23,7 +21,7 @@ type (
 
 	// internal config
 	configInt struct {
-		limit       rate.Limit
+		limit       Limit
 		burst       int
 		capacity    int
 		checkInt    time.Duration
@@ -32,7 +30,7 @@ type (
 	}
 )
 
-func toConfigInt(limit rate.Limit, burst int, c *Config) configInt {
+func toConfigInt(limit Limit, burst int, c *Config) configInt {
 	ci := configInt{
 		limit:       limit,
 		burst:       burst,

--- a/internal/rate/limiter.go
+++ b/internal/rate/limiter.go
@@ -24,10 +24,13 @@ type (
 		limiter  *rate.Limiter
 		lastCall time.Time
 	}
+
+	// Limit is an alias to rate.Limit which is internally an float64
+	Limit rate.Limit
 )
 
 // NewLimiterPerID creates a limit limiter based on ID
-func NewLimiterPerID(rate rate.Limit, burst int, c *Config) *limiterPerID {
+func NewLimiterPerID(rate Limit, burst int, c *Config) *limiterPerID {
 	lpi := &limiterPerID{
 		evictList: list.New(),
 		items:     make(map[string]*list.Element),
@@ -62,7 +65,7 @@ func (lpi *limiterPerID) getLimiterByID(id string) *rate.Limiter {
 
 	elem, ok := lpi.items[id]
 	if !ok || elem == nil {
-		lmt := rate.NewLimiter(lpi.c.limit, lpi.c.burst)
+		lmt := rate.NewLimiter(rate.Limit(lpi.c.limit), lpi.c.burst)
 		ent := &entry{id: id, limiter: lmt, lastCall: lpi.t.now()}
 		elem := lpi.evictList.PushFront(ent)
 		lpi.items[id] = elem

--- a/internal/rate/limiter_test.go
+++ b/internal/rate/limiter_test.go
@@ -127,7 +127,7 @@ func newTestLimiter() *limiterPerID {
 }
 
 var testConfig = configInt{
-	limit:       rate.Every(100 * time.Second),
+	limit:       Limit(rate.Every(100 * time.Second)),
 	burst:       2,
 	capacity:    1,
 	checkInt:    time.Second,


### PR DESCRIPTION
## Issue

Add a rate limiter that rate limit the incoming RPC requests per IP. This PR is rebased on top of https://github.com/harmony-one/harmony/pull/3983, which use harmony/eth/rpc as customized rpc module.

1. The rate limit will limit both websocket traffic and HTTP requests at server side.
2. The rate limit is IP wise.
3. The rate limit will not be applied to 127.0.0.1.
4. The current rate limit setup is at rate=2 req/second, and burst = 10. We may adjust these parameters after some test.

### Update 1/12

1. Added a default timeout (2s) to rate limiter. If the timeout expires, a "too many request" error will be returned. 
2. Added a prometheus metric to track the counter of rate limiter being hit.

```
# HELP hmy_rpc2_rate_limited Number of request being rate limited
# TYPE hmy_rpc2_rate_limited counter
hmy_rpc2_rate_limited 0
```

## Test

Tested locally. Intense amount of RPC calls will be dropped significantly.

### TODO

1. Test on a node behind a load balancer.
2. Add rate limit related parameters to harmony config, including rate, burst and whitelist.
2. Retire some of the existing rate limiter at RPCs to avoid degrading of use experience.