### PR TITLE
disable migrate

### DIFF
--- a/core/evm.go
+++ b/core/evm.go
@@ -74,17 +74,17 @@ func NewEVMContext(msg Message, header *block.Header, chain ChainContext, author
 		copy(vrf[:], vrfAndProof[:32])
 	}
 	return vm.Context{
-		CanTransfer:           CanTransfer,
-		Transfer:              Transfer,
-		IsValidator:           IsValidator,
-		GetHash:               GetHashFn(header, chain),
-		GetVRF:                GetVRFFn(header, chain),
-		CreateValidator:       CreateValidatorFn(header, chain),
-		EditValidator:         EditValidatorFn(header, chain),
-		Delegate:              DelegateFn(header, chain),
-		Undelegate:            UndelegateFn(header, chain),
-		CollectRewards:        CollectRewardsFn(header, chain),
-		MigrateDelegations:    MigrateDelegationsFn(header, chain),
+		CanTransfer:     CanTransfer,
+		Transfer:        Transfer,
+		IsValidator:     IsValidator,
+		GetHash:         GetHashFn(header, chain),
+		GetVRF:          GetVRFFn(header, chain),
+		CreateValidator: CreateValidatorFn(header, chain),
+		EditValidator:   EditValidatorFn(header, chain),
+		Delegate:        DelegateFn(header, chain),
+		Undelegate:      UndelegateFn(header, chain),
+		CollectRewards:  CollectRewardsFn(header, chain),
+		//MigrateDelegations:    MigrateDelegationsFn(header, chain),
 		CalculateMigrationGas: CalculateMigrationGasFn(chain),
 		Origin:                msg.From(),
 		Coinbase:              beneficiary,
@@ -231,27 +231,27 @@ func CollectRewardsFn(ref *block.Header, chain ChainContext) vm.CollectRewardsFu
 	}
 }
 
-func MigrateDelegationsFn(ref *block.Header, chain ChainContext) vm.MigrateDelegationsFunc {
-	return func(db vm.StateDB, migrationMsg *stakingTypes.MigrationMsg) ([]interface{}, error) {
-		// get existing delegations
-		fromDelegations, err := chain.ReadDelegationsByDelegator(migrationMsg.From)
-		if err != nil {
-			return nil, err
-		}
-		// get list of modified wrappers
-		wrappers, delegates, err := VerifyAndMigrateFromMsg(db, migrationMsg, fromDelegations)
-		if err != nil {
-			return nil, err
-		}
-		// add to state db
-		for _, wrapper := range wrappers {
-			if err := db.UpdateValidatorWrapperWithRevert(wrapper.Address, wrapper); err != nil {
-				return nil, err
-			}
-		}
-		return delegates, nil
-	}
-}
+//func MigrateDelegationsFn(ref *block.Header, chain ChainContext) vm.MigrateDelegationsFunc {
+//	return func(db vm.StateDB, migrationMsg *stakingTypes.MigrationMsg) ([]interface{}, error) {
+//		// get existing delegations
+//		fromDelegations, err := chain.ReadDelegationsByDelegator(migrationMsg.From)
+//		if err != nil {
+//			return nil, err
+//		}
+//		// get list of modified wrappers
+//		wrappers, delegates, err := VerifyAndMigrateFromMsg(db, migrationMsg, fromDelegations)
+//		if err != nil {
+//			return nil, err
+//		}
+//		// add to state db
+//		for _, wrapper := range wrappers {
+//			if err := db.UpdateValidatorWrapperWithRevert(wrapper.Address, wrapper); err != nil {
+//				return nil, err
+//			}
+//		}
+//		return delegates, nil
+//	}
+//}
 
 // calculate the gas for migration; no checks done here similar to other functions
 // the checks are handled by staking_verifier.go, ex, if you try to delegate to an address

--- a/core/evm_test.go
+++ b/core/evm_test.go
@@ -278,54 +278,54 @@ func TestEVMStaking(t *testing.T) {
 		t.Errorf("Got error %s in CheckDelegationsEqual", err)
 	}
 
