### PR TITLE
leveldb shard

### DIFF
--- a/cmd/harmony/config_migrations_test.go
+++ b/cmd/harmony/config_migrations_test.go
@@ -284,6 +284,11 @@ Version = "1.0.4"
   LegacyServer = true
   MinPeers = 6
 
+[ShardData]
+  EnableShardData = false
+  DiskCount = 8
+  ShardCount = 4
+
 [TxPool]
   BlacklistFile = "./.hmy/blacklist.txt"
 

--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -96,6 +96,11 @@ Version = "1.0.4"
   LegacyServer = true
   MinPeers = 6
 
+[ShardData]
+  EnableShardData = false
+  DiskCount = 8
+  ShardCount = 4
+
 [WS]
   Enabled = true
   IP = "127.0.0.1"

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -87,6 +87,11 @@ var defaultConfig = harmonyconfig.HarmonyConfig{
 		},
 	},
 	DNSSync: getDefaultDNSSyncConfig(defNetworkType),
+	ShardData: harmonyconfig.ShardDataConfig{
+		EnableShardData: false,
+		DiskCount:       8,
+		ShardCount:      4,
+	},
 }
 
 var defaultSysConfig = harmonyconfig.SysConfig{

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -213,6 +213,12 @@ var (
 		syncDiscHighFlag,
 		syncDiscBatchFlag,
 	}
+
+	shardDataFlags = []cli.Flag{
+		enableShardDataFlag,
+		diskCountFlag,
+		shardCountFlag,
+	}
 )
 
 var (
@@ -312,6 +318,7 @@ func getRootFlags() []cli.Flag {
 	flags = append(flags, legacyMiscFlags...)
 	flags = append(flags, prometheusFlags...)
 	flags = append(flags, syncFlags...)
+	flags = append(flags, shardDataFlags...)
 
 	return flags
 }
@@ -1594,5 +1601,36 @@ func applySyncFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 
 	if cli.IsFlagChanged(cmd, syncDiscBatchFlag) {
 		config.Sync.DiscBatch = cli.GetIntFlagValue(cmd, syncDiscBatchFlag)
+	}
+}
+
+// shard data flags
+var (
+	enableShardDataFlag = cli.BoolFlag{
+		Name:     "enable_shard_data",
+		Usage:    "whether use multi-database mode of levelDB",
+		DefValue: defaultConfig.ShardData.EnableShardData,
+	}
+	diskCountFlag = cli.IntFlag{
+		Name:     "disk_count",
+		Usage:    "the count of disks you want to storage block data",
+		DefValue: defaultConfig.ShardData.DiskCount,
+	}
+	shardCountFlag = cli.IntFlag{
+		Name:     "shard_count",
+		Usage:    "the count of shards you want to split in each disk",
+		DefValue: defaultConfig.ShardData.ShardCount,
+	}
+)
+
+func applyShardDataFlags(cmd *cobra.Command, cfg *harmonyconfig.HarmonyConfig) {
+	if cli.IsFlagChanged(cmd, enableShardDataFlag) {
+		cfg.ShardData.EnableShardData = cli.GetBoolFlagValue(cmd, enableShardDataFlag)
+	}
+	if cli.IsFlagChanged(cmd, diskCountFlag) {
+		cfg.ShardData.DiskCount = cli.GetIntFlagValue(cmd, diskCountFlag)
+	}
+	if cli.IsFlagChanged(cmd, shardCountFlag) {
+		cfg.ShardData.ShardCount = cli.GetIntFlagValue(cmd, shardCountFlag)
 	}
 }

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -1607,17 +1607,17 @@ func applySyncFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 // shard data flags
 var (
 	enableShardDataFlag = cli.BoolFlag{
-		Name:     "enable_shard_data",
+		Name:     "sharddata.enable",
 		Usage:    "whether use multi-database mode of levelDB",
 		DefValue: defaultConfig.ShardData.EnableShardData,
 	}
 	diskCountFlag = cli.IntFlag{
-		Name:     "disk_count",
+		Name:     "sharddata.disk_count",
 		Usage:    "the count of disks you want to storage block data",
 		DefValue: defaultConfig.ShardData.DiskCount,
 	}
 	shardCountFlag = cli.IntFlag{
-		Name:     "shard_count",
+		Name:     "sharddata.shard_count",
 		Usage:    "the count of shards you want to split in each disk",
 		DefValue: defaultConfig.ShardData.ShardCount,
 	}

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -218,6 +218,8 @@ var (
 		enableShardDataFlag,
 		diskCountFlag,
 		shardCountFlag,
+		cacheTimeFlag,
+		cacheSizeFlag,
 	}
 )
 

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -140,6 +140,11 @@ func TestHarmonyFlags(t *testing.T) {
 					Gateway:    "https://gateway.harmony.one",
 				},
 				Sync: defaultMainnetSyncConfig,
