### PR TITLE
Rewrite slashing rate calculation

### DIFF
--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -483,43 +483,24 @@ func applySlashes(
 	// Do the slashing by groups in the sorted order
 	for _, key := range sortedKeys {
 		records := groupedRecords[key]
-		superCommittee, err := chain.ReadShardState(big.NewInt(int64(key.epoch)))
 
-		if err != nil {
-			return errors.New("could not read shard state")
-		}
-
-		subComm, err := superCommittee.FindCommitteeByID(key.shardID)
-
-		if err != nil {
-			return errors.New("could not find shard committee")
-		}
-
-		// Apply the slashes, invariant: assume been verified as legit slash by this point
-		var slashApplied *slash.Application
-		votingPower, err := lookupVotingPower(
-			big.NewInt(int64(key.epoch)), subComm,
-		)
-		if err != nil {
-			return errors.Wrapf(err, "could not lookup cached voting power in slash application")
-		}
-		rate := slash.Rate(votingPower, records)
 		utils.Logger().Info().
-			Str("rate", rate.String()).
 			RawJSON("records", []byte(records.String())).
 			Msg("now applying slash to state during block finalization")
-		if slashApplied, err = slash.Apply(
+
+		// Apply the slashes, invariant: assume been verified as legit slash by this point
+		slashApplied, err := slash.Apply(
 			chain,
 			state,
 			records,
-			rate,
 			slashRewardBeneficiary,
-		); err != nil {
+		)
+
+		if err != nil {
 			return errors.New("[Finalize] could not apply slash")
 		}
 
 		utils.Logger().Info().
-			Str("rate", rate.String()).
 			RawJSON("records", []byte(records.String())).
 			RawJSON("applied", []byte(slashApplied.String())).
 			Msg("slash applied successfully")

--- a/internal/chain/engine_test.go
+++ b/internal/chain/engine_test.go
@@ -1,0 +1,387 @@
+package chain
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	bls_core "github.com/harmony-one/bls/ffi/go/bls"
+	"github.com/harmony-one/harmony/block"
+	blockfactory "github.com/harmony-one/harmony/block/factory"
+	"github.com/harmony-one/harmony/consensus/engine"
+	consensus_sig "github.com/harmony-one/harmony/consensus/signature"
+	"github.com/harmony-one/harmony/crypto/bls"
+	"github.com/harmony-one/harmony/numeric"
+	"github.com/harmony-one/harmony/shard"
+	"github.com/harmony-one/harmony/staking/effective"
+	"github.com/harmony-one/harmony/staking/slash"
+	staking "github.com/harmony-one/harmony/staking/types"
+	types2 "github.com/harmony-one/harmony/staking/types"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/harmony-one/harmony/core/state"
+	"github.com/harmony-one/harmony/core/types"
+	"github.com/harmony-one/harmony/internal/params"
+)
+
+var (
+	bigOne        = big.NewInt(1e18)
+	tenKOnes      = new(big.Int).Mul(big.NewInt(10000), bigOne)
+	twentyKOnes   = new(big.Int).Mul(big.NewInt(20000), bigOne)
+	fourtyKOnes   = new(big.Int).Mul(big.NewInt(40000), bigOne)
+	thousandKOnes = new(big.Int).Mul(big.NewInt(1000000), bigOne)
+)
+
+const (
+	// validator creation parameters
+	doubleSignShardID     = 0
+	doubleSignEpoch       = 4
+	doubleSignBlockNumber = 37
+	doubleSignViewID      = 38
+
+	creationHeight  = 33
+	lastEpochInComm = 5
+	currentEpoch    = 5
+
+	numShard        = 4
+	numNodePerShard = 5
+
+	offenderShard      = doubleSignShardID
+	offenderShardIndex = 0
+)
+
+var (
+	doubleSignBlock1 = makeBlockForTest(doubleSignEpoch, 0)
+	doubleSignBlock2 = makeBlockForTest(doubleSignEpoch, 1)
+)
+
+var (
+	keyPairs = genKeyPairs(25)
+
+	offIndex = offenderShard*numNodePerShard + offenderShardIndex
+	offAddr  = makeTestAddress(offIndex)
+	offKey   = keyPairs[offIndex]
+	offPub   = offKey.Pub()
+
+	leaderAddr = makeTestAddress("leader")
+)
+
+// Tests that slashing works on the engine level. Since all slashing is
+// thoroughly unit tested on `double-sign_test.go`, it just makes sure that
+// slashing is applied to the state.
+func TestApplySlashing(t *testing.T) {
+	chain := makeFakeBlockChain()
+	state := makeTestStateDB()
+	header := makeFakeHeader()
+	current := makeDefaultValidatorWrapper()
+	slashes := slash.Records{makeSlashRecord()}
+
+	if err := state.UpdateValidatorWrapper(current.Address, current); err != nil {
+		t.Error(err)
+	}
+	if _, err := state.Commit(true); err != nil {
+		t.Error(err)
+	}
+
+	// Inital Leader's balance: 0
+	// Initial Validator's self-delegation: FourtyKOnes
+	if err := applySlashes(chain, header, state, slashes); err != nil {
+		t.Error(err)
+	}
+
+	expDelAmountAfterSlash := twentyKOnes
+	expRewardToBeneficiary := tenKOnes
+
+	if current.Delegations[0].Amount.Cmp(expDelAmountAfterSlash) != 0 {
+		t.Errorf("Slashing was not applied properly to validator: %v/%v", expDelAmountAfterSlash, current.Delegations[0].Amount)
+	}
+
+	beneficiaryBalanceAfterSlash := state.GetBalance(leaderAddr)
+	if beneficiaryBalanceAfterSlash.Cmp(expRewardToBeneficiary) != 0 {
+		t.Errorf("Slashing reward was not added properly to beneficiary: %v/%v", expRewardToBeneficiary, beneficiaryBalanceAfterSlash)
+	}
+}
+
+//
+// Make slash record for testing
+//
+
+func makeSlashRecord() slash.Record {
+	return slash.Record{
+		Evidence: slash.Evidence{
+			ConflictingVotes: slash.ConflictingVotes{
+				FirstVote:  makeVoteData(offKey, doubleSignBlock1),
+				SecondVote: makeVoteData(offKey, doubleSignBlock2),
+			},
+			Moment: slash.Moment{
+				Epoch:   big.NewInt(doubleSignEpoch),
+				ShardID: doubleSignShardID,
+				Height:  doubleSignBlockNumber,
+				ViewID:  doubleSignViewID,
+			},
+			Offender: offAddr,
+		},
+		Reporter: makeTestAddress("reporter"),
+	}
+}
+
+//
+// Make validator for testing
+//
+
+func makeDefaultValidatorWrapper() *staking.ValidatorWrapper {
+	pubKeys := []bls.SerializedPublicKey{offPub}
+	v := defaultTestValidator(pubKeys)
+
+	ds := staking.Delegations{}
+	ds = append(ds, staking.Delegation{
+		DelegatorAddress: offAddr,
+		Amount:           new(big.Int).Set(fourtyKOnes),
+	})
+
+	return &staking.ValidatorWrapper{
+		Validator:   v,
+		Delegations: ds,
+	}
+}
+
+func defaultTestValidator(pubKeys []bls.SerializedPublicKey) staking.Validator {
+	comm := staking.Commission{
+		CommissionRates: staking.CommissionRates{
+			Rate:          numeric.MustNewDecFromStr("0.167983520183826780"),
+			MaxRate:       numeric.MustNewDecFromStr("0.179184469782137200"),
+			MaxChangeRate: numeric.MustNewDecFromStr("0.152212761523253600"),
+		},
+		UpdateHeight: big.NewInt(10),
+	}
+
+	desc := staking.Description{
+		Name:            "someoneA",
+		Identity:        "someoneB",
+		Website:         "someoneC",
+		SecurityContact: "someoneD",
+		Details:         "someoneE",
+	}
+	return staking.Validator{
+		Address:              offAddr,
+		SlotPubKeys:          pubKeys,
+		LastEpochInCommittee: big.NewInt(lastEpochInComm),
+		MinSelfDelegation:    new(big.Int).Set(tenKOnes),
+		MaxTotalDelegation:   new(big.Int).Set(thousandKOnes),
+		Status:               effective.Active,
+		Commission:           comm,
+		Description:          desc,
+		CreationHeight:       big.NewInt(creationHeight),
+	}
+}
+
+//
+// Make commitee for testing
+//
+
+func makeDefaultCommittee() shard.State {
+	epoch := big.NewInt(doubleSignEpoch)
+	maker := newShardSlotMaker(keyPairs)
+	sstate := shard.State{
+		Epoch:  epoch,
+		Shards: make([]shard.Committee, 0, int(numShard)),
+	}
+	for sid := uint32(0); sid != numNodePerShard; sid++ {
+		sstate.Shards = append(sstate.Shards, makeShardBySlotMaker(sid, maker))
+	}
+	return sstate
+}
+
+type shardSlotMaker struct {
+	kps []blsKeyPair
+	i   int
+}
+
+func makeShardBySlotMaker(shardID uint32, maker shardSlotMaker) shard.Committee {
+	cmt := shard.Committee{
+		ShardID: shardID,
+		Slots:   make(shard.SlotList, 0, numNodePerShard),
+	}
+	for nid := 0; nid != numNodePerShard; nid++ {
+		cmt.Slots = append(cmt.Slots, maker.makeSlot())
+	}
+	return cmt
+}
+
+func newShardSlotMaker(kps []blsKeyPair) shardSlotMaker {
+	return shardSlotMaker{kps, 0}
+}
+
+func (maker *shardSlotMaker) makeSlot() shard.Slot {
+	s := shard.Slot{
+		EcdsaAddress: makeTestAddress(maker.i),
+		BLSPublicKey: maker.kps[maker.i].Pub(), // Yes, will panic when not enough kps
+	}
+	maker.i++
+	return s
+}
+
+//
+// State DB for testing
+//
+
+func makeTestStateDB() *state.DB {
+	db := state.NewDatabase(rawdb.NewMemoryDatabase())
+	sdb, err := state.New(common.Hash{}, db)
+	if err != nil {
+		panic(err)
+	}
+
+	err = sdb.UpdateValidatorWrapper(offAddr, makeDefaultValidatorWrapper())
+	if err != nil {
+		panic(err)
+	}
+
+	return sdb
+}
+
+//
+// BLS keys for testing
+//
+
+type blsKeyPair struct {
+	pri *bls_core.SecretKey
+	pub *bls_core.PublicKey
+}
+
+func genKeyPairs(size int) []blsKeyPair {
+	kps := make([]blsKeyPair, 0, size)
+	for i := 0; i != size; i++ {
+		kps = append(kps, genKeyPair())
+	}
+	return kps
+}
+
+func genKeyPair() blsKeyPair {
+	pri := bls.RandPrivateKey()
+	pub := pri.GetPublicKey()
+	return blsKeyPair{
+		pri: pri,
+		pub: pub,
+	}
+}
+
+func (kp blsKeyPair) Pub() bls.SerializedPublicKey {
+	var pub bls.SerializedPublicKey
+	copy(pub[:], kp.pub.Serialize())
+	return pub
+}
+
+func (kp blsKeyPair) Sign(block *types.Block) []byte {
+	chain := &fakeBlockChain{config: *params.LocalnetChainConfig}
+	msg := consensus_sig.ConstructCommitPayload(chain, block.Epoch(), block.Hash(),
+		block.Number().Uint64(), block.Header().ViewID().Uint64())
+
+	sig := kp.pri.SignHash(msg)
+
+	return sig.Serialize()
+}
+
+//
+// Mock blockchain for testing
+//
+
+type fakeBlockChain struct {
+	config         params.ChainConfig
+	currentBlock   types.Block
+	superCommittee shard.State
+	snapshots      map[common.Address]staking.ValidatorWrapper
+}
+
+func makeFakeBlockChain() *fakeBlockChain {
+	return &fakeBlockChain{
+		config:         *params.LocalnetChainConfig,
+		currentBlock:   *makeBlockForTest(currentEpoch, 0),
+		superCommittee: makeDefaultCommittee(),
+		snapshots:      make(map[common.Address]staking.ValidatorWrapper),
+	}
+}
+
+func makeBlockForTest(epoch int64, index int) *types.Block {
+	h := blockfactory.NewTestHeader()
+
+	h.SetEpoch(big.NewInt(epoch))
+	h.SetNumber(big.NewInt(doubleSignBlockNumber))
+	h.SetViewID(big.NewInt(doubleSignViewID))
+	h.SetRoot(common.BigToHash(big.NewInt(int64(index))))
+
+	return types.NewBlockWithHeader(h)
+}
+
+func (bc *fakeBlockChain) CurrentBlock() *types.Block {
+	return &bc.currentBlock
+}
+func (bc *fakeBlockChain) CurrentHeader() *block.Header {
+	return bc.currentBlock.Header()
+}
+func (bc *fakeBlockChain) GetBlock(hash common.Hash, number uint64) *types.Block    { return nil }
+func (bc *fakeBlockChain) GetHeader(hash common.Hash, number uint64) *block.Header  { return nil }
+func (bc *fakeBlockChain) GetHeaderByHash(hash common.Hash) *block.Header           { return nil }
+func (bc *fakeBlockChain) ShardID() uint32                                          { return 0 }
+func (bc *fakeBlockChain) ReadShardState(epoch *big.Int) (*shard.State, error)      { return nil, nil }
+func (bc *fakeBlockChain) WriteCommitSig(blockNum uint64, lastCommits []byte) error { return nil }
+func (bc *fakeBlockChain) GetHeaderByNumber(number uint64) *block.Header            { return nil }
+func (bc *fakeBlockChain) ReadValidatorList() ([]common.Address, error)             { return nil, nil }
+func (bc *fakeBlockChain) ReadCommitSig(blockNum uint64) ([]byte, error)            { return nil, nil }
+func (bc *fakeBlockChain) ReadBlockRewardAccumulator(uint64) (*big.Int, error)      { return nil, nil }
+func (bc *fakeBlockChain) ValidatorCandidates() []common.Address                    { return nil }
+func (cr *fakeBlockChain) ReadValidatorInformationAtState(addr common.Address, state *state.DB) (*staking.ValidatorWrapper, error) {
+	return nil, nil
+}
+func (bc *fakeBlockChain) ReadValidatorSnapshotAtEpoch(epoch *big.Int, offender common.Address) (*types2.ValidatorSnapshot, error) {
+	return &types2.ValidatorSnapshot{
+		Validator: makeDefaultValidatorWrapper(),
+		Epoch:     epoch,
+	}, nil
+}
+func (bc *fakeBlockChain) ReadValidatorInformation(addr common.Address) (*staking.ValidatorWrapper, error) {
+	return nil, nil
+}
+func (bc *fakeBlockChain) Config() *params.ChainConfig {
+	return params.LocalnetChainConfig
+}
+func (cr *fakeBlockChain) StateAt(root common.Hash) (*state.DB, error) {
+	return nil, nil
+}
+func (bc *fakeBlockChain) ReadValidatorSnapshot(addr common.Address) (*staking.ValidatorSnapshot, error) {
+	return nil, nil
+}
+func (bc *fakeBlockChain) ReadValidatorStats(addr common.Address) (*staking.ValidatorStats, error) {
+	return nil, nil
+}
+func (bc *fakeBlockChain) SuperCommitteeForNextEpoch(beacon engine.ChainReader, header *block.Header, isVerify bool) (*shard.State, error) {
+	return nil, nil
+}
+
+//
+// Fake header for testing
+//
+
+func makeFakeHeader() *block.Header {
+	h := blockfactory.NewTestHeader()
+	h.SetCoinbase(leaderAddr)
+	return h
+}
+
+//
+// Utilities for testing
+//
+
+func makeTestAddress(item interface{}) common.Address {
+	s := fmt.Sprintf("harmony.one.%v", item)
+	return common.BytesToAddress([]byte(s))
+}
+
+func makeVoteData(kp blsKeyPair, block *types.Block) slash.Vote {
+	return slash.Vote{
+		SignerPubKeys:   []bls.SerializedPublicKey{kp.Pub()},
+		BlockHeaderHash: block.Hash(),
+		Signature:       kp.Sign(block),
+	}
+}

--- a/staking/slash/double-sign.go
+++ b/staking/slash/double-sign.go
@@ -398,7 +398,7 @@ func delegatorSlashApply(
 }
 
 // applySlashingToDelegator applies slashing to a delegator, given the amount that should be slashed.
-// Also, rewards the snitch half of the amount that was successfully slashed.
+// Also, rewards the beneficiary half of the amount that was successfully slashed.
 func applySlashingToDelegator(snapshot, current *staking.ValidatorWrapper, state *state.DB, rewardBeneficiary common.Address, doubleSignEpoch *big.Int, slashTrack *Application, slashDebt *big.Int, delegationSnapshot staking.Delegation) (*big.Int, error) {
 	snapshotAddr := delegationSnapshot.DelegatorAddress
 	slashDiff := &Application{big.NewInt(0), big.NewInt(0)}
@@ -466,7 +466,7 @@ func applySlashingToDelegator(snapshot, current *staking.ValidatorWrapper, state
 				}
 			}
 
-			// NOTE only need to pay snitch here,
+			// NOTE only need to pay beneficiary here,
 			// they only get half of what was actually dispersed
 			halfOfSlashDebt := new(big.Int).Div(slashDiff.TotalSlashed, common.Big2)
 			slashDiff.TotalBeneficiaryReward.Add(slashDiff.TotalBeneficiaryReward, halfOfSlashDebt)

--- a/staking/slash/double-sign_test.go
+++ b/staking/slash/double-sign_test.go
@@ -34,6 +34,8 @@ var (
 	thirtyKOnes     = new(big.Int).Mul(big.NewInt(30000), bigOne)
 	thirtyFiveKOnes = new(big.Int).Mul(big.NewInt(35000), bigOne)
 	fourtyKOnes     = new(big.Int).Mul(big.NewInt(40000), bigOne)
+	fiftyKOnes      = new(big.Int).Mul(big.NewInt(50000), bigOne)
+	hundredKOnes    = new(big.Int).Mul(big.NewInt(100000), bigOne)
 	thousandKOnes   = new(big.Int).Mul(big.NewInt(1000000), bigOne)
 )
 
@@ -373,99 +375,95 @@ func TestPayDownAsMuchAsCan(t *testing.T) {
 	}
 }
 
-func TestDelegatorSlashApply(t *testing.T) {
-	tests := []slashApplyTestCase{
+func TestApplySlashingToDelegator(t *testing.T) {
+	tests := []applySlashingToDelegatorTestCase{
 		{
-			rate:     numeric.ZeroDec(),
-			snapshot: defaultSnapValidatorWrapper(),
-			current:  defaultCurrentValidatorWrapper(),
-			expDels: []expDelegation{
-				{
-					expAmt:      twentyKOnes,
-					expReward:   tenKOnes,
-					expUndelAmt: []*big.Int{tenKOnes, tenKOnes},
-				},
-				{
-					expAmt:      fourtyKOnes,
-					expReward:   tenKOnes,
-					expUndelAmt: []*big.Int{},
-				},
+			snapshot:      defaultSnapValidatorWrapper(),
+			current:       defaultCurrentValidatorWrapper(),
+			delegationIdx: 0,
+			debt:          big.NewInt(0),
+			expDel: expDelegation{
+				expAmt:      twentyKOnes,
+				expReward:   tenKOnes,
+				expUndelAmt: []*big.Int{tenKOnes, tenKOnes},
 			},
 			expSlashed:           common.Big0,
 			expBeneficiaryReward: common.Big0,
 		},
 		{
-			rate:     numeric.NewDecWithPrec(25, 2),
-			snapshot: defaultSnapValidatorWrapper(),
-			current:  defaultCurrentValidatorWrapper(),
-			expDels: []expDelegation{
-				{
-					expAmt:      tenKOnes,
-					expReward:   tenKOnes,
-					expUndelAmt: []*big.Int{tenKOnes, tenKOnes},
-				},
-				{
-					expAmt:      fourtyKOnes,
-					expReward:   tenKOnes,
-					expUndelAmt: []*big.Int{},
-				},
+			snapshot:      defaultSnapValidatorWrapper(),
+			current:       defaultCurrentValidatorWrapper(),
+			delegationIdx: 0,
+			debt:          twentyKOnes,
+			expDel: expDelegation{
+				expAmt:      big.NewInt(0),
+				expReward:   tenKOnes,
+				expUndelAmt: []*big.Int{tenKOnes, tenKOnes},
 			},
-			expSlashed:           tenKOnes,
-			expBeneficiaryReward: fiveKOnes,
+			expSlashed:           twentyKOnes,
+			expBeneficiaryReward: tenKOnes,
 		},
 		{
-			rate:     numeric.NewDecWithPrec(625, 3),
-			snapshot: defaultSnapValidatorWrapper(),
-			current:  defaultCurrentValidatorWrapper(),
-			expDels: []expDelegation{
-				{
-					expAmt:      common.Big0,
-					expReward:   tenKOnes,
-					expUndelAmt: []*big.Int{tenKOnes, fiveKOnes},
-				},
-				{
-					expAmt:      fourtyKOnes,
-					expReward:   tenKOnes,
-					expUndelAmt: []*big.Int{},
-				},
+			snapshot:      defaultSnapValidatorWrapper(),
+			current:       defaultCurrentValidatorWrapper(),
+			delegationIdx: 0,
+			debt:          twentyFiveKOnes,
+			expDel: expDelegation{
+				expAmt:      big.NewInt(0),
+				expReward:   tenKOnes,
+				expUndelAmt: []*big.Int{tenKOnes, fiveKOnes},
 			},
 			expSlashed:           twentyFiveKOnes,
 			expBeneficiaryReward: new(big.Int).Div(twentyFiveKOnes, common.Big2),
 		},
 		{
-			rate:     numeric.NewDecWithPrec(875, 3),
-			snapshot: defaultSnapValidatorWrapper(),
-			current:  defaultCurrentValidatorWrapper(),
-			expDels: []expDelegation{
-				{
-					expAmt:      common.Big0,
-					expReward:   fiveKOnes,
-					expUndelAmt: []*big.Int{tenKOnes, common.Big0},
-				},
-				{
-					expAmt:      fourtyKOnes,
-					expReward:   tenKOnes,
-					expUndelAmt: []*big.Int{},
-				},
+			snapshot:      defaultSnapValidatorWrapper(),
+			current:       defaultCurrentValidatorWrapper(),
+			delegationIdx: 0,
+			debt:          thirtyKOnes,
+			expDel: expDelegation{
+				expAmt:      big.NewInt(0),
+				expReward:   tenKOnes,
+				expUndelAmt: []*big.Int{tenKOnes, big.NewInt(0)},
+			},
+			expSlashed:           thirtyKOnes,
+			expBeneficiaryReward: new(big.Int).Div(thirtyKOnes, common.Big2),
+		},
+		{
+			snapshot:      defaultSnapValidatorWrapper(),
+			current:       defaultCurrentValidatorWrapper(),
+			delegationIdx: 0,
+			debt:          thirtyFiveKOnes,
+			expDel: expDelegation{
+				expAmt:      big.NewInt(0),
+				expReward:   fiveKOnes,
+				expUndelAmt: []*big.Int{tenKOnes, big.NewInt(0)},
 			},
 			expSlashed:           thirtyFiveKOnes,
 			expBeneficiaryReward: new(big.Int).Div(thirtyFiveKOnes, common.Big2),
 		},
 		{
-			rate:     numeric.NewDecWithPrec(150, 2),
-			snapshot: defaultSnapValidatorWrapper(),
-			current:  defaultCurrentValidatorWrapper(),
-			expDels: []expDelegation{
-				{
-					expAmt:      common.Big0,
-					expReward:   common.Big0,
-					expUndelAmt: []*big.Int{tenKOnes, common.Big0},
-				},
-				{
-					expAmt:      fourtyKOnes,
-					expReward:   tenKOnes,
-					expUndelAmt: []*big.Int{},
-				},
+			snapshot:      defaultSnapValidatorWrapper(),
+			current:       defaultCurrentValidatorWrapper(),
+			delegationIdx: 0,
+			debt:          fourtyKOnes,
+			expDel: expDelegation{
+				expAmt:      big.NewInt(0),
+				expReward:   big.NewInt(0),
+				expUndelAmt: []*big.Int{tenKOnes, big.NewInt(0)},
+			},
+			expSlashed:           fourtyKOnes,
+			expBeneficiaryReward: twentyKOnes,
+		},
+		{
+			snapshot:      defaultSnapValidatorWrapper(),
+			current:       defaultCurrentValidatorWrapper(),
+			delegationIdx: 0,
+			debt:          fiftyKOnes,
+			expDel: expDelegation{
+				expAmt:      big.NewInt(0),
+				expReward:   big.NewInt(0),
+				expUndelAmt: []*big.Int{tenKOnes, big.NewInt(0)},
 			},
 			expSlashed:           fourtyKOnes,
 			expBeneficiaryReward: twentyKOnes,
@@ -481,9 +479,198 @@ func TestDelegatorSlashApply(t *testing.T) {
 	}
 }
 
+func TestDelegatorSlashApply(t *testing.T) {
+	tests := []slashApplyTestCase{
+		{
+			snapshot: generateValidatorWrapper([]testDelegation{
+				{
+					address: "off",
+					amount:  fourtyKOnes,
+				},
+			}),
+			current: generateValidatorWrapper([]testDelegation{
+				{
+					address: "off",
+					amount:  fourtyKOnes,
+				},
+			}),
+			expDels: []expDelegation{
+				{
+					expAmt:      twentyKOnes,
+					expReward:   tenKOnes,
+					expUndelAmt: []*big.Int{},
+				},
+			},
+			expSlashed:           twentyKOnes,
+			expBeneficiaryReward: tenKOnes,
+		},
+		{
+			snapshot: generateValidatorWrapper([]testDelegation{
+				{
+					address: "off",
+					amount:  fourtyKOnes,
+				},
+				{
+					address: "del1",
+					amount:  fourtyKOnes,
+				},
+			}),
+			current: generateValidatorWrapper([]testDelegation{
+				{
+					address: "off",
+					amount:  fourtyKOnes,
+				},
+				{
+					address: "del1",
+					amount:  fourtyKOnes,
+				},
+			}),
+			expDels: []expDelegation{
+				{
+					expAmt:      twentyKOnes,
+					expReward:   tenKOnes,
+					expUndelAmt: []*big.Int{},
+				},
+				{
+					expAmt:      new(big.Int).Mul(big.NewInt(24000), bigOne),
+					expReward:   tenKOnes,
+					expUndelAmt: []*big.Int{},
+				},
+			},
+			expSlashed:           new(big.Int).Mul(big.NewInt(36000), bigOne),
+			expBeneficiaryReward: new(big.Int).Mul(big.NewInt(18000), bigOne),
+		},
+		{
+			snapshot: generateValidatorWrapper([]testDelegation{
+				{
+					address: "off",
+					amount:  fiftyKOnes,
+				},
+				{
+					address: "del1",
+					amount:  fourtyKOnes,
+				},
+				{
+					address: "del2",
+					amount:  tenKOnes,
+				},
+			}),
+			current: generateValidatorWrapper([]testDelegation{
+				{
+					address: "off",
+					amount:  fiftyKOnes,
+				},
+				{
+					address: "del1",
+					amount:  fourtyKOnes,
+				},
+				{
+					address: "del2",
+					amount:  tenKOnes,
+				},
+			}),
+			expDels: []expDelegation{
+				{
+					expAmt:      twentyFiveKOnes,
+					expReward:   tenKOnes,
+					expUndelAmt: []*big.Int{},
+				},
+				{
+					expAmt:      new(big.Int).Mul(big.NewInt(24000), bigOne),
+					expReward:   tenKOnes,
+					expUndelAmt: []*big.Int{},
+				},
+				{
+					expAmt:      new(big.Int).Mul(big.NewInt(6000), bigOne),
+					expReward:   tenKOnes,
+					expUndelAmt: []*big.Int{},
+				},
+			},
+			expSlashed:           new(big.Int).Mul(big.NewInt(45000), bigOne),
+			expBeneficiaryReward: new(big.Int).Mul(big.NewInt(22500), bigOne),
+		},
+		{
+			snapshot: generateValidatorWrapper([]testDelegation{
+				{
+					address: "off",
+					amount:  hundredKOnes,
+				},
+				{
+					address: "del1",
+					amount:  twentyKOnes,
+				},
+				{
+					address: "del2",
+					amount:  twentyKOnes,
+				},
+			}),
+			current: generateValidatorWrapper([]testDelegation{
+				{
+					address: "off",
+					amount:  hundredKOnes,
+				},
+				{
+					address:        "del1",
+					amount:         common.Big0,
+					historyUndel:   twentyKOnes,
+					afterSignUndel: common.Big0,
+				},
+				{
+					address:        "del2",
+					amount:         common.Big0,
+					historyUndel:   common.Big0,
+					afterSignUndel: twentyKOnes,
+				},
+			}),
+			expDels: []expDelegation{
+				{
+					expAmt:      fiftyKOnes,
+					expReward:   tenKOnes,
+					expUndelAmt: []*big.Int{},
+				},
+				{
+					expAmt:      common.Big0,
+					expReward:   common.Big0,
+					expUndelAmt: []*big.Int{twentyKOnes, common.Big0},
+				},
+				{
+					expAmt:      common.Big0,
+					expReward:   tenKOnes,
+					expUndelAmt: []*big.Int{common.Big0, common.Big0},
+				},
+			},
+			expSlashed:           new(big.Int).Mul(big.NewInt(80000), bigOne),
+			expBeneficiaryReward: fourtyKOnes,
+		},
+	}
+
+	for i, tc := range tests {
+		tc.makeData()
+		tc.apply()
+
+		if err := tc.checkResult(); err != nil {
+			t.Errorf("Test %v: %v", i, err)
+		}
+	}
+}
+
+type applySlashingToDelegatorTestCase struct {
+	snapshot, current *staking.ValidatorWrapper
+	state             *state.DB
+	beneficiary       common.Address
+	slashTrack        *Application
+	debt              *big.Int
+	delegationIdx     int
+
+	gotErr error
+
+	expDel                           expDelegation
+	expSlashed, expBeneficiaryReward *big.Int
+	expErr                           error
+}
+
 type slashApplyTestCase struct {
 	snapshot, current *staking.ValidatorWrapper
-	rate              numeric.Dec
 
 	beneficiary common.Address
 	state       *state.DB
@@ -493,6 +680,41 @@ type slashApplyTestCase struct {
 	expDels                          []expDelegation
 	expSlashed, expBeneficiaryReward *big.Int
 	expErr                           error
+}
+
+func (tc *applySlashingToDelegatorTestCase) makeData() {
+	tc.beneficiary = leaderAddr
+	tc.state = makeTestStateDB()
+	tc.slashTrack = &Application{
+		TotalSlashed:           new(big.Int).Set(common.Big0),
+		TotalBeneficiaryReward: new(big.Int).Set(common.Big0),
+	}
+}
+
+func (tc *applySlashingToDelegatorTestCase) apply() {
+	_, tc.gotErr = applySlashingToDelegator(tc.snapshot, tc.current, tc.state, tc.beneficiary,
+		big.NewInt(doubleSignEpoch), tc.slashTrack, new(big.Int).Set(tc.debt), tc.snapshot.Delegations[tc.delegationIdx])
+}
+
+func (tc *applySlashingToDelegatorTestCase) checkResult() error {
+	if err := assertError(tc.gotErr, tc.expErr); err != nil {
+		return err
+	}
+	if err := tc.expDel.checkDelegation(tc.current.Delegations[tc.delegationIdx]); err != nil {
+		return fmt.Errorf("delegations[%v]: %v", tc.delegationIdx, err)
+	}
+	if tc.slashTrack.TotalSlashed.Cmp(tc.expSlashed) != 0 {
+		return fmt.Errorf("unexpected total slash %v / %v", tc.slashTrack.TotalSlashed,
+			tc.expSlashed)
+	}
+	if tc.slashTrack.TotalBeneficiaryReward.Cmp(tc.expBeneficiaryReward) != 0 {
+		return fmt.Errorf("unexpected beneficiary reward %v / %v", tc.slashTrack.TotalBeneficiaryReward,
+			tc.expBeneficiaryReward)
+	}
+	if bal := tc.state.GetBalance(tc.beneficiary); bal.Cmp(tc.expBeneficiaryReward) != 0 {
+		return fmt.Errorf("unexpected balance for beneficiary %v / %v", bal, tc.expBeneficiaryReward)
+	}
+	return nil
 }
 
 func (tc *slashApplyTestCase) makeData() {
@@ -574,16 +796,14 @@ func TestApply(t *testing.T) {
 			snapshot: defaultSnapValidatorWrapper(),
 			current:  defaultCurrentValidatorWrapper(),
 			slashes:  Records{defaultSlashRecord()},
-			rate:     numeric.NewDecWithPrec(625, 3),
 
-			expSlashed:           twentyFiveKOnes,
-			expBeneficiaryReward: new(big.Int).Div(twentyFiveKOnes, common.Big2),
+			expSlashed:           twentyKOnes,
+			expBeneficiaryReward: tenKOnes,
 		},
 		{
 			// missing snapshot in chain
 			current: defaultCurrentValidatorWrapper(),
 			slashes: Records{defaultSlashRecord()},
-			rate:    numeric.NewDecWithPrec(625, 3),
 
 			expErr: errors.New("could not find validator"),
 		},
@@ -591,7 +811,6 @@ func TestApply(t *testing.T) {
 			// missing vWrapper in state
 			snapshot: defaultSnapValidatorWrapper(),
 			slashes:  Records{defaultSlashRecord()},
-			rate:     numeric.NewDecWithPrec(625, 3),
 
 			expErr: errValidatorNotFoundDuringSlash,
 		},
@@ -610,7 +829,6 @@ func TestApply(t *testing.T) {
 type applyTestCase struct {
 	snapshot, current *staking.ValidatorWrapper
 	slashes           Records
-	rate              numeric.Dec
 
 	chain            *fakeBlockChain
 	state, stateSnap *state.DB
@@ -651,13 +869,13 @@ func (tc *applyTestCase) checkResult() error {
 	if (tc.gotErr != nil) || (tc.expErr != nil) {
 		return nil
 	}
-	if tc.gotDiff.TotalBeneficiaryReward.Cmp(tc.expBeneficiaryReward) != 0 {
-		return fmt.Errorf("unexpected beneficiry reward %v / %v", tc.gotDiff.TotalBeneficiaryReward,
-			tc.expBeneficiaryReward)
-	}
 	if tc.gotDiff.TotalSlashed.Cmp(tc.expSlashed) != 0 {
 		return fmt.Errorf("unexpected total slash %v / %v", tc.gotDiff.TotalSlashed,
 			tc.expSlashed)
+	}
+	if tc.gotDiff.TotalBeneficiaryReward.Cmp(tc.expBeneficiaryReward) != 0 {
+		return fmt.Errorf("unexpected beneficiary reward %v / %v", tc.gotDiff.TotalBeneficiaryReward,
+			tc.expBeneficiaryReward)
 	}
 	if err := tc.checkState(); err != nil {
 		return fmt.Errorf("state check: %v", err)
@@ -680,7 +898,7 @@ func (tc *applyTestCase) checkState() error {
 	if err != nil {
 		return err
 	}
-	if tc.rate != numeric.ZeroDec() && reflect.DeepEqual(vwSnap.Delegations, vw.Delegations) {
+	if reflect.DeepEqual(vwSnap.Delegations, vw.Delegations) {
 		return fmt.Errorf("status still unchanged")
 	}
 	return nil
@@ -784,6 +1002,45 @@ func defaultTestValidator(pubKeys []bls.SerializedPublicKey) staking.Validator {
 		Description:          desc,
 		CreationHeight:       big.NewInt(creationHeight),
 	}
+}
+
+func generateValidatorWrapper(delData []testDelegation) *staking.ValidatorWrapper {
+	pubKeys := []bls.SerializedPublicKey{offPub}
+	v := defaultTestValidator(pubKeys)
+	ds := generateDelegations(delData)
+
+	return &staking.ValidatorWrapper{
+		Validator:   v,
+		Delegations: ds,
+	}
+}
+
+func generateDelegations(delData []testDelegation) staking.Delegations {
+	delegations := make(staking.Delegations, len(delData))
+	for i, del := range delData {
+		delegations[i] = makeDelegation(makeTestAddress(del.address), new(big.Int).Set(del.amount))
+
+		if del.historyUndel != nil {
+			delegations[i].Undelegations = append(
+				delegations[i].Undelegations,
+				staking.Undelegation{
+					Amount: new(big.Int).Set(del.historyUndel),
+					Epoch:  big.NewInt(doubleSignEpoch - 1),
+				},
+			)
+		}
+		if del.afterSignUndel != nil {
+			delegations[i].Undelegations = append(
+				delegations[i].Undelegations,
+				staking.Undelegation{
+					Amount: new(big.Int).Set(del.afterSignUndel),
+					Epoch:  big.NewInt(doubleSignEpoch + 1),
+				},
+			)
+		}
+	}
+
+	return delegations
 }
 
 func defaultTestDelegations() staking.Delegations {


### PR DESCRIPTION
## Issue

Rewrite slashing rates according to this issue:  https://github.com/harmony-one/harmony/issues/405.

The slashing rate calculation is thoroughly unit tested, but any suggestions about higher-level tests are strongly invited! 

## Test

### Unit Test Coverage

Before:

```
=== RUN   TestVerify
--- PASS: TestVerify (0.03s)
=== RUN   TestApplySlashRate
--- PASS: TestApplySlashRate (0.00s)
=== RUN   TestSetDifference
--- PASS: TestSetDifference (0.00s)
=== RUN   TestPayDownAsMuchAsCan
--- PASS: TestPayDownAsMuchAsCan (0.00s)
=== RUN   TestDelegatorSlashApply
--- PASS: TestDelegatorSlashApply (0.00s)
=== RUN   TestApply
--- PASS: TestApply (0.01s)
=== RUN   TestRate
--- PASS: TestRate (0.00s)
PASS
coverage: 86.0% of statements
ok  	github.com/harmony-one/harmony/staking/slash	0.093s	coverage: 86.0% of statements
=== RUN   TestCopyRecord
--- PASS: TestCopyRecord (0.00s)
PASS
coverage: 100.0% of statements
ok  	github.com/harmony-one/harmony/staking/slash/test	0.048s	coverage: 100.0% of statements
```

After:

```
=== RUN   TestVerify
--- PASS: TestVerify (0.04s)
=== RUN   TestApplySlashRate
--- PASS: TestApplySlashRate (0.00s)
=== RUN   TestSetDifference
--- PASS: TestSetDifference (0.00s)
=== RUN   TestPayDownAsMuchAsCan
--- PASS: TestPayDownAsMuchAsCan (0.00s)
=== RUN   TestApplySlashingToDelegator
--- PASS: TestApplySlashingToDelegator (0.00s)
=== RUN   TestDelegatorSlashApply
--- PASS: TestDelegatorSlashApply (0.00s)
=== RUN   TestApply
--- PASS: TestApply (0.01s)
PASS
coverage: 84.8% of statements
ok  	github.com/harmony-one/harmony/staking/slash	0.098s	coverage: 84.8% of statements
=== RUN   TestCopyRecord
--- PASS: TestCopyRecord (0.00s)
PASS
coverage: 100.0% of statements
ok  	github.com/harmony-one/harmony/staking/slash/test	0.084s	coverage: 100.0% of statements
```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**
   No, since slashing is disabled for now.

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** 

    No, since slashing is disabled for now.

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?** 

     No