### PR TITLE
Make blockNumber rpc more efficient with atomic uint64

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -139,7 +139,7 @@ type BlockChain struct {
 	pendingSlashingCandidatesMU sync.RWMutex // pending slashing candidates
 
 	currentBlock     atomic.Value // Current head of the block chain
-	currentBlockNum  uint64       // Current head of the block chain
+	currentBlockNum  uint64       // Current head block number of the block chain
 	currentFastBlock atomic.Value // Current head of the fast-sync chain (may be above the block chain!)
 
 	stateCache                    state.Database // State database to reuse between imports (contains state cache)
@@ -263,9 +263,9 @@ func (bc *BlockChain) SetCurrentBlock(block *types.Block) {
 	bc.currentBlock.Store(block)
 	if block == nil {
 		atomic.StoreUint64(&bc.currentBlockNum, uint64(0))
+	} else {
+		atomic.StoreUint64(&bc.currentBlockNum, block.NumberU64())
 	}
-
-	atomic.StoreUint64(&bc.currentBlockNum, block.NumberU64())
 }
 
 // ValidateNewBlock validates new block.

--- a/hmy/blockchain.go
+++ b/hmy/blockchain.go
@@ -210,6 +210,11 @@ func (hmy *Harmony) CurrentBlock() *types.Block {
 	return types.NewBlockWithHeader(hmy.BlockChain.CurrentHeader())
 }
 
+// CurrentBlock ...
+func (hmy *Harmony) CurrentBlockNumber() uint64 {
+	return hmy.BlockChain.CurrentBlockNumber()
+}
+
 // GetBlock ...
 func (hmy *Harmony) GetBlock(ctx context.Context, hash common.Hash) (*types.Block, error) {
 	return hmy.BlockChain.GetBlockByHash(hash), nil

--- a/rpc/blockchain.go
+++ b/rpc/blockchain.go
@@ -51,7 +51,7 @@ type PublicBlockchainService struct {
 
 const (
 	DefaultRateLimiterWaitTimeout = 5 * time.Second
-	rpcGetBlocksLimit             = 1024
+	rpcGetBlocksLimit             = 64
 )
 
 // NewPublicBlockchainAPI creates a new API for the RPC interface

--- a/rpc/blockchain.go
+++ b/rpc/blockchain.go
@@ -135,18 +135,14 @@ func (s *PublicBlockchainService) getBalanceByBlockNumber(
 
 // BlockNumber returns the block number of the chain head.
 func (s *PublicBlockchainService) BlockNumber(ctx context.Context) (interface{}, error) {
-	// Fetch latest header
-	header, err := s.hmy.HeaderByNumber(ctx, rpc.LatestBlockNumber)
-	if err != nil {
-		return nil, err
-	}
+	curNum := s.hmy.CurrentBlockNumber()
 
 	// Format return base on version
 	switch s.version {
 	case V1, Eth:
-		return hexutil.Uint64(header.Number().Uint64()), nil
+		return hexutil.Uint64(curNum), nil
 	case V2:
-		return header.Number().Uint64(), nil
+		return curNum, nil
 	default:
 		return nil, ErrUnknownRPCVersion
 	}


### PR DESCRIPTION
Previous _blockNumber rpc is retrieving the latest block, copying the header and returning the number from the header, which is very unnecessary and expensive.

Adding a uint64 atomic value to store the latest block number and directly turning it.