### PR TITLE
[core] fix: Use time-based ordering to avoid spam

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"math/big"
 	"sync/atomic"
+	"time"
 
 	"github.com/harmony-one/harmony/internal/params"
 
@@ -100,6 +101,9 @@ type Transaction struct {
 	hash atomic.Value
 	size atomic.Value
 	from atomic.Value
+	// time at which the node received the tx
+	// and not the time set by the sender
+	time time.Time
 }
 
 // String print mode string
@@ -224,7 +228,7 @@ func newTransaction(nonce uint64, to *common.Address, shardID uint32, amount *bi
 		d.Price.Set(gasPrice)
 	}
 
-	return &Transaction{data: d}
+	return &Transaction{data: d, time: time.Now()}
 }
 
 func newCrossShardTransaction(nonce uint64, to *common.Address, shardID uint32, toShardID uint32, amount *big.Int, gasLimit uint64, gasPrice *big.Int, data []byte) *Transaction {
@@ -251,7 +255,7 @@ func newCrossShardTransaction(nonce uint64, to *common.Address, shardID uint32, 
 		d.Price.Set(gasPrice)
 	}
 
-	return &Transaction{data: d}
+	return &Transaction{data: d, time: time.Now()}
 }
 
 // From returns the sender address of the transaction
@@ -309,6 +313,11 @@ func (tx *Transaction) ToShardID() uint32 {
 	return tx.data.ToShardID
 }
 
