### PR TITLE
Change beneficiary to reporter in slash.Record marshal

### DIFF
--- a/staking/slash/double-sign.go
+++ b/staking/slash/double-sign.go
@@ -130,7 +130,7 @@ func (r Record) MarshalJSON() ([]byte, error) {
 		common2.MustAddressToBech32(r.Evidence.Offender)
 	return json.Marshal(struct {
 		Evidence         Evidence `json:"evidence"`
-		Beneficiary      string   `json:"beneficiary"`
+		Reporter         string   `json:"reporter"`
 		AddressForBLSKey string   `json:"offender"`
 	}{r.Evidence, reporter, offender})
 }


### PR DESCRIPTION
Following #4081, the `slash.Record` struct is not changed in any way, thus its marshal function shouldn't be changed either. 

Slashing is not enabled at the moment, so this change doesn't lead to any protocol changes.