### PR TITLE
Change beneficiary of slashing rewards to be the block leader

### DIFF
--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -477,6 +477,9 @@ func applySlashes(
 		return false
 	})
 
+	// The Leader of the block gets all slashing rewards.
+	slashRewardBeneficiary := header.Coinbase()
+
 	// Do the slashing by groups in the sorted order
 	for _, key := range sortedKeys {
 		records := groupedRecords[key]
@@ -510,6 +513,7 @@ func applySlashes(
 			state,
 			records,
 			rate,
+			slashRewardBeneficiary,
 		); err != nil {
 			return errors.New("[Finalize] could not apply slash")
 		}

--- a/staking/slash/double-sign.go
+++ b/staking/slash/double-sign.go
@@ -88,8 +88,8 @@ type Record struct {
 
 // Application tracks the slash application to state
 type Application struct {
-	TotalSlashed      *big.Int `json:"total-slashed"`
-	TotalSnitchReward *big.Int `json:"total-snitch-reward"`
+	TotalSlashed           *big.Int `json:"total-slashed"`
+	TotalBeneficiaryReward *big.Int `json:"total-beneficiary-reward"`
 }
 
 func (a *Application) String() string {
@@ -366,7 +366,7 @@ func delegatorSlashApply(
 	snapshot, current *staking.ValidatorWrapper,
 	rate numeric.Dec,
 	state *state.DB,
-	reporter common.Address,
+	rewardBeneficiary common.Address,
 	doubleSignEpoch *big.Int,
 	slashTrack *Application,
 ) error {
@@ -440,19 +440,19 @@ func delegatorSlashApply(
 					}
 				}
 
-				// NOTE only need to pay snitch here,
+				// NOTE only need to pay beneficiary here,
 				// they only get half of what was actually dispersed
 				halfOfSlashDebt := new(big.Int).Div(slashDiff.TotalSlashed, common.Big2)
-				slashDiff.TotalSnitchReward.Add(slashDiff.TotalSnitchReward, halfOfSlashDebt)
+				slashDiff.TotalBeneficiaryReward.Add(slashDiff.TotalBeneficiaryReward, halfOfSlashDebt)
 				utils.Logger().Info().
 					RawJSON("delegation-snapshot", []byte(delegationSnapshot.String())).
 					RawJSON("delegation-current", []byte(delegationNow.String())).
-					Uint64("reporter-reward", halfOfSlashDebt.Uint64()).
+					Uint64("beneficiary-reward", halfOfSlashDebt.Uint64()).
 					RawJSON("application", []byte(slashDiff.String())).
 					Msg("completed an application of slashing")
-				state.AddBalance(reporter, halfOfSlashDebt)
-				slashTrack.TotalSnitchReward.Add(
-					slashTrack.TotalSnitchReward, slashDiff.TotalSnitchReward,
+				state.AddBalance(rewardBeneficiary, halfOfSlashDebt)
+				slashTrack.TotalBeneficiaryReward.Add(
+					slashTrack.TotalBeneficiaryReward, slashDiff.TotalBeneficiaryReward,
 				)
 				slashTrack.TotalSlashed.Add(
 					slashTrack.TotalSlashed, slashDiff.TotalSlashed,
@@ -476,7 +476,7 @@ func delegatorSlashApply(
 // Apply ..
 func Apply(
 	chain staking.ValidatorSnapshotReader, state *state.DB,
-	slashes Records, rate numeric.Dec,
+	slashes Records, rate numeric.Dec, rewardBeneficiary common.Address,
 ) (*Application, error) {
 	slashDiff := &Application{big.NewInt(0), big.NewInt(0)}
 	for _, slash := range slashes {
@@ -503,7 +503,7 @@ func Apply(
 		// Bottom line: everyone will be slashed under the same rule.
 		if err := delegatorSlashApply(
 			snapshot.Validator, current, rate, state,
-			slash.Reporter, slash.Evidence.Epoch, slashDiff,
+			rewardBeneficiary, slash.Evidence.Epoch, slashDiff,
 		); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Issue
https://github.com/harmony-one/harmony/issues/4060

## Test

### Unit Test Coverage

Before:

```
=== RUN   TestVerify
--- PASS: TestVerify (0.03s)
=== RUN   TestApplySlashRate
--- PASS: TestApplySlashRate (0.00s)
=== RUN   TestSetDifference
--- PASS: TestSetDifference (0.00s)
=== RUN   TestPayDownAsMuchAsCan
--- PASS: TestPayDownAsMuchAsCan (0.00s)
=== RUN   TestDelegatorSlashApply
--- PASS: TestDelegatorSlashApply (0.00s)
=== RUN   TestApply
--- PASS: TestApply (0.01s)
=== RUN   TestRate
--- PASS: TestRate (0.00s)
PASS
coverage: 86.0% of statements
ok  	github.com/harmony-one/harmony/staking/slash	0.089s	coverage: 86.0% of statements
=== RUN   TestCopyRecord
--- PASS: TestCopyRecord (0.00s)
PASS
coverage: 100.0% of statements
ok  	github.com/harmony-one/harmony/staking/slash/test	0.045s	coverage: 100.0% of statements
```

After:

```
=== RUN   TestVerify
--- PASS: TestVerify (0.03s)
=== RUN   TestApplySlashRate
--- PASS: TestApplySlashRate (0.00s)
=== RUN   TestSetDifference
--- PASS: TestSetDifference (0.00s)
=== RUN   TestPayDownAsMuchAsCan
--- PASS: TestPayDownAsMuchAsCan (0.00s)
=== RUN   TestDelegatorSlashApply
--- PASS: TestDelegatorSlashApply (0.00s)
=== RUN   TestApply
--- PASS: TestApply (0.01s)
=== RUN   TestRate
--- PASS: TestRate (0.00s)
PASS
coverage: 86.0% of statements
ok  	github.com/harmony-one/harmony/staking/slash	0.099s	coverage: 86.0% of statements
=== RUN   TestCopyRecord
--- PASS: TestCopyRecord (0.00s)
PASS
coverage: 100.0% of statements
ok  	github.com/harmony-one/harmony/staking/slash/test	0.049s	coverage: 100.0% of statements
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**.

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**, since slashing is not enabled yet

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**
    
    **NO**

