### PR TITLE
[consensus] HIP-16: Enforce a 6% max keys per shard limit for each validator

### DIFF
--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -106,7 +106,7 @@ var defaultDevnetConfig = harmonyconfig.DevnetConfig{
 	NumShards:   2,
 	ShardSize:   10,
 	HmyNodeSize: 10,
-	SlotsLimit:  0,
+	SlotsLimit:  0, // 0 means no limit
 }
 
 var defaultRevertConfig = harmonyconfig.RevertConfig{

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -106,6 +106,7 @@ var defaultDevnetConfig = harmonyconfig.DevnetConfig{
 	NumShards:   2,
 	ShardSize:   10,
 	HmyNodeSize: 10,
+	SlotsLimit:  0,
 }
 
 var defaultRevertConfig = harmonyconfig.RevertConfig{

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -485,7 +485,7 @@ func nodeconfigSetShardSchedule(config harmonyconfig.HarmonyConfig) {
 		}
 
 		devnetConfig, err := shardingconfig.NewInstance(
-			uint32(dnConfig.NumShards), dnConfig.ShardSize, dnConfig.HmyNodeSize, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccounts, nil, shardingconfig.VLBPE)
+			uint32(dnConfig.NumShards), dnConfig.ShardSize, dnConfig.HmyNodeSize, dnConfig.SlotsLimit, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccounts, nil, shardingconfig.VLBPE)
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "ERROR invalid devnet sharding config: %s",
 				err)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2568,7 +2568,7 @@ func (bc *BlockChain) UpdateValidatorVotingPower(
 		if snapshot, err := bc.ReadValidatorSnapshotAtEpoch(
 			newEpochSuperCommittee.Epoch, key,
 		); err == nil {
-			spread := snapshot.RawStake()
+			spread := snapshot.RawStakePerSlot()
 			for i := range stats.MetricsPerShard {
 				stats.MetricsPerShard[i].Vote.RawStake = spread
 			}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2568,29 +2568,7 @@ func (bc *BlockChain) UpdateValidatorVotingPower(
 		if snapshot, err := bc.ReadValidatorSnapshotAtEpoch(
 			newEpochSuperCommittee.Epoch, key,
 		); err == nil {
-			wrapper := snapshot.Validator
-			spread := numeric.ZeroDec()
-			if len(wrapper.SlotPubKeys) > 0 {
-				spread = numeric.NewDecFromBigInt(wrapper.TotalDelegation()).
-					QuoInt64(int64(len(wrapper.SlotPubKeys)))
-			}
-			instance := shard.Schedule.InstanceForEpoch(newEpochSuperCommittee.Epoch)
-			limitedSlotsCount := 0 // limited slots count for HIP16
-			slotsLimit := instance.SlotsLimit()
-			if slotsLimit > 0 {
-				shardCount := big.NewInt(int64(instance.NumShards()))
-				shardSlotsCount := make([]int, shardCount.Uint64()) // number slots keys on each shard
-				for _, pubkey := range wrapper.SlotPubKeys {
-					shardIndex := new(big.Int).Mod(pubkey.Big(), shardCount).Uint64()
-					shardSlotsCount[shardIndex] += 1
-					if shardSlotsCount[shardIndex] > slotsLimit {
-						continue
-					}
-					limitedSlotsCount += 1
-				}
-				spread = numeric.NewDecFromBigInt(wrapper.TotalDelegation()).
-					QuoInt64(int64(limitedSlotsCount))
-			}
+			spread := snapshot.RawStake()
 			for i := range stats.MetricsPerShard {
 				stats.MetricsPerShard[i].Vote.RawStake = spread
 			}

--- a/hmy/staking.go
+++ b/hmy/staking.go
@@ -445,7 +445,8 @@ func (hmy *Harmony) GetMedianRawStakeSnapshot() (
 		func() (interface{}, error) {
 			// Compute for next epoch
 			epoch := big.NewInt(0).Add(hmy.CurrentBlock().Epoch(), big.NewInt(1))
-			return committee.NewEPoSRound(epoch, hmy.BlockChain, hmy.BlockChain.Config().IsEPoSBound35(epoch))
+			instance := shard.Schedule.InstanceForEpoch(epoch)
+			return committee.NewEPoSRound(epoch, hmy.BlockChain, hmy.BlockChain.Config().IsEPoSBound35(epoch), instance.SlotsLimit(), int(instance.NumShards()))
 		},
 	)
 	if err != nil {

--- a/hmy/staking.go
+++ b/hmy/staking.go
@@ -46,7 +46,7 @@ func (hmy *Harmony) readAndUpdateRawStakes(
 			if err != nil {
 				continue
 			}
-			spread = snapshot.RawStake()
+			spread = snapshot.RawStakePerSlot()
 			validatorSpreads[slotAddr] = spread
 		}
 

--- a/hmy/staking.go
+++ b/hmy/staking.go
@@ -46,9 +46,7 @@ func (hmy *Harmony) readAndUpdateRawStakes(
 			if err != nil {
 				continue
 			}
-			wrapper := snapshot.Validator
-			spread = numeric.NewDecFromBigInt(wrapper.TotalDelegation()).
-				QuoInt64(int64(len(wrapper.SlotPubKeys)))
+			spread = snapshot.RawStake()
 			validatorSpreads[slotAddr] = spread
 		}
 

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -725,7 +725,8 @@ func readShardState(chain engine.ChainReader, epoch *big.Int, targetShardID uint
 		return shardState, nil
 
 	} else {
-		shardState, err := chain.ReadShardState(epoch)
+		//shardState, err := chain.ReadShardState(epoch)
+		shardState, err := committee.WithStakingEnabled.ReadFromDB(epoch, chain)
 		if err != nil {
 			return nil, errors.Wrapf(err, "read shard state for epoch %v", epoch)
 		}

--- a/internal/configs/harmony/harmony.go
+++ b/internal/configs/harmony/harmony.go
@@ -174,7 +174,7 @@ type DevnetConfig struct {
 	NumShards   int
 	ShardSize   int
 	HmyNodeSize int
-	SlotsLimit  int // HIP-16: Enforce a 6% max keys per shard limit for each validator
+	SlotsLimit  int // HIP-16: The absolute number of maximum effective slots per shard limit for each validator.
 }
 
 // TODO: make `revert` to a separate command

--- a/internal/configs/harmony/harmony.go
+++ b/internal/configs/harmony/harmony.go
@@ -174,7 +174,7 @@ type DevnetConfig struct {
 	NumShards   int
 	ShardSize   int
 	HmyNodeSize int
-	SlotsLimit  int // HIP-16: The absolute number of maximum effective slots per shard limit for each validator.
+	SlotsLimit  int // HIP-16: The absolute number of maximum effective slots per shard limit for each validator. 0 means no limit.
 }
 
 // TODO: make `revert` to a separate command

--- a/internal/configs/harmony/harmony.go
+++ b/internal/configs/harmony/harmony.go
@@ -174,6 +174,7 @@ type DevnetConfig struct {
 	NumShards   int
 	ShardSize   int
 	HmyNodeSize int
+	SlotsLimit  int // HIP-16: Enforce a 6% max keys per shard limit for each validator
 }
 
 // TODO: make `revert` to a separate command

--- a/internal/configs/sharding/instance.go
+++ b/internal/configs/sharding/instance.go
@@ -32,7 +32,7 @@ type instance struct {
 	fnAccounts                      []genesis.DeployAccount
 	reshardingEpoch                 []*big.Int
 	blocksPerEpoch                  uint64
-	slotsLimit                      int // HIP-16: Enforce a 6% max keys per shard limit for each validator
+	slotsLimit                      int // HIP-16: The absolute number of maximum effective slots per shard limit for each validator.
 }
 
 // NewInstance creates and validates a new sharding configuration based

--- a/internal/configs/sharding/instance.go
+++ b/internal/configs/sharding/instance.go
@@ -32,12 +32,13 @@ type instance struct {
 	fnAccounts                      []genesis.DeployAccount
 	reshardingEpoch                 []*big.Int
 	blocksPerEpoch                  uint64
+	slotsLimit                      int // HIP-16: Enforce a 6% max keys per shard limit for each validator
 }
 
 // NewInstance creates and validates a new sharding configuration based
 // upon given parameters.
 func NewInstance(
-	numShards uint32, numNodesPerShard, numHarmonyOperatedNodesPerShard int, harmonyVotePercent numeric.Dec,
+	numShards uint32, numNodesPerShard, numHarmonyOperatedNodesPerShard, slotsLimit int, harmonyVotePercent numeric.Dec,
 	hmyAccounts []genesis.DeployAccount,
 	fnAccounts []genesis.DeployAccount,
 	reshardingEpoch []*big.Int, blocksE uint64,
@@ -82,6 +83,7 @@ func NewInstance(
 		fnAccounts:                      fnAccounts,
 		reshardingEpoch:                 reshardingEpoch,
 		blocksPerEpoch:                  blocksE,
+		slotsLimit:                      slotsLimit,
 	}, nil
 }
 
@@ -90,14 +92,14 @@ func NewInstance(
 // It is intended to be used for static initialization.
 func MustNewInstance(
 	numShards uint32,
-	numNodesPerShard, numHarmonyOperatedNodesPerShard int,
+	numNodesPerShard, numHarmonyOperatedNodesPerShard, slotsLimit int,
 	harmonyVotePercent numeric.Dec,
 	hmyAccounts []genesis.DeployAccount,
 	fnAccounts []genesis.DeployAccount,
 	reshardingEpoch []*big.Int, blocksPerEpoch uint64,
 ) Instance {
 	sc, err := NewInstance(
-		numShards, numNodesPerShard, numHarmonyOperatedNodesPerShard, harmonyVotePercent,
+		numShards, numNodesPerShard, numHarmonyOperatedNodesPerShard, slotsLimit, harmonyVotePercent,
 		hmyAccounts, fnAccounts, reshardingEpoch, blocksPerEpoch,
 	)
 	if err != nil {
@@ -114,6 +116,11 @@ func (sc instance) BlocksPerEpoch() uint64 {
 // NumShards returns the number of shards in the network.
 func (sc instance) NumShards() uint32 {
 	return sc.numShards
+}
+
+// SlotsLimit returns the max slots per shard limit for each validator
+func (sc instance) SlotsLimit() int {
+	return sc.slotsLimit
 }
 
 // HarmonyVotePercent returns total percentage of voting power harmony nodes possess.

--- a/internal/configs/sharding/instance.go
+++ b/internal/configs/sharding/instance.go
@@ -66,6 +66,9 @@ func NewInstance(
 			numNodesPerShard,
 		)
 	}
+	if slotsLimit < 0 {
+		return nil, errors.Errorf("SlotsLimit cannot be negative %d", slotsLimit)
+	}
 	if harmonyVotePercent.LT(numeric.ZeroDec()) ||
 		harmonyVotePercent.GT(numeric.OneDec()) {
 		return nil, errors.Errorf("" +
@@ -92,12 +95,13 @@ func NewInstance(
 // It is intended to be used for static initialization.
 func MustNewInstance(
 	numShards uint32,
-	numNodesPerShard, numHarmonyOperatedNodesPerShard, slotsLimit int,
+	numNodesPerShard, numHarmonyOperatedNodesPerShard int, slotsLimitPercent float32,
 	harmonyVotePercent numeric.Dec,
 	hmyAccounts []genesis.DeployAccount,
 	fnAccounts []genesis.DeployAccount,
 	reshardingEpoch []*big.Int, blocksPerEpoch uint64,
 ) Instance {
+	slotsLimit := int(float32(numNodesPerShard-numHarmonyOperatedNodesPerShard) * slotsLimitPercent)
 	sc, err := NewInstance(
 		numShards, numNodesPerShard, numHarmonyOperatedNodesPerShard, slotsLimit, harmonyVotePercent,
 		hmyAccounts, fnAccounts, reshardingEpoch, blocksPerEpoch,

--- a/internal/configs/sharding/instance.go
+++ b/internal/configs/sharding/instance.go
@@ -32,7 +32,7 @@ type instance struct {
 	fnAccounts                      []genesis.DeployAccount
 	reshardingEpoch                 []*big.Int
 	blocksPerEpoch                  uint64
-	slotsLimit                      int // HIP-16: The absolute number of maximum effective slots per shard limit for each validator.
+	slotsLimit                      int // HIP-16: The absolute number of maximum effective slots per shard limit for each validator. 0 means no limit.
 }
 
 // NewInstance creates and validates a new sharding configuration based

--- a/internal/configs/sharding/localnet.go
+++ b/internal/configs/sharding/localnet.go
@@ -142,9 +142,9 @@ var (
 		big.NewInt(0), big.NewInt(localnetV1Epoch), params.LocalnetChainConfig.StakingEpoch, params.LocalnetChainConfig.TwoSecondsEpoch,
 	}
 	// Number of shards, how many slots on each , how many slots owned by Harmony
-	localnetV0   = MustNewInstance(2, 7, 5, numeric.OneDec(), genesis.LocalHarmonyAccounts, genesis.LocalFnAccounts, localnetReshardingEpoch, LocalnetSchedule.BlocksPerEpochOld())
-	localnetV1   = MustNewInstance(2, 8, 5, numeric.OneDec(), genesis.LocalHarmonyAccountsV1, genesis.LocalFnAccountsV1, localnetReshardingEpoch, LocalnetSchedule.BlocksPerEpochOld())
-	localnetV2   = MustNewInstance(2, 9, 6, numeric.MustNewDecFromStr("0.68"), genesis.LocalHarmonyAccountsV2, genesis.LocalFnAccountsV2, localnetReshardingEpoch, LocalnetSchedule.BlocksPerEpochOld())
-	localnetV3   = MustNewInstance(2, 9, 6, numeric.MustNewDecFromStr("0.68"), genesis.LocalHarmonyAccountsV2, genesis.LocalFnAccountsV2, localnetReshardingEpoch, LocalnetSchedule.BlocksPerEpoch())
-	localnetV3_1 = MustNewInstance(2, 9, 6, numeric.MustNewDecFromStr("0.68"), genesis.LocalHarmonyAccountsV2, genesis.LocalFnAccountsV2, localnetReshardingEpoch, LocalnetSchedule.BlocksPerEpoch())
+	localnetV0   = MustNewInstance(2, 7, 5, 0, numeric.OneDec(), genesis.LocalHarmonyAccounts, genesis.LocalFnAccounts, localnetReshardingEpoch, LocalnetSchedule.BlocksPerEpochOld())
+	localnetV1   = MustNewInstance(2, 8, 5, 0, numeric.OneDec(), genesis.LocalHarmonyAccountsV1, genesis.LocalFnAccountsV1, localnetReshardingEpoch, LocalnetSchedule.BlocksPerEpochOld())
+	localnetV2   = MustNewInstance(2, 9, 6, 0, numeric.MustNewDecFromStr("0.68"), genesis.LocalHarmonyAccountsV2, genesis.LocalFnAccountsV2, localnetReshardingEpoch, LocalnetSchedule.BlocksPerEpochOld())
+	localnetV3   = MustNewInstance(2, 9, 6, 0, numeric.MustNewDecFromStr("0.68"), genesis.LocalHarmonyAccountsV2, genesis.LocalFnAccountsV2, localnetReshardingEpoch, LocalnetSchedule.BlocksPerEpoch())
+	localnetV3_1 = MustNewInstance(2, 9, 6, 0, numeric.MustNewDecFromStr("0.68"), genesis.LocalHarmonyAccountsV2, genesis.LocalFnAccountsV2, localnetReshardingEpoch, LocalnetSchedule.BlocksPerEpoch())
 )

--- a/internal/configs/sharding/mainnet.go
+++ b/internal/configs/sharding/mainnet.go
@@ -53,6 +53,8 @@ type mainnetSchedule struct{}
 
 func (ms mainnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	switch {
+	case params.MainnetChainConfig.IsSlotsLimited(epoch):
+		return mainnetV3_3
 	case params.MainnetChainConfig.IsHIP6And8Epoch(epoch):
 		// Decrease internal voting power from 60% to 49%
 		// Increase external nodes from 800 to 900
@@ -202,21 +204,22 @@ func (ms mainnetSchedule) IsSkippedEpoch(shardID uint32, epoch *big.Int) bool {
 var mainnetReshardingEpoch = []*big.Int{big.NewInt(0), big.NewInt(mainnetV0_1Epoch), big.NewInt(mainnetV0_2Epoch), big.NewInt(mainnetV0_3Epoch), big.NewInt(mainnetV0_4Epoch), big.NewInt(mainnetV1Epoch), big.NewInt(mainnetV1_1Epoch), big.NewInt(mainnetV1_2Epoch), big.NewInt(mainnetV1_3Epoch), big.NewInt(mainnetV1_4Epoch), big.NewInt(mainnetV1_5Epoch), big.NewInt(mainnetV2_0Epoch), big.NewInt(mainnetV2_1Epoch), big.NewInt(mainnetV2_2Epoch), params.MainnetChainConfig.TwoSecondsEpoch, params.MainnetChainConfig.SixtyPercentEpoch, params.MainnetChainConfig.HIP6And8Epoch}
 
 var (
-	mainnetV0   = MustNewInstance(4, 150, 112, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccounts, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
-	mainnetV0_1 = MustNewInstance(4, 152, 112, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_1, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
-	mainnetV0_2 = MustNewInstance(4, 200, 148, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_2, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
-	mainnetV0_3 = MustNewInstance(4, 210, 148, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_3, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
-	mainnetV0_4 = MustNewInstance(4, 216, 148, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_4, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
-	mainnetV1   = MustNewInstance(4, 250, 170, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
-	mainnetV1_1 = MustNewInstance(4, 250, 170, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_1, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
-	mainnetV1_2 = MustNewInstance(4, 250, 170, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_2, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
-	mainnetV1_3 = MustNewInstance(4, 250, 170, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_3, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
-	mainnetV1_4 = MustNewInstance(4, 250, 170, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_4, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
-	mainnetV1_5 = MustNewInstance(4, 250, 170, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
-	mainnetV2_0 = MustNewInstance(4, 250, 170, numeric.MustNewDecFromStr("0.68"), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
-	mainnetV2_1 = MustNewInstance(4, 250, 130, numeric.MustNewDecFromStr("0.68"), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
-	mainnetV2_2 = MustNewInstance(4, 250, 90, numeric.MustNewDecFromStr("0.68"), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
-	mainnetV3   = MustNewInstance(4, 250, 90, numeric.MustNewDecFromStr("0.68"), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
-	mainnetV3_1 = MustNewInstance(4, 250, 50, numeric.MustNewDecFromStr("0.60"), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
-	mainnetV3_2 = MustNewInstance(4, 250, 25, numeric.MustNewDecFromStr("0.49"), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV0   = MustNewInstance(4, 150, 112, 0, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccounts, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
+	mainnetV0_1 = MustNewInstance(4, 152, 112, 0, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_1, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
+	mainnetV0_2 = MustNewInstance(4, 200, 148, 0, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_2, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
+	mainnetV0_3 = MustNewInstance(4, 210, 148, 0, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_3, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
+	mainnetV0_4 = MustNewInstance(4, 216, 148, 0, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV0_4, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
+	mainnetV1   = MustNewInstance(4, 250, 170, 0, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
+	mainnetV1_1 = MustNewInstance(4, 250, 170, 0, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_1, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
+	mainnetV1_2 = MustNewInstance(4, 250, 170, 0, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_2, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
+	mainnetV1_3 = MustNewInstance(4, 250, 170, 0, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_3, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
+	mainnetV1_4 = MustNewInstance(4, 250, 170, 0, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_4, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
+	mainnetV1_5 = MustNewInstance(4, 250, 170, 0, numeric.OneDec(), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
+	mainnetV2_0 = MustNewInstance(4, 250, 170, 0, numeric.MustNewDecFromStr("0.68"), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
+	mainnetV2_1 = MustNewInstance(4, 250, 130, 0, numeric.MustNewDecFromStr("0.68"), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
+	mainnetV2_2 = MustNewInstance(4, 250, 90, 0, numeric.MustNewDecFromStr("0.68"), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpochOld())
+	mainnetV3   = MustNewInstance(4, 250, 90, 0, numeric.MustNewDecFromStr("0.68"), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV3_1 = MustNewInstance(4, 250, 50, 0, numeric.MustNewDecFromStr("0.60"), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV3_2 = MustNewInstance(4, 250, 25, 0, numeric.MustNewDecFromStr("0.49"), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV3_3 = MustNewInstance(4, 250, 25, 250*6/100, numeric.MustNewDecFromStr("0.49"), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
 )

--- a/internal/configs/sharding/mainnet.go
+++ b/internal/configs/sharding/mainnet.go
@@ -221,5 +221,5 @@ var (
 	mainnetV3   = MustNewInstance(4, 250, 90, 0, numeric.MustNewDecFromStr("0.68"), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
 	mainnetV3_1 = MustNewInstance(4, 250, 50, 0, numeric.MustNewDecFromStr("0.60"), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
 	mainnetV3_2 = MustNewInstance(4, 250, 25, 0, numeric.MustNewDecFromStr("0.49"), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
-	mainnetV3_3 = MustNewInstance(4, 250, 25, 250*6/100, numeric.MustNewDecFromStr("0.49"), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
+	mainnetV3_3 = MustNewInstance(4, 250, 25, 0.06, numeric.MustNewDecFromStr("0.49"), genesis.HarmonyAccounts, genesis.FoundationalNodeAccountsV1_5, mainnetReshardingEpoch, MainnetSchedule.BlocksPerEpoch())
 )

--- a/internal/configs/sharding/pangaea.go
+++ b/internal/configs/sharding/pangaea.go
@@ -75,5 +75,5 @@ var pangaeaReshardingEpoch = []*big.Int{
 	params.PangaeaChainConfig.StakingEpoch,
 }
 
-var pangaeaV0 = MustNewInstance(4, 30, 30, numeric.OneDec(), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, pangaeaReshardingEpoch, PangaeaSchedule.BlocksPerEpoch())
-var pangaeaV1 = MustNewInstance(4, 110, 30, numeric.MustNewDecFromStr("0.68"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, pangaeaReshardingEpoch, PangaeaSchedule.BlocksPerEpoch())
+var pangaeaV0 = MustNewInstance(4, 30, 30, 0, numeric.OneDec(), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, pangaeaReshardingEpoch, PangaeaSchedule.BlocksPerEpoch())
+var pangaeaV1 = MustNewInstance(4, 110, 30, 0, numeric.MustNewDecFromStr("0.68"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, pangaeaReshardingEpoch, PangaeaSchedule.BlocksPerEpoch())

--- a/internal/configs/sharding/partner.go
+++ b/internal/configs/sharding/partner.go
@@ -76,5 +76,5 @@ var partnerReshardingEpoch = []*big.Int{
 	params.PartnerChainConfig.StakingEpoch,
 }
 
-var partnerV0 = MustNewInstance(2, 5, 5, numeric.OneDec(), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, partnerReshardingEpoch, PartnerSchedule.BlocksPerEpoch())
-var partnerV1 = MustNewInstance(2, 5, 4, numeric.MustNewDecFromStr("0.9"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, partnerReshardingEpoch, PartnerSchedule.BlocksPerEpoch())
+var partnerV0 = MustNewInstance(2, 5, 5, 0, numeric.OneDec(), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, partnerReshardingEpoch, PartnerSchedule.BlocksPerEpoch())
+var partnerV1 = MustNewInstance(2, 5, 4, 0, numeric.MustNewDecFromStr("0.9"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, partnerReshardingEpoch, PartnerSchedule.BlocksPerEpoch())

--- a/internal/configs/sharding/shardingconfig.go
+++ b/internal/configs/sharding/shardingconfig.go
@@ -72,7 +72,7 @@ type Instance interface {
 
 	// Count of blocks per epoch
 	BlocksPerEpoch() uint64
-	// HIP-16: The absolute number of maximum effective slots per shard limit for each validator.
+	// HIP-16: The absolute number of maximum effective slots per shard limit for each validator. 0 means no limit.
 	SlotsLimit() int
 }
 

--- a/internal/configs/sharding/shardingconfig.go
+++ b/internal/configs/sharding/shardingconfig.go
@@ -72,6 +72,8 @@ type Instance interface {
 
 	// Count of blocks per epoch
 	BlocksPerEpoch() uint64
+	// HIP-16: Enforce a 6% max keys per shard limit for each validator
+	SlotsLimit() int
 }
 
 // genShardingStructure return sharding structure, given shard number and its patterns.

--- a/internal/configs/sharding/shardingconfig.go
+++ b/internal/configs/sharding/shardingconfig.go
@@ -72,7 +72,7 @@ type Instance interface {
 
 	// Count of blocks per epoch
 	BlocksPerEpoch() uint64
-	// HIP-16: Enforce a 6% max keys per shard limit for each validator
+	// HIP-16: The absolute number of maximum effective slots per shard limit for each validator.
 	SlotsLimit() int
 }
 

--- a/internal/configs/sharding/stress.go
+++ b/internal/configs/sharding/stress.go
@@ -78,6 +78,6 @@ var stressnetReshardingEpoch = []*big.Int{
 	params.StressnetChainConfig.StakingEpoch,
 }
 
-var stressnetV0 = MustNewInstance(2, 10, 10, numeric.OneDec(), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, stressnetReshardingEpoch, StressNetSchedule.BlocksPerEpoch())
-var stressnetV1 = MustNewInstance(2, 30, 10, numeric.MustNewDecFromStr("0.9"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, stressnetReshardingEpoch, StressNetSchedule.BlocksPerEpoch())
-var stressnetV2 = MustNewInstance(2, 30, 10, numeric.MustNewDecFromStr("0.6"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, stressnetReshardingEpoch, StressNetSchedule.BlocksPerEpoch())
+var stressnetV0 = MustNewInstance(2, 10, 10, 0, numeric.OneDec(), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, stressnetReshardingEpoch, StressNetSchedule.BlocksPerEpoch())
+var stressnetV1 = MustNewInstance(2, 30, 10, 0, numeric.MustNewDecFromStr("0.9"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, stressnetReshardingEpoch, StressNetSchedule.BlocksPerEpoch())
+var stressnetV2 = MustNewInstance(2, 30, 10, 0, numeric.MustNewDecFromStr("0.6"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, stressnetReshardingEpoch, StressNetSchedule.BlocksPerEpoch())

--- a/internal/configs/sharding/testnet.go
+++ b/internal/configs/sharding/testnet.go
@@ -121,4 +121,4 @@ var testnetV1 = MustNewInstance(4, 20, 15, 0, numeric.MustNewDecFromStr("0.90"),
 var testnetV2 = MustNewInstance(4, 30, 8, 0, numeric.MustNewDecFromStr("0.90"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpochOld())
 var testnetV3 = MustNewInstance(4, 30, 8, 0, numeric.MustNewDecFromStr("0.90"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())
 var testnetV3_1 = MustNewInstance(4, 30, 8, 0, numeric.MustNewDecFromStr("0.60"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())
-var testnetV3_2 = MustNewInstance(4, 30, 8, 30*6/100, numeric.MustNewDecFromStr("0.60"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())
+var testnetV3_2 = MustNewInstance(4, 30, 8, 0.06, numeric.MustNewDecFromStr("0.60"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())

--- a/internal/configs/sharding/testnet.go
+++ b/internal/configs/sharding/testnet.go
@@ -33,6 +33,8 @@ const (
 
 func (ts testnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	switch {
+	case params.TestnetChainConfig.IsSlotsLimited(epoch):
+		return testnetV3_2
 	case params.TestnetChainConfig.IsSixtyPercent(epoch):
 		return testnetV3_1
 	case params.TestnetChainConfig.IsTwoSeconds(epoch):
@@ -114,8 +116,9 @@ var testnetReshardingEpoch = []*big.Int{
 	params.TestnetChainConfig.TwoSecondsEpoch,
 }
 
-var testnetV0 = MustNewInstance(4, 16, 15, numeric.OneDec(), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpochOld())
-var testnetV1 = MustNewInstance(4, 20, 15, numeric.MustNewDecFromStr("0.90"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpochOld())
-var testnetV2 = MustNewInstance(4, 30, 8, numeric.MustNewDecFromStr("0.90"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpochOld())
-var testnetV3 = MustNewInstance(4, 30, 8, numeric.MustNewDecFromStr("0.90"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())
-var testnetV3_1 = MustNewInstance(4, 30, 8, numeric.MustNewDecFromStr("0.60"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())
+var testnetV0 = MustNewInstance(4, 16, 15, 0, numeric.OneDec(), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpochOld())
+var testnetV1 = MustNewInstance(4, 20, 15, 0, numeric.MustNewDecFromStr("0.90"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpochOld())
+var testnetV2 = MustNewInstance(4, 30, 8, 0, numeric.MustNewDecFromStr("0.90"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpochOld())
+var testnetV3 = MustNewInstance(4, 30, 8, 0, numeric.MustNewDecFromStr("0.90"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())
+var testnetV3_1 = MustNewInstance(4, 30, 8, 0, numeric.MustNewDecFromStr("0.60"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())
+var testnetV3_2 = MustNewInstance(4, 30, 8, 30*6/100, numeric.MustNewDecFromStr("0.60"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())

--- a/internal/configs/sharding/testnet.go
+++ b/internal/configs/sharding/testnet.go
@@ -121,4 +121,4 @@ var testnetV1 = MustNewInstance(4, 20, 15, 0, numeric.MustNewDecFromStr("0.90"),
 var testnetV2 = MustNewInstance(4, 30, 8, 0, numeric.MustNewDecFromStr("0.90"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpochOld())
 var testnetV3 = MustNewInstance(4, 30, 8, 0, numeric.MustNewDecFromStr("0.90"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())
 var testnetV3_1 = MustNewInstance(4, 30, 8, 0, numeric.MustNewDecFromStr("0.60"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())
-var testnetV3_2 = MustNewInstance(4, 30, 8, 0.06, numeric.MustNewDecFromStr("0.60"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())
+var testnetV3_2 = MustNewInstance(4, 30, 8, 0.15, numeric.MustNewDecFromStr("0.60"), genesis.TNHarmonyAccounts, genesis.TNFoundationalAccounts, testnetReshardingEpoch, TestnetSchedule.BlocksPerEpoch())

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -65,6 +65,7 @@ var (
 		SHA3Epoch:                  big.NewInt(725), // Around Mon Oct 11 2021, 19:00 UTC
 		HIP6And8Epoch:              big.NewInt(725), // Around Mon Oct 11 2021, 19:00 UTC
 		StakingPrecompileEpoch:     big.NewInt(871), // Around Tue Feb 11 2022
+		SlotsLimitedEpoch:          EpochTBD,        // epoch to enable HIP-16
 	}
 
 	// TestnetChainConfig contains the chain parameters to run a node on the harmony test network.
@@ -98,6 +99,7 @@ var (
 		SHA3Epoch:                  big.NewInt(74570),
 		HIP6And8Epoch:              big.NewInt(74570),
 		StakingPrecompileEpoch:     big.NewInt(75175),
+		SlotsLimitedEpoch:          EpochTBD, // epoch to enable HIP-16
 	}
 
 	// PangaeaChainConfig contains the chain parameters for the Pangaea network.
@@ -132,6 +134,7 @@ var (
 		SHA3Epoch:                  big.NewInt(0),
 		HIP6And8Epoch:              big.NewInt(0),
 		StakingPrecompileEpoch:     big.NewInt(2), // same as staking
+		SlotsLimitedEpoch:          EpochTBD,      // epoch to enable HIP-16
 	}
 
 	// PartnerChainConfig contains the chain parameters for the Partner network.
@@ -166,6 +169,7 @@ var (
 		SHA3Epoch:                  big.NewInt(0),
 		HIP6And8Epoch:              big.NewInt(0),
 		StakingPrecompileEpoch:     big.NewInt(2),
+		SlotsLimitedEpoch:          EpochTBD, // epoch to enable HIP-16
 	}
 
 	// StressnetChainConfig contains the chain parameters for the Stress test network.
@@ -200,6 +204,7 @@ var (
 		SHA3Epoch:                  big.NewInt(0),
 		HIP6And8Epoch:              big.NewInt(0),
 		StakingPrecompileEpoch:     big.NewInt(2),
+		SlotsLimitedEpoch:          EpochTBD, // epoch to enable HIP-16
 	}
 
 	// LocalnetChainConfig contains the chain parameters to run for local development.
@@ -233,6 +238,7 @@ var (
 		SHA3Epoch:                  big.NewInt(0),
 		HIP6And8Epoch:              EpochTBD, // Never enable it for localnet as localnet has no external validator setup
 		StakingPrecompileEpoch:     big.NewInt(2),
+		SlotsLimitedEpoch:          EpochTBD, // epoch to enable HIP-16
 	}
 
 	// AllProtocolChanges ...
@@ -268,6 +274,7 @@ var (
 		big.NewInt(0),                      // SHA3Epoch
 		big.NewInt(0),                      // HIP6And8Epoch
 		big.NewInt(0),                      // StakingPrecompileEpoch
+		big.NewInt(0),                      // SlotsLimitedEpoch
 	}
 
 	// TestChainConfig ...
@@ -303,6 +310,7 @@ var (
 		big.NewInt(0),        // SHA3Epoch
 		big.NewInt(0),        // HIP6And8Epoch
 		big.NewInt(0),        // StakingPrecompileEpoch
+		big.NewInt(0),        // SlotsLimitedEpoch
 	}
 
 	// TestRules ...
@@ -420,6 +428,9 @@ type ChainConfig struct {
 
 	// StakingPrecompileEpoch is the first epoch to support the staking precompiles
 	StakingPrecompileEpoch *big.Int `json:"staking-precompile-epoch,omitempty"`
+
+	// SlotsLimitedEpoch is the first epoch to enable HIP-16.
+	SlotsLimitedEpoch *big.Int `json:"slots-limit,omitempty"`
 }
 
 // String implements the fmt.Stringer interface.
@@ -475,6 +486,11 @@ func (c *ChainConfig) IsAggregatedRewardEpoch(epoch *big.Int) bool {
 // IsStaking determines whether it is staking epoch
 func (c *ChainConfig) IsStaking(epoch *big.Int) bool {
 	return isForked(c.StakingEpoch, epoch)
+}
+
+// IsSlotsLimited determines whether HIP-16 is enabled
+func (c *ChainConfig) IsSlotsLimited(epoch *big.Int) bool {
+	return isForked(c.SlotsLimitedEpoch, epoch)
 }
 
 // IsFiveSeconds determines whether it is the epoch to change to 5 seconds block time

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -99,7 +99,7 @@ var (
 		SHA3Epoch:                  big.NewInt(74570),
 		HIP6And8Epoch:              big.NewInt(74570),
 		StakingPrecompileEpoch:     big.NewInt(75175),
-		SlotsLimitedEpoch:          big.NewInt(75731), // epoch to enable HIP-16, around Wed, 11 May 2022 06:03:51 UTC with 2s block time
+		SlotsLimitedEpoch:          big.NewInt(75737), // epoch to enable HIP-16, around Thu, 12 May 2022 09:25:35 UTC with 2s block time
 	}
 
 	// PangaeaChainConfig contains the chain parameters for the Pangaea network.

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -99,7 +99,7 @@ var (
 		SHA3Epoch:                  big.NewInt(74570),
 		HIP6And8Epoch:              big.NewInt(74570),
 		StakingPrecompileEpoch:     big.NewInt(75175),
-		SlotsLimitedEpoch:          EpochTBD, // epoch to enable HIP-16
+		SlotsLimitedEpoch:          big.NewInt(75563), // epoch to enable HIP-16, around Sat Apr 8th 2022, 07:28 UTC with 2s block time
 	}
 
 	// PangaeaChainConfig contains the chain parameters for the Pangaea network.

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -430,7 +430,7 @@ type ChainConfig struct {
 	StakingPrecompileEpoch *big.Int `json:"staking-precompile-epoch,omitempty"`
 
 	// SlotsLimitedEpoch is the first epoch to enable HIP-16.
-	SlotsLimitedEpoch *big.Int `json:"slots-limit,omitempty"`
+	SlotsLimitedEpoch *big.Int `json:"slots-limit-epoch,omitempty"`
 }
 
 // String implements the fmt.Stringer interface.

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -99,7 +99,7 @@ var (
 		SHA3Epoch:                  big.NewInt(74570),
 		HIP6And8Epoch:              big.NewInt(74570),
 		StakingPrecompileEpoch:     big.NewInt(75175),
-		SlotsLimitedEpoch:          EpochTBD, // epoch to enable HIP-16, around Sat Apr 8th 2022, 07:28 UTC with 2s block time
+		SlotsLimitedEpoch:          big.NewInt(75731), // epoch to enable HIP-16, around Wed, 11 May 2022 06:03:51 UTC with 2s block time
 	}
 
 	// PangaeaChainConfig contains the chain parameters for the Pangaea network.

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -99,7 +99,7 @@ var (
 		SHA3Epoch:                  big.NewInt(74570),
 		HIP6And8Epoch:              big.NewInt(74570),
 		StakingPrecompileEpoch:     big.NewInt(75175),
-		SlotsLimitedEpoch:          big.NewInt(75737), // epoch to enable HIP-16, around Thu, 12 May 2022 09:25:35 UTC with 2s block time
+		SlotsLimitedEpoch:          big.NewInt(75684), // epoch to enable HIP-16, around Mon, 02 May 2022 08:18:45 UTC with 2s block time
 	}
 
 	// PangaeaChainConfig contains the chain parameters for the Pangaea network.

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -99,7 +99,7 @@ var (
 		SHA3Epoch:                  big.NewInt(74570),
 		HIP6And8Epoch:              big.NewInt(74570),
 		StakingPrecompileEpoch:     big.NewInt(75175),
-		SlotsLimitedEpoch:          big.NewInt(75563), // epoch to enable HIP-16, around Sat Apr 8th 2022, 07:28 UTC with 2s block time
+		SlotsLimitedEpoch:          EpochTBD, // epoch to enable HIP-16, around Sat Apr 8th 2022, 07:28 UTC with 2s block time
 	}
 
 	// PangaeaChainConfig contains the chain parameters for the Pangaea network.

--- a/shard/committee/assignment.go
+++ b/shard/committee/assignment.go
@@ -85,7 +85,7 @@ func (p CandidateOrder) MarshalJSON() ([]byte, error) {
 
 // NewEPoSRound runs a fresh computation of EPoS using
 // latest data always
-func NewEPoSRound(epoch *big.Int, stakedReader StakingCandidatesReader, isExtendedBound bool) (
+func NewEPoSRound(epoch *big.Int, stakedReader StakingCandidatesReader, isExtendedBound bool, slotsLimit, shardCount int) (
 	*CompletedEPoSRound, error,
 ) {
 	eligibleCandidate, err := prepareOrders(stakedReader)
@@ -96,7 +96,7 @@ func NewEPoSRound(epoch *big.Int, stakedReader StakingCandidatesReader, isExtend
 		epoch,
 	)
 	median, winners := effective.Apply(
-		eligibleCandidate, maxExternalSlots, isExtendedBound,
+		eligibleCandidate, maxExternalSlots, isExtendedBound, slotsLimit, shardCount,
 	)
 	auctionCandidates := make([]*CandidateOrder, len(eligibleCandidate))
 
@@ -353,7 +353,7 @@ func eposStakedCommittee(
 	}
 
 	// TODO(audit): make sure external validator BLS key are also not duplicate to Harmony's keys
-	completedEPoSRound, err := NewEPoSRound(epoch, stakerReader, stakerReader.Config().IsEPoSBound35(epoch))
+	completedEPoSRound, err := NewEPoSRound(epoch, stakerReader, stakerReader.Config().IsEPoSBound35(epoch), s.SlotsLimit(), shardCount)
 
 	if err != nil {
 		return nil, err

--- a/staking/effective/calculate.go
+++ b/staking/effective/calculate.go
@@ -127,13 +127,15 @@ func Compute(
 			}
 			shard := new(big.Int).Mod(slot.Key.Big(), big.NewInt(int64(shardCount))).Int64()
 			shardSlotsCount[int(shard)]++
+			// skip if count of slots in this shard exceeds the limit
 			if slotsLimit > 0 && shardSlotsCount[int(shard)] > slotsLimit {
 				continue
 			}
 			eposedSlots = append(eposedSlots, slot)
 		}
-		if effectiveSlotsCount := len(eposedSlots) - startIndex; effectiveSlotsCount != slotsCount {
-			effectiveSpread := numeric.NewDecFromBigInt(staker.slot.Stake).QuoInt64(int64(effectiveSlotsCount))
+		// recalculate the effectiveSpread if slots exceed the limit
+		if limitedSlotsCount := len(eposedSlots) - startIndex; limitedSlotsCount != slotsCount {
+			effectiveSpread := numeric.NewDecFromBigInt(staker.slot.Stake).QuoInt64(int64(limitedSlotsCount))
 			for _, slot := range eposedSlots[startIndex:] {
 				slot.RawStake = effectiveSpread
 				slot.EPoSStake = effectiveSpread

--- a/staking/effective/calculate.go
+++ b/staking/effective/calculate.go
@@ -114,6 +114,7 @@ func Compute(
 			continue
 		}
 		shardSlotsCount := make([]int, shardCount)
+		// may changed spread later
 		spread := numeric.NewDecFromBigInt(staker.slot.Stake).
 			QuoInt64(int64(slotsCount))
 		startIndex := len(eposedSlots)
@@ -136,10 +137,12 @@ func Compute(
 		// recalculate the effectiveSpread if slots exceed the limit
 		if limitedSlotsCount := len(eposedSlots) - startIndex; limitedSlotsCount != slotsCount {
 			effectiveSpread := numeric.NewDecFromBigInt(staker.slot.Stake).QuoInt64(int64(limitedSlotsCount))
-			for _, slot := range eposedSlots[startIndex:] {
-				slot.RawStake = effectiveSpread
-				slot.EPoSStake = effectiveSpread
-			}
+			// spread is wrapped pointer of big.Int, when we set it's value, releated slot.RawStake and slot.EPoSStake will also 'changed'
+			spread.Int.Set(effectiveSpread.Int)
+			//for _, slot := range eposedSlots[startIndex:] {
+			//	slot.RawStake = effectiveSpread
+			//	slot.EPoSStake = effectiveSpread
+			//}
 		}
 	}
 

--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -387,10 +387,12 @@ func (w *ValidatorWrapper) SanityCheck() error {
 	return nil
 }
 
-func (snapshot *ValidatorSnapshot) RawStake() numeric.Dec {
+// RawStakePerSlot return raw stake of each slot key. If HIP16 was activated at that apoch, it only calculate raw stake for keys not exceed the slotsLimit.
+func (snapshot ValidatorSnapshot) RawStakePerSlot() numeric.Dec {
 	wrapper := snapshot.Validator
 	instance := shard.Schedule.InstanceForEpoch(snapshot.Epoch)
 	slotsLimit := instance.SlotsLimit()
+	// HIP16 is acatived
 	if slotsLimit > 0 {
 		limitedSlotsCount := 0 // limited slots count for HIP16
 		shardCount := big.NewInt(int64(instance.NumShards()))


### PR DESCRIPTION
## Issue
#4045 
the rules of #4045 only applied to external validators. 

## Test

Localnet: SUCCESS https://github.com/harmony-one/harmony/pull/4100#issuecomment-1107415219

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**.

    **YES, the on-disk data structure is not modified, but the consensus algorithm is affected.**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.
     1. Pass the test in the testnet.
     2. Make sure all nodes contain this pr before HIP-16 epoch is reached.

3. **Describe how the plan was tested.**
There are two main tests, one is that before HIP16-Epoch, upgraded nodes can work properly with the nodes that are not upgraded. The other is that all upgraded nodes can work properly after HIP16-Epoch.
     1. Assume that the maximum number of effective slots for each validator on the same shard is 15.
     2. **Test1:** Before HIP16-Epoch, assign more than 15 slots keys to a shard for an external validator.  Make sure all slots are elected.
     3.  Upgrade a node to include this pr.
     **Test2:** Confirm node is able to to synchronize and produce BINGO. Test at least 2 epochs before HIP16-Epoch.
     4. Then upgrade all nodes to include this pr before HIP16-Epoch.
     **Test3:** When reaching HIP16-Epoch, confirm the slots elected for the validator must be reduced to 15 (exceeded keys should have an effective stake of 0). All nodes must be synchronized properly. test at least 2 epochs after HIP16-Epoch.
     **Test4:** try to add more keys to the validators, should have error message

7. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**
     **\>= 3 epochs**

8. **What should node operators know about this planned change?**
     ** All nodes must contain this pr before HIP-16 epoch is reached, otherwise, hard forks may occur when HIP-16 epoch is reached.**

9. **Does the existing `node.sh` continue to work with this change?**
    **no impact on this feature.**

10. **What should node operators know about this change?**
    **Avoid assigning more than 15(=250*6% Mainnet) slots BLS keys to the same shard. The slots beyond that will not participate in the election.**

12. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**
    ** NO **