-	// test for migration gas
-	db.RevertToSnapshot(snapshot)
-	// to calculate gas we need to test 0 / 1 / 2 delegations to migrate as per ReadDelegationsByDelegator
-	// case 0
-	evm := vm.NewEVM(ctx, db, params.TestChainConfig, vm.Config{})
-	gas, err := ctx.CalculateMigrationGas(db, &staking.MigrationMsg{
-		From: crypto.PubkeyToAddress(toKey.PublicKey),
-		To:   crypto.PubkeyToAddress(key.PublicKey),
-	}, evm.ChainConfig().IsS3(evm.EpochNumber), evm.ChainConfig().IsS3(evm.EpochNumber))
-	var expectedGasMin uint64 = params.TxGas
-	if err != nil {
-		t.Errorf("Gas error %s", err)
-	}
-	if gas < expectedGasMin {
-		t.Errorf("Gas for 0 migration was expected to be at least %d but got %d", expectedGasMin, gas)
-	}
-	// case 1
-	gas, err = ctx.CalculateMigrationGas(db, &migration,
-		evm.ChainConfig().IsS3(evm.EpochNumber), evm.ChainConfig().IsS3(evm.EpochNumber))
-	expectedGasMin = params.TxGas
-	if err != nil {
-		t.Errorf("Gas error %s", err)
-	}
-	if gas < expectedGasMin {
-		t.Errorf("Gas for 1 migration was expected to be at least %d but got %d", expectedGasMin, gas)
-	}
-	// case 2
-	createValidator = sampleCreateValidator(*toKey)
-	db.AddBalance(createValidator.ValidatorAddress, createValidator.Amount)
-	err = ctx.CreateValidator(db, &createValidator)
-	delegate = sampleDelegate(*toKey)
-	delegate.DelegatorAddress = crypto.PubkeyToAddress(key.PublicKey)
-	_ = ctx.Delegate(db, &delegate)
-	delegationIndex := staking.DelegationIndex{
-		ValidatorAddress: crypto.PubkeyToAddress(toKey.PublicKey),
-		Index:            uint64(1),
-		BlockNum:         common.Big0,
-	}
-	err = chain.writeDelegationsByDelegator(batch, migration.From, []staking.DelegationIndex{selfIndex, delegationIndex})
-	gas, err = ctx.CalculateMigrationGas(db, &migration,
-		evm.ChainConfig().IsS3(evm.EpochNumber), evm.ChainConfig().IsS3(evm.EpochNumber))
-	expectedGasMin = 2 * params.TxGas
-	if err != nil {
-		t.Errorf("Gas error %s", err)
-	}
-	if gas < expectedGasMin {
-		t.Errorf("Gas for 2 migrations was expected to be at least %d but got %d", expectedGasMin, gas)
-	}
+	//// test for migration gas
+	//db.RevertToSnapshot(snapshot)
+	//// to calculate gas we need to test 0 / 1 / 2 delegations to migrate as per ReadDelegationsByDelegator
+	//// case 0
+	//evm := vm.NewEVM(ctx, db, params.TestChainConfig, vm.Config{})
+	//gas, err := ctx.CalculateMigrationGas(db, &staking.MigrationMsg{
+	//	From: crypto.PubkeyToAddress(toKey.PublicKey),
+	//	To:   crypto.PubkeyToAddress(key.PublicKey),
+	//}, evm.ChainConfig().IsS3(evm.EpochNumber), evm.ChainConfig().IsS3(evm.EpochNumber))
+	//var expectedGasMin uint64 = params.TxGas
+	//if err != nil {
+	//	t.Errorf("Gas error %s", err)
+	//}
+	//if gas < expectedGasMin {
+	//	t.Errorf("Gas for 0 migration was expected to be at least %d but got %d", expectedGasMin, gas)
+	//}
+	//// case 1
+	//gas, err = ctx.CalculateMigrationGas(db, &migration,
+	//	evm.ChainConfig().IsS3(evm.EpochNumber), evm.ChainConfig().IsS3(evm.EpochNumber))
+	//expectedGasMin = params.TxGas
+	//if err != nil {
+	//	t.Errorf("Gas error %s", err)
+	//}
+	//if gas < expectedGasMin {
+	//	t.Errorf("Gas for 1 migration was expected to be at least %d but got %d", expectedGasMin, gas)
+	//}
+	//// case 2
+	//createValidator = sampleCreateValidator(*toKey)
+	//db.AddBalance(createValidator.ValidatorAddress, createValidator.Amount)
+	//err = ctx.CreateValidator(db, &createValidator)
+	//delegate = sampleDelegate(*toKey)
+	//delegate.DelegatorAddress = crypto.PubkeyToAddress(key.PublicKey)
+	//_ = ctx.Delegate(db, &delegate)
+	//delegationIndex := staking.DelegationIndex{
+	//	ValidatorAddress: crypto.PubkeyToAddress(toKey.PublicKey),
+	//	Index:            uint64(1),
+	//	BlockNum:         common.Big0,
+	//}
+	//err = chain.writeDelegationsByDelegator(batch, migration.From, []staking.DelegationIndex{selfIndex, delegationIndex})
+	//gas, err = ctx.CalculateMigrationGas(db, &migration,
+	//	evm.ChainConfig().IsS3(evm.EpochNumber), evm.ChainConfig().IsS3(evm.EpochNumber))
+	//expectedGasMin = 2 * params.TxGas
+	//if err != nil {
+	//	t.Errorf("Gas error %s", err)
+	//}
+	//if gas < expectedGasMin {
+	//	t.Errorf("Gas for 2 migrations was expected to be at least %d but got %d", expectedGasMin, gas)
+	//}
 }
 
 func generateBLSKeyAndSig() (bls.SerializedPublicKey, bls.SerializedSignature) {

--- a/core/evm_test.go
+++ b/core/evm_test.go
@@ -24,9 +24,7 @@ import (
 	chain2 "github.com/harmony-one/harmony/internal/chain"
 	"github.com/harmony-one/harmony/internal/params"
 	"github.com/harmony-one/harmony/numeric"
-	"github.com/harmony-one/harmony/staking/effective"
 	staking "github.com/harmony-one/harmony/staking/types"
-	staketest "github.com/harmony-one/harmony/staking/types/test"
 )
 
 func getTestEnvironment(testBankKey ecdsa.PrivateKey) (*BlockChain, *state.DB, *block.Header, ethdb.Database) {
@@ -131,152 +129,152 @@ func TestEVMStaking(t *testing.T) {
 		t.Errorf("Got error %v in CollectRewards", err)
 	}
 
-	// migration test - when from has no delegations
-	toKey, _ := crypto.GenerateKey()
-	migration := sampleMigrationMsg(*toKey, *key)
-	delegates, err := ctx.MigrateDelegations(db, &migration)
-	expectedError := errors.New("No delegations to migrate")
-	if err != nil && expectedError.Error() != err.Error() {
-		t.Errorf("Got error %v in MigrateDelegations but expected %v", err, expectedError)
-	}
-	if len(delegates) > 0 {
-		t.Errorf("Got delegates to migrate when none were expected")
-	}
-	// migration test - when from == to
-	migration = sampleMigrationMsg(*toKey, *toKey)
-	delegates, err = ctx.MigrateDelegations(db, &migration)
-	expectedError = errors.New("From and To are the same address")
-	if err != nil && expectedError.Error() != err.Error() {
-		t.Errorf("Got error %v in MigrateDelegations but expected %v", err, expectedError)
-	}
-	if len(delegates) > 0 {
-		t.Errorf("Got delegates to migrate when none were expected")
-	}
-	// migration test - when `to` has no delegations
-	snapshot := db.Snapshot()
-	migration = sampleMigrationMsg(*key, *toKey)
-	wrapper, _ = db.ValidatorWrapper(wrapper.Address, true, false)
-	expectedAmount := wrapper.Delegations[0].Amount
-	delegates, err = ctx.MigrateDelegations(db, &migration)
-	if err != nil {
-		t.Errorf("Got error %v in MigrateDelegations", err)
-	}
-	if len(delegates) != 1 {
-		t.Errorf("Got %d delegations to migrate, expected just 1", len(delegates))
-	}
-	wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, false, true)
-	if wrapper.Delegations[0].Amount.Cmp(common.Big0) != 0 {
-		t.Errorf("Expected delegation at index 0 to have amount 0, but it has amount %d",
-			wrapper.Delegations[0].Amount)
-	}
-	if wrapper.Delegations[1].Amount.Cmp(expectedAmount) != 0 {
-		t.Errorf("Expected delegation at index 1 to have amount %d, but it has amount %d",
-			expectedAmount, wrapper.Delegations[1].Amount)
-	}
-	db.RevertToSnapshot(snapshot)
-	snapshot = db.Snapshot()
-	// migration test - when `from` delegation amount = 0 and no undelegations
-	wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, false, true)
-	wrapper.Delegations[0].Undelegations = make([]staking.Undelegation, 0)
-	wrapper.Delegations[0].Amount = common.Big0
-	wrapper.Status = effective.Inactive
-	err = db.UpdateValidatorWrapperWithRevert(wrapper.Address, wrapper)
-	if err != nil {
-		t.Errorf("Got error %v in UpdateValidatorWrapperWithRevert", err)
-	}
-	delegates, err = ctx.MigrateDelegations(db, &migration)
-	if err != nil {
-		t.Errorf("Got error %v in MigrateDelegations", err)
-	}
-	if len(delegates) != 0 {
-		t.Errorf("Got %d delegations to migrate, expected none", len(delegates))
-	}
-	db.RevertToSnapshot(snapshot)
-	snapshot = db.Snapshot()
-	// migration test - when `to` has one delegation
-	wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, false, true)
-	wrapper.Delegations = append(wrapper.Delegations, staking.NewDelegation(
-		migration.To, new(big.Int).Mul(big.NewInt(denominations.One), big.NewInt(100))))
-	expectedAmount = big.NewInt(0).Add(
-		wrapper.Delegations[0].Amount, wrapper.Delegations[1].Amount,
-	)
-	err = db.UpdateValidatorWrapperWithRevert(wrapper.Address, wrapper)
-	if err != nil {
-		t.Errorf("Got error %v in UpdateValidatorWrapperWithRevert", err)
-	}
-	delegates, err = ctx.MigrateDelegations(db, &migration)
-	if err != nil {
-		t.Errorf("Got error %v in MigrateDelegations", err)
-	}
-	if len(delegates) != 1 {
-		t.Errorf("Got %d delegations to migrate, expected just 1", len(delegates))
-	}
-	// read from updated wrapper
-	wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, true, false)
-	if wrapper.Delegations[0].Amount.Cmp(common.Big0) != 0 {
-		t.Errorf("Expected delegation at index 0 to have amount 0, but it has amount %d",
-			wrapper.Delegations[0].Amount)
-	}
-	if wrapper.Delegations[1].Amount.Cmp(expectedAmount) != 0 {
-		t.Errorf("Expected delegation at index 1 to have amount %d, but it has amount %d",
-			expectedAmount, wrapper.Delegations[1].Amount)
-	}
-	db.RevertToSnapshot(snapshot)
-	snapshot = db.Snapshot()
-	// migration test - when `to` has one undelegation in the current epoch and so does `from`
-	wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, false, true)
-	delegation := staking.NewDelegation(migration.To, big.NewInt(0))
-	delegation.Undelegations = []staking.Undelegation{
-		staking.Undelegation{
-			Amount: new(big.Int).Mul(big.NewInt(denominations.One), big.NewInt(100)),
-			Epoch:  common.Big0,
-		},
-	}
-	wrapper.Delegations[0].Undelegate(
-		big.NewInt(0), new(big.Int).Mul(big.NewInt(denominations.One), big.NewInt(100)),
-	)
-	expectedAmount = big.NewInt(0).Add(
-		wrapper.Delegations[0].Amount, big.NewInt(0),
-	)
-	wrapper.Delegations = append(wrapper.Delegations, delegation)
-	expectedDelegations := []staking.Delegation{
-		staking.Delegation{
-			DelegatorAddress: wrapper.Address,
-			Amount:           big.NewInt(0),
-			Reward:           big.NewInt(0),
-			Undelegations:    []staking.Undelegation{},
-		},
-		staking.Delegation{
-			DelegatorAddress: crypto.PubkeyToAddress(toKey.PublicKey),
-			Amount:           expectedAmount,
-			Undelegations: []staking.Undelegation{
-				staking.Undelegation{
-					Amount: new(big.Int).Mul(big.NewInt(denominations.One), big.NewInt(200)),
-					Epoch:  common.Big0,
-				},
-			},
-		},
-	}
-	err = db.UpdateValidatorWrapperWithRevert(wrapper.Address, wrapper)
-	if err != nil {
-		t.Errorf("Got error %v in UpdateValidatorWrapperWithRevert", err)
-	}
-	delegates, err = ctx.MigrateDelegations(db, &migration)
-	if err != nil {
-		t.Errorf("Got error %v in MigrateDelegations", err)
-	}
-	if len(delegates) != 1 {
-		t.Errorf("Got %d delegations to migrate, expected just 1", len(delegates))
-	}
-	// read from updated wrapper
-	wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, true, false)
-	// and finally the check for delegations being equal
-	if err := staketest.CheckDelegationsEqual(
-		wrapper.Delegations,
-		expectedDelegations,
-	); err != nil {
-		t.Errorf("Got error %s in CheckDelegationsEqual", err)
-	}
+	//// migration test - when from has no delegations
+	//toKey, _ := crypto.GenerateKey()
+	//migration := sampleMigrationMsg(*toKey, *key)
+	//delegates, err := ctx.MigrateDelegations(db, &migration)
+	//expectedError := errors.New("No delegations to migrate")
+	//if err != nil && expectedError.Error() != err.Error() {
+	//	t.Errorf("Got error %v in MigrateDelegations but expected %v", err, expectedError)
+	//}
+	//if len(delegates) > 0 {
+	//	t.Errorf("Got delegates to migrate when none were expected")
+	//}
+	//// migration test - when from == to
+	//migration = sampleMigrationMsg(*toKey, *toKey)
+	//delegates, err = ctx.MigrateDelegations(db, &migration)
+	//expectedError = errors.New("From and To are the same address")
+	//if err != nil && expectedError.Error() != err.Error() {
+	//	t.Errorf("Got error %v in MigrateDelegations but expected %v", err, expectedError)
+	//}
+	//if len(delegates) > 0 {
+	//	t.Errorf("Got delegates to migrate when none were expected")
+	//}
+	//// migration test - when `to` has no delegations
+	//snapshot := db.Snapshot()
+	//migration = sampleMigrationMsg(*key, *toKey)
+	//wrapper, _ = db.ValidatorWrapper(wrapper.Address, true, false)
+	//expectedAmount := wrapper.Delegations[0].Amount
+	//delegates, err = ctx.MigrateDelegations(db, &migration)
+	//if err != nil {
+	//	t.Errorf("Got error %v in MigrateDelegations", err)
+	//}
+	//if len(delegates) != 1 {
+	//	t.Errorf("Got %d delegations to migrate, expected just 1", len(delegates))
+	//}
+	//wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, false, true)
+	//if wrapper.Delegations[0].Amount.Cmp(common.Big0) != 0 {
+	//	t.Errorf("Expected delegation at index 0 to have amount 0, but it has amount %d",
+	//		wrapper.Delegations[0].Amount)
+	//}
+	//if wrapper.Delegations[1].Amount.Cmp(expectedAmount) != 0 {
+	//	t.Errorf("Expected delegation at index 1 to have amount %d, but it has amount %d",
+	//		expectedAmount, wrapper.Delegations[1].Amount)
+	//}
+	//db.RevertToSnapshot(snapshot)
+	//snapshot = db.Snapshot()
+	//// migration test - when `from` delegation amount = 0 and no undelegations
+	//wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, false, true)
+	//wrapper.Delegations[0].Undelegations = make([]staking.Undelegation, 0)
+	//wrapper.Delegations[0].Amount = common.Big0
+	//wrapper.Status = effective.Inactive
+	//err = db.UpdateValidatorWrapperWithRevert(wrapper.Address, wrapper)
+	//if err != nil {
+	//	t.Errorf("Got error %v in UpdateValidatorWrapperWithRevert", err)
+	//}
+	//delegates, err = ctx.MigrateDelegations(db, &migration)
+	//if err != nil {
+	//	t.Errorf("Got error %v in MigrateDelegations", err)
+	//}
+	//if len(delegates) != 0 {
+	//	t.Errorf("Got %d delegations to migrate, expected none", len(delegates))
+	//}
+	//db.RevertToSnapshot(snapshot)
+	//snapshot = db.Snapshot()
+	//// migration test - when `to` has one delegation
+	//wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, false, true)
+	//wrapper.Delegations = append(wrapper.Delegations, staking.NewDelegation(
+	//	migration.To, new(big.Int).Mul(big.NewInt(denominations.One), big.NewInt(100))))
+	//expectedAmount = big.NewInt(0).Add(
+	//	wrapper.Delegations[0].Amount, wrapper.Delegations[1].Amount,
+	//)
+	//err = db.UpdateValidatorWrapperWithRevert(wrapper.Address, wrapper)
+	//if err != nil {
+	//	t.Errorf("Got error %v in UpdateValidatorWrapperWithRevert", err)
+	//}
+	//delegates, err = ctx.MigrateDelegations(db, &migration)
+	//if err != nil {
+	//	t.Errorf("Got error %v in MigrateDelegations", err)
+	//}
+	//if len(delegates) != 1 {
+	//	t.Errorf("Got %d delegations to migrate, expected just 1", len(delegates))
+	//}
+	//// read from updated wrapper
+	//wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, true, false)
+	//if wrapper.Delegations[0].Amount.Cmp(common.Big0) != 0 {
+	//	t.Errorf("Expected delegation at index 0 to have amount 0, but it has amount %d",
+	//		wrapper.Delegations[0].Amount)
+	//}
+	//if wrapper.Delegations[1].Amount.Cmp(expectedAmount) != 0 {
+	//	t.Errorf("Expected delegation at index 1 to have amount %d, but it has amount %d",
+	//		expectedAmount, wrapper.Delegations[1].Amount)
+	//}
+	//db.RevertToSnapshot(snapshot)
+	//snapshot = db.Snapshot()
+	//// migration test - when `to` has one undelegation in the current epoch and so does `from`
+	//wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, false, true)
+	//delegation := staking.NewDelegation(migration.To, big.NewInt(0))
+	//delegation.Undelegations = []staking.Undelegation{
+	//	staking.Undelegation{
+	//		Amount: new(big.Int).Mul(big.NewInt(denominations.One), big.NewInt(100)),
+	//		Epoch:  common.Big0,
+	//	},
+	//}
+	//wrapper.Delegations[0].Undelegate(
+	//	big.NewInt(0), new(big.Int).Mul(big.NewInt(denominations.One), big.NewInt(100)),
+	//)
+	//expectedAmount = big.NewInt(0).Add(
+	//	wrapper.Delegations[0].Amount, big.NewInt(0),
+	//)
+	//wrapper.Delegations = append(wrapper.Delegations, delegation)
+	//expectedDelegations := []staking.Delegation{
+	//	staking.Delegation{
+	//		DelegatorAddress: wrapper.Address,
+	//		Amount:           big.NewInt(0),
+	//		Reward:           big.NewInt(0),
+	//		Undelegations:    []staking.Undelegation{},
+	//	},
+	//	staking.Delegation{
+	//		DelegatorAddress: crypto.PubkeyToAddress(toKey.PublicKey),
+	//		Amount:           expectedAmount,
+	//		Undelegations: []staking.Undelegation{
+	//			staking.Undelegation{
+	//				Amount: new(big.Int).Mul(big.NewInt(denominations.One), big.NewInt(200)),
+	//				Epoch:  common.Big0,
+	//			},
+	//		},
+	//	},
+	//}
+	//err = db.UpdateValidatorWrapperWithRevert(wrapper.Address, wrapper)
+	//if err != nil {
+	//	t.Errorf("Got error %v in UpdateValidatorWrapperWithRevert", err)
+	//}
+	//delegates, err = ctx.MigrateDelegations(db, &migration)
+	//if err != nil {
+	//	t.Errorf("Got error %v in MigrateDelegations", err)
+	//}
+	//if len(delegates) != 1 {
+	//	t.Errorf("Got %d delegations to migrate, expected just 1", len(delegates))
+	//}
+	//// read from updated wrapper
+	//wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, true, false)
+	//// and finally the check for delegations being equal
+	//if err := staketest.CheckDelegationsEqual(
+	//	wrapper.Delegations,
+	//	expectedDelegations,
+	//); err != nil {
+	//	t.Errorf("Got error %s in CheckDelegationsEqual", err)
+	//}
 
 	//// test for migration gas
 	//db.RevertToSnapshot(snapshot)

