### PR TITLE
dockerfile uses target platform's CPU arch and fix aarch64 mapping in install_protoc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM ubuntu:18.04
 
-SHELL ["/bin/bash", "-c"]
+ARG TARGETARCH
+ARG GOLANG_VERSION="1.16.3"
 
-RUN apt update && apt upgrade -y
+SHELL ["/bin/bash", "-c"]
 
 ENV GOPATH=/root/go
 ENV GO111MODULE=on
@@ -13,23 +14,20 @@ ENV BLS_DIR=${HMY_PATH}/bls
 ENV CGO_CFLAGS="-I${BLS_DIR}/include -I${MCL_DIR}/include"
 ENV CGO_LDFLAGS="-L${BLS_DIR}/lib"
 ENV LD_LIBRARY_PATH=${BLS_DIR}/lib:${MCL_DIR}/lib
-ENV GIMME_GO_VERSION="1.16.3"
+ENV GIMME_GO_VERSION=${GOLANG_VERSION}
 ENV PATH="/root/bin:${PATH}"
 
-RUN apt-get update -y
-RUN apt install libgmp-dev libssl-dev curl git \
-psmisc dnsutils jq make gcc g++ bash tig tree sudo vim \
-silversearcher-ag unzip emacs-nox nano bash-completion -y
+RUN apt update && apt upgrade -y && \
+	apt install libgmp-dev libssl-dev curl git \
+	psmisc dnsutils jq make gcc g++ bash tig tree sudo vim \
+	silversearcher-ag unzip emacs-nox nano bash-completion -y
 
 RUN mkdir ~/bin && \
 	curl -sL -o ~/bin/gimme \
-	https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
-
-RUN chmod +x ~/bin/gimme
+	https://raw.githubusercontent.com/travis-ci/gimme/master/gimme && \
+	chmod +x ~/bin/gimme
 
 RUN eval "$(~/bin/gimme ${GIMME_GO_VERSION})"
-
-RUN mkdir /root/workspace
 
 RUN git clone https://github.com/harmony-one/harmony.git ${HMY_PATH}/harmony
 
@@ -41,42 +39,32 @@ RUN git clone https://github.com/harmony-one/go-sdk.git ${HMY_PATH}/go-sdk
 
 RUN cd ${HMY_PATH}/bls && make -j8 BLS_SWAP_G=1
 
-RUN touch /root/.bash_profile
+RUN touch /root/.bash_profile && \
+	gimme ${GIMME_GO_VERSION} >> /root/.bash_profile && \
+	echo "GIMME_GO_VERSION='${GIMME_GO_VERSION}'" >> /root/.bash_profile && \
+	echo "GO111MODULE='on'" >> /root/.bash_profile && \
+	echo ". ~/.bash_profile" >> /root/.profile && \
+	echo ". ~/.bash_profile" >> /root/.bashrc
 
-RUN gimme ${GIMME_GO_VERSION} >> /root/.bash_profile
+ENV PATH="/root/.gimme/versions/go${GIMME_GO_VERSION}.linux.${TARGETARCH:-amd64}/bin:${GOPATH}/bin:${PATH}"
 
