### PR TITLE
Fix BaseStream buf io concurrent access.

### DIFF
--- a/p2p/stream/types/stream.go
+++ b/p2p/stream/types/stream.go
@@ -25,8 +25,9 @@ type Stream interface {
 
 // BaseStream is the wrapper around
 type BaseStream struct {
-	raw libp2p_network.Stream
-	rw  *bufio.ReadWriter
+	raw      libp2p_network.Stream
+	reader   *bufio.Reader
+	readLock sync.Mutex
 
 	// parse protocol spec fields
 	spec     ProtoSpec
@@ -36,10 +37,10 @@ type BaseStream struct {
 
 // NewBaseStream creates BaseStream as the wrapper of libp2p Stream
 func NewBaseStream(st libp2p_network.Stream) *BaseStream {
-	rw := bufio.NewReadWriter(bufio.NewReader(st), bufio.NewWriter(st))
+	reader := bufio.NewReader(st)
 	return &BaseStream{
-		raw: st,
-		rw:  rw,
+		raw:    st,
+		reader: reader,
 	}
 }
 
@@ -89,18 +90,19 @@ func (st *BaseStream) WriteBytes(b []byte) (err error) {
 		err = errors.New("message too long")
 		return
 	}
-	if _, err = st.rw.Write(intToBytes(len(b))); err != nil {
-		return
+	size := sizeBytes + len(b)
+	message := make([]byte, size)
+	copy(message, intToBytes(len(b)))
+	copy(message[sizeBytes:], b)
+
+	if _, err = st.raw.Write(message); err != nil {
+		return err
 	}
-	bytesWriteCounter.Add(sizeBytes)
-	if _, err = st.rw.Write(b); err != nil {
-		return
-	}
-	bytesWriteCounter.Add(float64(len(b)))
-	return st.rw.Flush()
+	bytesWriteCounter.Add(float64(size))
+	return nil
 }
 
-// ReadMsg read the bytes from the stream
+// ReadBytes read the bytes from the stream.
 func (st *BaseStream) ReadBytes() (cb []byte, err error) {
 	defer func() {
 		msgReadCounter.Inc()
@@ -109,8 +111,11 @@ func (st *BaseStream) ReadBytes() (cb []byte, err error) {
 		}
 	}()
 
+	st.readLock.Lock()
+	defer st.readLock.Unlock()
+
 	sb := make([]byte, sizeBytes)
-	_, err = st.rw.Read(sb)
+	_, err = st.reader.Read(sb)
 	if err != nil {
 		err = errors.Wrap(err, "read size")
 		return
@@ -123,7 +128,7 @@ func (st *BaseStream) ReadBytes() (cb []byte, err error) {
 	}
 
 	cb = make([]byte, size)
-	n, err := io.ReadFull(st.rw, cb)
+	n, err := io.ReadFull(st.reader, cb)
 	if err != nil {
 		err = errors.Wrap(err, "read content")
 		return

--- a/p2p/stream/types/stream.go
+++ b/p2p/stream/types/stream.go
@@ -25,9 +25,10 @@ type Stream interface {
 
 // BaseStream is the wrapper around
 type BaseStream struct {
-	raw      libp2p_network.Stream
-	reader   *bufio.Reader
-	readLock sync.Mutex
+	raw       libp2p_network.Stream
+	reader    *bufio.Reader
+	readLock  sync.Mutex
+	writeLock sync.Mutex
 
 	// parse protocol spec fields
 	spec     ProtoSpec
@@ -95,6 +96,8 @@ func (st *BaseStream) WriteBytes(b []byte) (err error) {
 	copy(message, intToBytes(len(b)))
 	copy(message[sizeBytes:], b)
 
+	st.writeLock.Lock()
+	defer st.writeLock.Unlock()
 	if _, err = st.raw.Write(message); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Issue

Bufio Reader/Writer is not thread safe, different goroutines can work with BaseStream at the same time.


## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**
