### PR TITLE
feat: Add AccountSlots flag for TxPool

### DIFF
--- a/cmd/harmony/config_migrations.go
+++ b/cmd/harmony/config_migrations.go
@@ -220,4 +220,13 @@ func init() {
 		confTree.Set("Version", "2.5.0")
 		return confTree
 	}
+
+	migrations["2.5.0"] = func(confTree *toml.Tree) *toml.Tree {
+		if confTree.Get("TxPool.AccountSlots") == nil {
+			confTree.Set("TxPool.AccountSlots", defaultConfig.TxPool.AccountSlots)
+		}
+
+		confTree.Set("Version", "2.5.1")
+		return confTree
+	}
 }

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -5,7 +5,7 @@ import (
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 )
 
-const tomlConfigVersion = "2.5.0"
+const tomlConfigVersion = "2.5.1" // bump from 2.5.0 for AccountSlots
 
 const (
 	defNetworkType = nodeconfig.Mainnet
@@ -65,6 +65,7 @@ var defaultConfig = harmonyconfig.HarmonyConfig{
 	TxPool: harmonyconfig.TxPoolConfig{
 		BlacklistFile:  "./.hmy/blacklist.txt",
 		RosettaFixFile: "",
+		AccountSlots:   16,
 	},
 	Sync: getDefaultSyncConfig(defNetworkType),
 	Pprof: harmonyconfig.PprofConfig{

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -123,6 +123,7 @@ var (
 	}
 
 	txPoolFlags = []cli.Flag{
+		tpAccountSlotsFlag,
 		rosettaFixFileFlag,
 		tpBlacklistFileFlag,
 		legacyTPBlacklistFileFlag,
@@ -977,6 +978,11 @@ func applyConsensusFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig
 
 // transaction pool flags
 var (
+	tpAccountSlotsFlag = cli.IntFlag{
+		Name:     "txpool.accountslots",
+		Usage:    "number of executable transaction slots guaranteed per account",
+		DefValue: int(defaultConfig.TxPool.AccountSlots),
+	}
 	tpBlacklistFileFlag = cli.StringFlag{
 		Name:     "txpool.blacklist",
 		Usage:    "file of blacklisted wallet addresses",
@@ -999,7 +1005,13 @@ func applyTxPoolFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	if cli.IsFlagChanged(cmd, rosettaFixFileFlag) {
 		config.TxPool.RosettaFixFile = cli.GetStringFlagValue(cmd, rosettaFixFileFlag)
 	}
-
+	if cli.IsFlagChanged(cmd, tpAccountSlotsFlag) {
+		value := cli.GetIntFlagValue(cmd, tpAccountSlotsFlag) // int, so fits in uint64 when positive
+		if value <= 0 {
+			panic("Must provide positive for txpool.accountslots")
+		}
+		config.TxPool.AccountSlots = uint64(cli.GetIntFlagValue(cmd, tpAccountSlotsFlag))
+	}
 	if cli.IsFlagChanged(cmd, tpBlacklistFileFlag) {
 		config.TxPool.BlacklistFile = cli.GetStringFlagValue(cmd, tpBlacklistFileFlag)
 	} else if cli.IsFlagChanged(cmd, legacyTPBlacklistFileFlag) {

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -102,6 +102,7 @@ func TestHarmonyFlags(t *testing.T) {
 				TxPool: harmonyconfig.TxPoolConfig{
 					BlacklistFile:  "./.hmy/blacklist.txt",
 					RosettaFixFile: "",
+					AccountSlots:   16,
 				},
 				Pprof: harmonyconfig.PprofConfig{
 					Enabled:            false,
@@ -780,6 +781,7 @@ func TestTxPoolFlags(t *testing.T) {
 			expConfig: harmonyconfig.TxPoolConfig{
 				BlacklistFile:  defaultConfig.TxPool.BlacklistFile,
 				RosettaFixFile: defaultConfig.TxPool.RosettaFixFile,
+				AccountSlots:   defaultConfig.TxPool.AccountSlots,
 			},
 		},
 		{
@@ -787,11 +789,21 @@ func TestTxPoolFlags(t *testing.T) {
 			expConfig: harmonyconfig.TxPoolConfig{
 				BlacklistFile:  "blacklist.file",
 				RosettaFixFile: "rosettafix.file",
+				AccountSlots:   16, // default
 			},
 		},
 		{
 			args: []string{"--blacklist", "blacklist.file", "--txpool.rosettafixfile", "rosettafix.file"},
 			expConfig: harmonyconfig.TxPoolConfig{
+				BlacklistFile:  "blacklist.file",
+				RosettaFixFile: "rosettafix.file",
+				AccountSlots:   16, // default
+			},
+		},
+		{
+			args: []string{"--txpool.accountslots", "5", "--txpool.blacklist", "blacklist.file", "--txpool.rosettafixfile", "rosettafix.file"},
+			expConfig: harmonyconfig.TxPoolConfig{
+				AccountSlots:   5,
 				BlacklistFile:  "blacklist.file",
 				RosettaFixFile: "rosettafix.file",
 			},

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -213,6 +213,13 @@ func (config *TxPoolConfig) sanitize() TxPoolConfig {
 		utils.Logger().Warn().Msg("Sanitizing nil blacklist set")
 		conf.Blacklist = DefaultTxPoolConfig.Blacklist
 	}
+	if conf.AccountSlots == 0 {
+		utils.Logger().Warn().
+			Uint64("provided", conf.AccountSlots).
+			Uint64("updated", DefaultTxPoolConfig.AccountSlots).
+			Msg("Sanitizing invalid txpool account slots")
+		conf.AccountSlots = DefaultTxPoolConfig.AccountSlots
+	}
 
 	return conf
 }

--- a/internal/configs/harmony/harmony.go
+++ b/internal/configs/harmony/harmony.go
@@ -88,6 +88,7 @@ type BlsConfig struct {
 type TxPoolConfig struct {
 	BlacklistFile  string
 	RosettaFixFile string
+	AccountSlots   uint64
 }
 
 type PprofConfig struct {

--- a/node/node.go
+++ b/node/node.go
@@ -1034,6 +1034,9 @@ func New(
 			txPoolConfig.PriceLimit = 1e9
 			txPoolConfig.PriceBump = 10
 		}
+		if harmonyconfig != nil {
+			txPoolConfig.AccountSlots = harmonyconfig.TxPool.AccountSlots
+		}
 
 		txPoolConfig.Blacklist = blacklist
 		txPoolConfig.Journal = fmt.Sprintf("%v/%v", node.NodeConfig.DBDir, txPoolConfig.Journal)

--- a/rosetta/infra/harmony-mainnet.conf
+++ b/rosetta/infra/harmony-mainnet.conf
@@ -1,4 +1,4 @@
-Version = "2.5.0"
+Version = "2.5.1"
 
 [BLSKeys]
   KMSConfigFile = ""
@@ -90,6 +90,7 @@ Version = "2.5.0"
 [TxPool]
   BlacklistFile = "./.hmy/blacklist.txt"
   RosettaFixFile = "./rosetta_local_fix.csv"
+  AccountSlots = 16
 
 [WS]
   AuthPort = 9801

--- a/rosetta/infra/harmony-pstn.conf
+++ b/rosetta/infra/harmony-pstn.conf
@@ -1,4 +1,4 @@
-Version = "2.5.0"
+Version = "2.5.1"
 
 [BLSKeys]
   KMSConfigFile = ""
@@ -89,6 +89,7 @@ Version = "2.5.0"
 
 [TxPool]
   BlacklistFile = "./.hmy/blacklist.txt"
+  AccountSlots = 16
 
 [WS]
   AuthPort = 9801


### PR DESCRIPTION
## Issue
Develop a `txpool.accountslots` flag to determine the "number of executable transaction slots guaranteed per account" according to node runners instead of a default value of 16.

## Test

### Unit Test Coverage

Before:

```
?   	github.com/harmony-one/harmony/internal/configs/harmony	[no test files]
ok  	github.com/harmony-one/harmony/cmd/harmony	0.049s	coverage: 50.3% of statements
ok  	github.com/harmony-one/harmony/core	(cached)	coverage: 31.2% of statements
ok  	github.com/harmony-one/harmony/node	(cached)	coverage: 9.7% of statements
```

After:

```
?   	github.com/harmony-one/harmony/internal/configs/harmony	[no test files]
ok  	github.com/harmony-one/harmony/cmd/harmony	0.049s	coverage: 50.7% of statements
ok  	github.com/harmony-one/harmony/core	(cached)	coverage: 31.2% of statements
ok  	github.com/harmony-one/harmony/node	(cached)	coverage: 9.8% of statements
```

### Test/Run Logs
```bash
$ ./harmony -c harmony.conf
Old config version detected 2.5.0
Do you want to update config to the latest version: [y/N]
y
Original config backed up to harmony.conf.backup
Successfully migrated harmony.conf from 2.5.0 to 2.5.1
^CGot interrupt signal. Gracefully shutting down...
Successfully shut down!
$ cat harmony.conf.backup | grep -i Account
$ cat harmony.conf | grep -i Account
  AccountSlots = 16
```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)
No.

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)
No.

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**
No.