+// Time returns the time at which the transaction was received by the node
+func (tx *Transaction) Time() time.Time {
+	return tx.time
+}
+
 // Protected returns whether the transaction is protected from replay protection.
 func (tx *Transaction) Protected() bool {
 	return isProtectedV(tx.data.V)
@@ -334,6 +343,7 @@ func (tx *Transaction) DecodeRLP(s *rlp.Stream) error {
 	err := s.Decode(&tx.data)
 	if err == nil {
 		tx.size.Store(common.StorageSize(rlp.ListSize(size)))
+		tx.time = time.Now()
 	}
 
 	return err
@@ -448,6 +458,8 @@ func (tx *Transaction) ConvertToEth() *EthTransaction {
 	copy := tx2.Hash()
 	d2.Hash = &copy
 
+	tx2.time = tx.time
+
 	return &tx2
 }
 
@@ -500,6 +512,7 @@ func (tx *Transaction) RawSignatureValues() (*big.Int, *big.Int, *big.Int) {
 func (tx *Transaction) Copy() *Transaction {
 	var tx2 Transaction
 	tx2.data.CopyFrom(&tx.data)
+	tx2.time = tx.time
 	return &tx2
 }
 
@@ -550,12 +563,40 @@ func (s *TxByPrice) Pop() interface{} {
 	return x
 }
 
+// TxByPriceAndTime implements both the sort and the heap interface, making it useful
+// for all at once sorting as well as individually adding and removing elements.
+type TxByPriceAndTime Transactions
+
+func (s TxByPriceAndTime) Len() int { return len(s) }
+func (s TxByPriceAndTime) Less(i, j int) bool {
+	// If the prices are equal, use the time the transaction was first seen for
+	// deterministic sorting
+	cmp := s[i].data.Price.Cmp(s[j].data.Price)
+	if cmp == 0 {
+		return s[i].time.Before(s[j].time)
+	}
+	return cmp > 0
+}
+func (s TxByPriceAndTime) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+func (s *TxByPriceAndTime) Push(x interface{}) {
+	*s = append(*s, x.(*Transaction))
+}
+
+func (s *TxByPriceAndTime) Pop() interface{} {
+	old := *s
+	n := len(old)
+	x := old[n-1]
+	*s = old[0 : n-1]
+	return x
+}
+
 // TransactionsByPriceAndNonce represents a set of transactions that can return
 // transactions in a profit-maximizing sorted order, while supporting removing
 // entire batches of transactions for non-executable accounts.
 type TransactionsByPriceAndNonce struct {
 	txs       map[common.Address]Transactions // Per account nonce-sorted list of transactions
-	heads     TxByPrice                       // Next transaction for each unique account (price heap)
+	heads     TxByPriceAndTime                // Next transaction for each unique account (price heap)
 	signer    Signer                          // Signer for the set of transactions
 	ethSigner Signer                          // Signer for the set of transactions
 }
@@ -567,7 +608,7 @@ type TransactionsByPriceAndNonce struct {
 // if after providing it to the constructor.
 func NewTransactionsByPriceAndNonce(hmySigner Signer, ethSigner Signer, txs map[common.Address]Transactions) *TransactionsByPriceAndNonce {
 	// Initialize a price based heap with the head transactions
-	heads := make(TxByPrice, 0, len(txs))
+	heads := make(TxByPriceAndTime, 0, len(txs))
 	for from, accTxs := range txs {
 		if accTxs.Len() == 0 {
 			continue

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -21,9 +21,11 @@ import (
 	"encoding/json"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/harmony-one/harmony/internal/params"
 )
 
 func defaultTestKey() (*ecdsa.PrivateKey, common.Address) {
@@ -130,6 +132,59 @@ func TestTransactionJSON(t *testing.T) {
 		}
 		if tx.ChainID().Cmp(parsedTx.ChainID()) != 0 {
 			t.Errorf("invalid chain id, want %d, got %d", tx.ChainID(), parsedTx.ChainID())
+		}
+	}
+}
+
+// Tests that if multiple transactions have the same price, the ones seen earlier
+// are prioritized to avoid network spam attacks aiming for a specific ordering.
+func TestTransactionTimeSort(t *testing.T) {
+	// Generate a batch of accounts to start with
+	keys := make([]*ecdsa.PrivateKey, 5)
+	for i := 0; i < len(keys); i++ {
+		keys[i], _ = crypto.GenerateKey()
+	}
+	signer := HomesteadSigner{}
+
+	// Generate a batch of transactions with overlapping prices, but different creation times
+	groups := map[common.Address]Transactions{}
+	for start, key := range keys {
+		addr := crypto.PubkeyToAddress(key.PublicKey)
+
+		tx, _ := SignTx(NewTransaction(0, common.Address{}, 0, big.NewInt(100), 100, big.NewInt(1), nil), signer, key)
+		tx.time = time.Unix(0, int64(len(keys)-start))
+
+		groups[addr] = append(groups[addr], tx)
+	}
+	// Sort the transactions and cross check the nonce ordering
+	config := params.TestChainConfig
+	txset := NewTransactionsByPriceAndNonce(
+		NewEIP155Signer(config.ChainID),
+		NewEIP155Signer(config.EthCompatibleChainID),
+		groups,
+	)
+
+	txs := Transactions{}
+	for tx := txset.Peek(); tx != nil; tx = txset.Peek() {
+		txs = append(txs, tx)
+		txset.Shift()
+	}
+	if len(txs) != len(keys) {
+		t.Errorf("expected %d transactions, found %d", len(keys), len(txs))
+	}
+	for i, txi := range txs {
+		fromi, _ := Sender(signer, txi)
+		if i+1 < len(txs) {
+			next := txs[i+1]
+			fromNext, _ := Sender(signer, next)
+
+			if txi.GasPrice().Cmp(next.GasPrice()) < 0 {
+				t.Errorf("invalid gasprice ordering: tx #%d (A=%x P=%v) < tx #%d (A=%x P=%v)", i, fromi[:4], txi.GasPrice(), i+1, fromNext[:4], next.GasPrice())
+			}
+			// Make sure time order is ascending if the txs have the same gas price
+			if txi.GasPrice().Cmp(next.GasPrice()) == 0 && txi.time.After(next.time) {
+				t.Errorf("invalid received time ordering: tx #%d (A=%x T=%v) > tx #%d (A=%x T=%v)", i, fromi[:4], txi.time, i+1, fromNext[:4], next.time)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Closes harmony-one/harmony#4113 by sorting transactions by time received
instead of using a hashmap based transaction ordering. This sorting is
on top of the gas price and nonce sorting already implemented.

Effectively, this allows the production of almost a deterministic order
of transaction ordering, as opposed to a heap-based hash map ordering
which is affected by Golang's internal operations. Consequently,
arbitrageurs, who spam the network with a view to exist around
arbitrag-able transactions, will have to focus on latency instead of
network spamming.

See also bnb-chain/bsc#269 and ethereum/go-ethereum#21358 for related
issues in other chains.

## Issue
#4113

## Test


### Unit Test Coverage

Before:

```
core/test: 19.4%
```

After:

```
core/test: 19.6%
```

### Test/Run Logs
Ran the following contract + brownie script to observe that time based ordering is dependent on latency and that all transactions go through as expected.
```Solidity

//SPDX-License-Identifier: Unlicense
pragma solidity ^0.8.0;

contract SampleContract {
    address deployer;
    address setter;
    event SampleEvent(bool result);

    constructor() {
        deployer = msg.sender;
        setter = msg.sender;
    }

    function sampleFunction() public {
        bool result = false;
        if (setter == deployer) {
            setter = msg.sender;
            result = true;
        }
        emit SampleEvent(result);
    }
}
```
```python
from brownie import (
    accounts,
    SampleContract,
    web3
)
from pyhmy import (
    signing,
    transaction,
    util
)
import multiprocessing
import pytest
from eth_utils import to_checksum_address
import time

@pytest.fixture( scope = "module", autouse = True )
def setup():
    accounts.add( '1f84c95ac16e6a50f08d44c7bde7aff8742212fda6e4321fde48bf83bef266dc' )
    print( "Deploying contract" )
    SampleContract.deploy( { 'from': accounts[ 0 ] } )
    print( "Contract ready" )

def send_tx( signed_tx ):
    hash = transaction.send_raw_transaction( signed_tx.rawTransaction.hex() )
    return hash

def check_result( tx_hash ):
    receipt = web3.eth.wait_for_transaction_receipt( tx_hash )
    print( receipt[ 'logs' ][ -1 ][ 'data' ][ -1 ] )
    if receipt[ 'logs' ][ -1 ][ 'data' ][ -1 ] == '1':
        from_address = util.convert_one_to_hex( transaction.get_transaction_by_hash( tx_hash )[ 'from' ] )
        for i, account in enumerate( accounts ):
            print( account.address, from_address )
            if to_checksum_address( account.address ) == to_checksum_address( from_address ):
                print( 'Transaction from account {} went through'.format( i ) )

def test_sample_function():
    signed_txs = []
    # get the latest instance
    sample_contract = SampleContract[ -1 ]
    sample_contract_w3 = web3.eth.contract(
        abi = SampleContract.abi,
        address = to_checksum_address( sample_contract.address )
    )
    pks = [
        # needs PKs
    ]
    # add 10 fake accounts
    for i in range( 1, 11 ):
        print( "Running for account", i )
        if len( accounts ) <= i:
            accounts.add( pks[ i - 1 ][ 2: ] )
        account = accounts[ i ]
        accounts[ 0 ].transfer( account, amount = web3.toWei( 5, 'ether' ) )
        tx_dict = sample_contract_w3.functions.sampleFunction(
            ).buildTransaction(
                {
                    'nonce': 0,
                    'gasPrice': 31 * int( 1e9 ) * 1000, # 31 gwei
                    'gas': 100000, # 100k
                    'chainId': 2,
                    'shardID': 0,
                    'toShardID': 0,
                    'value': 0,
                }
            )
        signed_tx = signing.sign_transaction( tx_dict, account.private_key[ 2: ] )
        signed_txs.append( signed_tx )
    print( "Running pooled transactions" )
    with multiprocessing.Pool( len( signed_txs ) ) as p:
        results = p.map( send_tx, signed_txs )
    print( "Done" )
    for tx_hash in results:
        check_result( tx_hash )
    # Extra buffer on top
    time.sleep( 5 )
```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)
No.

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)
No.

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**
No.
