### PR TITLE
add rpc getShardState and getShardStateRLPHex by epoch number

### DIFF
--- a/rpc/metrics.go
+++ b/rpc/metrics.go
@@ -28,6 +28,8 @@ const (
 	GetLastCrossLinks        = "GetLastCrossLinks"
 	GetHeaderByNumber        = "GetHeaderByNumber"
 	GetHeaderByNumberRLPHex  = "GetHeaderByNumberRLPHex"
+	GetShardState            = "GetShardState"
+	GetShardStateRLPHex      = "GetShardStateRLPHex"
 	GetProof                 = "GetProof"
 	GetCurrentUtilityMetrics = "GetCurrentUtilityMetrics"
 	GetSuperCommittees       = "GetSuperCommittees"


### PR DESCRIPTION
Added following RPC methods:
1. `hmyv2_getShardState`
    Return shardState for given epoch number.
2. `hmyv2_getShardStateRLPHex`
    Return RLP -> Hex encoded shardState for given epoch number.