### PR TITLE
Fix dumpdb bug and add SnapdbInfo into dumped db

### DIFF
--- a/cmd/harmony/dumpdb.go
+++ b/cmd/harmony/dumpdb.go
@@ -266,7 +266,6 @@ func (db *KakashiDB) offchainDataDump(block *types.Block) {
 			break
 		}
 		latestNumber := block.NumberU64() - uint64(i)
-		fmt.Println("blockx:", i, latestNumber)
 		latestBlock := db.GetBlockByNumber(latestNumber)
 		db.GetBlockByHash(latestBlock.Hash())
 		db.GetHeaderByHash(latestBlock.Hash())
@@ -408,4 +407,5 @@ func dumpMain(srcDBDir, destDBDir string, batchLimit int) {
 	if !snapdbInfo.StateDataDumped {
 		copier.stateDataDump(block)
 	}
+	fmt.Println("Dump completed!")
 }

--- a/core/rawdb/accessors_snapdb.go
+++ b/core/rawdb/accessors_snapdb.go
@@ -1,0 +1,49 @@
+package rawdb
+
+import (
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/harmony-one/harmony/block"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
+	"github.com/harmony-one/harmony/internal/utils"
+)
+
+type SnapdbInfo struct {
+	NetworkType         nodeconfig.NetworkType // network type
+	BlockHeader         *block.Header          // latest header at snapshot
+	AccountCount        int                    // number of dumped account
+	OffchainDataDumped  bool                   // is OffchainData dumped
+	IndexerDataDumped   bool                   // is IndexerData dumped
+	StateDataDumped     bool                   // is StateData dumped
+	DumpedSize          uint64                 // size of key-value already dumped
+	LastAccountKey      hexutil.Bytes          // MPT key of the account last dumped, use this to continue dumping
+	LastAccountStateKey hexutil.Bytes          // MPT key of the account's state last dumped, use this to continue dumping
+}
+
+// ReadSnapdbInfo return the SnapdbInfo of the db
+func ReadSnapdbInfo(db DatabaseReader) *SnapdbInfo {
+	data, _ := db.Get(snapdbInfoKey)
+	if len(data) == 0 {
+		return nil
+	}
+	info := &SnapdbInfo{}
+	if err := rlp.DecodeBytes(data, info); err != nil {
+		utils.Logger().Error().Err(err).Msg("Invalid SnapdbInfo RLP")
+		return nil
+	}
+	return info
+}
+
+// WriteSnapdbInfo write the SnapdbInfo into db
+func WriteSnapdbInfo(db DatabaseWriter, info *SnapdbInfo) error {
+	data, err := rlp.EncodeToBytes(info)
+	if err != nil {
+		utils.Logger().Error().Msg("Failed to RLP encode SnapdbInfo")
+		return err
+	}
+	if err := db.Put(snapdbInfoKey, data); err != nil {
+		utils.Logger().Error().Msg("Failed to store SnapdbInfo")
+		return err
+	}
+	return nil
+}

