### PR TITLE
[core] feat: Add cross shard transfer precompile

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -19,9 +19,11 @@ package abi
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
+	"math/big"
+
+	"github.com/pkg/errors"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -276,4 +278,36 @@ func UnpackRevert(data []byte) (string, error) {
 		return "", err
 	}
 	return unpacked[0].(string), nil
+}
+
+// ParseAddressFromKey pulls out the address value from a map with provided key,
+// andv alidates the data type for it
+func ParseAddressFromKey(args map[string]interface{}, key string) (common.Address, error) {
+	if address, ok := args[key].(common.Address); ok {
+		return address, nil
+	} else {
+		return common.Address{}, errors.Errorf("Cannot parse address from %v", args[key])
+	}
+}
+
+// ParseBigIntFromKey pulls out the *big.Int value from a map with provided key,
+// and validates the data type for it
+func ParseBigIntFromKey(args map[string]interface{}, key string) (*big.Int, error) {
+	bigInt, ok := args[key].(*big.Int)
+	if !ok {
+		return nil, errors.Errorf(
+			"Cannot parse BigInt from %v", args[key])
+	} else {
+		return bigInt, nil
+	}
+}
+
+// ParseUint32FromKey pulls out the uint64 value from a map with provided key,
+// and validates the data type for it
+func ParseUint32FromKey(args map[string]interface{}, key string) (uint32, error) {
+	if val, ok := args[key].(uint32); ok {
+		return val, nil
+	} else {
+		return 0, errors.Errorf("Cannot parse uint32 from %v", args[key])
+	}
 }

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -1143,3 +1143,39 @@ func TestUnpackRevert(t *testing.T) {
 		})
 	}
 }
+
+func TestParseBigIntFromKey(t *testing.T) {
+	args := map[string]interface{}{}
+	expectedError := errors.New("Cannot parse BigInt from <nil>")
+	if _, err := ParseBigIntFromKey(args, "PotentialBigInt"); err != nil {
+		if expectedError.Error() != err.Error() {
+			t.Errorf("Expected error %v, got %v", expectedError, err)
+		}
+	} else {
+		t.Errorf("Expected error %v, got result", expectedError)
+	}
+}
+
+func TestParseAddressFromKey(t *testing.T) {
+	args := map[string]interface{}{}
+	expectedError := errors.New("Cannot parse address from <nil>")
+	if _, err := ParseAddressFromKey(args, "PotentialAddress"); err != nil {
+		if expectedError.Error() != err.Error() {
+			t.Errorf("Expected error %v, got %v", expectedError, err)
+		}
+	} else {
+		t.Errorf("Expected error %v, got result", expectedError)
+	}
+}
+
+func TestParseUint32FromKey(t *testing.T) {
+	args := map[string]interface{}{}
+	expectedError := errors.New("Cannot parse uint32 from <nil>")
+	if _, err := ParseUint32FromKey(args, "PotentialUint32"); err != nil {
+		if expectedError.Error() != err.Error() {
+			t.Errorf("Expected error %v, got %v", expectedError, err)
+		}
+	} else {
+		t.Errorf("Expected error %v, got result", expectedError)
+	}
+}

--- a/core/evm.go
+++ b/core/evm.go
@@ -31,6 +31,7 @@ import (
 	"github.com/harmony-one/harmony/core/vm"
 	"github.com/harmony-one/harmony/internal/params"
 	"github.com/harmony-one/harmony/internal/utils"
+	"github.com/harmony-one/harmony/shard"
 	staking "github.com/harmony-one/harmony/staking"
 	stakingTypes "github.com/harmony-one/harmony/staking/types"
 )
@@ -77,27 +78,28 @@ func NewEVMContext(msg Message, header *block.Header, chain ChainContext, author
 		copy(vrf[:], vrfAndProof[:32])
 	}
 	return vm.Context{
-		CanTransfer:     CanTransfer,
-		Transfer:        Transfer,
-		IsValidator:     IsValidator,
-		GetHash:         GetHashFn(header, chain),
-		GetVRF:          GetVRFFn(header, chain),
-		CreateValidator: CreateValidatorFn(header, chain),
-		EditValidator:   EditValidatorFn(header, chain),
-		Delegate:        DelegateFn(header, chain),
-		Undelegate:      UndelegateFn(header, chain),
-		CollectRewards:  CollectRewardsFn(header, chain),
-		//MigrateDelegations:    MigrateDelegationsFn(header, chain),
-		CalculateMigrationGas: CalculateMigrationGasFn(chain),
+		CanTransfer:           CanTransfer,
+		Transfer:              Transfer,
+		GetHash:               GetHashFn(header, chain),
+		GetVRF:                GetVRFFn(header, chain),
+		IsValidator:           IsValidator,
 		Origin:                msg.From(),
+		GasPrice:              new(big.Int).Set(msg.GasPrice()),
 		Coinbase:              beneficiary,
+		GasLimit:              header.GasLimit(),
 		BlockNumber:           header.Number(),
 		EpochNumber:           header.Epoch(),
-		VRF:                   vrf,
 		Time:                  header.Time(),
-		GasLimit:              header.GasLimit(),
-		GasPrice:              new(big.Int).Set(msg.GasPrice()),
+		VRF:                   vrf,
+		TxType:                0,
+		CreateValidator:       CreateValidatorFn(header, chain),
+		EditValidator:         EditValidatorFn(header, chain),
+		Delegate:              DelegateFn(header, chain),
+		Undelegate:            UndelegateFn(header, chain),
+		CollectRewards:        CollectRewardsFn(header, chain),
+		CalculateMigrationGas: CalculateMigrationGasFn(chain),
 		ShardID:               chain.ShardID(),
+		NumShards:             shard.Schedule.InstanceForEpoch(header.Epoch()).NumShards(),
 	}
 }
 

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -299,9 +299,30 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	var cxReceipt *types.CXReceipt
 	// Do not create cxReceipt if EVM call failed
 	if txType == types.SubtractionOnly && !failedExe {
-		cxReceipt = &types.CXReceipt{TxHash: tx.Hash(), From: msg.From(), To: msg.To(), ShardID: tx.ShardID(), ToShardID: tx.ToShardID(), Amount: msg.Value()}
+		cxReceipt = &types.CXReceipt{
+			TxHash:    tx.Hash(),
+			From:      msg.From(),
+			To:        msg.To(),
+			ShardID:   tx.ShardID(),
+			ToShardID: tx.ToShardID(),
+			Amount:    msg.Value(),
+		}
+		if vmenv.CXReceipt != nil {
+			return nil, nil, nil, 0, errors.New("cannot have cross shard receipt via precompile and directly")
+		}
 	} else {
-		cxReceipt = nil
+		if !failedExe {
+			if vmenv.CXReceipt != nil {
+				cxReceipt = vmenv.CXReceipt
+				// this tx.Hash needs to be the "original" tx.Hash
+				// since, in effect, we have added
+				// support for cross shard txs
+				// to eth txs
+				cxReceipt.TxHash = tx.HashByType()
+			}
+		} else {
+			cxReceipt = nil
+		}
 	}
 
 	return receipt, cxReceipt, vmenv.StakeMsgs, result.UsedGas, err

--- a/core/vm/contracts_write.go
+++ b/core/vm/contracts_write.go
@@ -2,9 +2,13 @@ package vm
 
 import (
 	"errors"
+	"math/big"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/harmony-one/harmony/accounts/abi"
+	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/shard"
 	"github.com/harmony-one/harmony/staking"
 	stakingTypes "github.com/harmony-one/harmony/staking/types"
@@ -17,6 +21,19 @@ var WriteCapablePrecompiledContractsStaking = map[common.Address]WriteCapablePre
 	common.BytesToAddress([]byte{252}): &stakingPrecompile{},
 }
 
