### PR TITLE
[core]: fix: Cap suggested gas price to 500 gwei

### DIFF
--- a/hmy/gasprice.go
+++ b/hmy/gasprice.go
@@ -34,7 +34,7 @@ import (
 
 const sampleNumber = 3 // Number of transactions sampled in a block
 
-var DefaultMaxPrice = big.NewInt(1 * params.Ether)
+var DefaultMaxPrice = big.NewInt(5e11) // 500 gwei is the max suggested limit
 
 type GasPriceConfig struct {
 	Blocks     int

--- a/hmy/hmy.go
+++ b/hmy/hmy.go
@@ -151,9 +151,9 @@ func New(
 
 	// Setup gas price oracle
 	gpoParams := GasPriceConfig{
-		Blocks:     20,
-		Percentile: 60,
-		Default:    big.NewInt(3e10),
+		Blocks:     20,               // take all eligible txs past 20 blocks and sort them
+		Percentile: 40,               // get the 40th percentile when sorted in an ascending manner
+		Default:    big.NewInt(3e10), // minimum of 30 gwei
 	}
 	gpo := NewOracle(backend, gpoParams)
 	backend.gpo = gpo


### PR DESCRIPTION
...and set suggested gas percentile to 40 instead of 60.

Recently, the recommended gas price requested via `eth_gasPrice`,
`hmy_gasPrice` or `hmyv2_gasPrice` has been fairly high (think 100k
gwei). This patch changes the maximum suggested gas price via these APIs
to be capped at 500 gwei. Users are still allowed to change the gas
price manually to be higher than this, for faster execution.

The occurence of these extremely high gas prices can be attributed to
the self reinforcing mechanism of this implementation. If some 20 blocks
are produced with extremely high gas prices for all transactions, the
API queries the transactions and returns the (erstwhile) 60th percentile
from them. This then results in a feedback loop for the following
blocks. This loop continues until transactions which do not use the
suggested gas price become part of the following blocks - which in
itself is unlikely, since transactions are sorted by gas price for
inclusion.

## Issue
Screenshot from a Discord user
![unknown](https://user-images.githubusercontent.com/82761650/162644159-27eefc9d-e6e2-4899-a717-a176b4dba6b2.png)

## Test

### Unit Test Coverage

Before:

```
?   	github.com/harmony-one/harmony/hmy	[no test files]
```

After:

```
?   	github.com/harmony-one/harmony/hmy	[no test files]
```

### Test/Run Logs
Not needed.

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)
No.

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)
No.

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**
No.