### PR TITLE
Make rpc/v1 StakingTxReceipt type field ethereum compatible

### DIFF
--- a/rpc/metrics.go
+++ b/rpc/metrics.go
@@ -16,6 +16,7 @@ const (
 	IsLastBlock              = "IsLastBlock"
 	EpochLastBlock           = "EpochLastBlock"
 	GetBlockSigners          = "GetBlockSigners"
+	GetBlockReceipts         = "GetBlockReceipts"
 	GetBlockSignerKeys       = "GetBlockSignerKeys"
 	IsBlockSigner            = "IsBlockSigner"
 	GetSignedBlocks          = "GetSignedBlocks"

--- a/rpc/v1/types.go
+++ b/rpc/v1/types.go
@@ -192,19 +192,19 @@ type TxReceipt struct {
 
 // StakingTxReceipt represents a staking transaction receipt that will serialize to the RPC representation.
 type StakingTxReceipt struct {
-	BlockHash         common.Hash       `json:"blockHash"`
-	TransactionHash   common.Hash       `json:"transactionHash"`
-	BlockNumber       hexutil.Uint64    `json:"blockNumber"`
-	TransactionIndex  hexutil.Uint64    `json:"transactionIndex"`
-	GasUsed           hexutil.Uint64    `json:"gasUsed"`
-	CumulativeGasUsed hexutil.Uint64    `json:"cumulativeGasUsed"`
-	ContractAddress   common.Address    `json:"contractAddress"`
-	Logs              []*types.Log      `json:"logs"`
-	LogsBloom         ethtypes.Bloom    `json:"logsBloom"`
-	Sender            string            `json:"sender"`
-	Type              staking.Directive `json:"type"`
-	Root              hexutil.Bytes     `json:"root"`
-	Status            hexutil.Uint      `json:"status"`
+	BlockHash         common.Hash    `json:"blockHash"`
+	TransactionHash   common.Hash    `json:"transactionHash"`
+	BlockNumber       hexutil.Uint64 `json:"blockNumber"`
+	TransactionIndex  hexutil.Uint64 `json:"transactionIndex"`
+	GasUsed           hexutil.Uint64 `json:"gasUsed"`
+	CumulativeGasUsed hexutil.Uint64 `json:"cumulativeGasUsed"`
+	ContractAddress   common.Address `json:"contractAddress"`
+	Logs              []*types.Log   `json:"logs"`
+	LogsBloom         ethtypes.Bloom `json:"logsBloom"`
+	Sender            string         `json:"sender"`
+	Type              hexutil.Uint64 `json:"type"`
+	Root              hexutil.Bytes  `json:"root"`
+	Status            hexutil.Uint   `json:"status"`
 }
 
 // CxReceipt represents a CxReceipt that will serialize to the RPC representation of a CxReceipt
@@ -398,7 +398,7 @@ func NewStakingTxReceipt(
 		Logs:              receipt.Logs,
 		LogsBloom:         receipt.Bloom,
 		Sender:            sender,
-		Type:              tx.StakingType(),
+		Type:              hexutil.Uint64(tx.StakingType()),
 		Root:              receipt.PostState,
 		Status:            hexutil.Uint(receipt.Status),
 	}

--- a/rpc/v2/types.go
+++ b/rpc/v2/types.go
@@ -206,35 +206,35 @@ type UndelegateMsg struct {
 type TxReceipt struct {
 	BlockHash         common.Hash    `json:"blockHash"`
 	TransactionHash   common.Hash    `json:"transactionHash"`
-	BlockNumber       hexutil.Uint64 `json:"blockNumber"`
-	TransactionIndex  hexutil.Uint64 `json:"transactionIndex"`
-	GasUsed           hexutil.Uint64 `json:"gasUsed"`
-	CumulativeGasUsed hexutil.Uint64 `json:"cumulativeGasUsed"`
+	BlockNumber       uint64         `json:"blockNumber"`
+	TransactionIndex  uint64         `json:"transactionIndex"`
+	GasUsed           uint64         `json:"gasUsed"`
+	CumulativeGasUsed uint64         `json:"cumulativeGasUsed"`
 	ContractAddress   common.Address `json:"contractAddress"`
 	Logs              []*types.Log   `json:"logs"`
 	LogsBloom         ethtypes.Bloom `json:"logsBloom"`
-	ShardID           hexutil.Uint64 `json:"shardID"`
+	ShardID           uint32         `json:"shardID"`
 	From              string         `json:"from"`
 	To                string         `json:"to"`
 	Root              hexutil.Bytes  `json:"root"`
-	Status            hexutil.Uint64 `json:"status"`
+	Status            uint           `json:"status"`
 }
 
 // StakingTxReceipt represents a staking transaction receipt that will serialize to the RPC representation.
 type StakingTxReceipt struct {
 	BlockHash         common.Hash       `json:"blockHash"`
 	TransactionHash   common.Hash       `json:"transactionHash"`
-	BlockNumber       hexutil.Uint64    `json:"blockNumber"`
-	TransactionIndex  hexutil.Uint64    `json:"transactionIndex"`
-	GasUsed           hexutil.Uint64    `json:"gasUsed"`
-	CumulativeGasUsed hexutil.Uint64    `json:"cumulativeGasUsed"`
+	BlockNumber       uint64            `json:"blockNumber"`
+	TransactionIndex  uint64            `json:"transactionIndex"`
+	GasUsed           uint64            `json:"gasUsed"`
+	CumulativeGasUsed uint64            `json:"cumulativeGasUsed"`
 	ContractAddress   common.Address    `json:"contractAddress"`
 	Logs              []*types.Log      `json:"logs"`
 	LogsBloom         ethtypes.Bloom    `json:"logsBloom"`
 	Sender            string            `json:"sender"`
 	Type              staking.Directive `json:"type"`
 	Root              hexutil.Bytes     `json:"root"`
-	Status            hexutil.Uint64    `json:"status"`
+	Status            uint              `json:"status"`
 }
 
 // CxReceipt represents a CxReceipt that will serialize to the RPC representation of a CxReceipt
@@ -377,24 +377,24 @@ func NewTxReceipt(
 	txReceipt := &TxReceipt{
 		BlockHash:         blockHash,
 		TransactionHash:   tx.Hash(),
-		BlockNumber:       hexutil.Uint64(blockNumber),
-		TransactionIndex:  hexutil.Uint64(blockIndex),
-		GasUsed:           hexutil.Uint64(receipt.GasUsed),
-		CumulativeGasUsed: hexutil.Uint64(receipt.CumulativeGasUsed),
+		BlockNumber:       blockNumber,
+		TransactionIndex:  blockIndex,
+		GasUsed:           receipt.GasUsed,
+		CumulativeGasUsed: receipt.CumulativeGasUsed,
 		Logs:              receipt.Logs,
 		LogsBloom:         receipt.Bloom,
-		ShardID:           hexutil.Uint64(tx.ShardID()),
+		ShardID:           tx.ShardID(),
 		From:              sender,
 		To:                receiver,
 		Root:              receipt.PostState,
-		Status:            hexutil.Uint64(receipt.Status),
+		Status:            uint(receipt.Status),
 	}
 
 	// Set optionals
 	if len(receipt.PostState) > 0 {
 		txReceipt.Root = receipt.PostState
 	} else {
-		txReceipt.Status = hexutil.Uint64(receipt.Status)
+		txReceipt.Status = uint(receipt.Status)
 	}
 
 	// Set empty array for empty logs
@@ -427,16 +427,16 @@ func NewStakingTxReceipt(
 	txReceipt := &StakingTxReceipt{
 		BlockHash:         blockHash,
 		TransactionHash:   tx.Hash(),
-		BlockNumber:       hexutil.Uint64(blockNumber),
-		TransactionIndex:  hexutil.Uint64(blockIndex),
-		GasUsed:           hexutil.Uint64(receipt.GasUsed),
-		CumulativeGasUsed: hexutil.Uint64(receipt.CumulativeGasUsed),
+		BlockNumber:       blockNumber,
+		TransactionIndex:  blockIndex,
+		GasUsed:           receipt.GasUsed,
+		CumulativeGasUsed: receipt.CumulativeGasUsed,
 		Logs:              receipt.Logs,
 		LogsBloom:         receipt.Bloom,
 		Sender:            sender,
 		Type:              tx.StakingType(),
 		Root:              receipt.PostState,
-		Status:            hexutil.Uint64(receipt.Status),
+		Status:            uint(receipt.Status),
 	}
 
 	// Set empty array for empty logs

--- a/rpc/v2/types.go
+++ b/rpc/v2/types.go
@@ -206,35 +206,35 @@ type UndelegateMsg struct {
 type TxReceipt struct {
 	BlockHash         common.Hash    `json:"blockHash"`
 	TransactionHash   common.Hash    `json:"transactionHash"`
-	BlockNumber       uint64         `json:"blockNumber"`
-	TransactionIndex  uint64         `json:"transactionIndex"`
-	GasUsed           uint64         `json:"gasUsed"`
-	CumulativeGasUsed uint64         `json:"cumulativeGasUsed"`
+	BlockNumber       hexutil.Uint64 `json:"blockNumber"`
+	TransactionIndex  hexutil.Uint64 `json:"transactionIndex"`
+	GasUsed           hexutil.Uint64 `json:"gasUsed"`
+	CumulativeGasUsed hexutil.Uint64 `json:"cumulativeGasUsed"`
 	ContractAddress   common.Address `json:"contractAddress"`
 	Logs              []*types.Log   `json:"logs"`
 	LogsBloom         ethtypes.Bloom `json:"logsBloom"`
-	ShardID           uint32         `json:"shardID"`
+	ShardID           hexutil.Uint64 `json:"shardID"`
 	From              string         `json:"from"`
 	To                string         `json:"to"`
 	Root              hexutil.Bytes  `json:"root"`
-	Status            uint           `json:"status"`
+	Status            hexutil.Uint64 `json:"status"`
 }
 
 // StakingTxReceipt represents a staking transaction receipt that will serialize to the RPC representation.
 type StakingTxReceipt struct {
 	BlockHash         common.Hash       `json:"blockHash"`
 	TransactionHash   common.Hash       `json:"transactionHash"`
-	BlockNumber       uint64            `json:"blockNumber"`
-	TransactionIndex  uint64            `json:"transactionIndex"`
-	GasUsed           uint64            `json:"gasUsed"`
-	CumulativeGasUsed uint64            `json:"cumulativeGasUsed"`
+	BlockNumber       hexutil.Uint64    `json:"blockNumber"`
+	TransactionIndex  hexutil.Uint64    `json:"transactionIndex"`
+	GasUsed           hexutil.Uint64    `json:"gasUsed"`
+	CumulativeGasUsed hexutil.Uint64    `json:"cumulativeGasUsed"`
 	ContractAddress   common.Address    `json:"contractAddress"`
 	Logs              []*types.Log      `json:"logs"`
 	LogsBloom         ethtypes.Bloom    `json:"logsBloom"`
 	Sender            string            `json:"sender"`
 	Type              staking.Directive `json:"type"`
 	Root              hexutil.Bytes     `json:"root"`
-	Status            uint              `json:"status"`
+	Status            hexutil.Uint64    `json:"status"`
 }
 
 // CxReceipt represents a CxReceipt that will serialize to the RPC representation of a CxReceipt
@@ -377,24 +377,24 @@ func NewTxReceipt(
 	txReceipt := &TxReceipt{
 		BlockHash:         blockHash,
 		TransactionHash:   tx.Hash(),
-		BlockNumber:       blockNumber,
-		TransactionIndex:  blockIndex,
-		GasUsed:           receipt.GasUsed,
-		CumulativeGasUsed: receipt.CumulativeGasUsed,
+		BlockNumber:       hexutil.Uint64(blockNumber),
+		TransactionIndex:  hexutil.Uint64(blockIndex),
+		GasUsed:           hexutil.Uint64(receipt.GasUsed),
+		CumulativeGasUsed: hexutil.Uint64(receipt.CumulativeGasUsed),
 		Logs:              receipt.Logs,
 		LogsBloom:         receipt.Bloom,
-		ShardID:           tx.ShardID(),
+		ShardID:           hexutil.Uint64(tx.ShardID()),
 		From:              sender,
 		To:                receiver,
 		Root:              receipt.PostState,
-		Status:            uint(receipt.Status),
+		Status:            hexutil.Uint64(receipt.Status),
 	}
 
 	// Set optionals
 	if len(receipt.PostState) > 0 {
 		txReceipt.Root = receipt.PostState
 	} else {
-		txReceipt.Status = uint(receipt.Status)
+		txReceipt.Status = hexutil.Uint64(receipt.Status)
 	}
 
 	// Set empty array for empty logs
@@ -427,16 +427,16 @@ func NewStakingTxReceipt(
 	txReceipt := &StakingTxReceipt{
 		BlockHash:         blockHash,
 		TransactionHash:   tx.Hash(),
-		BlockNumber:       blockNumber,
-		TransactionIndex:  blockIndex,
-		GasUsed:           receipt.GasUsed,
-		CumulativeGasUsed: receipt.CumulativeGasUsed,
+		BlockNumber:       hexutil.Uint64(blockNumber),
+		TransactionIndex:  hexutil.Uint64(blockIndex),
+		GasUsed:           hexutil.Uint64(receipt.GasUsed),
+		CumulativeGasUsed: hexutil.Uint64(receipt.CumulativeGasUsed),
 		Logs:              receipt.Logs,
 		LogsBloom:         receipt.Bloom,
 		Sender:            sender,
 		Type:              tx.StakingType(),
 		Root:              receipt.PostState,
-		Status:            uint(receipt.Status),
+		Status:            hexutil.Uint64(receipt.Status),
 	}
 
 	// Set empty array for empty logs


### PR DESCRIPTION
As type field in StakingTxReceipt is not encoded properly as per rpc/v1 specification, it could not be decoded into standard ethereum Receipt. This PR updates the type to hexutil.Uint64 (as done in geth client).