### PR TITLE
[rpc] make PRCs metrics cover all RPCs

### DIFF
--- a/rpc/blockchain.go
+++ b/rpc/blockchain.go
@@ -333,6 +333,9 @@ func (s *PublicBlockchainService) GetBlocks(
 
 // IsLastBlock checks if block is last epoch block.
 func (s *PublicBlockchainService) IsLastBlock(ctx context.Context, blockNum uint64) (bool, error) {
+	timer := DoMetricRPCRequest(IsLastBlock)
+	defer DoRPCRequestDuration(IsLastBlock, timer)
+
 	if !isBeaconShard(s.hmy) {
 		return false, ErrNotBeaconShard
 	}
@@ -341,6 +344,9 @@ func (s *PublicBlockchainService) IsLastBlock(ctx context.Context, blockNum uint
 
 // EpochLastBlock returns epoch last block.
 func (s *PublicBlockchainService) EpochLastBlock(ctx context.Context, epoch uint64) (uint64, error) {
+	timer := DoMetricRPCRequest(EpochLastBlock)
+	defer DoRPCRequestDuration(EpochLastBlock, timer)
+
 	if !isBeaconShard(s.hmy) {
 		return 0, ErrNotBeaconShard
 	}
@@ -351,6 +357,9 @@ func (s *PublicBlockchainService) EpochLastBlock(ctx context.Context, epoch uint
 func (s *PublicBlockchainService) GetBlockSigners(
 	ctx context.Context, blockNumber BlockNumber,
 ) ([]string, error) {
+	timer := DoMetricRPCRequest(GetBlockSigners)
+	defer DoRPCRequestDuration(GetBlockSigners, timer)
+
 	// Process arguments based on version
 	blockNum := blockNumber.EthBlockNumber()
 	if blockNum == rpc.PendingBlockNumber {
@@ -381,6 +390,9 @@ func (s *PublicBlockchainService) GetBlockSigners(
 func (s *PublicBlockchainService) GetBlockSignerKeys(
 	ctx context.Context, blockNumber BlockNumber,
 ) ([]string, error) {
+	timer := DoMetricRPCRequest(GetBlockSignerKeys)
+	defer DoRPCRequestDuration(GetBlockSignerKeys, timer)
+
 	// Process arguments based on version
 	blockNum := blockNumber.EthBlockNumber()
 	if blockNum == rpc.PendingBlockNumber {
@@ -407,6 +419,9 @@ func (s *PublicBlockchainService) GetBlockSignerKeys(
 func (s *PublicBlockchainService) IsBlockSigner(
 	ctx context.Context, blockNumber BlockNumber, address string,
 ) (bool, error) {
+	timer := DoMetricRPCRequest(IsBlockSigner)
+	defer DoRPCRequestDuration(IsBlockSigner, timer)
+
 	// Process arguments based on version
 	blockNum := blockNumber.EthBlockNumber()
 
@@ -435,6 +450,9 @@ func (s *PublicBlockchainService) IsBlockSigner(
 func (s *PublicBlockchainService) GetSignedBlocks(
 	ctx context.Context, address string,
 ) (interface{}, error) {
+	timer := DoMetricRPCRequest(GetSignedBlocks)
+	defer DoRPCRequestDuration(GetSignedBlocks, timer)
+
 	// Fetch the number of signed blocks within default period
 	curEpoch := s.hmy.CurrentBlock().Epoch()
 	var totalSigned uint64
@@ -486,6 +504,9 @@ func (s *PublicBlockchainService) GetSignedBlocks(
 
 // GetEpoch returns current epoch.
 func (s *PublicBlockchainService) GetEpoch(ctx context.Context) (interface{}, error) {
+	timer := DoMetricRPCRequest(GetEpoch)
+	defer DoRPCRequestDuration(GetEpoch, timer)
+
 	// Fetch Header
 	header, err := s.hmy.HeaderByNumber(ctx, rpc.LatestBlockNumber)
 	if err != nil {
@@ -506,6 +527,9 @@ func (s *PublicBlockchainService) GetEpoch(ctx context.Context) (interface{}, er
 
 // GetLeader returns current shard leader.
 func (s *PublicBlockchainService) GetLeader(ctx context.Context) (string, error) {
+	timer := DoMetricRPCRequest(GetLeader)
+	defer DoRPCRequestDuration(GetLeader, timer)
+
 	// Fetch Header
 	blk := s.hmy.BlockChain.CurrentBlock()
 	// Response output is the same for all versions
@@ -905,6 +929,8 @@ func (s *PublicBlockchainService) GetCurrentBadBlocks(
 func (s *PublicBlockchainService) GetTotalSupply(
 	ctx context.Context,
 ) (numeric.Dec, error) {
+	timer := DoMetricRPCRequest(GetTotalSupply)
+	defer DoRPCRequestDuration(GetTotalSupply, timer)
 	return stakingReward.GetTotalTokens(s.hmy.BlockChain)
 }
 
@@ -912,6 +938,8 @@ func (s *PublicBlockchainService) GetTotalSupply(
 func (s *PublicBlockchainService) GetCirculatingSupply(
 	ctx context.Context,
 ) (numeric.Dec, error) {
+	timer := DoMetricRPCRequest(GetCirculatingSupply)
+	defer DoRPCRequestDuration(GetCirculatingSupply, timer)
 	return chain.GetCirculatingSupply(s.hmy.BlockChain)
 }
 
@@ -976,6 +1004,8 @@ const (
 
 // InSync returns if shard chain is syncing
 func (s *PublicBlockchainService) InSync(ctx context.Context) (bool, error) {
+	timer := DoMetricRPCRequest(InSync)
+	defer DoRPCRequestDuration(InSync, timer)
 	inSync, _, diff := s.hmy.NodeAPI.SyncStatus(s.hmy.BlockChain.ShardID())
 	if !inSync && diff <= inSyncTolerance {
 		inSync = true
@@ -985,6 +1015,8 @@ func (s *PublicBlockchainService) InSync(ctx context.Context) (bool, error) {
 
 // BeaconInSync returns if beacon chain is syncing
 func (s *PublicBlockchainService) BeaconInSync(ctx context.Context) (bool, error) {
+	timer := DoMetricRPCRequest(BeaconInSync)
+	defer DoRPCRequestDuration(BeaconInSync, timer)
 	inSync, _, diff := s.hmy.NodeAPI.SyncStatus(s.hmy.BeaconChain.ShardID())
 	if !inSync && diff <= inSyncTolerance {
 		inSync = true
@@ -1032,6 +1064,8 @@ func isBlockGreaterThanLatest(hmy *hmy.Harmony, blockNum rpc.BlockNumber) bool {
 }
 
 func (s *PublicBlockchainService) SetNodeToBackupMode(ctx context.Context, isBackup bool) (bool, error) {
+	timer := DoMetricRPCRequest(SetNodeToBackupMode)
+	defer DoRPCRequestDuration(SetNodeToBackupMode, timer)
 	return s.hmy.NodeAPI.SetNodeBackupMode(isBackup), nil
 }
 

--- a/rpc/contract.go
+++ b/rpc/contract.go
@@ -65,6 +65,9 @@ func (s *PublicContractService) wait(limiter *rate.Limiter, ctx context.Context)
 func (s *PublicContractService) Call(
 	ctx context.Context, args CallArgs, blockNumber BlockNumber,
 ) (hexutil.Bytes, error) {
+	timer := DoMetricRPCRequest(Call)
+	defer DoRPCRequestDuration(Call, timer)
+
 	// Process number based on version
 	blockNum := blockNumber.EthBlockNumber()
 
@@ -144,9 +147,6 @@ func DoEVMCall(
 	ctx context.Context, hmy *hmy.Harmony, args CallArgs, blockNum rpc.BlockNumber,
 	timeout time.Duration,
 ) (core.ExecutionResult, error) {
-	timer := DoMetricRPCRequest(DoEvmCall)
-	defer DoRPCRequestDuration(DoEvmCall, timer)
-
 	defer func(start time.Time) {
 		utils.Logger().Debug().
 			Dur("runtime", time.Since(start)).

--- a/rpc/filters/api.go
+++ b/rpc/filters/api.go
@@ -96,6 +96,9 @@ func (api *PublicFilterAPI) timeoutLoop() {
 //
 // https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_newpendingtransactionfilter
 func (api *PublicFilterAPI) NewPendingTransactionFilter() rpc.ID {
+	timer := hmy_rpc.DoMetricRPCRequest(hmy_rpc.NewPendingTransactionFilter)
+	defer hmy_rpc.DoRPCRequestDuration(hmy_rpc.NewPendingTransactionFilter, timer)
+
 	var (
 		pendingTxs   = make(chan []common.Hash)
 		pendingTxSub = api.events.SubscribePendingTxs(pendingTxs)
@@ -129,6 +132,9 @@ func (api *PublicFilterAPI) NewPendingTransactionFilter() rpc.ID {
 // NewPendingTransactions creates a subscription that is triggered each time a transaction
 // enters the transaction pool and was signed from one of the transactions this nodes manages.
 func (api *PublicFilterAPI) NewPendingTransactions(ctx context.Context) (*rpc.Subscription, error) {
+	timer := hmy_rpc.DoMetricRPCRequest(hmy_rpc.NewPendingTransactions)
+	defer hmy_rpc.DoRPCRequestDuration(hmy_rpc.NewPendingTransactions, timer)
+
 	notifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {
 		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
@@ -166,6 +172,9 @@ func (api *PublicFilterAPI) NewPendingTransactions(ctx context.Context) (*rpc.Su
 //
 // https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_newblockfilter
 func (api *PublicFilterAPI) NewBlockFilter() rpc.ID {
+	timer := hmy_rpc.DoMetricRPCRequest(hmy_rpc.NewBlockFilter)
+	defer hmy_rpc.DoRPCRequestDuration(hmy_rpc.NewBlockFilter, timer)
+
 	var (
 		headers   = make(chan *block.Header)
 		headerSub = api.events.SubscribeNewHeads(headers)
@@ -198,6 +207,8 @@ func (api *PublicFilterAPI) NewBlockFilter() rpc.ID {
 
 // NewHeads send a notification each time a new (header) block is appended to the chain.
 func (api *PublicFilterAPI) NewHeads(ctx context.Context) (*rpc.Subscription, error) {
+	timer := hmy_rpc.DoMetricRPCRequest(hmy_rpc.NewHeads)
+	defer hmy_rpc.DoRPCRequestDuration(hmy_rpc.NewHeads, timer)
 	notifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {
 		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
@@ -234,6 +245,9 @@ func (api *PublicFilterAPI) NewHeads(ctx context.Context) (*rpc.Subscription, er
 //
 // https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getfilterchanges
 func (api *PublicFilterAPI) GetFilterChanges(id rpc.ID) (interface{}, error) {
+	timer := hmy_rpc.DoMetricRPCRequest(hmy_rpc.GetFilterChanges)
+	defer hmy_rpc.DoRPCRequestDuration(hmy_rpc.GetFilterChanges, timer)
+
 	api.filtersMu.Lock()
 	defer api.filtersMu.Unlock()
 
@@ -280,6 +294,8 @@ func returnLogs(logs []*types.Log) []*types.Log {
 
 // Logs creates a subscription that fires for all new log that match the given filter criteria.
 func (api *PublicFilterAPI) Logs(ctx context.Context, crit FilterCriteria) (*rpc.Subscription, error) {
+	timer := hmy_rpc.DoMetricRPCRequest(hmy_rpc.Logs)
+	defer hmy_rpc.DoRPCRequestDuration(hmy_rpc.Logs, timer)
 	notifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {
 		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
@@ -330,6 +346,9 @@ func (api *PublicFilterAPI) Logs(ctx context.Context, crit FilterCriteria) (*rpc
 //
 // https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_newfilter
 func (api *PublicFilterAPI) NewFilter(crit FilterCriteria) (rpc.ID, error) {
+	timer := hmy_rpc.DoMetricRPCRequest(hmy_rpc.NewFilter)
+	defer hmy_rpc.DoRPCRequestDuration(hmy_rpc.NewFilter, timer)
+
 	logs := make(chan []*types.Log)
 	logsSub, err := api.events.SubscribeLogs(ethereum.FilterQuery(crit), logs)
 	if err != nil {

--- a/rpc/metrics.go
+++ b/rpc/metrics.go
@@ -13,6 +13,14 @@ const (
 	GetBlockByHashNew        = "GetBlockByHashNew"
 	GetBlockByHash           = "GetBlockByHash"
 	GetBlocks                = "GetBlocks"
+	IsLastBlock              = "IsLastBlock"
+	EpochLastBlock           = "EpochLastBlock"
+	GetBlockSigners          = "GetBlockSigners"
+	GetBlockSignerKeys       = "GetBlockSignerKeys"
+	IsBlockSigner            = "IsBlockSigner"
+	GetSignedBlocks          = "GetSignedBlocks"
+	GetEpoch                 = "GetEpoch"
+	GetLeader                = "GetLeader"
 	GetShardingStructure     = "GetShardingStructure"
 	GetBalanceByBlockNumber  = "GetBalanceByBlockNumber"
 	LatestHeader             = "LatestHeader"
@@ -24,7 +32,12 @@ const (
 	GetCurrentUtilityMetrics = "GetCurrentUtilityMetrics"
 	GetSuperCommittees       = "GetSuperCommittees"
 	GetCurrentBadBlocks      = "GetCurrentBadBlocks"
+	GetTotalSupply           = "GetTotalSupply"
+	GetCirculatingSupply     = "GetCirculatingSupply"
 	GetStakingNetworkInfo    = "GetStakingNetworkInfo"
+	InSync                   = "InSync"
+	BeaconInSync             = "BeaconInSync"
+	SetNodeToBackupMode      = "SetNodeToBackupMode"
 
 	// contract
 	GetCode      = "GetCode"
@@ -33,7 +46,8 @@ const (
 	DoEvmCall    = "DoEVMCall"
 
 	// net
-	PeerCount = "PeerCount"
+	PeerCount  = "PeerCount"
+	NetVersion = "Version"
 
 	// pool
 	SendRawTransaction             = "SendRawTransaction"
@@ -46,32 +60,73 @@ const (
 	GetPendingCXReceipts           = "GetPendingCXReceipts"
 
 	// staking
+	GetTotalStaking                         = "GetTotalStaking"
+	GetMedianRawStakeSnapshot               = "GetMedianRawStakeSnapshot"
+	GetElectedValidatorAddresses            = "GetElectedValidatorAddresses"
+	GetValidators                           = "GetValidators"
+	GetAllValidatorAddresses                = "GetAllValidatorAddresses"
+	GetValidatorKeys                        = "GetValidatorKeys"
 	GetAllValidatorInformation              = "GetAllValidatorInformation"
 	GetAllValidatorInformationByBlockNumber = "GetAllValidatorInformationByBlockNumber"
 	GetValidatorInformation                 = "GetValidatorInformation"
 	GetValidatorInformationByBlockNumber    = "GetValidatorInformationByBlockNumber"
+	GetValidatorSelfDelegation              = "GetValidatorSelfDelegation"
+	GetValidatorTotalDelegation             = "GetValidatorTotalDelegation"
 	GetAllDelegationInformation             = "GetAllDelegationInformation"
 	GetDelegationsByDelegator               = "GetDelegationsByDelegator"
+	GetDelegationsByDelegatorByBlockNumber  = "GetDelegationsByDelegatorByBlockNumber"
 	GetDelegationsByValidator               = "GetDelegationsByValidator"
 	GetDelegationByDelegatorAndValidator    = "GetDelegationByDelegatorAndValidator"
+	GetAvailableRedelegationBalance         = "GetAvailableRedelegationBalance"
 
 	// tracer
+	TraceChain         = "TraceChain"
 	TraceBlockByNumber = "TraceBlockByNumber"
 	TraceBlockByHash   = "TraceBlockByHash"
 	TraceBlock         = "TraceBlock"
 	TraceTransaction   = "TraceTransaction"
 	TraceCall          = "TraceCall"
 
+	// tracer parity
+	Block       = "Block"
+	Transaction = "Transaction"
+
 	// transaction
-	GetTransactionByHash          = "GetTransactionByHash"
-	GetStakingTransactionByHash   = "GetStakingTransactionByHash"
-	GetTransactionsHistory        = "GetTransactionsHistory"
-	GetStakingTransactionsHistory = "GetStakingTransactionsHistory"
+	GetAccountNonce                            = "GetAccountNonce"
+	GetTransactionCount                        = "GetTransactionCount"
+	GetTransactionsCount                       = "GetTransactionsCount"
+	GetStakingTransactionsCount                = "GetStakingTransactionsCount"
+	RpcEstimateGas                             = "EstimateGas"
+	GetTransactionByHash                       = "GetTransactionByHash"
+	GetStakingTransactionByHash                = "GetStakingTransactionByHash"
+	GetTransactionsHistory                     = "GetTransactionsHistory"
+	GetStakingTransactionsHistory              = "GetStakingTransactionsHistory"
+	GetBlockTransactionCountByNumber           = "GetBlockTransactionCountByNumber"
+	GetBlockTransactionCountByHash             = "GetBlockTransactionCountByHash"
+	GetTransactionByBlockNumberAndIndex        = "GetTransactionByBlockNumberAndIndex"
+	GetTransactionByBlockHashAndIndex          = "GetTransactionByBlockHashAndIndex"
+	GetBlockStakingTransactionCountByNumber    = "GetBlockStakingTransactionCountByNumber"
+	GetBlockStakingTransactionCountByHash      = "GetBlockStakingTransactionCountByHash"
+	GetStakingTransactionByBlockNumberAndIndex = "GetStakingTransactionByBlockNumberAndIndex"
+	GetStakingTransactionByBlockHashAndIndex   = "GetStakingTransactionByBlockHashAndIndex"
+	GetTransactionReceipt                      = "GetTransactionReceipt"
+	GetCXReceiptByHash                         = "GetCXReceiptByHash"
+	ResendCx                                   = "ResendCx"
 
 	// filters
-	GetLogs         = "GetLogs"
-	UninstallFilter = "UninstallFilter"
-	GetFilterLogs   = "GetFilterLogs"
+	NewPendingTransactionFilter = "NewPendingTransactionFilter"
+	NewPendingTransactions      = "NewPendingTransactions"
+	NewBlockFilter              = "NewBlockFilter"
+	NewHeads                    = "NewHeads"
+	GetFilterChanges            = "GetFilterChanges"
+	Logs                        = "Logs"
+	NewFilter                   = "NewFilter"
+	GetLogs                     = "GetLogs"
+	UninstallFilter             = "UninstallFilter"
+	GetFilterLogs               = "GetFilterLogs"
+
+	// Web3
+	ClientVersion = "ClientVersion"
 )
 
 // info type const

--- a/rpc/net.go
+++ b/rpc/net.go
@@ -60,6 +60,8 @@ func (s *PublicNetService) PeerCount(ctx context.Context) (interface{}, error) {
 
 // Version returns the network version, i.e. ChainID identifying which network we are using
 func (s *PublicNetService) Version(ctx context.Context) interface{} {
+	timer := DoMetricRPCRequest(NetVersion)
+	defer DoRPCRequestDuration(NetVersion, timer)
 	switch s.version {
 	case Eth:
 		return nodeconfig.GetDefaultConfig().GetNetworkType().ChainConfig().EthCompatibleChainID.String()

--- a/rpc/staking.go
+++ b/rpc/staking.go
@@ -92,6 +92,9 @@ func (s *PublicStakingService) getBalanceByBlockNumber(
 func (s *PublicStakingService) GetTotalStaking(
 	ctx context.Context,
 ) (*big.Int, error) {
+	timer := DoMetricRPCRequest(GetTotalStaking)
+	defer DoRPCRequestDuration(GetTotalStaking, timer)
+
 	if !isBeaconShard(s.hmy) {
 		return nil, ErrNotBeaconShard
 	}
@@ -105,6 +108,9 @@ func (s *PublicStakingService) GetTotalStaking(
 func (s *PublicStakingService) GetMedianRawStakeSnapshot(
 	ctx context.Context,
 ) (StructuredResponse, error) {
+	timer := DoMetricRPCRequest(GetMedianRawStakeSnapshot)
+	defer DoRPCRequestDuration(GetMedianRawStakeSnapshot, timer)
+
 	if !isBeaconShard(s.hmy) {
 		return nil, ErrNotBeaconShard
 	}
@@ -123,6 +129,9 @@ func (s *PublicStakingService) GetMedianRawStakeSnapshot(
 func (s *PublicStakingService) GetElectedValidatorAddresses(
 	ctx context.Context,
 ) ([]string, error) {
+	timer := DoMetricRPCRequest(GetElectedValidatorAddresses)
+	defer DoRPCRequestDuration(GetElectedValidatorAddresses, timer)
+
 	if !isBeaconShard(s.hmy) {
 		return nil, ErrNotBeaconShard
 	}
@@ -142,6 +151,9 @@ func (s *PublicStakingService) GetElectedValidatorAddresses(
 func (s *PublicStakingService) GetValidators(
 	ctx context.Context, epoch int64,
 ) (StructuredResponse, error) {
+	timer := DoMetricRPCRequest(GetValidators)
+	defer DoRPCRequestDuration(GetValidators, timer)
+
 	// Fetch the Committee
 	cmt, err := s.hmy.GetValidators(big.NewInt(epoch))
 	if err != nil {
@@ -193,6 +205,9 @@ func (s *PublicStakingService) GetValidators(
 func (s *PublicStakingService) GetAllValidatorAddresses(
 	ctx context.Context,
 ) ([]string, error) {
+	timer := DoMetricRPCRequest(GetAllValidatorAddresses)
+	defer DoRPCRequestDuration(GetAllValidatorAddresses, timer)
+
 	if !isBeaconShard(s.hmy) {
 		return nil, ErrNotBeaconShard
 	}
@@ -212,6 +227,9 @@ func (s *PublicStakingService) GetAllValidatorAddresses(
 func (s *PublicStakingService) GetValidatorKeys(
 	ctx context.Context, epoch int64,
 ) ([]string, error) {
+	timer := DoMetricRPCRequest(GetValidatorKeys)
+	defer DoRPCRequestDuration(GetValidatorKeys, timer)
+
 	// Fetch the Committee
 	cmt, err := s.hmy.GetValidators(big.NewInt(epoch))
 	if err != nil {
@@ -440,6 +458,9 @@ func (s *PublicStakingService) GetValidatorInformationByBlockNumber(
 func (s *PublicStakingService) GetValidatorSelfDelegation(
 	ctx context.Context, address string,
 ) (interface{}, error) {
+	timer := DoMetricRPCRequest(GetValidatorSelfDelegation)
+	defer DoRPCRequestDuration(GetValidatorSelfDelegation, timer)
+
 	// Ensure node is for beacon shard
 	if !isBeaconShard(s.hmy) {
 		return nil, ErrNotBeaconShard
@@ -467,6 +488,9 @@ func (s *PublicStakingService) GetValidatorSelfDelegation(
 func (s *PublicStakingService) GetValidatorTotalDelegation(
 	ctx context.Context, address string,
 ) (interface{}, error) {
+	timer := DoMetricRPCRequest(GetValidatorTotalDelegation)
+	defer DoRPCRequestDuration(GetValidatorTotalDelegation, timer)
+
 	// Ensure node is for beacon shard
 	if s.hmy.ShardID != shard.BeaconChainShardID {
 		return nil, ErrNotBeaconShard
@@ -607,6 +631,9 @@ func (s *PublicStakingService) GetDelegationsByDelegator(
 func (s *PublicStakingService) GetDelegationsByDelegatorByBlockNumber(
 	ctx context.Context, aol AddressOrList, blockNumber BlockNumber,
 ) (interface{}, error) {
+	timer := DoMetricRPCRequest(GetDelegationsByDelegatorByBlockNumber)
+	defer DoRPCRequestDuration(GetDelegationsByDelegatorByBlockNumber, timer)
+
 	// Process number based on version
 	blockNum := blockNumber.EthBlockNumber()
 
@@ -796,6 +823,9 @@ func (s *PublicStakingService) GetDelegationByDelegatorAndValidator(
 func (s *PublicStakingService) GetAvailableRedelegationBalance(
 	ctx context.Context, address string,
 ) (*big.Int, error) {
+	timer := DoMetricRPCRequest(GetAvailableRedelegationBalance)
+	defer DoRPCRequestDuration(GetAvailableRedelegationBalance, timer)
+
 	if !isBeaconShard(s.hmy) {
 		return nil, ErrNotBeaconShard
 	}

--- a/rpc/tracer.go
+++ b/rpc/tracer.go
@@ -72,6 +72,9 @@ func NewPublicTraceAPI(hmy *hmy.Harmony, version Version) rpc.API {
 // TraceChain returns the structured logs created during the execution of EVM
 // between two blocks (excluding start) and returns them as a JSON object.
 func (s *PublicTracerService) TraceChain(ctx context.Context, start, end rpc.BlockNumber, config *hmy.TraceConfig) (*rpc.Subscription, error) {
+	timer := DoMetricRPCRequest(TraceChain)
+	defer DoRPCRequestDuration(TraceChain, timer)
+
 	// TODO (JL): Make API available after DoS testing
 	return nil, ErrNotAvailable
 	if uint64(start) >= uint64(end) {

--- a/rpc/tracerParity.go
+++ b/rpc/tracerParity.go
@@ -19,11 +19,16 @@ type PublicParityTracerService struct {
 }
 
 func (s *PublicParityTracerService) Transaction(ctx context.Context, hash common.Hash) (interface{}, error) {
+	timer := DoMetricRPCRequest(Transaction)
+	defer DoRPCRequestDuration(Transaction, timer)
 	return s.TraceTransaction(ctx, hash, &hmy.TraceConfig{Tracer: &parityTraceGO})
 }
 
 // trace_block RPC
 func (s *PublicParityTracerService) Block(ctx context.Context, number rpc.BlockNumber) (interface{}, error) {
+	timer := DoMetricRPCRequest(Block)
+	defer DoRPCRequestDuration(Block, timer)
+
 	block := s.hmy.BlockChain.GetBlockByNumber(uint64(number))
 	if block == nil {
 		return nil, nil

--- a/rpc/transaction.go
+++ b/rpc/transaction.go
@@ -51,6 +51,9 @@ func NewPublicTransactionAPI(hmy *hmy.Harmony, version Version) rpc.API {
 func (s *PublicTransactionService) GetAccountNonce(
 	ctx context.Context, address string, blockNumber BlockNumber,
 ) (uint64, error) {
+	timer := DoMetricRPCRequest(GetAccountNonce)
+	defer DoRPCRequestDuration(GetAccountNonce, timer)
+
 	// Process number based on version
 	blockNum := blockNumber.EthBlockNumber()
 
@@ -69,6 +72,9 @@ func (s *PublicTransactionService) GetAccountNonce(
 func (s *PublicTransactionService) GetTransactionCount(
 	ctx context.Context, addr string, blockNumber BlockNumber,
 ) (response interface{}, err error) {
+	timer := DoMetricRPCRequest(GetTransactionCount)
+	defer DoRPCRequestDuration(GetTransactionCount, timer)
+
 	// Process arguments based on version
 	blockNum := blockNumber.EthBlockNumber()
 	address, err := internal_common.ParseAddr(addr)
@@ -114,6 +120,9 @@ func (s *PublicTransactionService) GetTransactionCount(
 func (s *PublicTransactionService) GetTransactionsCount(
 	ctx context.Context, address, txType string,
 ) (count uint64, err error) {
+	timer := DoMetricRPCRequest(GetTransactionsCount)
+	defer DoRPCRequestDuration(GetTransactionsCount, timer)
+
 	if !strings.HasPrefix(address, "one1") {
 		// Handle hex address
 		addr, err := internal_common.ParseAddr(address)
@@ -134,6 +143,9 @@ func (s *PublicTransactionService) GetTransactionsCount(
 func (s *PublicTransactionService) GetStakingTransactionsCount(
 	ctx context.Context, address, txType string,
 ) (count uint64, err error) {
+	timer := DoMetricRPCRequest(GetStakingTransactionsCount)
+	defer DoRPCRequestDuration(GetStakingTransactionsCount, timer)
+
 	if !strings.HasPrefix(address, "one1") {
 		// Handle hex address
 		addr, err := internal_common.ParseAddr(address)
@@ -155,6 +167,9 @@ func (s *PublicTransactionService) GetStakingTransactionsCount(
 func (s *PublicTransactionService) EstimateGas(
 	ctx context.Context, args CallArgs,
 ) (hexutil.Uint64, error) {
+	timer := DoMetricRPCRequest(RpcEstimateGas)
+	defer DoRPCRequestDuration(RpcEstimateGas, timer)
+
 	gas, err := EstimateGas(ctx, s.hmy, args, nil)
 	if err != nil {
 		return 0, err
@@ -411,6 +426,9 @@ func (s *PublicTransactionService) GetStakingTransactionsHistory(
 func (s *PublicTransactionService) GetBlockTransactionCountByNumber(
 	ctx context.Context, blockNumber BlockNumber,
 ) (interface{}, error) {
+	timer := DoMetricRPCRequest(GetBlockTransactionCountByNumber)
+	defer DoRPCRequestDuration(GetBlockTransactionCountByNumber, timer)
+
 	// Process arguments based on version
 	blockNum := blockNumber.EthBlockNumber()
 
@@ -440,6 +458,9 @@ func (s *PublicTransactionService) GetBlockTransactionCountByNumber(
 func (s *PublicTransactionService) GetBlockTransactionCountByHash(
 	ctx context.Context, blockHash common.Hash,
 ) (interface{}, error) {
+	timer := DoMetricRPCRequest(GetBlockTransactionCountByHash)
+	defer DoRPCRequestDuration(GetBlockTransactionCountByHash, timer)
+
 	// Fetch block
 	block, err := s.hmy.GetBlock(ctx, blockHash)
 	if err != nil {
@@ -465,6 +486,9 @@ func (s *PublicTransactionService) GetBlockTransactionCountByHash(
 func (s *PublicTransactionService) GetTransactionByBlockNumberAndIndex(
 	ctx context.Context, blockNumber BlockNumber, index TransactionIndex,
 ) (StructuredResponse, error) {
+	timer := DoMetricRPCRequest(GetTransactionByBlockNumberAndIndex)
+	defer DoRPCRequestDuration(GetTransactionByBlockNumberAndIndex, timer)
+
 	// Process arguments based on version
 	blockNum := blockNumber.EthBlockNumber()
 
@@ -507,6 +531,9 @@ func (s *PublicTransactionService) GetTransactionByBlockNumberAndIndex(
 func (s *PublicTransactionService) GetTransactionByBlockHashAndIndex(
 	ctx context.Context, blockHash common.Hash, index TransactionIndex,
 ) (StructuredResponse, error) {
+	timer := DoMetricRPCRequest(GetTransactionByBlockHashAndIndex)
+	defer DoRPCRequestDuration(GetTransactionByBlockHashAndIndex, timer)
+
 	// Fetch Block
 	block, err := s.hmy.GetBlock(ctx, blockHash)
 	if err != nil {
@@ -547,6 +574,9 @@ func (s *PublicTransactionService) GetTransactionByBlockHashAndIndex(
 func (s *PublicTransactionService) GetBlockStakingTransactionCountByNumber(
 	ctx context.Context, blockNumber BlockNumber,
 ) (interface{}, error) {
+	timer := DoMetricRPCRequest(GetBlockStakingTransactionCountByNumber)
+	defer DoRPCRequestDuration(GetBlockStakingTransactionCountByNumber, timer)
+
 	// Process arguments based on version
 	blockNum := blockNumber.EthBlockNumber()
 
@@ -576,6 +606,9 @@ func (s *PublicTransactionService) GetBlockStakingTransactionCountByNumber(
 func (s *PublicTransactionService) GetBlockStakingTransactionCountByHash(
 	ctx context.Context, blockHash common.Hash,
 ) (interface{}, error) {
+	timer := DoMetricRPCRequest(GetBlockStakingTransactionCountByHash)
+	defer DoRPCRequestDuration(GetBlockStakingTransactionCountByHash, timer)
+
 	// Fetch block
 	block, err := s.hmy.GetBlock(ctx, blockHash)
 	if err != nil {
@@ -601,6 +634,9 @@ func (s *PublicTransactionService) GetBlockStakingTransactionCountByHash(
 func (s *PublicTransactionService) GetStakingTransactionByBlockNumberAndIndex(
 	ctx context.Context, blockNumber BlockNumber, index TransactionIndex,
 ) (StructuredResponse, error) {
+	timer := DoMetricRPCRequest(GetStakingTransactionByBlockNumberAndIndex)
+	defer DoRPCRequestDuration(GetStakingTransactionByBlockNumberAndIndex, timer)
+
 	// Process arguments based on version
 	blockNum := blockNumber.EthBlockNumber()
 
@@ -637,6 +673,9 @@ func (s *PublicTransactionService) GetStakingTransactionByBlockNumberAndIndex(
 func (s *PublicTransactionService) GetStakingTransactionByBlockHashAndIndex(
 	ctx context.Context, blockHash common.Hash, index TransactionIndex,
 ) (StructuredResponse, error) {
+	timer := DoMetricRPCRequest(GetStakingTransactionByBlockHashAndIndex)
+	defer DoRPCRequestDuration(GetStakingTransactionByBlockHashAndIndex, timer)
+
 	// Fetch Block
 	block, err := s.hmy.GetBlock(ctx, blockHash)
 	if err != nil {
@@ -670,6 +709,9 @@ func (s *PublicTransactionService) GetStakingTransactionByBlockHashAndIndex(
 func (s *PublicTransactionService) GetTransactionReceipt(
 	ctx context.Context, hash common.Hash,
 ) (StructuredResponse, error) {
+	timer := DoMetricRPCRequest(GetTransactionReceipt)
+	defer DoRPCRequestDuration(GetTransactionReceipt, timer)
+
 	// Fetch receipt for plain & staking transaction
 	var tx *types.Transaction
 	var stx *staking.StakingTransaction
@@ -735,6 +777,9 @@ func (s *PublicTransactionService) GetTransactionReceipt(
 func (s *PublicTransactionService) GetCXReceiptByHash(
 	ctx context.Context, hash common.Hash,
 ) (StructuredResponse, error) {
+	timer := DoMetricRPCRequest(GetCXReceiptByHash)
+	defer DoRPCRequestDuration(GetCXReceiptByHash, timer)
+
 	if cx, blockHash, blockNumber, _ := rawdb.ReadCXReceipt(s.hmy.ChainDb(), hash); cx != nil {
 		// Format response according to version
 		switch s.version {
@@ -766,6 +811,9 @@ func (s *PublicTransactionService) GetCXReceiptByHash(
 // withdrawn already from the source shard but not credited yet in the
 // destination account due to transient failures.
 func (s *PublicTransactionService) ResendCx(ctx context.Context, txID common.Hash) (bool, error) {
+	timer := DoMetricRPCRequest(ResendCx)
+	defer DoRPCRequestDuration(ResendCx, timer)
+
 	_, success := s.hmy.ResendCx(ctx, txID)
 
 	// Response output is the same for all versions

--- a/rpc/web3.go
+++ b/rpc/web3.go
@@ -22,5 +22,7 @@ func NewPublicWeb3API() rpc.API {
 
 // ClientVersion - returns the current client version of the running node
 func (s *PublicWeb3Service) ClientVersion(ctx context.Context) interface{} {
+	timer := DoMetricRPCRequest(ClientVersion)
+	defer DoRPCRequestDuration(ClientVersion, timer)
 	return nodeconfig.GetVersion()
 }


### PR DESCRIPTION
## Issue

Cover all RPCs metrics

## Test

Tested locally

```bash
 curl -d '{ "jsonrpc":"2.0", "method":"hmy_inSync", "params":[], "id":1 }' -H "Content-Type:application/json" -X POST "http://127.0.0.1:9500"
{"jsonrpc":"2.0","id":1,"result":false}
mathxh@MathxH:~/go/src/github.com/harmony-one/go-sdk$ curl http://127.0.0.1:9900/metrics | grep inSync
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  9202    0  9202    0     0  8986k      0 --:--:-- -hmy_rpc2_delay_histogram_bucket{method="hmy_inSync",le="0.05"} 3
-:hmy_rpc2_delay_histogram_bucket{method="hmy_inSync",le="0.1"} 3
--hmy_rpc2_delay_histogram_bucket{method="hmy_inSync",le="0.2"} 3
:hmy_rpc2_delay_histogram_bucket{method="hmy_inSync",le="0.4"} 3
-- --:-hmy_rpc2_delay_histogram_bucket{method="hmy_inSync",le="0.8"} 3
-:hmy_rpc2_delay_histogram_bucket{method="hmy_inSync",le="1.6"} 3
-hmy_rpc2_delay_histogram_bucket{method="hmy_inSync",le="3.2"} 3
-hmy_rpc2_delay_histogram_bucket{method="hmy_inSync",le="6.4"} 3
 hmy_rpc2_delay_histogram_bucket{method="hmy_inSync",le="+Inf"} 3
8hmy_rpc2_delay_histogram_sum{method="hmy_inSync"} 9.47e-05
9hmy_rpc2_delay_histogram_count{method="hmy_inSync"} 3
86hmy_rpc2_request_count{method="hmy_inSync"} 3
k
```