### PR TITLE
[downloader] fix explorer node get stuck when doing short range sync

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -811,7 +811,7 @@ func setupSyncService(node *node.Node, host p2p.Host, hc harmonyconfig.HarmonyCo
 	node.RegisterService(service.Synchronize, s)
 
 	d := s.Downloaders.GetShardDownloader(node.Blockchain().ShardID())
-	if hc.Sync.Downloader {
+	if hc.Sync.Downloader && hc.General.NodeType != nodeTypeExplorer {
 		node.Consensus.SetDownloader(d) // Set downloader when stream client is active
 	}
 }

--- a/hmy/downloader/downloader.go
+++ b/hmy/downloader/downloader.go
@@ -80,7 +80,7 @@ func NewDownloader(host p2p.Host, bc *core.BlockChain, config Config) *Downloade
 
 		status: newStatus(),
 		config: config,
-		logger: utils.Logger().With().Str("module", "downloader").Logger(),
+		logger: utils.Logger().With().Str("module", "downloader").Uint32("ShardID", bc.ShardID()).Logger(),
 	}
 }
 


### PR DESCRIPTION
## Issue

Explorer testnet nodes get stuck when doing stream sync. 

Disable the subscription sending feed when the node is explorer node to avoid a sync process stuck observed on testnet.

The issue is caused by sending an event to a subscription that is not subscribed. When the subscription is not subscribed by any handler, the notification service will be blocked at:

```
// hmy/downloader/downloader.go:254
d.evtDownloadStarted.Send(struct{}{})
```

Adding a boolean value to tell whether the subscription is subscribed before will resolve the issue (not not send the event when the subscription is not subscribed).


## Test

Tested on testnet node. 