--- a/core/rawdb/accessors_snapdb.go
+++ b/core/rawdb/accessors_snapdb.go
@@ -11,7 +11,7 @@ import (
 type SnapdbInfo struct {
 	NetworkType         nodeconfig.NetworkType // network type
 	BlockHeader         *block.Header          // latest header at snapshot
-	AccountCount        int                    // number of dumped account
+	AccountCount        uint64                 // number of dumped account
 	OffchainDataDumped  bool                   // is OffchainData dumped
 	IndexerDataDumped   bool                   // is IndexerData dumped
 	StateDataDumped     bool                   // is StateData dumped

--- a/core/rawdb/accessors_snapdb.go
+++ b/core/rawdb/accessors_snapdb.go
@@ -8,6 +8,7 @@ import (
 	"github.com/harmony-one/harmony/internal/utils"
 )
 
+// SnapdbInfo only used by cmd/harmony/dumpdb.go
 type SnapdbInfo struct {
 	NetworkType         nodeconfig.NetworkType // network type
 	BlockHeader         *block.Header          // latest header at snapshot

--- a/core/rawdb/accessors_snapdb_test.go
+++ b/core/rawdb/accessors_snapdb_test.go
@@ -1,0 +1,37 @@
+package rawdb
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	ethRawDB "github.com/ethereum/go-ethereum/core/rawdb"
+	blockfactory "github.com/harmony-one/harmony/block/factory"
+	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
+)
+
+func TestSnapdbInfo(t *testing.T) {
+	src := &SnapdbInfo{
+		NetworkType:         nodeconfig.Mainnet,
+		BlockHeader:         blockfactory.NewTestHeader(),
+		AccountCount:        12,
+		OffchainDataDumped:  true,
+		IndexerDataDumped:   true,
+		StateDataDumped:     false,
+		DumpedSize:          100 * 1024 * 1024 * 1024,
+		LastAccountKey:      hexutil.MustDecode("0x1339383fd90ed804e28464763a13fafad66dd0f88434b8e5d8b410eb75a10331"),
+		LastAccountStateKey: hexutil.MustDecode("0xa940a0bb9eca4f9d5eee3f4059f458bd4a05bb1d680c5f7c781b06bc43c20df6"),
+	}
+	db := ethRawDB.NewMemoryDatabase()
+	if err := WriteSnapdbInfo(db, src); err != nil {
+		t.Fatal(err)
+	}
+	info := ReadSnapdbInfo(db)
+	if src.BlockHeader.String() != info.BlockHeader.String() {
+		t.Fatal("header of SnapdbInfo doest not equal")
+	}
+	src.BlockHeader = info.BlockHeader
+	if !reflect.DeepEqual(src, info) {
+		t.Fatal("snapdbInfo doest not equal")
+	}
+}

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -72,6 +72,8 @@ var (
 	preimageCounter             = metrics.NewRegisteredCounter("db/preimage/total", nil)
 	preimageHitCounter          = metrics.NewRegisteredCounter("db/preimage/hits", nil)
 	currentRewardGivenOutPrefix = []byte("blk-rwd-")
+	// key of SnapdbInfo
+	snapdbInfoKey = []byte("SnapdbInfo")
 )
 
 // TxLookupEntry is a positional metadata to help looking up the data content of

--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -35,6 +35,7 @@ type DumpConfig struct {
 	SkipCode          bool
 	SkipStorage       bool
 	OnlyWithAddresses bool
+	HoldStorage       bool
 	Start             []byte
 	End               []byte
 	StateStart        []byte
@@ -211,12 +212,14 @@ func (s *DB) DumpToCollector(c DumpCollector, conf *DumpConfig) (nextKey []byte)
 				}
 				key := s.trie.GetKey(storageIt.Key)
 				c.OnAccountState(addr, storageIt.Key, key, storageIt.Value)
-				_, content, _, err := rlp.Split(storageIt.Value)
-				if err != nil {
-					log.Error("Failed to decode the value returned by iterator", "error", err)
-					continue
+				if conf.HoldStorage {
+					_, content, _, err := rlp.Split(storageIt.Value)
+					if err != nil {
+						log.Error("Failed to decode the value returned by iterator", "error", err)
+						continue
+					}
+					account.Storage[common.BytesToHash(s.trie.GetKey(storageIt.Key))] = common.Bytes2Hex(content)
 				}
-				account.Storage[common.BytesToHash(s.trie.GetKey(storageIt.Key))] = common.Bytes2Hex(content)
 			}
 			stateStart = nil
 			hasStateEnd = false

--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -170,7 +170,7 @@ func (s *DB) DumpToCollector(c DumpCollector, conf *DumpConfig) (nextKey []byte)
 	c.OnRoot(s.trie.Hash())
 
 	hasEnd := len(conf.End) > 0
-	stateStart := conf.Start
+	stateStart := conf.StateStart
 	hasStateEnd := len(conf.StateEnd) > 0
 	it := trie.NewIterator(s.trie.NodeIterator(conf.Start))
 	for it.Next() {


### PR DESCRIPTION
In the process of creating a 'snapdb' via 'dumpdb'(#4069), it may exit. The reason has not been found, but it can be continued, by restarting this command with some iterator keys manually entered. 
1. One issue is when restart the dump cmd, it incorrectly uses account iterator key as the state iterator key. This may cause the new DB to miss some state data.
2. Another issue is that it is a bit annoying to have to manually enter the key for restarting the cmd.

This pr fixed bug 1, and add 'SnapdbInfo' into the new DB. After restarting the cmd, it will read ‘SnapdbInfo’ from the new DB, and continue the process according to it.