### PR TITLE
Add defer statement to mutex critical code in consensus package

### DIFF
--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -453,7 +453,7 @@ func (consensus *Consensus) onViewChange(recvMsg *FBFTMessage) {
 // from the new leader
 func (consensus *Consensus) onNewView(recvMsg *FBFTMessage) {
 	consensus.mutex.Lock()
-	consensus.mutex.Unlock()
+	defer consensus.mutex.Unlock()
 
 	consensus.getLogger().Info().
 		Uint64("viewID", recvMsg.ViewID).


### PR DESCRIPTION
## Issue

`func (consensus *Consensus) onNewView(recvMsg *FBFTMessage)` locks and then immediately unlocks its mutex.

I can only assume the `Unlock()` should be deferred, since otherwise there's no point to it. I don't know if this has caused critical changes previously.

## Test

### Unit Test Coverage

No changes.

### Test/Run Logs

No interesting logs or changes.

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

2. ~~**Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.~~

3. ~~**Describe how the plan was tested.**~~

4. ~~**How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**~~

5. ~~**What are the planned flag epoch numbers and their ETAs on Pangaea?**~~

6. ~~**What are the planned flag epoch numbers and their ETAs on mainnet?**~~

7. ~~**What should node operators know about this planned change?**~~

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

9. ~~**Does the existing `node.sh` continue to work with this change?**~~

10. ~~**What should node operators know about this change?**~~

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

NO