+				ShardData: harmonyconfig.ShardDataConfig{
+					EnableShardData: false,
+					DiskCount:       1,
+					ShardCount:      1,
+				},
 			},
 		},
 	}
@@ -1227,6 +1232,48 @@ func TestSyncFlags(t *testing.T) {
 		}
 		if !reflect.DeepEqual(hc.Sync, test.expConfig) {
 			t.Errorf("Test %v:\n\t%+v\n\t%+v", i, hc.Sync, test.expConfig)
+		}
+
+		ts.tearDown()
+	}
+}
+
+func TestShardDataFlags(t *testing.T) {
+	tests := []struct {
+		args      []string
+		expConfig harmonyconfig.ShardDataConfig
+		expErr    error
+	}{
+		{
+			args:      []string{},
+			expConfig: defaultConfig.ShardData,
+		},
+		{
+			args: []string{"--sharddata.enable_shard_data",
+				"--sharddata.disk_count", "8",
+				"--sharddata.shard_count", "4",
+			},
+			expConfig: harmonyconfig.ShardDataConfig{
+				EnableShardData: true,
+				DiskCount:       8,
+				ShardCount:      4,
+			},
+		},
+	}
+	for i, test := range tests {
+		ts := newFlagTestSuite(t, shardDataFlags, func(command *cobra.Command, config *harmonyconfig.HarmonyConfig) {
+			applyShardDataFlags(command, config)
+		})
+		hc, err := ts.run(test.args)
+
+		if assErr := assertError(err, test.expErr); assErr != nil {
+			t.Fatalf("Test %v: %v", i, assErr)
+		}
+		if err != nil || test.expErr != nil {
+			continue
+		}
+		if !reflect.DeepEqual(hc.ShardData, test.expConfig) {
+			t.Errorf("Test %v:\n\t%+v\n\t%+v", i, hc.ShardData, test.expConfig)
 		}
 
 		ts.tearDown()

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -142,8 +142,8 @@ func TestHarmonyFlags(t *testing.T) {
 				Sync: defaultMainnetSyncConfig,
 				ShardData: harmonyconfig.ShardDataConfig{
 					EnableShardData: false,
-					DiskCount:       1,
-					ShardCount:      1,
+					DiskCount:       8,
+					ShardCount:      4,
 				},
 			},
 		},
@@ -1249,7 +1249,7 @@ func TestShardDataFlags(t *testing.T) {
 			expConfig: defaultConfig.ShardData,
 		},
 		{
-			args: []string{"--sharddata.enable_shard_data",
+			args: []string{"--sharddata.enable",
 				"--sharddata.disk_count", "8",
 				"--sharddata.shard_count", "4",
 			},

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -144,6 +144,8 @@ func TestHarmonyFlags(t *testing.T) {
 					EnableShardData: false,
 					DiskCount:       8,
 					ShardCount:      4,
+					CacheTime:       10,
+					CacheSize:       512,
 				},
 			},
 		},

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -231,6 +231,7 @@ func applyRootFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	applyRevertFlags(cmd, config)
 	applyPrometheusFlags(cmd, config)
 	applySyncFlags(cmd, config)
+	applyShardDataFlags(cmd, config)
 }
 
 func setupNodeLog(config harmonyconfig.HarmonyConfig) {
@@ -655,7 +656,16 @@ func setupConsensusAndNode(hc harmonyconfig.HarmonyConfig, nodeConfig *nodeconfi
 	}
 
 	// Current node.
-	chainDBFactory := &shardchain.LDBFactory{RootDir: nodeConfig.DBDir}
+	var chainDBFactory shardchain.DBFactory
+	if hc.ShardData.EnableShardData {
+		chainDBFactory = &shardchain.LDBShardFactory{
+			RootDir:    nodeConfig.DBDir,
+			DiskCount:  hc.ShardData.DiskCount,
+			ShardCount: hc.ShardData.ShardCount,
+		}
+	} else {
+		chainDBFactory = &shardchain.LDBFactory{RootDir: nodeConfig.DBDir}
+	}
 
 	currentNode := node.New(myHost, currentConsensus, chainDBFactory, blacklist, nodeConfig.ArchiveModes(), &hc)
 

--- a/go.mod
+++ b/go.mod
@@ -1,21 +1,21 @@
 module github.com/harmony-one/harmony
 
-go 1.16
+		go 1.16
 
-require (
-	github.com/VictoriaMetrics/fastcache v1.5.7 // indirect
-	github.com/Workiva/go-datastructures v1.0.50
-	github.com/allegro/bigcache v1.2.1 // indirect
-	github.com/aristanetworks/goarista v0.0.0-20190607111240-52c2a7864a08 // indirect
-	github.com/aws/aws-sdk-go v1.30.1
-	github.com/beevik/ntp v0.3.0
-	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
-	github.com/cespare/cp v1.1.1
-	github.com/coinbase/rosetta-sdk-go v0.7.0
-	github.com/davecgh/go-spew v1.1.1
-	github.com/deckarep/golang-set v1.7.1
-	github.com/ethereum/go-ethereum v1.9.25
-	github.com/fjl/memsize v0.0.0-20180929194037-2a09253e352a // indirect
+		require (
+		github.com/VictoriaMetrics/fastcache v1.5.7 // indirect
+		github.com/Workiva/go-datastructures v1.0.50
+		github.com/allegro/bigcache v1.2.1
+		github.com/aristanetworks/goarista v0.0.0-20190607111240-52c2a7864a08 // indirect
+		github.com/aws/aws-sdk-go v1.30.1
+		github.com/beevik/ntp v0.3.0
+		github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
+		github.com/cespare/cp v1.1.1
+		github.com/coinbase/rosetta-sdk-go v0.7.0
+		github.com/davecgh/go-spew v1.1.1
+		github.com/deckarep/golang-set v1.7.1
+		github.com/ethereum/go-ethereum v1.9.25
+		github.com/fjl/memsize v0.0.0-20180929194037-2a09253e352a // indirect
 	github.com/garslo/gogen v0.0.0-20170307003452-d6ebae628c7c // indirect
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.2

--- a/go.mod
+++ b/go.mod
@@ -1,21 +1,21 @@
 module github.com/harmony-one/harmony
 
-		go 1.16
+go 1.16
 
-		require (
-		github.com/VictoriaMetrics/fastcache v1.5.7 // indirect
-		github.com/Workiva/go-datastructures v1.0.50
-		github.com/allegro/bigcache v1.2.1
-		github.com/aristanetworks/goarista v0.0.0-20190607111240-52c2a7864a08 // indirect
-		github.com/aws/aws-sdk-go v1.30.1
-		github.com/beevik/ntp v0.3.0
-		github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
-		github.com/cespare/cp v1.1.1
-		github.com/coinbase/rosetta-sdk-go v0.7.0
-		github.com/davecgh/go-spew v1.1.1
-		github.com/deckarep/golang-set v1.7.1
-		github.com/ethereum/go-ethereum v1.9.25
-		github.com/fjl/memsize v0.0.0-20180929194037-2a09253e352a // indirect
+require (
+	github.com/VictoriaMetrics/fastcache v1.5.7 // indirect
+	github.com/Workiva/go-datastructures v1.0.50
+	github.com/allegro/bigcache v1.2.1
+	github.com/aristanetworks/goarista v0.0.0-20190607111240-52c2a7864a08 // indirect
+	github.com/aws/aws-sdk-go v1.30.1
+	github.com/beevik/ntp v0.3.0
+	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
+	github.com/cespare/cp v1.1.1
+	github.com/coinbase/rosetta-sdk-go v0.7.0
+	github.com/davecgh/go-spew v1.1.1
+	github.com/deckarep/golang-set v1.7.1
+	github.com/ethereum/go-ethereum v1.9.25
+	github.com/fjl/memsize v0.0.0-20180929194037-2a09253e352a // indirect
 	github.com/garslo/gogen v0.0.0-20170307003452-d6ebae628c7c // indirect
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.2

--- a/internal/configs/harmony/harmony.go
+++ b/internal/configs/harmony/harmony.go
@@ -28,6 +28,7 @@ type HarmonyConfig struct {
 	Legacy     *LegacyConfig     `toml:",omitempty"`
 	Prometheus *PrometheusConfig `toml:",omitempty"`
 	DNSSync    DnsSync
+	ShardData  ShardDataConfig
 }
 
 type DnsSync struct {
@@ -63,6 +64,12 @@ type GeneralConfig struct {
 	IsOffline              bool
 	DataDir                string
 	EnablePruneBeaconChain bool
+}
+
+type ShardDataConfig struct {
+	EnableShardData bool
+	DiskCount       int
+	ShardCount      int
 }
 
 type ConsensusConfig struct {

--- a/internal/shardchain/dbfactory.go
+++ b/internal/shardchain/dbfactory.go
@@ -13,6 +13,11 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 )
 
+const (
+	LDBDirPrefix      = "harmony_db"
+	LDBShardDirPrefix = "harmony_sharddb"
+)
+
 // DBFactory is a blockchain database factory.
 type DBFactory interface {
 	// NewChainDB returns a new database for the blockchain for
@@ -27,7 +32,7 @@ type LDBFactory struct {
 
 // NewChainDB returns a new LDB for the blockchain for given shard.
 func (f *LDBFactory) NewChainDB(shardID uint32) (ethdb.Database, error) {
-	dir := path.Join(f.RootDir, fmt.Sprintf("harmony_db_%d", shardID))
+	dir := path.Join(f.RootDir, fmt.Sprintf("%s_%d", LDBDirPrefix, shardID))
 	return rawdb.NewLevelDBDatabase(dir, 256, 1024, "")
 }
 
@@ -48,7 +53,7 @@ type LDBShardFactory struct {
 
 // NewChainDB returns a new memDB for the blockchain for given shard.
 func (f *LDBShardFactory) NewChainDB(shardID uint32) (ethdb.Database, error) {
-	dir := filepath.Join(f.RootDir, fmt.Sprintf("harmony_sharddb_%d", shardID))
+	dir := filepath.Join(f.RootDir, fmt.Sprintf("%s_%d", LDBShardDirPrefix, shardID))
 	shard, err := leveldb_shard.NewLeveldbShard(dir, f.DiskCount, f.ShardCount)
 	if err != nil {
 		return nil, err

--- a/internal/shardchain/dbfactory.go
+++ b/internal/shardchain/dbfactory.go
@@ -2,10 +2,11 @@ package shardchain
 
 import (
 	"fmt"
-	"github.com/harmony-one/harmony/internal/shardchain/leveldb_shard"
-	"github.com/harmony-one/harmony/internal/shardchain/local_cache"
 	"path"
 	"path/filepath"
+
+	"github.com/harmony-one/harmony/internal/shardchain/leveldb_shard"
+	"github.com/harmony-one/harmony/internal/shardchain/local_cache"
 
 	"github.com/ethereum/go-ethereum/core/rawdb"
 

--- a/internal/shardchain/dbfactory.go
+++ b/internal/shardchain/dbfactory.go
@@ -2,7 +2,10 @@ package shardchain
 
 import (
 	"fmt"
+	"github.com/harmony-one/harmony/internal/shardchain/leveldb_shard"
+	"github.com/harmony-one/harmony/internal/shardchain/local_cache"
 	"path"
+	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/core/rawdb"
 
@@ -33,4 +36,22 @@ type MemDBFactory struct{}
 // NewChainDB returns a new memDB for the blockchain for given shard.
 func (f *MemDBFactory) NewChainDB(shardID uint32) (ethdb.Database, error) {
 	return rawdb.NewMemoryDatabase(), nil
+}
+
+// LDBShardFactory is a merged Multi-LDB-backed blockchain database factory.
+type LDBShardFactory struct {
+	RootDir    string // directory in which to put shard databases in.
+	DiskCount  int
+	ShardCount int
+}
+
+// NewChainDB returns a new memDB for the blockchain for given shard.
+func (f *LDBShardFactory) NewChainDB(shardID uint32) (ethdb.Database, error) {
+	dir := filepath.Join(f.RootDir, fmt.Sprintf("harmony_sharddb_%d", shardID))
+	shard, err := leveldb_shard.NewLeveldbShard(dir, f.DiskCount, f.ShardCount)
+	if err != nil {
+		return nil, err
+	}
+
+	return rawdb.NewDatabase(local_cache.NewLocalCacheDatabase(shard)), nil
 }

--- a/internal/shardchain/leveldb_shard/common.go
+++ b/internal/shardchain/leveldb_shard/common.go
@@ -1,0 +1,37 @@
+package leveldb_shard
+
+import (
+	"hash/crc32"
+	"sync"
+	"sync/atomic"
+)
+
+func mapDBIndex(key []byte, dbCount uint32) uint32 {
+	return crc32.ChecksumIEEE(key) % dbCount
+}
+
+func parallelRunAndReturnErr(parallelNum int, cb func(index int) error) error {
+	wg := sync.WaitGroup{}
+	errAtomic := atomic.Value{}
+
+	for i := 0; i < parallelNum; i++ {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			err := cb(i)
+			if err != nil {
+				errAtomic.Store(err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	if err := errAtomic.Load(); err != nil {
+		return errAtomic.Load().(error)
+	} else {
+		return nil
+	}
+}

--- a/internal/shardchain/leveldb_shard/shard.go
+++ b/internal/shardchain/leveldb_shard/shard.go
@@ -1,0 +1,199 @@
+package leveldb_shard
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/comparer"
+	"github.com/syndtr/goleveldb/leveldb/filter"
+	"github.com/syndtr/goleveldb/leveldb/iterator"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/syndtr/goleveldb/leveldb/util"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+type LeveldbShard struct {
+	dbs     []*leveldb.DB
+	dbCount uint32
+}
+
+var shardIdxKey = []byte("__DB_SHARED_INDEX__")
+
+func NewLeveldbShard(savePath string, diskCount int, diskShards int) (shard *LeveldbShard, err error) {
+	shard = &LeveldbShard{
+		dbs:     make([]*leveldb.DB, diskCount*diskShards),
+		dbCount: uint32(diskCount * diskShards),
+	}
+
+	// clean when error
+	defer func() {
+		if err != nil {
+			for _, db := range shard.dbs {
+				if db != nil {
+					_ = db.Close()
+				}
+			}
+
+			shard = nil
+		}
+	}()
+
+	levelDBOptions := &opt.Options{
+		OpenFilesCacheCapacity: 128,
+		WriteBuffer:            8 << 20,  //8MB, max memory occupyv = 8*2*diskCount*diskShards
+		BlockCacheCapacity:     16 << 20, //16MB
+		Filter:                 filter.NewBloomFilter(8),
+		DisableSeeksCompaction: true,
+	}
+
+	// async open
+	wg := sync.WaitGroup{}
+	for i := 0; i < diskCount; i++ {
+		for j := 0; j < diskShards; j++ {
+			shardPath := filepath.Join(savePath, fmt.Sprintf("disk%02d", i), fmt.Sprintf("block%02d", j))
+			dbIndex := i*diskShards + j
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				ldb, openErr := leveldb.OpenFile(shardPath, levelDBOptions)
+				if openErr != nil {
+					err = openErr
+					return
+				}
+
+				indexByte := make([]byte, 8)
+				binary.BigEndian.PutUint64(indexByte, uint64(dbIndex))
+				inDBIndex, getErr := ldb.Get(shardIdxKey, nil)
+				if getErr != nil {
+					if getErr == leveldb.ErrNotFound {
+						putErr := ldb.Put(shardIdxKey, indexByte, nil)
+						if putErr != nil {
+							err = putErr
+							return
+						}
+					} else {
+						err = getErr
+						return
+					}
+				} else if bytes.Compare(indexByte, inDBIndex) != 0 {
+					err = fmt.Errorf("db shard index error, need %v, got %v", indexByte, inDBIndex)
+					return
+				}
+
+				shard.dbs[dbIndex] = ldb
+			}()
+		}
+	}
+
+	wg.Wait()
+
+	return shard, err
+}
+
+func (l *LeveldbShard) mapDB(key []byte) *leveldb.DB {
+	return l.dbs[mapDBIndex(key, l.dbCount)]
+}
+
+// Has retrieves if a key is present in the key-value data store.
+func (l *LeveldbShard) Has(key []byte) (bool, error) {
+	return l.mapDB(key).Has(key, nil)
+}
+
+// Get retrieves the given key if it's present in the key-value data store.
+func (l *LeveldbShard) Get(key []byte) ([]byte, error) {
+	return l.mapDB(key).Get(key, nil)
+}
+
+// Put inserts the given value into the key-value data store.
+func (l *LeveldbShard) Put(key []byte, value []byte) error {
+	return l.mapDB(key).Put(key, value, nil)
+}
+
+// Delete removes the key from the key-value data store.
+func (l *LeveldbShard) Delete(key []byte) error {
+	return l.mapDB(key).Delete(key, nil)
+}
+
+// NewBatch creates a write-only database that buffers changes to its host db
+// until a final write is called.
+func (l *LeveldbShard) NewBatch() ethdb.Batch {
+	return NewLeveldbShardBatch(l)
+}
+
+// NewIterator creates a binary-alphabetical iterator over the entire keyspace
+// contained within the key-value database.
+func (l *LeveldbShard) NewIterator() ethdb.Iterator {
+	return l.iterator(nil)
+}
+
+// NewIteratorWithStart creates a binary-alphabetical iterator over a subset of
+// database content starting at a particular initial key (or after, if it does
+// not exist).
+func (l *LeveldbShard) NewIteratorWithStart(start []byte) ethdb.Iterator {
+	return l.iterator(&util.Range{Start: start})
+}
+
+// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
+// of database content with a particular key prefix.
+func (l *LeveldbShard) NewIteratorWithPrefix(prefix []byte) ethdb.Iterator {
+	return l.iterator(util.BytesPrefix(prefix))
+}
+
+func (l *LeveldbShard) iterator(slice *util.Range) ethdb.Iterator {
+	iters := make([]iterator.Iterator, l.dbCount)
+
+	for i, db := range l.dbs {
+		iter := db.NewIterator(slice, nil)
+		iters[i] = iter
+	}
+
+	return iterator.NewMergedIterator(iters, comparer.DefaultComparer, true)
+}
+
+// Stat returns a particular internal stat of the database.
+func (l *LeveldbShard) Stat(property string) (string, error) {
+	sb := strings.Builder{}
+
+	for i, db := range l.dbs {
+		getProperty, err := db.GetProperty(property)
+		if err != nil {
+			return "", err
+		}
+
+		sb.WriteString(fmt.Sprintf("=== shard %02d ===\n", i))
+		sb.WriteString(getProperty)
+		sb.WriteString("\n")
+	}
+
+	return sb.String(), nil
+}
+
+// Compact flattens the underlying data store for the given key range. In essence,
+// deleted and overwritten versions are discarded, and the data is rearranged to
+// reduce the cost of operations needed to access them.
+//
+// A nil start is treated as a key before all keys in the data store; a nil limit
+// is treated as a key after all keys in the data store. If both is nil then it
+// will compact entire data store.
+func (l *LeveldbShard) Compact(start []byte, limit []byte) (err error) {
+	return parallelRunAndReturnErr(int(l.dbCount), func(i int) error {
+		return l.dbs[i].CompactRange(util.Range{Start: start, Limit: limit})
+	})
+}
+
+// Close all the DB
+func (l *LeveldbShard) Close() error {
+	for _, db := range l.dbs {
+		err := db.Close()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/shardchain/leveldb_shard/shard.go
+++ b/internal/shardchain/leveldb_shard/shard.go
@@ -4,6 +4,10 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/comparer"
@@ -11,9 +15,6 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/iterator"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/util"
-	"path/filepath"
-	"strings"
-	"sync"
 )
 
 type LeveldbShard struct {

--- a/internal/shardchain/leveldb_shard/shard_batch.go
+++ b/internal/shardchain/leveldb_shard/shard_batch.go
@@ -1,10 +1,11 @@
 package leveldb_shard
 
 import (
-	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/syndtr/goleveldb/leveldb"
 	"runtime"
 	"sync"
+
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/syndtr/goleveldb/leveldb"
 )
 
 var batchesPool = sync.Pool{

--- a/internal/shardchain/leveldb_shard/shard_batch.go
+++ b/internal/shardchain/leveldb_shard/shard_batch.go
@@ -1,0 +1,118 @@
+package leveldb_shard
+
+import (
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/syndtr/goleveldb/leveldb"
+	"runtime"
+	"sync"
+)
+
+var batchesPool = sync.Pool{
+	New: func() interface{} {
+		return &leveldb.Batch{}
+	},
+}
+
+type LeveldbShardBatch struct {
+	shard        *LeveldbShard
+	batches      []*leveldb.Batch
+	batchesCount uint32
+}
+
+func NewLeveldbShardBatch(shard *LeveldbShard) *LeveldbShardBatch {
+	shardBatch := &LeveldbShardBatch{
+		batches:      make([]*leveldb.Batch, shard.dbCount),
+		batchesCount: shard.dbCount,
+		shard:        shard,
+	}
+
+	for i := uint32(0); i < shard.dbCount; i++ {
+		shardBatch.batches[i] = batchesPool.Get().(*leveldb.Batch)
+	}
+
+	runtime.SetFinalizer(shardBatch, func(o *LeveldbShardBatch) {
+		for _, batch := range o.batches {
+			batch.Reset()
+			batchesPool.Put(batch)
+		}
+
+		o.batches = nil
+	})
+
+	return shardBatch
+}
+
+func (l *LeveldbShardBatch) mapBatch(key []byte) *leveldb.Batch {
+	return l.batches[mapDBIndex(key, l.batchesCount)]
+}
+
+// Put inserts the given value into the key-value data store.
+func (l *LeveldbShardBatch) Put(key []byte, value []byte) error {
+	l.mapBatch(key).Put(key, value)
+	return nil
+}
+
+// Delete removes the key from the key-value data store.
+func (l *LeveldbShardBatch) Delete(key []byte) error {
+	l.mapBatch(key).Delete(key)
+	return nil
+}
+
+// ValueSize retrieves the amount of data queued up for writing.
+func (l *LeveldbShardBatch) ValueSize() int {
+	size := 0
+	for _, batch := range l.batches {
+		size += batch.Len()
+	}
+	return size
+}
+
+// Write flushes any accumulated data to disk.
+func (l *LeveldbShardBatch) Write() (err error) {
+	return parallelRunAndReturnErr(int(l.batchesCount), func(i int) error {
+		return l.shard.dbs[i].Write(l.batches[i], nil)
+	})
+}
+
+// Reset resets the batch for reuse.
+func (l *LeveldbShardBatch) Reset() {
+	for _, batch := range l.batches {
+		batch.Reset()
+	}
+}
+
+// Replay replays the batch contents.
+func (l *LeveldbShardBatch) Replay(w ethdb.KeyValueWriter) error {
+	for _, batch := range l.batches {
+		err := batch.Replay(&replayer{writer: w})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// replayer is a small wrapper to implement the correct replay methods.
+type replayer struct {
+	writer  ethdb.KeyValueWriter
+	failure error
+}
+
+// Put inserts the given value into the key-value data store.
+func (r *replayer) Put(key, value []byte) {
+	// If the replay already failed, stop executing ops
+	if r.failure != nil {
+		return
+	}
+	r.failure = r.writer.Put(key, value)
+}
+
+// Delete removes the key from the key-value data store.
+func (r *replayer) Delete(key []byte) {
+	// If the replay already failed, stop executing ops
+	if r.failure != nil {
+		return
+	}
+	r.failure = r.writer.Delete(key)
+}

--- a/internal/shardchain/local_cache/hack.go
+++ b/internal/shardchain/local_cache/hack.go
@@ -1,0 +1,22 @@
+package local_cache
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+func String(b []byte) (s string) {
+	if len(b) == 0 {
+		return ""
+	}
+	return *(*string)(unsafe.Pointer(&b))
+}
+
+func StringBytes(s string) []byte {
+	var b []byte
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	hdr.Data = (*reflect.StringHeader)(unsafe.Pointer(&s)).Data
+	hdr.Cap = len(s)
+	hdr.Len = len(s)
+	return b
+}

--- a/internal/shardchain/local_cache/local_cache_batch.go
+++ b/internal/shardchain/local_cache/local_cache_batch.go
@@ -1,0 +1,82 @@
+package local_cache
+
+import (
+	"github.com/ethereum/go-ethereum/ethdb"
+	"sync"
+)
+
+type LocalCacheBatch struct {
+	db   *LocalCacheDatabase
+	lock sync.Mutex
+
+	size            int
+	batchWriteKey   [][]byte
+	batchWriteValue [][]byte
+	batchDeleteKey  [][]byte
+}
+
+func newLocalCacheBatch(db *LocalCacheDatabase) *LocalCacheBatch {
+	return &LocalCacheBatch{db: db}
+}
+
+func (b *LocalCacheBatch) Put(key []byte, value []byte) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	b.batchWriteKey = append(b.batchWriteKey, key)
+	b.batchWriteValue = append(b.batchWriteValue, value)
+	b.size += len(key) + len(value)
+	return nil
+}
+
+func (b *LocalCacheBatch) Delete(key []byte) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	b.batchDeleteKey = append(b.batchDeleteKey, key)
+	b.size += len(key)
+	return nil
+}
+
+func (b *LocalCacheBatch) ValueSize() int {
+	return b.size
+}
+
+func (b *LocalCacheBatch) Write() error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	return b.db.batchWrite(b)
+}
+
+func (b *LocalCacheBatch) Reset() {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	b.batchWriteKey = b.batchWriteKey[:0]
+	b.batchWriteValue = b.batchWriteValue[:0]
+	b.batchDeleteKey = b.batchDeleteKey[:0]
+	b.size = 0
+}
+
+func (b *LocalCacheBatch) Replay(w ethdb.KeyValueWriter) error {
+	if len(b.batchWriteKey) > 0 {
+		for i, key := range b.batchWriteKey {
+			err := w.Put(key, b.batchWriteValue[i])
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if len(b.batchDeleteKey) > 0 {
+		for _, key := range b.batchDeleteKey {
+			err := w.Delete(key)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/shardchain/local_cache/local_cache_batch.go
+++ b/internal/shardchain/local_cache/local_cache_batch.go
@@ -1,8 +1,9 @@
 package local_cache
 
 import (
-	"github.com/ethereum/go-ethereum/ethdb"
 	"sync"
+
+	"github.com/ethereum/go-ethereum/ethdb"
 )
 
 type LocalCacheBatch struct {

--- a/internal/shardchain/local_cache/local_cache_database.go
+++ b/internal/shardchain/local_cache/local_cache_database.go
@@ -2,7 +2,8 @@ package local_cache
 
 import (
 	"bytes"
-	"log"
+	"github.com/harmony-one/harmony/internal/utils"
+	"go.uber.org/zap"
 	"time"
 
 	"github.com/allegro/bigcache"
@@ -45,8 +46,8 @@ func NewLocalCacheDatabase(remoteDB ethdb.KeyValueStore) *LocalCacheDatabase {
 	}
 
 	go func() {
-		for range time.Tick(time.Second) {
-			log.Printf("cache: %#v %d (%d)", cache.Stats(), cache.Len(), cache.Capacity())
+		for range time.Tick(time.Minute) {
+			utils.GetLogger().Info("local-cache", zap.Any("stats", cache.Stats()), zap.Int("count", cache.Len()), zap.Int("size", cache.Capacity()))
 		}
 	}()
 

--- a/internal/shardchain/local_cache/local_cache_database.go
+++ b/internal/shardchain/local_cache/local_cache_database.go
@@ -2,9 +2,10 @@ package local_cache
 
 import (
 	"bytes"
+	"time"
+
 	"github.com/harmony-one/harmony/internal/utils"
 	"go.uber.org/zap"
-	"time"
 
 	"github.com/allegro/bigcache"
 	"github.com/ethereum/go-ethereum/ethdb"

--- a/internal/shardchain/local_cache/local_cache_database.go
+++ b/internal/shardchain/local_cache/local_cache_database.go
@@ -2,10 +2,11 @@ package local_cache
 
 import (
 	"bytes"
-	"github.com/allegro/bigcache"
-	"github.com/ethereum/go-ethereum/ethdb"
 	"log"
 	"time"
+
+	"github.com/allegro/bigcache"
+	"github.com/ethereum/go-ethereum/ethdb"
 )
 
 type cacheWrapper struct {

--- a/rosetta/infra/Dockerfile
+++ b/rosetta/infra/Dockerfile
@@ -35,7 +35,7 @@ RUN cp ./rosetta/infra/harmony-pstn.conf /root/harmony-pstn.conf && \
 FROM ubuntu:latest
 
 RUN apt update -y && \
-    apt install libgmp-dev libssl-dev rclone -y && \
+    apt install libgmp-dev libssl-dev rclone ca-certificates -y && \
     apt -y clean all
 
 WORKDIR /root

--- a/rosetta/infra/Dockerfile
+++ b/rosetta/infra/Dockerfile
@@ -24,7 +24,8 @@ RUN go mod tidy
 
 RUN make linux_static && \
     cp ./bin/harmony /root/harmony && \
-    cp ./rosetta/infra/run.sh /root/run.sh
+    cp ./rosetta/infra/run.sh /root/run.sh && \
+    cp ./rosetta/infra/rclone.conf /root/rclone.conf
 
 RUN cp ./rosetta/infra/harmony-pstn.conf /root/harmony-pstn.conf && \
     cp ./rosetta/infra/harmony-mainnet.conf /root/harmony-mainnet.conf && \
@@ -34,13 +35,14 @@ RUN cp ./rosetta/infra/harmony-pstn.conf /root/harmony-pstn.conf && \
 FROM ubuntu:latest
 
 RUN apt update -y && \
-    apt install libgmp-dev libssl-dev -y && \
+    apt install libgmp-dev libssl-dev rclone -y && \
     apt -y clean all
 
 WORKDIR /root
 
 COPY --from=build /root/harmony /root/harmony
 COPY --from=build /root/run.sh /root/run.sh
+COPY --from=build /root/rclone.conf /root/.config/rclone/rclone.conf
 COPY --from=build /root/harmony-pstn.conf /root/harmony-pstn.conf
 COPY --from=build /root/harmony-mainnet.conf /root/harmony-mainnet.conf
 COPY --from=build /root/rosetta_local_fix.csv /root/rosetta_local_fix.csv

--- a/rosetta/infra/rclone.conf
+++ b/rosetta/infra/rclone.conf
@@ -1,0 +1,8 @@
+[release]
+type = s3
+provider = AWS
+env_auth = false
+region = us-west-1
+acl = public-read
+server_side_encryption = AES256
+storage_class = REDUCED_REDUNDANCY

--- a/rosetta/infra/run.sh
+++ b/rosetta/infra/run.sh
@@ -6,6 +6,10 @@ DATA="$DIR/data"
 LOGS="$DATA/logs"
 BASE_ARGS=(--http.ip "0.0.0.0" --ws.ip "0.0.0.0" --http.rosetta --node_type "explorer" --datadir "$DATA" --log.dir "$LOGS")
 
+if [ -n "$RCLONE_DB_0_URL" ]; then
+  rclone -P -L sync $RCLONE_DB_0_URL $DATA/harmony_db_0 --multi-thread-streams 4 --transfers=8
+fi
+
 mkdir -p "$LOGS"
 echo -e NODE ARGS: \" "$@"  "${BASE_ARGS[@]}" \"
 echo "NODE VERSION: $(./harmony --version)"

--- a/rosetta/infra/run.sh
+++ b/rosetta/infra/run.sh
@@ -5,9 +5,10 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DATA="$DIR/data"
 LOGS="$DATA/logs"
 BASE_ARGS=(--http.ip "0.0.0.0" --ws.ip "0.0.0.0" --http.rosetta --node_type "explorer" --datadir "$DATA" --log.dir "$LOGS")
+DATA_NAME="${DATA_NAME:=harmony_db_0}"
 
 if [ -n "$RCLONE_DB_0_URL" ]; then
-  rclone -P -L sync $RCLONE_DB_0_URL $DATA/harmony_db_0 --multi-thread-streams 4 --transfers=8
+  rclone -P -L sync $RCLONE_DB_0_URL $DATA/$DATA_NAME --multi-thread-streams 4 --transfers=8
 fi
 
 mkdir -p "$LOGS"


### PR DESCRIPTION
Add new leveldb shard db mode, significantly improved read and write performance

during the testing for rosetta check data, the bottleneck of performance was found in the leveldb database.

afte we did an in-depth performance investigation on leveldb and found that there are 2 problems as follows:
1. when leveldb has reach more than 1T large amount of data, the read and write performance is greatly reduced, so the overall performance is degraded
2. when leveldb is multi-threaded concurrently reading, there is a lot of lock overhead, resulting in a decrease in competition performance too

so we upgraded the db of harmony node underlying architecture, evolved into a new model, which split the original one leveldb database into 32 to improve db performance

in the new mode, it will take up an additional 1-2GB of memory:
- about 1GB is used by memdb of leveldb
- 512MB is used by local cache