### PR TITLE
Fix rpc delegation method.

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2640,10 +2640,9 @@ func (bc *BlockChain) UpdateValidatorSnapshots(
 // ReadValidatorList reads the addresses of current all validators
 func (bc *BlockChain) ReadValidatorList() ([]common.Address, error) {
 	if cached, ok := bc.validatorListCache.Get("validatorList"); ok {
-		by := cached.([]byte)
-		m := []common.Address{}
-		if err := rlp.DecodeBytes(by, &m); err != nil {
-			return nil, err
+		m, ok := cached.([]common.Address)
+		if !ok {
+			return nil, errors.New("failed to get validator list")
 		}
 		return m, nil
 	}
@@ -2658,10 +2657,7 @@ func (bc *BlockChain) WriteValidatorList(
 	if err := rawdb.WriteValidatorList(db, addrs); err != nil {
 		return err
 	}
-	bytes, err := rlp.EncodeToBytes(addrs)
-	if err == nil {
-		bc.validatorListCache.Add("validatorList", bytes)
-	}
+	bc.validatorListCache.Add("validatorList", addrs)
 	return nil
 }
 

--- a/hmy/staking.go
+++ b/hmy/staking.go
@@ -453,31 +453,23 @@ func (hmy *Harmony) GetMedianRawStakeSnapshot() (
 }
 
 // GetDelegationsByValidator returns all delegation information of a validator
-func (hmy *Harmony) GetDelegationsByValidator(validator common.Address) []*staking.Delegation {
+func (hmy *Harmony) GetDelegationsByValidator(validator common.Address) []staking.Delegation {
 	wrapper, err := hmy.BlockChain.ReadValidatorInformation(validator)
 	if err != nil || wrapper == nil {
 		return nil
 	}
-	delegations := []*staking.Delegation{}
-	for i := range wrapper.Delegations {
-		delegations = append(delegations, &wrapper.Delegations[i])
-	}
-	return delegations
+	return wrapper.Delegations
 }
 
 // GetDelegationsByValidatorAtBlock returns all delegation information of a validator at the given block
 func (hmy *Harmony) GetDelegationsByValidatorAtBlock(
 	validator common.Address, block *types.Block,
-) []*staking.Delegation {
+) []staking.Delegation {
 	wrapper, err := hmy.BlockChain.ReadValidatorInformationAtRoot(validator, block.Root())
 	if err != nil || wrapper == nil {
 		return nil
 	}
-	delegations := []*staking.Delegation{}
-	for i := range wrapper.Delegations {
-		delegations = append(delegations, &wrapper.Delegations[i])
-	}
-	return delegations
+	return wrapper.Delegations
 }
 
 // GetDelegationsByDelegator returns all delegation information of a delegator
@@ -492,13 +484,14 @@ func (hmy *Harmony) GetDelegationsByDelegator(
 func (hmy *Harmony) GetDelegationsByDelegatorByBlock(
 	delegator common.Address, block *types.Block,
 ) ([]common.Address, []*staking.Delegation) {
-	addresses := []common.Address{}
-	delegations := []*staking.Delegation{}
 	delegationIndexes, err := hmy.BlockChain.
 		ReadDelegationsByDelegatorAt(delegator, block.Number())
 	if err != nil {
 		return nil, nil
 	}
+
+	addresses := make([]common.Address, 0, len(delegationIndexes))
+	delegations := make([]*staking.Delegation, 0, len(delegationIndexes))
 
 	for i := range delegationIndexes {
 		wrapper, err := hmy.BlockChain.ReadValidatorInformationAtRoot(

--- a/rpc/staking.go
+++ b/rpc/staking.go
@@ -338,25 +338,22 @@ func (s *PublicStakingService) getPagedValidatorInformationCached(ctx context.Co
 func (s *PublicStakingService) getAllValidatorInformation(
 	ctx context.Context, page int, blockNum uint64,
 ) (interface{}, error) {
-	if page < -1 {
-		return nil, errors.Errorf("page given %d cannot be less than -1", page)
+	if page < 0 {
+		return nil, errors.Errorf("page given %d cannot be less than 0", page)
 	}
 
 	// Get all validators
 	addresses := s.hmy.GetAllValidatorAddresses()
-	if page != -1 && len(addresses) <= page*validatorsPageSize {
+	if len(addresses) <= page*validatorsPageSize {
 		return []StructuredResponse{}, nil
 	}
 
 	// Set page start
-	validatorsNum := len(addresses)
 	start := 0
-	if page != -1 {
-		validatorsNum = validatorsPageSize
-		start = page * validatorsPageSize
-		if len(addresses)-start < validatorsPageSize {
-			validatorsNum = len(addresses) - start
-		}
+	validatorsNum := validatorsPageSize
+	start = page * validatorsPageSize
+	if len(addresses)-start < validatorsPageSize {
+		validatorsNum = len(addresses) - start
 	}
 
 	// Fetch block

--- a/rpc/staking.go
+++ b/rpc/staking.go
@@ -520,7 +520,6 @@ func (s *PublicStakingService) GetValidatorTotalDelegation(
 
 // GetAllDelegationInformation returns delegation information about `validatorsPageSize` validators,
 // starting at `page*validatorsPageSize`.
-// If page is -1, return all instead of `validatorsPageSize` elements.
 // TODO(dm): optimize with single flight
 func (s *PublicStakingService) GetAllDelegationInformation(
 	ctx context.Context, page int,
@@ -538,7 +537,7 @@ func (s *PublicStakingService) GetAllDelegationInformation(
 		DoMetricRPCQueryInfo(GetAllDelegationInformation, FailedNumber)
 		return nil, ErrNotBeaconShard
 	}
-	if page < -1 {
+	if page < 0 {
 		return make([][]StructuredResponse, 0), nil
 	}
 
@@ -546,19 +545,16 @@ func (s *PublicStakingService) GetAllDelegationInformation(
 	addresses := s.hmy.GetAllValidatorAddresses()
 
 	// Return nothing if no delegation on page
-	if page != -1 && len(addresses) <= page*validatorsPageSize {
+	if len(addresses) <= page*validatorsPageSize {
 		return make([][]StructuredResponse, 0), nil
 	}
 
 	// Set page start
-	validatorsNum := len(addresses)
 	start := 0
-	if page != -1 {
-		validatorsNum = validatorsPageSize
-		start = page * validatorsPageSize
-		if len(addresses)-start < validatorsPageSize {
-			validatorsNum = len(addresses) - start
-		}
+	validatorsNum := validatorsPageSize
+	start = page * validatorsPageSize
+	if len(addresses)-start < validatorsPageSize {
+		validatorsNum = len(addresses) - start
 	}
 
 	// Fetch all delegations
@@ -729,16 +725,15 @@ func (s *PublicStakingService) getDelegationByValidatorHelper(address string) ([
 	delegations := s.hmy.GetDelegationsByValidator(validatorAddress)
 
 	// Format response
-	result := []StructuredResponse{}
-	for i := range delegations {
-		delegation := delegations[i]
-		undelegations := make([]Undelegation, len(delegation.Undelegations))
+	result := make([]StructuredResponse, 0, len(delegations))
+	for _, delegation := range delegations {
+		undelegations := make([]Undelegation, 0, len(delegation.Undelegations))
 
-		for j := range delegation.Undelegations {
-			undelegations[j] = Undelegation{
-				Amount: delegation.Undelegations[j].Amount,
-				Epoch:  delegation.Undelegations[j].Epoch,
-			}
+		for _, undelegation := range delegation.Undelegations {
+			undelegations = append(undelegations, Undelegation{
+				Amount: undelegation.Amount,
+				Epoch:  undelegation.Epoch,
+			})
 		}
 		valAddr, _ := internal_common.AddressToBech32(validatorAddress)
 		delAddr, _ := internal_common.AddressToBech32(delegation.DelegatorAddress)
@@ -749,17 +744,13 @@ func (s *PublicStakingService) getDelegationByValidatorHelper(address string) ([
 		}
 
 		// Response output is the same for all versions
-		del, err := NewStructuredResponse(Delegation{
+		del := Delegation{
 			ValidatorAddress: valAddr,
 			DelegatorAddress: delAddr,
 			Amount:           delegation.Amount,
 			Reward:           delegation.Reward,
 			Undelegations:    undelegations,
-		})
-		if err != nil {
-			DoMetricRPCQueryInfo(GetDelegationsByValidator, FailedNumber)
-			return nil, err
-		}
+		}.IntoStructuredResponse()
 		result = append(result, del)
 	}
 	return result, nil

--- a/rpc/staking.go
+++ b/rpc/staking.go
@@ -245,7 +245,6 @@ func (s *PublicStakingService) GetValidatorKeys(
 }
 
 // GetAllValidatorInformation returns information about all validators.
-// If page is -1, return all instead of `validatorsPageSize` elements.
 func (s *PublicStakingService) GetAllValidatorInformation(
 	ctx context.Context, page int,
 ) (interface{}, error) {

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -94,6 +94,16 @@ type Delegation struct {
 	Undelegations    []Undelegation `json:"Undelegations"`
 }
 
+func (d Delegation) IntoStructuredResponse() StructuredResponse {
+	return StructuredResponse{
+		"validator_address": d.ValidatorAddress,
+		"delegator_address": d.DelegatorAddress,
+		"amount":            d.Amount,
+		"reward":            d.Reward,
+		"Undelegations":     d.Undelegations,
+	}
+}
+
 // Undelegation represents one undelegation entry
 type Undelegation struct {
 	Amount *big.Int

--- a/rpc/types_test.go
+++ b/rpc/types_test.go
@@ -3,11 +3,13 @@ package rpc
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	internal_common "github.com/harmony-one/harmony/internal/common"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -69,4 +71,26 @@ func checkAddressOrListEqual(a, b *AddressOrList) error {
 		}
 	}
 	return nil
+}
+
+func TestDelegation_IntoStructuredResponse(t *testing.T) {
+	d := Delegation{
+		ValidatorAddress: "one1hwe68yprkhp5sqq5u7sm9uqu8jxz87fd7ffex7",
+		DelegatorAddress: "one1c5yja54ksccgmn4njz5w4cqyjwhqatlly7gkm3",
+		Amount:           big.NewInt(1000),
+		Reward:           big.NewInt(1014),
+		Undelegations:    make([]Undelegation, 0),
+	}
+	rs1, err := NewStructuredResponse(d)
+	require.NoError(t, err)
+
+	rs2 := d.IntoStructuredResponse()
+
+	js1, err := json.Marshal(rs1)
+	require.NoError(t, err)
+
+	js2, err := json.Marshal(rs2)
+	require.NoError(t, err)
+
+	require.JSONEq(t, string(js1), string(js2))
 }


### PR DESCRIPTION
## Issue

Methods `GetAllValidatorInformation` and `GetAllDelegationInformation` could be called without pagination, which leads to huge amount of response data above 10 megabytes.

## Tests

https://gist.github.com/Frozen/1b4fc7eb1f66606f4b08b7f4c0e297b7

## Changes

For methods `hmy_getAllDelegationInformation` and `hmy_getAllValidatorInformation` we removed possibility to provide page `-1` and get all information at once. To get same data now pagination should be used. 

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**
