### PR TITLE
Rename hundredKOnes constant to thousandKOnes in doubleSign tests

### DIFF
--- a/staking/slash/double-sign_test.go
+++ b/staking/slash/double-sign_test.go
@@ -35,7 +35,7 @@ var (
 	thirtyKOnes     = new(big.Int).Mul(big.NewInt(30000), bigOne)
 	thirtyFiveKOnes = new(big.Int).Mul(big.NewInt(35000), bigOne)
 	fourtyKOnes     = new(big.Int).Mul(big.NewInt(40000), bigOne)
-	hundredKOnes    = new(big.Int).Mul(big.NewInt(1000000), bigOne)
+	thousandKOnes   = new(big.Int).Mul(big.NewInt(1000000), bigOne)
 )
 
 const (
@@ -847,7 +847,7 @@ func defaultTestValidator(pubKeys []bls.SerializedPublicKey) staking.Validator {
 		SlotPubKeys:          pubKeys,
 		LastEpochInCommittee: big.NewInt(lastEpochInComm),
 		MinSelfDelegation:    new(big.Int).Set(tenKOnes),
-		MaxTotalDelegation:   new(big.Int).Set(hundredKOnes),
+		MaxTotalDelegation:   new(big.Int).Set(thousandKOnes),
 		Status:               effective.Active,
 		Commission:           comm,
 		Description:          desc,


### PR DESCRIPTION
## Issue

In `staking/slash/double-sign_test.go`, there exists a big.Int constant with a wrong name. 

This may lead to logic errors in testing if this constant is used in more key parts of the code (since currently it's used as a placeholder in the `MaxTotalDelegation` property of the default validator).

## Test

All unit tests pass. There's nothing more that can be tested since this is a unit testing fix.   
