### PR TITLE
[RPC] add print rate stat logs

### DIFF
--- a/eth/rpc/http.go
+++ b/eth/rpc/http.go
@@ -263,6 +263,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if origin := r.Header.Get("Origin"); origin != "" {
 		ctx = context.WithValue(ctx, "Origin", origin)
 	}
+	if xForwardedFor := r.Header.Get("X-Forwarded-For"); xForwardedFor != "" {
+		ctx = context.WithValue(ctx, "X-Forwarded-For", xForwardedFor)
+	}
 
 	w.Header().Set("content-type", contentType)
 	codec := newHTTPServerConn(r, w)


### PR DESCRIPTION
## Issue

Add RPC rate stats in harmony zerolog.

```
{"level":"info","ip":"127.0.0.1","rate":73.34,"caller":"/Users/yanxiangwang/go/src/github.com/harmony-one/harmony/eth/rpc/handler.go:341","time":"2022-01-21T09:43:22.8244-08:00","message":"[RPC] rate stats"}
```

The stats will collect the RPC request rate (req/s) per IP averaged overtime since node start, and print the rate for all known IPs every 10s. Note this is the code only used for testing purpose, and it shall be removed after metrics collected. 

## Test

Tested locally.