--- a/core/vm/contracts_write.go
+++ b/core/vm/contracts_write.go
@@ -126,20 +126,21 @@ func (c *stakingPrecompile) RunWriteCapable(
 	if collectRewards, ok := stakeMsg.(*stakingTypes.CollectRewards); ok {
 		return nil, evm.CollectRewards(evm.StateDB, collectRewards)
 	}
-	if migrationMsg, ok := stakeMsg.(*stakingTypes.MigrationMsg); ok {
-		stakeMsgs, err := evm.MigrateDelegations(evm.StateDB, migrationMsg)
-		if err != nil {
-			return nil, err
-		} else {
-			for _, stakeMsg := range stakeMsgs {
-				if delegate, ok := stakeMsg.(*stakingTypes.Delegate); ok {
-					evm.StakeMsgs = append(evm.StakeMsgs, delegate)
-				} else {
-					return nil, errors.New("[StakingPrecompile] Received incompatible stakeMsg from evm.MigrateDelegations")
-				}
-			}
-			return nil, nil
-		}
-	}
+	// Migrate is not supported in precompile and will be done in a batch hard fork
+	//if migrationMsg, ok := stakeMsg.(*stakingTypes.MigrationMsg); ok {
+	//	stakeMsgs, err := evm.MigrateDelegations(evm.StateDB, migrationMsg)
+	//	if err != nil {
+	//		return nil, err
+	//	} else {
+	//		for _, stakeMsg := range stakeMsgs {
+	//			if delegate, ok := stakeMsg.(*stakingTypes.Delegate); ok {
+	//				evm.StakeMsgs = append(evm.StakeMsgs, delegate)
+	//			} else {
+	//				return nil, errors.New("[StakingPrecompile] Received incompatible stakeMsg from evm.MigrateDelegations")
+	//			}
+	//		}
+	//		return nil, nil
+	//	}
+	//}
 	return nil, errors.New("[StakingPrecompile] Received incompatible stakeMsg from staking.ParseStakeMsg")
 }