-RUN echo "GIMME_GO_VERSION='${GIMME_GO_VERSION}'" >> /root/.bash_profile
-
-RUN echo "GO111MODULE='on'" >> /root/.bash_profile
-
-RUN echo ". ~/.bash_profile" >> /root/.profile
-
-RUN echo ". ~/.bash_profile" >> /root/.bashrc
-
-ENV GOPATH='/root/go'
-
-ENV PATH="/root/.gimme/versions/go${GIMME_GO_VERSION}.linux.amd64/bin:${GOPATH}/bin:${PATH}"
-
-RUN eval "$(~/bin/gimme ${GIMME_GO_VERSION})" ; . ~/.bash_profile; \
-go get -u golang.org/x/tools/cmd/goimports; \
-go get -u golang.org/x/lint/golint ; \
-go get -u github.com/rogpeppe/godef ; \
-go get -u github.com/go-delve/delve/cmd/dlv; \
-go get -u github.com/golang/mock/mockgen; \
-go get -u github.com/stamblerre/gocode; \
-go get -u golang.org/x/tools/...
-
-
-RUN eval "$(~/bin/gimme ${GIMME_GO_VERSION})" ; . ~/.bash_profile; \
-go get -u honnef.co/go/tools/cmd/staticcheck/...
+RUN . ~/.bash_profile; \
+	go get -u golang.org/x/tools/cmd/goimports; \
+	go get -u golang.org/x/lint/golint ; \
+	go get -u github.com/rogpeppe/godef ; \
+	go get -u github.com/go-delve/delve/cmd/dlv; \
+	go get -u github.com/golang/mock/mockgen; \
+	go get -u github.com/stamblerre/gocode; \
+	go get -u golang.org/x/tools/...; \
+	go get -u honnef.co/go/tools/cmd/staticcheck/...
 
 WORKDIR ${HMY_PATH}/harmony
 
-RUN eval "$(~/bin/gimme ${GIMME_GO_VERSION})" ; scripts/install_build_tools.sh
+RUN scripts/install_build_tools.sh
 
 RUN go mod tidy
 
-RUN eval "$(~/bin/gimme ${GIMME_GO_VERSION})" ; scripts/go_executable_build.sh -S
+RUN scripts/go_executable_build.sh -S
 
 RUN cd ${HMY_PATH}/go-sdk && make -j8 && cp hmy /root/bin
 
@@ -88,27 +76,16 @@ ARG KS1=8d222cffa99eb1fb86c581d9dfe7d60dd40ec62aa29056b7ff48028385270541
 ARG KS2=da1800da5dedf02717696675c7a7e58383aff90b1014dfa1ab5b7bd1ce3ef535
 ARG KS3=f4267bb5a2f0e65b8f5792bb6992597fac2b35ebfac9885ce0f4152c451ca31a
 
-RUN hmy keys import-private-key ${KS1}
+RUN hmy keys import-private-key ${KS1} && \
+	hmy keys import-private-key ${KS2} && \
+	hmy keys import-private-key ${KS3} && \
+	hmy keys generate-bls-key > keys.json 
 
-RUN hmy keys import-private-key ${KS2}
-
-RUN hmy keys import-private-key ${KS3}
-
-RUN hmy keys generate-bls-key > keys.json 
-
-RUN jq  '.["encrypted-private-key-path"]' -r keys.json > /root/keypath && cp keys.json /root
-
-RUN echo "export BLS_KEY_PATH=$(cat /root/keypath)" >> /root/.bashrc
-
-RUN echo "export BLS_KEY=$(jq '.["public-key"]' -r keys.json)" >> /root/.bashrc
-
-RUN echo "printf '${K1}, ${K2}, ${K3} are imported accounts in hmy for local dev\n\n'" >> /root/.bashrc
-
-RUN echo "printf 'test with: hmy blockchain validator information ${K1}\n\n'" >> /root/.bashrc
-
-RUN echo "echo "$(jq '.["public-key"]' -r keys.json)" is an extern bls key" \
-	>> /root/.bashrc
-
-RUN echo ". /etc/bash_completion" >> /root/.bashrc
-
-RUN echo ". <(hmy completion)" >> /root/.bashrc
+RUN jq  '.["encrypted-private-key-path"]' -r keys.json > /root/keypath && cp keys.json /root && \
+	echo "export BLS_KEY_PATH=$(cat /root/keypath)" >> /root/.bashrc && \
+	echo "export BLS_KEY=$(jq '.["public-key"]' -r keys.json)" >> /root/.bashrc && \
+	echo "printf '${K1}, ${K2}, ${K3} are imported accounts in hmy for local dev\n\n'" >> /root/.bashrc && \
+	echo "printf 'test with: hmy blockchain validator information ${K1}\n\n'" >> /root/.bashrc && \
+	echo "echo "$(jq '.["public-key"]' -r keys.json)" is an extern bls key" >> /root/.bashrc && \
+	echo ". /etc/bash_completion" >> /root/.bashrc && \
+	echo ". <(hmy completion)" >> /root/.bashrc

