### PR TITLE
add script to check snapdb

### DIFF
--- a/scripts/snapdb_checker.sh
+++ b/scripts/snapdb_checker.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -e
+
+declare -a DBHashList
+DBHashList=(
+    [22816574]=f5894991e83cff54b215cda93f18bc813bb9bf9a45643c8751f09891aad1f091
+)
+
+DB_FILES="CURRENT MANIFEST* *.log *.ldb"
+
+function dbFilesHash() {
+    sha256sum $DB_FILES
+}
+
+function dbRootHash() {
+    echo -ne "$1" | tr -s [:space:] : | sha256sum | cut -d " " -f 1
+}
+
+function checkRootHash() {
+    rootHash=$1
+    for height in "${!DBHashList[@]}"
+    do
+        dbhash=${DBHashList[$height]}
+        if [ $dbhash == $rootHash ];then
+            echo "Success! The hash matches the height $height."
+            exit 0
+        fi
+    done
+    echo "check failed!" >&2
+    exit 1
+}
+
+print_usage() {
+    progname="${0##*/}"
+    cat <<- ENDEND
+
+usage: ${progname} COMMAND DBDIR
+
+The COMMAND are:
+    hash    calculate root hash for snapdb
+    check   verify root hash of snpadb
+DBDIR is path of db
+
+Ex:
+   ${progname} hash ./harmony_db_0
+   ${progname} check ./harmony_db_0
+ENDEND
+}
+
+CMD=$1
+DBDIR=$2
+if [ -z $DBDIR ];then
+    print_usage
+    exit 1
+fi
+cd $DBDIR
+
+case "$CMD" in
+   check)
+    rootHash=`dbRootHash "$(dbFilesHash)"`
+    checkRootHash $rootHash
+    ;;
+   hash)
+    dbRootHash "$(dbFilesHash)"
+    ;;
+   *)
+    print_usage
+    ;;
+esac


### PR DESCRIPTION
Add a script to check that the snapdb(#4096) downloaded by users is complete.
Usage:
`snapdb_checker.sh hash ./harmony_db_0` calculate hash of given DB
`snapdb_checker.sh check ./harmony_db_0` check that the DB is complete.

When a new snapdb is published, the hash should be calculated and added to the DBHashList map of the script. The key of DBHashList is block height, and the value is hash.