--- a/core/vm/contracts_write_test.go
+++ b/core/vm/contracts_write_test.go
@@ -190,24 +190,24 @@ var StakingPrecompileTests = []writeCapablePrecompileTest{
 		expectedError: errors.New("data too short (2 bytes) for abi method lookup"),
 		name:          "malformedInput",
 	},
-	{
-		input:    []byte{42, 5, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56},
-		expected: nil,
-		name:     "migrationSuccess",
-	},
-	{
-		input:         []byte{42, 5, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55},
-		expectedError: errors.New("[StakingPrecompile] Address mismatch, expected 0x0000000000000000000000000000000000001337 have 0x0000000000000000000000000000000000001338"),
-		name:          "migrationAddressMismatch",
-	},
-	{
-		input:         []byte{42, 6, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55},
-		expectedError: errors.New("no method with id: 0x2a06bb71"),
-		name:          "migrationNoMatchingMethod",
-	},
-	{
-		input:         []byte{42, 5, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19},
-		expectedError: errors.New("abi: cannot marshal in to go type: length insufficient 63 require 64"),
-		name:          "migrationAddressMismatch",
-	},
+	//{
+	//	input:    []byte{42, 5, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56},
+	//	expected: nil,
+	//	name:     "migrationSuccess",
+	//},
+	//{
+	//	input:         []byte{42, 5, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55},
+	//	expectedError: errors.New("[StakingPrecompile] Address mismatch, expected 0x0000000000000000000000000000000000001337 have 0x0000000000000000000000000000000000001338"),
+	//	name:          "migrationAddressMismatch",
+	//},
+	//{
+	//	input:         []byte{42, 6, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55},
+	//	expectedError: errors.New("no method with id: 0x2a06bb71"),
+	//	name:          "migrationNoMatchingMethod",
+	//},
+	//{
+	//	input:         []byte{42, 5, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19},
+	//	expectedError: errors.New("abi: cannot marshal in to go type: length insufficient 63 require 64"),
+	//	name:          "migrationAddressMismatch",
+	//},
 }

