### PR TITLE
[downloader] fix the local test. Do not set sync mode when bootstrapping.

### DIFF
--- a/hmy/downloader/longrange.go
+++ b/hmy/downloader/longrange.go
@@ -19,9 +19,6 @@ import (
 func (d *Downloader) doLongRangeSync() (int, error) {
 	var totalInserted int
 
-	d.startSyncing()
-	defer d.finishSyncing()
-
 	for {
 		ctx, cancel := context.WithCancel(d.ctx)
 
@@ -71,6 +68,15 @@ func (lsi *lrSyncIter) doLongRangeSync() error {
 	if err != nil {
 		return err
 	}
+	if curBN := lsi.bc.CurrentBlock().NumberU64(); bn <= curBN {
+		lsi.logger.Info().Uint64("current number", curBN).Uint64("target number", bn).
+			Msg("early return of long range sync")
+		return nil
+	}
+
+	lsi.d.startSyncing()
+	defer lsi.d.finishSyncing()
+
 	lsi.logger.Info().Uint64("target number", bn).Msg("estimated remote current number")
 	lsi.d.status.setTargetBN(bn)
 


### PR DESCRIPTION
## Issue

When starting the local machine with downloader turned on, the initial consensus will not start for a while because the node will immediately set consensus to "SYNCING" mode when starting with long range sync. 

This PR defer the downloader set "SYNCING" mode and will only set consensus to "SYNCING" mode when it discovers that it is only behind the latest consensus.