+var (
+	// reserve 250 for read only staking precompile and 251 for epoch
+	crossShardXferPrecompileAddress = common.BytesToAddress([]byte{249})
+)
+
+// WriteCapablePrecompiledContractsCrossXfer lists out the write capable precompiled contracts
+// which are available after the CrossShardXferPrecompileEpoch
+// It includes the staking precompile and the cross-shard transfer precompile
+var WriteCapablePrecompiledContractsCrossXfer = map[common.Address]WriteCapablePrecompiledContract{
+	crossShardXferPrecompileAddress:    &crossShardXferPrecompile{address: crossShardXferPrecompileAddress},
+	common.BytesToAddress([]byte{252}): &stakingPrecompile{},
+}
+
 // WriteCapablePrecompiledContract represents the interface for Native Go contracts
 // which are available as a precompile in the EVM
 // As with (read-only) PrecompiledContracts, these need a RequiredGas function
@@ -26,7 +43,7 @@ type WriteCapablePrecompiledContract interface {
 	// RequiredGas calculates the contract gas use
 	RequiredGas(evm *EVM, contract *Contract, input []byte) (uint64, error)
 	// use a different name from read-only contracts to be safe
-	RunWriteCapable(evm *EVM, contract *Contract, input []byte) ([]byte, error)
+	RunWriteCapable(evm *EVM, contract *Contract, input []byte, value *big.Int) ([]byte, error)
 }
 
 // RunWriteCapablePrecompiledContract runs and evaluates the output of a write capable precompiled contract.
