### PR TITLE
temporarily reduce gas limit to 20m

### DIFF
--- a/node/worker/worker.go
+++ b/node/worker/worker.go
@@ -69,6 +69,12 @@ func (w *Worker) CommitSortedTransactions(
 	coinbase common.Address,
 ) {
 	for {
+		if w.current.gasPool.Gas() < 60000000 {
+			// Temporary solution to reduce the fullness of the block. Break here when the available gas left hit 60M.
+			// Effectively making the gas limit 20M (since 80M is the default gas limit)
+			utils.Logger().Info().Uint64("have", w.current.gasPool.Gas()).Uint64("want", params.TxGas).Msg("[Temp Gas Limit] Not enough gas for further transactions")
+			break
+		}
 		// If we don't have enough gas for any further transactions then we're done
 		if w.current.gasPool.Gas() < params.TxGas {
 			utils.Logger().Info().Uint64("have", w.current.gasPool.Gas()).Uint64("want", params.TxGas).Msg("Not enough gas for further transactions")


### PR DESCRIPTION
Spam txns are making most of blocks full. Causing network slow down. Temporarily reduce the gas limit to 20m. A more long-term gas limit solution will be added once https://github.com/harmony-one/harmony/issues/4113 is fixed.