--- a/core/vm/contracts_write_test.go
+++ b/core/vm/contracts_write_test.go
@@ -185,11 +185,11 @@ var StakingPrecompileTests = []writeCapablePrecompileTest{
 		expectedError: errors.New("abi: attempting to unmarshall an empty string while arguments are expected"),
 		name:          "yesMethodNoData",
 	},
-	{
-		input:         []byte{0, 0},
-		expectedError: errors.New("data too short (2 bytes) for abi method lookup"),
-		name:          "malformedInput",
-	},
+	//{
+	//	input:         []byte{0, 0},
+	//	expectedError: errors.New("data too short (2 bytes) for abi method lookup"),
+	//	name:          "malformedInput",
+	//},
 	//{
 	//	input:    []byte{42, 5, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56},
 	//	expected: nil,

--- a/core/vm/contracts_write_test.go
+++ b/core/vm/contracts_write_test.go
@@ -49,11 +49,11 @@ func EditValidatorFn() EditValidatorFunc {
 	}
 }
 
-func MigrateDelegationsFn() MigrateDelegationsFunc {
-	return func(db StateDB, migrationMsg *stakingTypes.MigrationMsg) ([]interface{}, error) {
-		return nil, nil
-	}
-}
+//func MigrateDelegationsFn() MigrateDelegationsFunc {
+//	return func(db StateDB, migrationMsg *stakingTypes.MigrationMsg) ([]interface{}, error) {
+//		return nil, nil
+//	}
+//}
 
 func CalculateMigrationGasFn() CalculateMigrationGasFunc {
 	return func(db StateDB, migrationMsg *stakingTypes.MigrationMsg, homestead bool, istanbul bool) (uint64, error) {
@@ -63,12 +63,12 @@ func CalculateMigrationGasFn() CalculateMigrationGasFunc {
 
 func testStakingPrecompile(test writeCapablePrecompileTest, t *testing.T) {
 	var env = NewEVM(Context{CollectRewards: CollectRewardsFn(),
-		Delegate:              DelegateFn(),
-		Undelegate:            UndelegateFn(),
-		CreateValidator:       CreateValidatorFn(),
-		EditValidator:         EditValidatorFn(),
-		ShardID:               0,
-		MigrateDelegations:    MigrateDelegationsFn(),
+		Delegate:        DelegateFn(),
+		Undelegate:      UndelegateFn(),
+		CreateValidator: CreateValidatorFn(),
+		EditValidator:   EditValidatorFn(),
+		ShardID:         0,
+		//MigrateDelegations:    MigrateDelegationsFn(),
 		CalculateMigrationGas: CalculateMigrationGasFn(),
 	}, nil, params.TestChainConfig, Config{})
 	// use required gas to avoid out of gas errors

--- a/core/vm/contracts_write_test.go
+++ b/core/vm/contracts_write_test.go
@@ -180,11 +180,11 @@ var StakingPrecompileTests = []writeCapablePrecompileTest{
 		expectedError: errors.New("[StakingPrecompile] Address mismatch, expected 0x0000000000000000000000000000000000001337 have 0x0000000000000000000000000000000000001338"),
 		name:          "undelegateAddressMismatch",
 	},
-	{
-		input:         []byte{42, 5, 187, 113},
-		expectedError: errors.New("abi: attempting to unmarshall an empty string while arguments are expected"),
-		name:          "yesMethodNoData",
-	},
+	//{
+	//	input:         []byte{42, 5, 187, 113},
+	//	expectedError: errors.New("abi: attempting to unmarshall an empty string while arguments are expected"),
+	//	name:          "yesMethodNoData",
+	//},
 	//{
 	//	input:         []byte{0, 0},
 	//	expectedError: errors.New("data too short (2 bytes) for abi method lookup"),

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -52,7 +52,7 @@ type (
 	UndelegateFunc      func(db StateDB, stakeMsg *stakingTypes.Undelegate) error
 	CollectRewardsFunc  func(db StateDB, stakeMsg *stakingTypes.CollectRewards) error
 	// Used for migrating delegations via the staking precompile
-	MigrateDelegationsFunc    func(db StateDB, migrationMsg *stakingTypes.MigrationMsg) ([]interface{}, error)
+	//MigrateDelegationsFunc    func(db StateDB, migrationMsg *stakingTypes.MigrationMsg) ([]interface{}, error)
 	CalculateMigrationGasFunc func(db StateDB, migrationMsg *stakingTypes.MigrationMsg, homestead bool, istanbul bool) (uint64, error)
 )
 
@@ -163,7 +163,6 @@ type Context struct {
 	Delegate              DelegateFunc
 	Undelegate            UndelegateFunc
 	CollectRewards        CollectRewardsFunc
-	MigrateDelegations    MigrateDelegationsFunc
 	CalculateMigrationGas CalculateMigrationGasFunc
 
 	// staking precompile checks this before proceeding forward

--- a/staking/precompile.go
+++ b/staking/precompile.go
@@ -76,27 +76,30 @@ func init() {
 	    "outputs": [],
 	    "stateMutability": "nonpayable",
 	    "type": "function"
-	  },
-	  {
-	    "inputs": [
-	      {
-	        "internalType": "address",
-	        "name": "from",
-	        "type": "address"
-	      },
-	      {
-	        "internalType": "address",
-	        "name": "to",
-	        "type": "address"
-	      }
-	    ],
-	    "name": "Migrate",
-	    "outputs": [],
-	    "stateMutability": "nonpayable",
-	    "type": "function"
 	  }
 	]
 	`
+
+	// ABI for migrate which is not enabled for precompile
+	//,
+	//{
+	//	"inputs": [
+	//{
+	//"internalType": "address",
+	//"name": "from",
+	//"type": "address"
+	//},
+	//{
+	//"internalType": "address",
+	//"name": "to",
+	//"type": "address"
+	//}
+	//],
+	//"name": "Migrate",
+	//"outputs": [],
+	//"stateMutability": "nonpayable",
+	//"type": "function"
+	//}
 	abiStaking, _ = abi.JSON(strings.NewReader(StakingABIJSON))
 }
 
@@ -173,22 +176,22 @@ func ParseStakeMsg(contractCaller common.Address, input []byte) (interface{}, er
 			}
 			return stakeMsg, nil
 		}
-	case "Migrate":
-		{
-			from, err := ValidateContractAddress(contractCaller, args, "from")
-			if err != nil {
-				return nil, err
-			}
-			to, err := ParseAddressFromKey(args, "to")
-			if err != nil {
-				return nil, err
-			}
-			// no sanity check for migrating to same address, just do nothing
-			return &stakingTypes.MigrationMsg{
-				From: from,
-				To:   to,
-			}, nil
-		}
+	//case "Migrate":
+	//	{
+	//		from, err := ValidateContractAddress(contractCaller, args, "from")
+	//		if err != nil {
+	//			return nil, err
+	//		}
+	//		to, err := ParseAddressFromKey(args, "to")
+	//		if err != nil {
+	//			return nil, err
+	//		}
+	//		// no sanity check for migrating to same address, just do nothing
+	//		return &stakingTypes.MigrationMsg{
+	//			From: from,
+	//			To:   to,
+	//		}, nil
+	//	}
 	default:
 		{
 			return nil, errors.New("[StakingPrecompile] Invalid method name from ABI selector")

--- a/staking/precompile_test.go
+++ b/staking/precompile_test.go
@@ -108,11 +108,11 @@ var ParseStakeMsgTests = []parseTest{
 		expectedError: errors.New("[StakingPrecompile] Address mismatch, expected 0x0000000000000000000000000000000000001337 have 0x0000000000000000000000000000000000001338"),
 		name:          "undelegateAddressMismatch",
 	},
-	{
-		input:         []byte{42, 5, 187, 113},
-		expectedError: errors.New("abi: attempting to unmarshall an empty string while arguments are expected"),
-		name:          "yesMethodNoData",
-	},
+	//{
+	//	input:         []byte{42, 5, 187, 113},
+	//	expectedError: errors.New("abi: attempting to unmarshall an empty string while arguments are expected"),
+	//	name:          "yesMethodNoData",
+	//},
 	//{
 	//	input:         []byte{0, 0},
 	//	expectedError: errors.New("data too short (2 bytes) for abi method lookup"),

--- a/staking/precompile_test.go
+++ b/staking/precompile_test.go
@@ -113,11 +113,11 @@ var ParseStakeMsgTests = []parseTest{
 		expectedError: errors.New("abi: attempting to unmarshall an empty string while arguments are expected"),
 		name:          "yesMethodNoData",
 	},
-	{
-		input:         []byte{0, 0},
-		expectedError: errors.New("data too short (2 bytes) for abi method lookup"),
-		name:          "malformedInput",
-	},
+	//{
+	//	input:         []byte{0, 0},
+	//	expectedError: errors.New("data too short (2 bytes) for abi method lookup"),
+	//	name:          "malformedInput",
+	//},
 	//{
 	//	input: []byte{42, 5, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56},
 	//	expected: &stakingTypes.MigrationMsg{

--- a/staking/precompile_test.go
+++ b/staking/precompile_test.go
@@ -118,29 +118,29 @@ var ParseStakeMsgTests = []parseTest{
 		expectedError: errors.New("data too short (2 bytes) for abi method lookup"),
 		name:          "malformedInput",
 	},
-	{
-		input: []byte{42, 5, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56},
-		expected: &stakingTypes.MigrationMsg{
-			From: common.HexToAddress("0x1337"),
-			To:   common.HexToAddress("0x1338"),
-		},
-		name: "migrationSuccess",
-	},
-	{
-		input:         []byte{42, 5, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55},
-		expectedError: errors.New("[StakingPrecompile] Address mismatch, expected 0x0000000000000000000000000000000000001337 have 0x0000000000000000000000000000000000001338"),
-		name:          "migrationAddressMismatch",
-	},
-	{
-		input:         []byte{42, 6, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55},
-		expectedError: errors.New("no method with id: 0x2a06bb71"),
-		name:          "migrationNoMatchingMethod",
-	},
-	{
-		input:         []byte{42, 5, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19},
-		expectedError: errors.New("abi: cannot marshal in to go type: length insufficient 63 require 64"),
-		name:          "migrationAddressMismatch",
-	},
+	//{
+	//	input: []byte{42, 5, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56},
+	//	expected: &stakingTypes.MigrationMsg{
+	//		From: common.HexToAddress("0x1337"),
+	//		To:   common.HexToAddress("0x1338"),
+	//	},
+	//	name: "migrationSuccess",
+	//},
+	//{
+	//	input:         []byte{42, 5, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55},
+	//	expectedError: errors.New("[StakingPrecompile] Address mismatch, expected 0x0000000000000000000000000000000000001337 have 0x0000000000000000000000000000000000001338"),
+	//	name:          "migrationAddressMismatch",
+	//},
+	//{
+	//	input:         []byte{42, 6, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55},
+	//	expectedError: errors.New("no method with id: 0x2a06bb71"),
+	//	name:          "migrationNoMatchingMethod",
+	//},
+	//{
+	//	input:         []byte{42, 5, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19},
+	//	expectedError: errors.New("abi: cannot marshal in to go type: length insufficient 63 require 64"),
+	//	name:          "migrationAddressMismatch",
+	//},
 }
 
 func testParseStakeMsg(test parseTest, t *testing.T) {


### PR DESCRIPTION
Disable migrate() precompile since we are not doing it as a user-facing feature anymore.