@@ -36,6 +53,7 @@ func RunWriteCapablePrecompiledContract(
 	contract *Contract,
 	input []byte,
 	readOnly bool,
+	value *big.Int,
 ) ([]byte, error) {
 	// immediately error out if readOnly
 	if readOnly {
@@ -48,7 +66,7 @@ func RunWriteCapablePrecompiledContract(
 	if !contract.UseGas(gas) {
 		return nil, ErrOutOfGas
 	}
-	return p.RunWriteCapable(evm, contract, input)
+	return p.RunWriteCapable(evm, contract, input, value)
 }
 
 type stakingPrecompile struct{}
@@ -104,6 +122,7 @@ func (c *stakingPrecompile) RunWriteCapable(
 	evm *EVM,
 	contract *Contract,
 	input []byte,
+	value *big.Int,
 ) ([]byte, error) {
 	if evm.Context.ShardID != shard.BeaconChainShardID {
 		return nil, errors.New("Staking not supported on this shard")
@@ -149,4 +168,169 @@ func (c *stakingPrecompile) RunWriteCapable(
 	//	}
 	//}
 	return nil, errors.New("[StakingPrecompile] Received incompatible stakeMsg from staking.ParseStakeMsg")
+}
+
+var abiCrossShardXfer abi.ABI
+
+func init() {
+	// msg.Value is used for transfer and is also a parameter
+	// otherwise it might be possible for a user to retrieve money from the precompile
+	// that was sent by someone else prior to the hard fork
+	// contract.Caller is used as fromAddress, not a parameter
+	// originating ShardID is pulled from the EVM object, not a parameter
+	crossShardXferABIJSON := `
+	[
+	  {
+	    "inputs": [
+		  {
+	        "internalType": "uint256",
+	        "name": "value",
+	        "type": "uint256"
+	      },
+		  {
+	        "internalType": "address",
+	        "name": "to",
+	        "type": "address"
+	      },
+		  {
+	        "internalType": "uint64",
+	        "name": "toShardID",
+	        "type": "uint32"
+	      }
+	    ],
+	    "name": "crossShardTransfer",
+	    "outputs": [],
+	    "stateMutability": "payable",
+	    "type": "function"
+	  }
+	]`
+	var err error
+	abiCrossShardXfer, err = abi.JSON(strings.NewReader(crossShardXferABIJSON))
+	if err != nil {
+		// means an error in the code
+		panic("Invalid cross shard transfer ABI JSON")
+	}
+}
+
+type crossShardXferPrecompile struct {
+	address common.Address
+}
+
+// RequiredGas returns the gas required to execute the pre-compiled contract.
+//
+// This method does not require any overflow checking as the input size gas costs
+// required for anything significant is so high it's impossible to pay for.
+func (c *crossShardXferPrecompile) RequiredGas(
+	evm *EVM,
+	contract *Contract,
+	input []byte,
+) (uint64, error) {
+	// we just charge the intrinsic gas here
+	// using data that includes: fromAddress, toAddress, fromShardID, toShardID, value
+	var payload []byte = make([]byte, 0)
+	fromAddress, toAddress, fromShardID, toShardID, value, err := parseCrossShardXferData(evm, contract, input)
+	if err == nil {
+		data := struct {
+			fromAddress common.Address
+			toAddress   common.Address
+			fromShardID uint32
+			toShardID   uint32
+			value       *big.Int
+		}{
+			fromAddress: fromAddress,
+			toAddress:   toAddress,
+			fromShardID: fromShardID,
+			toShardID:   toShardID,
+			value:       value,
+		}
+		if encoded, err := rlp.EncodeToBytes(data); err == nil {
+			payload = encoded
+		}
+	}
+	if gas, err := IntrinsicGas(
+		payload,
+		false,                                   // contractCreation
+		evm.ChainConfig().IsS3(evm.EpochNumber), // homestead
+		evm.ChainConfig().IsIstanbul(evm.EpochNumber), // istanbul
+		false, // isValidatorCreation
+	); err != nil {
+		return 0, err // ErrOutOfGas occurs when gas payable > uint64
+	} else {
+		return gas, nil
+	}
+}
+
+// RunWriteCapable runs the actual contract
+func (c *crossShardXferPrecompile) RunWriteCapable(
+	evm *EVM,
+	contract *Contract,
+	input []byte,
+	sentValue *big.Int,
+) ([]byte, error) {
+	fromAddress, toAddress, fromShardID, toShardID, value, err := parseCrossShardXferData(evm, contract, input)
+	if err != nil {
+		return nil, err
+	}
+	// validate not a contract
+	if len(evm.StateDB.GetCode(fromAddress)) > 0 && !evm.IsValidator(evm.StateDB, fromAddress) {
+		return nil, errors.New("cross shard xfer not yet implemented for contracts")
+	}
+	// validate not a contract
+	if len(evm.StateDB.GetCode(toAddress)) > 0 && !evm.IsValidator(evm.StateDB, toAddress) {
+		return nil, errors.New("cross shard xfer not yet implemented for contracts")
+	}
+	// can't have too many shards
+	if toShardID >= evm.Context.NumShards {
+		return nil, errors.New("toShardId out of bounds")
+	}
+	// not for simple transfers
+	if fromShardID == toShardID {
+		return nil, errors.New("from and to shard id can't be equal")
+	}
+	// make sure nobody sends extra or less money
+	// no need to check `nil` because that only happens in readOnly
+	// which has already been checked
+	if sentValue.Cmp(value) != 0 {
+		return nil, errors.New("argument value and msg.value not equal")
+	}
+	// now do the actual transfer
+	// step 1 -> remove funds from the precompile address
+	evm.Transfer(evm.StateDB, c.address, toAddress, value, types.SubtractionOnly)
+	// step 2 -> make a cross link
+	// note that the transaction hash is added by state_processor.go to this receipt
+	evm.CXReceipt = &types.CXReceipt{
+		From:      fromAddress,
+		To:        &toAddress,
+		ShardID:   fromShardID,
+		ToShardID: toShardID,
+		Amount:    value,
+	}
+	return nil, nil
+}
+
+// parseCrossShardXferData does a simple parse with only data types validation
+func parseCrossShardXferData(evm *EVM, contract *Contract, input []byte) (
+	common.Address, common.Address, uint32, uint32, *big.Int, error) {
+	method, err := abiCrossShardXfer.MethodById(input)
+	if err != nil {
+		return common.Address{}, common.Address{}, 0, 0, nil, err
+	}
+	input = input[4:]
+	args := map[string]interface{}{}
+	if err = method.Inputs.UnpackIntoMap(args, input); err != nil {
+		return common.Address{}, common.Address{}, 0, 0, nil, err
+	}
+	value, err := abi.ParseBigIntFromKey(args, "value")
+	if err != nil {
+		return common.Address{}, common.Address{}, 0, 0, nil, err
+	}
+	toAddress, err := abi.ParseAddressFromKey(args, "to")
+	if err != nil {
+		return common.Address{}, common.Address{}, 0, 0, nil, err
+	}
+	toShardID, err := abi.ParseUint32FromKey(args, "toShardID")
+	if err != nil {
+		return common.Address{}, common.Address{}, 0, 0, nil, err
+	}
+	return contract.Caller(), toAddress, evm.ShardID, toShardID, value, nil
 }

--- a/core/vm/contracts_write_test.go
+++ b/core/vm/contracts_write_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/harmony-one/harmony/core/state"
+	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/internal/params"
 	stakingTypes "github.com/harmony-one/harmony/staking/types"
 )
@@ -17,6 +21,7 @@ type writeCapablePrecompileTest struct {
 	name            string
 	expectedError   error
 	p               *WriteCapablePrecompiledContract
+	value           *big.Int
 }
 
 func CollectRewardsFn() CollectRewardsFunc {
@@ -61,18 +66,7 @@ func CalculateMigrationGasFn() CalculateMigrationGasFunc {
 	}
 }
 
-func testStakingPrecompile(test writeCapablePrecompileTest, t *testing.T) {
-	var env = NewEVM(Context{CollectRewards: CollectRewardsFn(),
-		Delegate:        DelegateFn(),
-		Undelegate:      UndelegateFn(),
-		CreateValidator: CreateValidatorFn(),
-		EditValidator:   EditValidatorFn(),
-		ShardID:         0,
-		//MigrateDelegations:    MigrateDelegationsFn(),
-		CalculateMigrationGas: CalculateMigrationGasFn(),
-	}, nil, params.TestChainConfig, Config{})
-	// use required gas to avoid out of gas errors
-	p := &stakingPrecompile{}
+func testWriteCapablePrecompile(test writeCapablePrecompileTest, t *testing.T, env *EVM, p WriteCapablePrecompiledContract) {
 	t.Run(fmt.Sprintf("%s", test.name), func(t *testing.T) {
 		contract := NewContract(AccountRef(common.HexToAddress("1337")), AccountRef(common.HexToAddress("1338")), new(big.Int), 0)
 		gas, err := p.RequiredGas(env, contract, test.input)
@@ -80,7 +74,7 @@ func testStakingPrecompile(test writeCapablePrecompileTest, t *testing.T) {
 			t.Error(err)
 		}
 		contract.Gas = gas
-		if res, err := RunWriteCapablePrecompiledContract(p, env, contract, test.input, false); err != nil {
+		if res, err := RunWriteCapablePrecompiledContract(p, env, contract, test.input, false, test.value); err != nil {
 			if test.expectedError != nil {
 				if test.expectedError.Error() != err.Error() {
 					t.Errorf("Expected error %v, got %v", test.expectedError, err)
@@ -99,23 +93,18 @@ func testStakingPrecompile(test writeCapablePrecompileTest, t *testing.T) {
 	})
 }
 
-func TestStakingPrecompiles(t *testing.T) {
-	for _, test := range StakingPrecompileTests {
-		testStakingPrecompile(test, t)
-	}
-}
-
-func TestWriteCapablePrecompilesReadOnly(t *testing.T) {
+func testStakingPrecompile(test writeCapablePrecompileTest, t *testing.T) {
+	var env = NewEVM(Context{CollectRewards: CollectRewardsFn(),
+		Delegate:        DelegateFn(),
+		Undelegate:      UndelegateFn(),
+		CreateValidator: CreateValidatorFn(),
+		EditValidator:   EditValidatorFn(),
+		ShardID:         0,
+		//MigrateDelegations:    MigrateDelegationsFn(),
+		CalculateMigrationGas: CalculateMigrationGasFn(),
+	}, nil, params.TestChainConfig, Config{})
 	p := &stakingPrecompile{}
-	expectedError := errWriteProtection
-	res, err := RunWriteCapablePrecompiledContract(p, nil, nil, []byte{}, true)
-	if err != nil {
-		if err.Error() != expectedError.Error() {
-			t.Errorf("Expected error %v, got %v", expectedError, err)
-		}
-	} else {
-		t.Errorf("Expected an error %v but instead got result %v", expectedError, res)
-	}
+	testWriteCapablePrecompile(test, t, env, p)
 }
 
 var StakingPrecompileTests = []writeCapablePrecompileTest{
@@ -210,4 +199,93 @@ var StakingPrecompileTests = []writeCapablePrecompileTest{
 	//	expectedError: errors.New("abi: cannot marshal in to go type: length insufficient 63 require 64"),
 	//	name:          "migrationAddressMismatch",
 	//},
+}
+
+func TestStakingPrecompiles(t *testing.T) {
+	for _, test := range StakingPrecompileTests {
+		testStakingPrecompile(test, t)
+	}
+}
+
+func TestWriteCapablePrecompilesReadOnly(t *testing.T) {
+	p := &stakingPrecompile{}
+	expectedError := errWriteProtection
+	res, err := RunWriteCapablePrecompiledContract(p, nil, nil, []byte{}, true, nil)
+	if err != nil {
+		if err.Error() != expectedError.Error() {
+			t.Errorf("Expected error %v, got %v", expectedError, err)
+		}
+	} else {
+		t.Errorf("Expected an error %v but instead got result %v", expectedError, res)
+	}
+}
+
+func transfer(db StateDB, sender, recipient common.Address, amount *big.Int, txType types.TransactionType) {
+}
+
+func testCrossShardXferPrecompile(test writeCapablePrecompileTest, t *testing.T) {
+	// this EVM needs stateDB, Transfer, and NumShards
+	var db ethdb.Database
+	var err error
+	defer func() {
+		if db != nil {
+			db.Close()
+		}
+	}()
+	if db, err = rawdb.NewLevelDBDatabase("/tmp/harmony_shard_0", 256, 1024, ""); err != nil {
+		db = nil
+		t.Fatalf("Could not initialize db %s", err)
+	}
+	stateCache := state.NewDatabase(db)
+	state, err := state.New(common.Hash{}, stateCache)
+	if err != nil {
+		t.Fatalf("Error while initializing state %s", err)
+	}
+	var env = NewEVM(Context{
+		NumShards: 4,
+		Transfer:  transfer,
+	}, state, params.TestChainConfig, Config{})
+	p := &crossShardXferPrecompile{}
+	testWriteCapablePrecompile(test, t, env, p)
+}
+
+func TestCrossShardXferPrecompile(t *testing.T) {
+	for _, test := range CrossShardXferPrecompileTests {
+		testCrossShardXferPrecompile(test, t)
+	}
+}
+
+var CrossShardXferPrecompileTests = []writeCapablePrecompileTest{
+	{
+		input:    []byte{40, 72, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 107, 199, 94, 45, 99, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 165, 36, 21, 19, 218, 159, 68, 99, 241, 212, 135, 75, 84, 141, 251, 172, 41, 217, 31, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+		expected: nil,
+		name:     "crossShardSuccess",
+		value:    new(big.Int).Mul(big.NewInt(100), big.NewInt(1e18)),
+	},
+	{
+		input:         []byte{40, 72, 8, 1},
+		expectedError: errors.New("no method with id: 0x28480801"),
+		name:          "crossShardMethodSigFail",
+	},
+	{
+		input:         []byte{40, 72, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 107, 199, 94, 45, 99, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 165, 36, 21, 19, 218, 159, 68, 99, 241, 212, 135, 75, 84, 141, 251, 172, 41, 217, 31, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		expectedError: errors.New("abi: cannot marshal in to go type: length insufficient 95 require 96"),
+		name:          "crossShardMalformedInputFail",
+	},
+	{
+		input:         []byte{40, 72, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 107, 199, 94, 45, 99, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 165, 36, 21, 19, 218, 159, 68, 99, 241, 212, 135, 75, 84, 141, 251, 172, 41, 217, 31, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6},
+		expectedError: errors.New("toShardId out of bounds"),
+		name:          "crossShardOutOfBoundsFail",
+	},
+	{
+		input:         []byte{40, 72, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 107, 199, 94, 45, 99, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 165, 36, 21, 19, 218, 159, 68, 99, 241, 212, 135, 75, 84, 141, 251, 172, 41, 217, 31, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		expectedError: errors.New("from and to shard id can't be equal"),
+		name:          "crossShardSameShardFail",
+	},
+	{
+		input:         []byte{40, 72, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 107, 199, 94, 45, 99, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 165, 36, 21, 19, 218, 159, 68, 99, 241, 212, 135, 75, 84, 141, 251, 172, 41, 217, 31, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+		expectedError: errors.New("argument value and msg.value not equal"),
+		name:          "crossShardDiffValueFail",
+		value:         new(big.Int).Mul(big.NewInt(1000), big.NewInt(1e18)),
+	},
 }

--- a/core/vm/evm_test.go
+++ b/core/vm/evm_test.go
@@ -24,6 +24,7 @@ func TestEpochPrecompile(t *testing.T) {
 		&contract,
 		input,
 		true,
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("Got error%v\n", err)

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -36,209 +36,215 @@ var once sync.Once
 var (
 	// MainnetChainConfig is the chain parameters to run a node on the main network.
 	MainnetChainConfig = &ChainConfig{
-		ChainID:                    MainnetChainID,
-		EthCompatibleChainID:       EthMainnetShard0ChainID,
-		EthCompatibleShard0ChainID: EthMainnetShard0ChainID,
-		EthCompatibleEpoch:         big.NewInt(442), // Around Thursday Feb 4th 2020, 10AM PST
-		CrossTxEpoch:               big.NewInt(28),
-		CrossLinkEpoch:             big.NewInt(186),
-		AggregatedRewardEpoch:      big.NewInt(689), // Around Wed Sept 15th 2021 with 3.5s block time
-		StakingEpoch:               big.NewInt(186),
-		PreStakingEpoch:            big.NewInt(185),
-		QuickUnlockEpoch:           big.NewInt(191),
-		FiveSecondsEpoch:           big.NewInt(230),
-		TwoSecondsEpoch:            big.NewInt(366), // Around Tuesday Dec 8th 2020, 8AM PST
-		SixtyPercentEpoch:          big.NewInt(530), // Around Monday Apr 12th 2021, 22:30 UTC
-		RedelegationEpoch:          big.NewInt(290),
-		NoEarlyUnlockEpoch:         big.NewInt(530), // Around Monday Apr 12th 2021, 22:30 UTC
-		VRFEpoch:                   big.NewInt(631), // Around Wed July 7th 2021
-		PrevVRFEpoch:               big.NewInt(689), // Around Wed Sept 15th 2021 with 3.5s block time
-		MinDelegation100Epoch:      big.NewInt(631), // Around Wed July 7th 2021
-		MinCommissionRateEpoch:     big.NewInt(631), // Around Wed July 7th 2021
-		MinCommissionPromoPeriod:   big.NewInt(100),
-		EPoSBound35Epoch:           big.NewInt(631), // Around Wed July 7th 2021
-		EIP155Epoch:                big.NewInt(28),
-		S3Epoch:                    big.NewInt(28),
-		DataCopyFixEpoch:           big.NewInt(689), // Around Wed Sept 15th 2021 with 3.5s block time
-		IstanbulEpoch:              big.NewInt(314),
-		ReceiptLogEpoch:            big.NewInt(101),
-		SHA3Epoch:                  big.NewInt(725), // Around Mon Oct 11 2021, 19:00 UTC
-		HIP6And8Epoch:              big.NewInt(725), // Around Mon Oct 11 2021, 19:00 UTC
-		StakingPrecompileEpoch:     big.NewInt(871), // Around Tue Feb 11 2022
-		SlotsLimitedEpoch:          EpochTBD,        // epoch to enable HIP-16
+		ChainID:                       MainnetChainID,
+		EthCompatibleChainID:          EthMainnetShard0ChainID,
+		EthCompatibleShard0ChainID:    EthMainnetShard0ChainID,
+		EthCompatibleEpoch:            big.NewInt(442), // Around Thursday Feb 4th 2020, 10AM PST
+		CrossTxEpoch:                  big.NewInt(28),
+		CrossLinkEpoch:                big.NewInt(186),
+		AggregatedRewardEpoch:         big.NewInt(689), // Around Wed Sept 15th 2021 with 3.5s block time
+		StakingEpoch:                  big.NewInt(186),
+		PreStakingEpoch:               big.NewInt(185),
+		QuickUnlockEpoch:              big.NewInt(191),
+		FiveSecondsEpoch:              big.NewInt(230),
+		TwoSecondsEpoch:               big.NewInt(366), // Around Tuesday Dec 8th 2020, 8AM PST
+		SixtyPercentEpoch:             big.NewInt(530), // Around Monday Apr 12th 2021, 22:30 UTC
+		RedelegationEpoch:             big.NewInt(290),
+		NoEarlyUnlockEpoch:            big.NewInt(530), // Around Monday Apr 12th 2021, 22:30 UTC
+		VRFEpoch:                      big.NewInt(631), // Around Wed July 7th 2021
+		PrevVRFEpoch:                  big.NewInt(689), // Around Wed Sept 15th 2021 with 3.5s block time
+		MinDelegation100Epoch:         big.NewInt(631), // Around Wed July 7th 2021
+		MinCommissionRateEpoch:        big.NewInt(631), // Around Wed July 7th 2021
+		MinCommissionPromoPeriod:      big.NewInt(100),
+		EPoSBound35Epoch:              big.NewInt(631), // Around Wed July 7th 2021
+		EIP155Epoch:                   big.NewInt(28),
+		S3Epoch:                       big.NewInt(28),
+		DataCopyFixEpoch:              big.NewInt(689), // Around Wed Sept 15th 2021 with 3.5s block time
+		IstanbulEpoch:                 big.NewInt(314),
+		ReceiptLogEpoch:               big.NewInt(101),
+		SHA3Epoch:                     big.NewInt(725), // Around Mon Oct 11 2021, 19:00 UTC
+		HIP6And8Epoch:                 big.NewInt(725), // Around Mon Oct 11 2021, 19:00 UTC
+		StakingPrecompileEpoch:        big.NewInt(871), // Around Tue Feb 11 2022
+		SlotsLimitedEpoch:             EpochTBD,        // epoch to enable HIP-16
+		CrossShardXferPrecompileEpoch: EpochTBD,
 	}
 
 	// TestnetChainConfig contains the chain parameters to run a node on the harmony test network.
 	TestnetChainConfig = &ChainConfig{
-		ChainID:                    TestnetChainID,
-		EthCompatibleChainID:       EthTestnetShard0ChainID,
-		EthCompatibleShard0ChainID: EthTestnetShard0ChainID,
-		EthCompatibleEpoch:         big.NewInt(73290),
-		CrossTxEpoch:               big.NewInt(0),
-		CrossLinkEpoch:             big.NewInt(2),
-		AggregatedRewardEpoch:      big.NewInt(74275),
-		StakingEpoch:               big.NewInt(2),
-		PreStakingEpoch:            big.NewInt(1),
-		QuickUnlockEpoch:           big.NewInt(0),
-		FiveSecondsEpoch:           big.NewInt(16500),
-		TwoSecondsEpoch:            big.NewInt(73000),
-		SixtyPercentEpoch:          big.NewInt(73282),
-		RedelegationEpoch:          big.NewInt(36500),
-		NoEarlyUnlockEpoch:         big.NewInt(73580),
-		VRFEpoch:                   big.NewInt(73880),
-		PrevVRFEpoch:               big.NewInt(74384),
-		MinDelegation100Epoch:      big.NewInt(73880),
-		MinCommissionRateEpoch:     big.NewInt(73880),
-		MinCommissionPromoPeriod:   big.NewInt(10),
-		EPoSBound35Epoch:           big.NewInt(73880),
-		EIP155Epoch:                big.NewInt(0),
-		S3Epoch:                    big.NewInt(0),
-		DataCopyFixEpoch:           big.NewInt(74412),
-		IstanbulEpoch:              big.NewInt(43800),
-		ReceiptLogEpoch:            big.NewInt(0),
-		SHA3Epoch:                  big.NewInt(74570),
-		HIP6And8Epoch:              big.NewInt(74570),
-		StakingPrecompileEpoch:     big.NewInt(75175),
-		SlotsLimitedEpoch:          big.NewInt(75684), // epoch to enable HIP-16, around Mon, 02 May 2022 08:18:45 UTC with 2s block time
+		ChainID:                       TestnetChainID,
+		EthCompatibleChainID:          EthTestnetShard0ChainID,
+		EthCompatibleShard0ChainID:    EthTestnetShard0ChainID,
+		EthCompatibleEpoch:            big.NewInt(73290),
+		CrossTxEpoch:                  big.NewInt(0),
+		CrossLinkEpoch:                big.NewInt(2),
+		AggregatedRewardEpoch:         big.NewInt(74275),
+		StakingEpoch:                  big.NewInt(2),
+		PreStakingEpoch:               big.NewInt(1),
+		QuickUnlockEpoch:              big.NewInt(0),
+		FiveSecondsEpoch:              big.NewInt(16500),
+		TwoSecondsEpoch:               big.NewInt(73000),
+		SixtyPercentEpoch:             big.NewInt(73282),
+		RedelegationEpoch:             big.NewInt(36500),
+		NoEarlyUnlockEpoch:            big.NewInt(73580),
+		VRFEpoch:                      big.NewInt(73880),
+		PrevVRFEpoch:                  big.NewInt(74384),
+		MinDelegation100Epoch:         big.NewInt(73880),
+		MinCommissionRateEpoch:        big.NewInt(73880),
+		MinCommissionPromoPeriod:      big.NewInt(10),
+		EPoSBound35Epoch:              big.NewInt(73880),
+		EIP155Epoch:                   big.NewInt(0),
+		S3Epoch:                       big.NewInt(0),
+		DataCopyFixEpoch:              big.NewInt(74412),
+		IstanbulEpoch:                 big.NewInt(43800),
+		ReceiptLogEpoch:               big.NewInt(0),
+		SHA3Epoch:                     big.NewInt(74570),
+		HIP6And8Epoch:                 big.NewInt(74570),
+		StakingPrecompileEpoch:        big.NewInt(75175),
+		SlotsLimitedEpoch:             big.NewInt(75684), // epoch to enable HIP-16, around Mon, 02 May 2022 08:18:45 UTC with 2s block time
+		CrossShardXferPrecompileEpoch: EpochTBD,
 	}
 
 	// PangaeaChainConfig contains the chain parameters for the Pangaea network.
 	// All features except for CrossLink are enabled at launch.
 	PangaeaChainConfig = &ChainConfig{
-		ChainID:                    PangaeaChainID,
-		EthCompatibleChainID:       EthPangaeaShard0ChainID,
-		EthCompatibleShard0ChainID: EthPangaeaShard0ChainID,
-		EthCompatibleEpoch:         big.NewInt(0),
-		CrossTxEpoch:               big.NewInt(0),
-		CrossLinkEpoch:             big.NewInt(2),
-		AggregatedRewardEpoch:      big.NewInt(3),
-		StakingEpoch:               big.NewInt(2),
-		PreStakingEpoch:            big.NewInt(1),
-		QuickUnlockEpoch:           big.NewInt(0),
-		FiveSecondsEpoch:           big.NewInt(0),
-		TwoSecondsEpoch:            big.NewInt(0),
-		SixtyPercentEpoch:          big.NewInt(0),
-		RedelegationEpoch:          big.NewInt(0),
-		NoEarlyUnlockEpoch:         big.NewInt(0),
-		VRFEpoch:                   big.NewInt(0),
-		PrevVRFEpoch:               big.NewInt(0),
-		MinDelegation100Epoch:      big.NewInt(0),
-		MinCommissionRateEpoch:     big.NewInt(0),
-		MinCommissionPromoPeriod:   big.NewInt(10),
-		EPoSBound35Epoch:           big.NewInt(0),
-		EIP155Epoch:                big.NewInt(0),
-		S3Epoch:                    big.NewInt(0),
-		DataCopyFixEpoch:           big.NewInt(0),
-		IstanbulEpoch:              big.NewInt(0),
-		ReceiptLogEpoch:            big.NewInt(0),
-		SHA3Epoch:                  big.NewInt(0),
-		HIP6And8Epoch:              big.NewInt(0),
-		StakingPrecompileEpoch:     big.NewInt(2), // same as staking
-		SlotsLimitedEpoch:          EpochTBD,      // epoch to enable HIP-16
+		ChainID:                       PangaeaChainID,
+		EthCompatibleChainID:          EthPangaeaShard0ChainID,
+		EthCompatibleShard0ChainID:    EthPangaeaShard0ChainID,
+		EthCompatibleEpoch:            big.NewInt(0),
+		CrossTxEpoch:                  big.NewInt(0),
+		CrossLinkEpoch:                big.NewInt(2),
+		AggregatedRewardEpoch:         big.NewInt(3),
+		StakingEpoch:                  big.NewInt(2),
+		PreStakingEpoch:               big.NewInt(1),
+		QuickUnlockEpoch:              big.NewInt(0),
+		FiveSecondsEpoch:              big.NewInt(0),
+		TwoSecondsEpoch:               big.NewInt(0),
+		SixtyPercentEpoch:             big.NewInt(0),
+		RedelegationEpoch:             big.NewInt(0),
+		NoEarlyUnlockEpoch:            big.NewInt(0),
+		VRFEpoch:                      big.NewInt(0),
+		PrevVRFEpoch:                  big.NewInt(0),
+		MinDelegation100Epoch:         big.NewInt(0),
+		MinCommissionRateEpoch:        big.NewInt(0),
+		MinCommissionPromoPeriod:      big.NewInt(10),
+		EPoSBound35Epoch:              big.NewInt(0),
+		EIP155Epoch:                   big.NewInt(0),
+		S3Epoch:                       big.NewInt(0),
+		DataCopyFixEpoch:              big.NewInt(0),
+		IstanbulEpoch:                 big.NewInt(0),
+		ReceiptLogEpoch:               big.NewInt(0),
+		SHA3Epoch:                     big.NewInt(0),
+		HIP6And8Epoch:                 big.NewInt(0),
+		StakingPrecompileEpoch:        big.NewInt(2), // same as staking
+		SlotsLimitedEpoch:             EpochTBD,      // epoch to enable HIP-16
+		CrossShardXferPrecompileEpoch: big.NewInt(1), // cross tx + 1
 	}
 
 	// PartnerChainConfig contains the chain parameters for the Partner network.
 	// All features except for CrossLink are enabled at launch.
 	PartnerChainConfig = &ChainConfig{
-		ChainID:                    PartnerChainID,
-		EthCompatibleChainID:       EthPartnerShard0ChainID,
-		EthCompatibleShard0ChainID: EthPartnerShard0ChainID,
-		EthCompatibleEpoch:         big.NewInt(0),
-		CrossTxEpoch:               big.NewInt(0),
-		CrossLinkEpoch:             big.NewInt(2),
-		AggregatedRewardEpoch:      big.NewInt(3),
-		StakingEpoch:               big.NewInt(2),
-		PreStakingEpoch:            big.NewInt(1),
-		QuickUnlockEpoch:           big.NewInt(0),
-		FiveSecondsEpoch:           big.NewInt(0),
-		TwoSecondsEpoch:            big.NewInt(0),
-		SixtyPercentEpoch:          big.NewInt(4),
-		RedelegationEpoch:          big.NewInt(0),
-		NoEarlyUnlockEpoch:         big.NewInt(0),
-		VRFEpoch:                   big.NewInt(0),
-		PrevVRFEpoch:               big.NewInt(0),
-		MinDelegation100Epoch:      big.NewInt(0),
-		MinCommissionRateEpoch:     big.NewInt(0),
-		MinCommissionPromoPeriod:   big.NewInt(10),
-		EPoSBound35Epoch:           big.NewInt(0),
-		EIP155Epoch:                big.NewInt(0),
-		S3Epoch:                    big.NewInt(0),
-		DataCopyFixEpoch:           big.NewInt(0),
-		IstanbulEpoch:              big.NewInt(0),
-		ReceiptLogEpoch:            big.NewInt(0),
-		SHA3Epoch:                  big.NewInt(0),
-		HIP6And8Epoch:              big.NewInt(0),
-		StakingPrecompileEpoch:     big.NewInt(2),
-		SlotsLimitedEpoch:          EpochTBD, // epoch to enable HIP-16
+		ChainID:                       PartnerChainID,
+		EthCompatibleChainID:          EthPartnerShard0ChainID,
+		EthCompatibleShard0ChainID:    EthPartnerShard0ChainID,
+		EthCompatibleEpoch:            big.NewInt(0),
+		CrossTxEpoch:                  big.NewInt(0),
+		CrossLinkEpoch:                big.NewInt(2),
+		AggregatedRewardEpoch:         big.NewInt(3),
+		StakingEpoch:                  big.NewInt(2),
+		PreStakingEpoch:               big.NewInt(1),
+		QuickUnlockEpoch:              big.NewInt(0),
+		FiveSecondsEpoch:              big.NewInt(0),
+		TwoSecondsEpoch:               big.NewInt(0),
+		SixtyPercentEpoch:             big.NewInt(4),
+		RedelegationEpoch:             big.NewInt(0),
+		NoEarlyUnlockEpoch:            big.NewInt(0),
+		VRFEpoch:                      big.NewInt(0),
+		PrevVRFEpoch:                  big.NewInt(0),
+		MinDelegation100Epoch:         big.NewInt(0),
+		MinCommissionRateEpoch:        big.NewInt(0),
+		MinCommissionPromoPeriod:      big.NewInt(10),
+		EPoSBound35Epoch:              big.NewInt(0),
+		EIP155Epoch:                   big.NewInt(0),
+		S3Epoch:                       big.NewInt(0),
+		DataCopyFixEpoch:              big.NewInt(0),
+		IstanbulEpoch:                 big.NewInt(0),
+		ReceiptLogEpoch:               big.NewInt(0),
+		SHA3Epoch:                     big.NewInt(0),
+		HIP6And8Epoch:                 big.NewInt(0),
+		StakingPrecompileEpoch:        big.NewInt(2),
+		SlotsLimitedEpoch:             EpochTBD,      // epoch to enable HIP-16
+		CrossShardXferPrecompileEpoch: big.NewInt(1), // cross tx + 1
 	}
 
 	// StressnetChainConfig contains the chain parameters for the Stress test network.
 	// All features except for CrossLink are enabled at launch.
 	StressnetChainConfig = &ChainConfig{
-		ChainID:                    StressnetChainID,
-		EthCompatibleChainID:       EthStressnetShard0ChainID,
-		EthCompatibleShard0ChainID: EthStressnetShard0ChainID,
-		EthCompatibleEpoch:         big.NewInt(0),
-		CrossTxEpoch:               big.NewInt(0),
-		CrossLinkEpoch:             big.NewInt(2),
-		AggregatedRewardEpoch:      big.NewInt(3),
-		StakingEpoch:               big.NewInt(2),
-		PreStakingEpoch:            big.NewInt(1),
-		QuickUnlockEpoch:           big.NewInt(0),
-		FiveSecondsEpoch:           big.NewInt(0),
-		TwoSecondsEpoch:            big.NewInt(0),
-		SixtyPercentEpoch:          big.NewInt(10),
-		RedelegationEpoch:          big.NewInt(0),
-		NoEarlyUnlockEpoch:         big.NewInt(0),
-		VRFEpoch:                   big.NewInt(0),
-		PrevVRFEpoch:               big.NewInt(0),
-		MinDelegation100Epoch:      big.NewInt(0),
-		MinCommissionRateEpoch:     big.NewInt(0),
-		MinCommissionPromoPeriod:   big.NewInt(10),
-		EPoSBound35Epoch:           big.NewInt(0),
-		EIP155Epoch:                big.NewInt(0),
-		S3Epoch:                    big.NewInt(0),
-		DataCopyFixEpoch:           big.NewInt(0),
-		IstanbulEpoch:              big.NewInt(0),
-		ReceiptLogEpoch:            big.NewInt(0),
-		SHA3Epoch:                  big.NewInt(0),
-		HIP6And8Epoch:              big.NewInt(0),
-		StakingPrecompileEpoch:     big.NewInt(2),
-		SlotsLimitedEpoch:          EpochTBD, // epoch to enable HIP-16
+		ChainID:                       StressnetChainID,
+		EthCompatibleChainID:          EthStressnetShard0ChainID,
+		EthCompatibleShard0ChainID:    EthStressnetShard0ChainID,
+		EthCompatibleEpoch:            big.NewInt(0),
+		CrossTxEpoch:                  big.NewInt(0),
+		CrossLinkEpoch:                big.NewInt(2),
+		AggregatedRewardEpoch:         big.NewInt(3),
+		StakingEpoch:                  big.NewInt(2),
+		PreStakingEpoch:               big.NewInt(1),
+		QuickUnlockEpoch:              big.NewInt(0),
+		FiveSecondsEpoch:              big.NewInt(0),
+		TwoSecondsEpoch:               big.NewInt(0),
+		SixtyPercentEpoch:             big.NewInt(10),
+		RedelegationEpoch:             big.NewInt(0),
+		NoEarlyUnlockEpoch:            big.NewInt(0),
+		VRFEpoch:                      big.NewInt(0),
+		PrevVRFEpoch:                  big.NewInt(0),
+		MinDelegation100Epoch:         big.NewInt(0),
+		MinCommissionRateEpoch:        big.NewInt(0),
+		MinCommissionPromoPeriod:      big.NewInt(10),
+		EPoSBound35Epoch:              big.NewInt(0),
+		EIP155Epoch:                   big.NewInt(0),
+		S3Epoch:                       big.NewInt(0),
+		DataCopyFixEpoch:              big.NewInt(0),
+		IstanbulEpoch:                 big.NewInt(0),
+		ReceiptLogEpoch:               big.NewInt(0),
+		SHA3Epoch:                     big.NewInt(0),
+		HIP6And8Epoch:                 big.NewInt(0),
+		StakingPrecompileEpoch:        big.NewInt(2),
+		SlotsLimitedEpoch:             EpochTBD,      // epoch to enable HIP-16
+		CrossShardXferPrecompileEpoch: big.NewInt(1), // cross tx + 1
 	}
 
 	// LocalnetChainConfig contains the chain parameters to run for local development.
 	LocalnetChainConfig = &ChainConfig{
-		ChainID:                    TestnetChainID,
-		EthCompatibleChainID:       EthTestnetShard0ChainID,
-		EthCompatibleShard0ChainID: EthTestnetShard0ChainID,
-		EthCompatibleEpoch:         big.NewInt(0),
-		CrossTxEpoch:               big.NewInt(0),
-		CrossLinkEpoch:             big.NewInt(2),
-		AggregatedRewardEpoch:      big.NewInt(3),
-		StakingEpoch:               big.NewInt(2),
-		PreStakingEpoch:            big.NewInt(0),
-		QuickUnlockEpoch:           big.NewInt(0),
-		FiveSecondsEpoch:           big.NewInt(0),
-		TwoSecondsEpoch:            big.NewInt(3),
-		SixtyPercentEpoch:          EpochTBD, // Never enable it for localnet as localnet has no external validator setup
-		RedelegationEpoch:          big.NewInt(0),
-		NoEarlyUnlockEpoch:         big.NewInt(0),
-		VRFEpoch:                   big.NewInt(0),
-		PrevVRFEpoch:               big.NewInt(0),
-		MinDelegation100Epoch:      big.NewInt(0),
-		MinCommissionRateEpoch:     big.NewInt(0),
-		MinCommissionPromoPeriod:   big.NewInt(10),
-		EPoSBound35Epoch:           big.NewInt(0),
-		EIP155Epoch:                big.NewInt(0),
-		S3Epoch:                    big.NewInt(0),
-		DataCopyFixEpoch:           big.NewInt(0),
-		IstanbulEpoch:              big.NewInt(0),
-		ReceiptLogEpoch:            big.NewInt(0),
-		SHA3Epoch:                  big.NewInt(0),
-		HIP6And8Epoch:              EpochTBD, // Never enable it for localnet as localnet has no external validator setup
-		StakingPrecompileEpoch:     big.NewInt(2),
-		SlotsLimitedEpoch:          EpochTBD, // epoch to enable HIP-16
+		ChainID:                       TestnetChainID,
+		EthCompatibleChainID:          EthTestnetShard0ChainID,
+		EthCompatibleShard0ChainID:    EthTestnetShard0ChainID,
+		EthCompatibleEpoch:            big.NewInt(0),
+		CrossTxEpoch:                  big.NewInt(0),
+		CrossLinkEpoch:                big.NewInt(2),
+		AggregatedRewardEpoch:         big.NewInt(3),
+		StakingEpoch:                  big.NewInt(2),
+		PreStakingEpoch:               big.NewInt(0),
+		QuickUnlockEpoch:              big.NewInt(0),
+		FiveSecondsEpoch:              big.NewInt(0),
+		TwoSecondsEpoch:               big.NewInt(3),
+		SixtyPercentEpoch:             EpochTBD, // Never enable it for localnet as localnet has no external validator setup
+		RedelegationEpoch:             big.NewInt(0),
+		NoEarlyUnlockEpoch:            big.NewInt(0),
+		VRFEpoch:                      big.NewInt(0),
+		PrevVRFEpoch:                  big.NewInt(0),
+		MinDelegation100Epoch:         big.NewInt(0),
+		MinCommissionRateEpoch:        big.NewInt(0),
+		MinCommissionPromoPeriod:      big.NewInt(10),
+		EPoSBound35Epoch:              big.NewInt(0),
+		EIP155Epoch:                   big.NewInt(0),
+		S3Epoch:                       big.NewInt(0),
+		DataCopyFixEpoch:              big.NewInt(0),
+		IstanbulEpoch:                 big.NewInt(0),
+		ReceiptLogEpoch:               big.NewInt(0),
+		SHA3Epoch:                     big.NewInt(0),
+		HIP6And8Epoch:                 EpochTBD, // Never enable it for localnet as localnet has no external validator setup
+		StakingPrecompileEpoch:        big.NewInt(2),
+		SlotsLimitedEpoch:             EpochTBD,      // epoch to enable HIP-16
+		CrossShardXferPrecompileEpoch: big.NewInt(1), // cross tx + 1
 	}
 
 	// AllProtocolChanges ...
@@ -275,6 +281,7 @@ var (
 		big.NewInt(0),                      // HIP6And8Epoch
 		big.NewInt(0),                      // StakingPrecompileEpoch
 		big.NewInt(0),                      // SlotsLimitedEpoch
+		big.NewInt(1),                      // CrossShardXferPrecompileEpoch
 	}
 
 	// TestChainConfig ...
@@ -311,6 +318,7 @@ var (
 		big.NewInt(0),        // HIP6And8Epoch
 		big.NewInt(0),        // StakingPrecompileEpoch
 		big.NewInt(0),        // SlotsLimitedEpoch
+		big.NewInt(1),        // CrossShardXferPrecompileEpoch
 	}
 
 	// TestRules ...
@@ -431,11 +439,14 @@ type ChainConfig struct {
 
 	// SlotsLimitedEpoch is the first epoch to enable HIP-16.
 	SlotsLimitedEpoch *big.Int `json:"slots-limit-epoch,omitempty"`
+
+	// CrossShardXferPrecompileEpoch is the first epoch to feature cross shard transfer precompile
+	CrossShardXferPrecompileEpoch *big.Int `json:"cross-shard-xfer-precompile-epoch,omitempty"`
 }
 
 // String implements the fmt.Stringer interface.
 func (c *ChainConfig) String() string {
-	return fmt.Sprintf("{ChainID: %v EthCompatibleChainID: %v EIP155: %v CrossTx: %v Staking: %v CrossLink: %v ReceiptLog: %v SHA3Epoch: %v StakingPrecompileEpoch: %v}",
+	return fmt.Sprintf("{ChainID: %v EthCompatibleChainID: %v EIP155: %v CrossTx: %v Staking: %v CrossLink: %v ReceiptLog: %v SHA3Epoch: %v StakingPrecompileEpoch: %v CrossShardXferPrecompileEpoch: %v}",
 		c.ChainID,
 		c.EthCompatibleChainID,
 		c.EIP155Epoch,
@@ -445,6 +456,7 @@ func (c *ChainConfig) String() string {
 		c.ReceiptLogEpoch,
 		c.SHA3Epoch,
 		c.StakingPrecompileEpoch,
+		c.CrossShardXferPrecompileEpoch,
 	)
 }
 
@@ -596,6 +608,12 @@ func (c *ChainConfig) IsStakingPrecompile(epoch *big.Int) bool {
 	return isForked(c.StakingPrecompileEpoch, epoch)
 }
 
+// IsCrossShardXferPrecompile determines whether the
+// Cross Shard Transfer Precompile is available in the EVM
+func (c *ChainConfig) IsCrossShardXferPrecompile(epoch *big.Int) bool {
+	return isForked(c.CrossShardXferPrecompileEpoch, epoch)
+}
+
 // UpdateEthChainIDByShard update the ethChainID based on shard ID.
 func UpdateEthChainIDByShard(shardID uint32) {
 	once.Do(func() {
@@ -644,16 +662,22 @@ func isForked(s, epoch *big.Int) bool {
 // Rules is a one time interface meaning that it shouldn't be used in between transition
 // phases.
 type Rules struct {
-	ChainID                                                                                              *big.Int
-	EthChainID                                                                                           *big.Int
-	IsCrossLink, IsEIP155, IsS3, IsReceiptLog, IsIstanbul, IsVRF, IsPrevVRF, IsSHA3, IsStakingPrecompile bool
+	ChainID    *big.Int
+	EthChainID *big.Int
+	IsCrossLink, IsEIP155, IsS3, IsReceiptLog, IsIstanbul, IsVRF, IsPrevVRF, IsSHA3,
+	IsStakingPrecompile, IsCrossShardXferPrecompile bool
 }
 
 // Rules ensures c's ChainID is not nil.
 func (c *ChainConfig) Rules(epoch *big.Int) Rules {
 	if c.IsStakingPrecompile(epoch) {
 		if !c.IsPreStaking(epoch) {
-			panic("Cannot have staking precompile epoch if not prestaking epoch")
+			panic("cannot have staking precompile epoch if not prestaking epoch")
+		}
+	}
+	if c.IsCrossShardXferPrecompile(epoch) {
+		if !c.AcceptsCrossTx(epoch) {
+			panic("cannot have cross shard xfer precompile epoch if not accepting cross tx")
 		}
 	}
 	chainID := c.ChainID
@@ -665,16 +689,17 @@ func (c *ChainConfig) Rules(epoch *big.Int) Rules {
 		ethChainID = new(big.Int)
 	}
 	return Rules{
-		ChainID:             new(big.Int).Set(chainID),
-		EthChainID:          new(big.Int).Set(ethChainID),
-		IsCrossLink:         c.IsCrossLink(epoch),
-		IsEIP155:            c.IsEIP155(epoch),
-		IsS3:                c.IsS3(epoch),
-		IsReceiptLog:        c.IsReceiptLog(epoch),
-		IsIstanbul:          c.IsIstanbul(epoch),
-		IsVRF:               c.IsVRF(epoch),
-		IsPrevVRF:           c.IsPrevVRF(epoch),
-		IsSHA3:              c.IsSHA3(epoch),
-		IsStakingPrecompile: c.IsStakingPrecompile(epoch),
+		ChainID:                    new(big.Int).Set(chainID),
+		EthChainID:                 new(big.Int).Set(ethChainID),
+		IsCrossLink:                c.IsCrossLink(epoch),
+		IsEIP155:                   c.IsEIP155(epoch),
+		IsS3:                       c.IsS3(epoch),
+		IsReceiptLog:               c.IsReceiptLog(epoch),
+		IsIstanbul:                 c.IsIstanbul(epoch),
+		IsVRF:                      c.IsVRF(epoch),
+		IsPrevVRF:                  c.IsPrevVRF(epoch),
+		IsSHA3:                     c.IsSHA3(epoch),
+		IsStakingPrecompile:        c.IsStakingPrecompile(epoch),
+		IsCrossShardXferPrecompile: c.IsCrossShardXferPrecompile(epoch),
 	}
 }

--- a/staking/precompile.go
+++ b/staking/precompile.go
@@ -2,7 +2,6 @@ package staking
 
 import (
 	"bytes"
-	"math/big"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -126,11 +125,11 @@ func ParseStakeMsg(contractCaller common.Address, input []byte) (interface{}, er
 			if err != nil {
 				return nil, err
 			}
-			validatorAddress, err := ParseAddressFromKey(args, "validatorAddress")
+			validatorAddress, err := abi.ParseAddressFromKey(args, "validatorAddress")
 			if err != nil {
 				return nil, err
 			}
-			amount, err := ParseBigIntFromKey(args, "amount")
+			amount, err := abi.ParseBigIntFromKey(args, "amount")
 			if err != nil {
 				return nil, err
 			}
@@ -148,12 +147,12 @@ func ParseStakeMsg(contractCaller common.Address, input []byte) (interface{}, er
 			if err != nil {
 				return nil, err
 			}
-			validatorAddress, err := ParseAddressFromKey(args, "validatorAddress")
+			validatorAddress, err := abi.ParseAddressFromKey(args, "validatorAddress")
 			if err != nil {
 				return nil, err
 			}
 			// this type assertion is needed by Golang
-			amount, err := ParseBigIntFromKey(args, "amount")
+			amount, err := abi.ParseBigIntFromKey(args, "amount")
 			if err != nil {
 				return nil, err
 			}
@@ -201,7 +200,7 @@ func ParseStakeMsg(contractCaller common.Address, input []byte) (interface{}, er
 
 // used to ensure caller == delegatorAddress
 func ValidateContractAddress(contractCaller common.Address, args map[string]interface{}, key string) (common.Address, error) {
-	address, err := ParseAddressFromKey(args, key)
+	address, err := abi.ParseAddressFromKey(args, key)
 	if err != nil {
 		return common.Address{}, err
 	}
@@ -212,25 +211,5 @@ func ValidateContractAddress(contractCaller common.Address, args map[string]inte
 		)
 	} else {
 		return address, nil
-	}
-}
-
-// used for both delegatorAddress and validatorAddress
-func ParseAddressFromKey(args map[string]interface{}, key string) (common.Address, error) {
-	if address, ok := args[key].(common.Address); ok {
-		return address, nil
-	} else {
-		return common.Address{}, errors.Errorf("Cannot parse address from %v", args[key])
-	}
-}
-
-// used for amounts
-func ParseBigIntFromKey(args map[string]interface{}, key string) (*big.Int, error) {
-	bigInt, ok := args[key].(*big.Int)
-	if !ok {
-		return nil, errors.Errorf(
-			"Cannot parse BigInt from %v", args[key])
-	} else {
-		return bigInt, nil
 	}
 }

--- a/staking/precompile_test.go
+++ b/staking/precompile_test.go
@@ -24,18 +24,6 @@ func TestValidateContractAddress(t *testing.T) {
 	}
 }
 
-func TestParseBigIntFromKey(t *testing.T) {
-	args := map[string]interface{}{}
-	expectedError := errors.New("Cannot parse BigInt from <nil>")
-	if _, err := ParseBigIntFromKey(args, "PotentialBigInt"); err != nil {
-		if expectedError.Error() != err.Error() {
-			t.Errorf("Expected error %v, got %v", expectedError, err)
-		}
-	} else {
-		t.Errorf("Expected error %v, got result", expectedError)
-	}
-}
-
 type parseTest struct {
 	input         []byte
 	name          string


### PR DESCRIPTION
...for native tokens only, and not for smart contracts (which will be
added later). Resolves #4132 and requires a hard fork, currently
scheduled at EpochTBD on main and test nets, but epoch 1 (after
AcceptsCrossTx) on other nets.

The precompile is at address 249 and the method has the signature
`crossShardTransfer(uint256 amount, address to, uint32 toShardID)`. It
requires a transfer of the `amount` to the precompile address first, in
the form of `msg.value`, and cascades a cross shard receipt to the
network when executed. At this stage, it is blocked for use by smart
contracts by checking that there is no code at the address, and that the
address is not a validator. Documentation for Python integration tests
to follow.

## Issue
#4132

## Test

### Unit Test Coverage

Before:

```
?   	github.com/harmony-one/harmony/internal/params	[no test files]
ok  	github.com/harmony-one/harmony/accounts/abi	(cached)	coverage: 90.2% of statements
ok  	github.com/harmony-one/harmony/core	(cached)	coverage: 30.8% of statements
ok  	github.com/harmony-one/harmony/core/vm	(cached)	coverage: 42.4% of statements
ok  	github.com/harmony-one/harmony/staking	(cached)	coverage: 89.1% of statements
```

After:

```
?   	github.com/harmony-one/harmony/internal/params	[no test files]
ok  	github.com/harmony-one/harmony/accounts/abi	(cached)	coverage: 90.0% of statements
ok  	github.com/harmony-one/harmony/core	(cached)	coverage: 30.7% of statements
ok  	github.com/harmony-one/harmony/core/vm	(cached)	coverage: 43.6% of statements
ok  	github.com/harmony-one/harmony/staking	(cached)	coverage: 87.5% of statements
```

### Test/Run Logs
```
Transaction sent: 0xf05827de42a3df6081b372f37a6d53e7b6de2ef0922e8b0096f4112de88603bd
  Gas price: 30.0 gwei   Gas limit: 50000   Nonce: 0
  CrossShardXfer.crossShardTransfer confirmed   Block: 12   Gas used: 42788 (85.58%)
```

### Integration Tests Code
```python
from brownie import network, Contract, accounts
from pyhmy import account, blockchain, transaction
from web3 import Web3
import time

abi = [
	  {
	    "inputs": [
		  {
	        "internalType": "uint256",
	        "name": "value",
	        "type": "uint256"
	      },
		  {
	        "internalType": "address",
	        "name": "to",
	        "type": "address"
	      },
		  {
	        "internalType": "uint64",
	        "name": "toShardID",
	        "type": "uint32"
	      }
	    ],
	    "name": "crossShardTransfer",
	    "outputs": [],
	    "stateMutability": "payable",
	    "type": "function"
	  }
]
timeout = 20

network.connect( "hmyLocal" )
precompile = Contract.from_abi( "CrossShardXfer", "0x00000000000000000000000000000000000000F9", abi )
pk = "1f84c95ac16e6a50f08d44c7bde7aff8742212fda6e4321fde48bf83bef266dc"
accounts.add( pk )
endpoints = [ 'http://localhost:9500', 'http://localhost:9598' ]
web3 = Web3( Web3.HTTPProvider( endpoints[ 0 ] ) )

while blockchain.get_current_epoch( endpoints[ 0 ] ) < 1:
    time.sleep( 5 )
for i, endpoint in enumerate( endpoints ):
    if blockchain.get_shard( endpoint ) != i:
        raise Exception( f'Shard {i} endpoint wrong' )
before = [ accounts[ 0 ].balance(), account.get_balance( accounts[ 0 ].address, endpoints[ 1 ] ) ]
value = web3.toWei( 100, 'ether' )
tx = precompile.crossShardTransfer( 
    value,
    accounts[ 0 ].address,
    1,
    {
        'from': accounts[ 0 ],
        'nonce': account.get_account_nonce( accounts[ 0 ].address, 'latest', endpoints[ 0 ] ),
        'gas_limit': 50000,
        'value': value,
    }
)
receipt = web3.eth.wait_for_transaction_receipt( tx.txid )
# get the cx receipt (use timeout so it can reach shard 1)
cx_receipt = None
start = time.time()
while time.time() - start <= timeout and cx_receipt is None:
    cx_receipt = transaction.get_cx_receipt_by_hash( tx.txid, endpoints[ 1 ] )
# wait upto 20s for it to be processed
start = time.time()
while time.time() - start <= timeout and \
    account.get_balance( accounts[ 0 ].address, endpoints[ 1 ] ) == before[ 1 ]:
        transaction.resend_cx_receipt( cx_receipt, endpoints[ 0 ] )
        time.sleep( 1 )
after = [ accounts[ 0 ].balance(), account.get_balance( accounts[ 0 ].address, endpoints[ 1 ] ) ]
assert before[ 0 ] - value - tx.gas_used * tx.gas_price == after[ 0 ]
assert before[ 1 ] + value == after[ 1 ]
```


## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)
No.

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)
No.

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**
No.