--- a/README.md
+++ b/README.md
@@ -87,11 +87,17 @@ cd $(go env GOPATH)/src/github.com/harmony-one/harmony
 make clean
 docker build -t harmony .
 ```
+> If your build machine has an ARM-based chip, like Apple silicon (M1), the image is built for `linux/arm64` by default. To build for `x86_64`, apply the `--platform` arg like so:
+> ```bash
+> docker build --platform linux/amd64 -t harmony .
+> ```
+> Learn more about the `--platform` arg and multi-CPU architecture support, [here](https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope) and [here](https://docs.docker.com/desktop/multi-arch/).
+
+
 
 Then you can start your docker container with the following command:
 ```bash
-docker rm harmony # Remove old docker container
-docker run --name harmony -it -v "$(go env GOPATH)/src/github.com/harmony-one/harmony:/root/go/src/github.com/harmony-one/harmony" harmony /bin/bash
+docker run --rm --name harmony -it -v "$(go env GOPATH)/src/github.com/harmony-one/harmony:/root/go/src/github.com/harmony-one/harmony" harmony /bin/bash
 ```
 > Note that the harmony repo will be shared between your docker container and your host machine. However, everything else in the docker container will be ephemeral.
 

--- a/scripts/install_protoc.sh
+++ b/scripts/install_protoc.sh
@@ -43,7 +43,11 @@ case "${platform}" in
 	Linux) platform=linux;;
 	*) echo "unsupported OS name (${platform})" >&2; exit 69;;
 	esac
-	platform="${platform}-$(uname -m)"
+	arch=$(uname -m)
+	case "${arch}" in
+	aarch64) arch=aarch_64;;
+	esac
+	platform="${platform}-${arch}"
 	;;
 esac
 unset -v tmpdir


### PR DESCRIPTION
## Issue
Unable to build main docker image for ARM-based platforms. I'm using a MBP M1 and cannot build the docker image unless i include, `--platform linux/amd64`; this builds me an image for `x86_64` arch. however, building for other supported archs, like `arm64`, should still be possible (better adoption? lower barrier to entry?). _side-note: my validator nodes run on `arm64` chips, so this allows me to build `hmy` properly_

Required changes
- in `Dockerfile`, use `$TARGETARCH` when defining gimme go platform
- in `install_protoc.sh`, fix mapping issue w/ `protoc` binaries. it denotes `aarch64` as `aarch_64` (legacy based on how maven does it?)
 ```bash
#27 55.62 Downloading protoc v3.15.8 for linux-aarch64...
#27 56.35 Downloaded as protoc-3.15.8-linux-aarch64.zip; unzipping into /usr/local...
#27 56.37 Archive:  protoc-3.15.8-linux-aarch64.zip
#27 56.37   End-of-central-directory signature not found.  Either this file is not
#27 56.37   a zipfile, or it constitutes one disk of a multi-part archive.  In the
#27 56.37   latter case the central directory and zipfile comment will be found on
#27 56.37   the last disk(s) of this archive.
#27 56.37 unzip:  cannot find zipfile directory in one of protoc-3.15.8-linux-aarch64.zip or
#27 56.37         protoc-3.15.8-linux-aarch64.zip.zip, and cannot find protoc-3.15.8-linux-aarch64.zip.ZIP, period.
------
executor failed running [/bin/bash -c eval "$(~/bin/gimme ${GIMME_GO_VERSION})" ; scripts/install_build_tools.sh]: exit code: 9
```

Other changes:
did some "clean-up" while working on this, and can revert if they seem unnecessary
- consolidate layers in `Dockerfile`
- remove redundant or unused statements
  - extra `PATH` definitions
  - creating `/root/workspace` (unused)
  - always invoking `eval "$(~/bin/gimme ${GIMME_GO_VERSION})"` before executing any go commands
- override version of go via build arg

### Unit Test Coverage

No changes

### Test/Run Logs

No changes

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**
