### PR TITLE
[rpc] enable publicDebugAPI with config flag

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -161,12 +161,16 @@ func getAPIs(hmy *hmy.Harmony, debugEnable bool, rateLimiterEnable bool, ratelim
 		NewPublicPoolAPI(hmy, Eth),
 		NewPublicStakingAPI(hmy, V1),
 		NewPublicStakingAPI(hmy, V2),
-		NewPublicDebugAPI(hmy, V1),
-		NewPublicDebugAPI(hmy, V2),
 		// Legacy methods (subject to removal)
 		v1.NewPublicLegacyAPI(hmy, "hmy"),
 		eth.NewPublicEthService(hmy, "eth"),
 		v2.NewPublicLegacyAPI(hmy, "hmyv2"),
+	}
+
+	publicDebugAPIs := []rpc.API{
+		//Public debug API
+		NewPublicDebugAPI(hmy, V1),
+		NewPublicDebugAPI(hmy, V2),
 	}
 
 	privateAPIs := []rpc.API{
@@ -175,7 +179,8 @@ func getAPIs(hmy *hmy.Harmony, debugEnable bool, rateLimiterEnable bool, ratelim
 	}
 
 	if debugEnable {
-		return append(publicAPIs, privateAPIs...)
+		apis := append(publicAPIs, publicDebugAPIs...)
+		return append(apis, privateAPIs...)
 	}
 	return publicAPIs
 }


### PR DESCRIPTION
## Issue

#4092

## Test

### Unit Test Coverage
NA

### Test/Run Logs

Previous code would allow the logverbose settings even when the RPCOpt.DebugEnabled is false

now with `RPCOpt.DebugEnabled = false` :
```
curl -H "Content-Type: application/json" -d '{"method":"hmy_setLogVerbosity","params":[5],"id":1}' http://127.0.0.1:9500
{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"the method hmy_setLogVerbosity does not exist/is not available"}}
```
updating config `RPCOpt.DebugEnabled  = true`
````
curl -H "Content-Type: application/json" -d '{"method":"hmy_setLogVerbosity","params":[5],"id":1}' http://127.0.0.1:9500
{"jsonrpc":"2.0","id":1,"result":{"verbosity":"trce"}}
````

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.
NA

3. **Describe how the plan was tested.**
NA
4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**
NA
5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**
NA
6. **What are the planned flag epoch numbers and their ETAs on mainnet?**
NA
    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**
NO
8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

 

9. **Does the existing `node.sh` continue to work with this change?**
NA
10. **What should node operators know about this change?**
None
11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**
NA
## TODO
