### PR TITLE
Add staking read only precompile

### DIFF
--- a/core/staking_verifier_test.go
+++ b/core/staking_verifier_test.go
@@ -1759,6 +1759,10 @@ func (chain *fakeChainContext) ReadValidatorSnapshot(addr common.Address) (*stak
 	}, nil
 }
 
+func (chain *fakeChainContext) GetHeaderByNumber(number uint64) *block.Header {
+	return nil
+}
+
 type fakeErrChainContext struct{}
 
 func (chain *fakeErrChainContext) ReadValidatorList() ([]common.Address, error) {
@@ -1793,6 +1797,10 @@ func (chain *fakeErrChainContext) ShardID() uint32 {
 
 func (chain *fakeErrChainContext) ReadValidatorSnapshot(common.Address) (*staking.ValidatorSnapshot, error) {
 	return nil, errors.New("error intended")
+}
+
+func (chain *fakeErrChainContext) GetHeaderByNumber(number uint64) *block.Header {
+	return nil
 }
 
 func makeIdentityStr(item interface{}) string {

--- a/core/staking_verifier_test.go
+++ b/core/staking_verifier_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/harmony-one/harmony/block"
 	consensus_engine "github.com/harmony-one/harmony/consensus/engine"
 	"github.com/harmony-one/harmony/core/state"
+	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/core/vm"
 	"github.com/harmony-one/harmony/crypto/hash"
 	"github.com/harmony-one/harmony/numeric"
@@ -1724,6 +1725,30 @@ func (chain *fakeChainContext) Engine() consensus_engine.Engine {
 	return nil
 }
 
+func (chain *fakeChainContext) ValidatorCandidates() []common.Address {
+	vs, _ := chain.ReadValidatorList()
+	return vs
+}
+
+func (chain *fakeChainContext) CurrentBlock() *types.Block {
+	return nil
+}
+
+func (chain *fakeChainContext) ReadValidatorInformation(address common.Address) (*staking.ValidatorWrapper, error) {
+	if wrapper, ok := chain.vWrappers[address]; ok {
+		return wrapper, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (chain *fakeChainContext) ReadValidatorInformationAtState(address common.Address, state *state.DB) (*staking.ValidatorWrapper, error) {
+	return chain.ReadValidatorInformation(address)
+}
+
+func (chain *fakeChainContext) StateAt(root common.Hash) (*state.DB, error) {
+	return nil, nil
+}
+
 func (chain *fakeChainContext) Config() *params.ChainConfig {
 	config := &params.ChainConfig{}
 	config.MinCommissionRateEpoch = big.NewInt(0)
@@ -1801,6 +1826,27 @@ func (chain *fakeErrChainContext) ReadValidatorSnapshot(common.Address) (*stakin
 
 func (chain *fakeErrChainContext) GetHeaderByNumber(number uint64) *block.Header {
 	return nil
+}
+
+func (chain *fakeErrChainContext) ValidatorCandidates() []common.Address {
+	vs, _ := chain.ReadValidatorList()
+	return vs
+}
+
+func (chain *fakeErrChainContext) CurrentBlock() *types.Block {
+	return nil
+}
+
+func (chain *fakeErrChainContext) ReadValidatorInformation(address common.Address) (*staking.ValidatorWrapper, error) {
+	return nil, errors.New("not found")
+}
+
+func (chain *fakeErrChainContext) ReadValidatorInformationAtState(address common.Address, state *state.DB) (*staking.ValidatorWrapper, error) {
+	return chain.ReadValidatorInformation(address)
+}
+
+func (chain *fakeErrChainContext) StateAt(root common.Hash) (*state.DB, error) {
+	return nil, nil
 }
 
 func makeIdentityStr(item interface{}) string {

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -140,7 +140,7 @@ var PrecompiledContractsStaking = map[common.Address]PrecompiledContract{
 func init() {
 	// check that there is no overlap, and panic if there is
 	readOnlyContracts := PrecompiledContractsStaking
-	writeCapableContracts := WriteCapablePrecompiledContractsStaking
+	writeCapableContracts := StateDependentPrecompiledContractsRoStaking
 	for address, readOnlyContract := range readOnlyContracts {
 		if readOnlyContract != nil && writeCapableContracts[address] != nil {
 			panic(fmt.Errorf("Address %v is included in both readOnlyContracts and writeCapableContracts", address))

--- a/core/vm/contracts_state_test.go
+++ b/core/vm/contracts_state_test.go
@@ -212,13 +212,18 @@ var StakingPrecompileTests = []writeCapablePrecompileTest{
 	//},
 }
 
-func FetchStakingInfoFn(db StateDB, roStakeMsg *stakingTypes.ReadOnlyStakeMsg) ([]byte, error) {
+func RoStakingInfoFn(db StateDB, roStakeMsg *stakingTypes.ReadOnlyStakeMsg) ([]byte, error) {
 	return nil, nil
+}
+
+func RoStakingGasFn(db StateDB, input []byte) (uint64, error) {
+	return 0, nil
 }
 
 func TestRoStakingPrecompile(t *testing.T) {
 	var env = NewEVM(Context{
-		FetchStakingInfo: FetchStakingInfoFn,
+		RoStakingInfo: RoStakingInfoFn,
+		RoStakingGas:  RoStakingGasFn,
 	}, nil, params.TestChainConfig, Config{})
 	p := &roStakingPrecompile{}
 	input := []byte{102, 54, 146, 228, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -64,7 +64,8 @@ type (
 	//MigrateDelegationsFunc    func(db StateDB, migrationMsg *stakingTypes.MigrationMsg) ([]interface{}, error)
 	CalculateMigrationGasFunc func(db StateDB, migrationMsg *stakingTypes.MigrationMsg, homestead bool, istanbul bool) (uint64, error)
 	// Read only staking precompile
-	RoStakingPrecompileFunc func(db StateDB, roStakeMsg *stakingTypes.ReadOnlyStakeMsg) ([]byte, error)
+	RoStakingInfoFunc func(db StateDB, roStakeMsg *stakingTypes.ReadOnlyStakeMsg) ([]byte, error)
+	RoStakingGasFunc  func(db StateDB, input []byte) (uint64, error)
 )
 
 // run runs the given contract and takes care of running precompiles with a fallback to the byte code interpreter.
@@ -183,7 +184,8 @@ type Context struct {
 	ShardID uint32
 
 	// read only staking precompile
-	FetchStakingInfo RoStakingPrecompileFunc
+	RoStakingInfo RoStakingInfoFunc
+	RoStakingGas  RoStakingGasFunc
 }
 
 // EVM is the Ethereum Virtual Machine base object and provides

--- a/internal/params/protocol_params.go
+++ b/internal/params/protocol_params.go
@@ -175,6 +175,11 @@ const (
 	Sha3FipsGas     uint64 = 30 // Once per SHA3-256 operation.
 	Sha3FipsWordGas uint64 = 6  // Once per word of the SHA3-256 operation's data.
 
+	// ValidatorInformationGas for a single piece of information (no loops)
+	ValidatorInformationGas             uint64 = 500
+	ValidatorInformationGasLoops        uint64 = 5000
+	ValidatorInformationGasLoopsComplex uint64 = 10000
+	DelegatorInformationGas             uint64 = 5000
 )
 
 // nolint

--- a/staking/effective/eligible.go
+++ b/staking/effective/eligible.go
@@ -34,6 +34,14 @@ func (e Eligibility) String() string {
 	}
 }
 
+func (e Eligibility) Byte() byte {
+	return byte(e)
+}
+
+func (e Eligibility) Bytes() []byte {
+	return []byte{e.Byte()}
+}
+
 // Candidacy is a more semantically meaningful
 // value that is derived from core protocol logic but
 // meant more for the presentation of user, like at RPC

--- a/staking/params.go
+++ b/staking/params.go
@@ -5,9 +5,11 @@ import (
 )
 
 const (
-	isValidatorKeyStr     = "Harmony/IsValidator/Key/v1"
-	isValidatorStr        = "Harmony/IsValidator/Value/v1"
-	collectRewardsStr     = "Harmony/CollectRewards"
+	isValidatorKeyStr = "Harmony/IsValidator/Key/v1"
+	isValidatorStr    = "Harmony/IsValidator/Value/v1"
+	collectRewardsStr = "Harmony/CollectRewards"
+	// used after the ro staking precompile hard fork
+	collectRewardsStrV2   = "Harmony/CollectRewards(uint256)"
 	delegateStr           = "Harmony/Delegate"
 	unDelegateStr         = "Harmony/UnDelegate"
 	firstElectionEpochStr = "Harmony/FirstElectionEpoch/Key/v1"
@@ -18,6 +20,7 @@ var (
 	IsValidatorKey        = crypto.Keccak256Hash([]byte(isValidatorKeyStr))
 	IsValidator           = crypto.Keccak256Hash([]byte(isValidatorStr))
 	CollectRewardsTopic   = crypto.Keccak256Hash([]byte(collectRewardsStr))
+	CollectRewardsTopicV2 = crypto.Keccak256Hash([]byte(collectRewardsStrV2))
 	DelegateTopic         = crypto.Keccak256Hash([]byte(delegateStr))
 	UnDelegateTopic       = crypto.Keccak256Hash([]byte(unDelegateStr))
 	FirstElectionEpochKey = crypto.Keccak256Hash([]byte(firstElectionEpochStr))

--- a/staking/precompile.go
+++ b/staking/precompile.go
@@ -100,139 +100,175 @@ func init() {
 	//"type": "function"
 	//}
 	ReadOnlyStakingABIJSON := `
-	[
-	  {
-	    "inputs": [
-	      {
-	        "internalType": "address",
-	        "name": "delegatorAddress",
-	        "type": "address"
-	      }
-	    ],
-	    "name": "getBalanceAvailableForRedelegation",
-	    "outputs": [
-	      {
-	        "internalType": "uint256",
-	        "name": "",
-	        "type": "uint256"
-	      }
-	    ],
-	    "stateMutability": "view",
-	    "type": "function"
-	  },
-	  {
-	    "inputs": [
-	      {
-	        "internalType": "address",
-	        "name": "delegatorAddress",
-	        "type": "address"
-	      },
-	      {
-	        "internalType": "address",
-	        "name": "validatorAddress",
-	        "type": "address"
-	      }
-	    ],
-	    "name": "getDelegationByDelegatorAndValidator",
-	    "outputs": [
-	      {
-	        "internalType": "uint256",
-	        "name": "",
-	        "type": "uint256"
-	      }
-	    ],
-	    "stateMutability": "view",
-	    "type": "function"
-	  },
-	  {
-	    "inputs": [
-	      {
-	        "internalType": "address",
-	        "name": "validatorAddress",
-	        "type": "address"
-	      },
-	      {
-	        "internalType": "uint256",
-	        "name": "blockNumber",
-	        "type": "uint256"
-	      }
-	    ],
-	    "name": "getSlashingHeightFromBlockForValidator",
-	    "outputs": [
+    [
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "delegatorAddress",
+            "type": "address"
+          }
+        ],
+        "name": "getBalanceAvailableForRedelegation",
+        "outputs": [
           {
             "internalType": "uint256",
             "name": "",
             "type": "uint256"
           }
         ],
-	    "stateMutability": "view",
-	    "type": "function"
-	  },
-	  {
-	    "inputs": [
-	      {
-	        "internalType": "address",
-	        "name": "validatorAddress",
-	        "type": "address"
-	      }
-	    ],
-	    "name": "getValidatorCommissionRate",
-	    "outputs": [
-	      {
-	        "internalType": "uint256",
-	        "name": "",
-	        "type": "uint256"
-	      }
-	    ],
-	    "stateMutability": "view",
-	    "type": "function"
-	  },
-	  {
-	    "inputs": [
-	      {
-	        "internalType": "address",
-	        "name": "validatorAddress",
-	        "type": "address"
-	      }
-	    ],
-	    "name": "getValidatorMaxTotalDelegation",
-	    "outputs": [
-	      {
-	        "internalType": "uint256",
-	        "name": "",
-	        "type": "uint256"
-	      }
-	    ],
-	    "stateMutability": "view",
-	    "type": "function"
-	  },
-	  {
-	    "inputs": [
-	      {
-	        "internalType": "address",
-	        "name": "validatorAddress",
-	        "type": "address"
-	      }
-	    ],
-	    "name": "getValidatorTotalDelegation",
-	    "outputs": [
-	      {
-	        "internalType": "uint256",
-	        "name": "",
-	        "type": "uint256"
-	      }
-	    ],
-	    "stateMutability": "view",
-	    "type": "function"
-	  }
-	]
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "delegatorAddress",
+            "type": "address"
+          }
+        ],
+        "name": "getBalanceDelegatedByDelegator",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "delegatorAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "validatorAddress",
+            "type": "address"
+          }
+        ],
+        "name": "getDelegationByDelegatorAndValidator",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "getMedianRawStakeSnapshot",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "getTotalStakingSnapshot",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "validatorAddress",
+            "type": "address"
+          }
+        ],
+        "name": "getValidatorCommissionRate",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "validatorAddress",
+            "type": "address"
+          }
+        ],
+        "name": "getValidatorMaxTotalDelegation",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "validatorAddress",
+            "type": "address"
+          }
+        ],
+        "name": "getValidatorStatus",
+        "outputs": [
+          {
+            "internalType": "uint8",
+            "name": "",
+            "type": "uint8"
+          }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "validatorAddress",
+            "type": "address"
+          }
+        ],
+        "name": "getValidatorTotalDelegation",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    ]
 	`
 	abiStaking, _ = abi.JSON(strings.NewReader(StakingABIJSON))
-	var err error
-	abiRoStaking, err = abi.JSON(strings.NewReader(ReadOnlyStakingABIJSON))
-	if err != nil {
-		panic(err)
-	}
+	abiRoStaking, _ = abi.JSON(strings.NewReader(ReadOnlyStakingABIJSON))
 }
 
 // contractCaller (and not Contract) is used here to avoid import cycle
@@ -410,31 +446,20 @@ func ParseReadOnlyStakeMsg(input []byte) (*stakingTypes.ReadOnlyStakeMsg, error)
 		return makeRoStakeMsgWithValidator(args, method.Name[3:])
 	case "getValidatorTotalDelegation":
 		return makeRoStakeMsgWithValidator(args, method.Name[3:])
-	case "getSlashingHeightFromBlockForValidator":
-		msg, err := makeRoStakeMsgWithValidator(
-			args,
-			method.Name[3:],
-		)
-		if err != nil {
-			return nil, err
-		}
-		blockNumber, err := ParseBigIntFromKey(args, "blockNumber")
-		if err != nil {
-			return nil, err
-		}
-		msg.BlockNumber = blockNumber
-		return msg, nil
+	case "getValidatorStatus":
+		return makeRoStakeMsgWithValidator(args, method.Name[3:])
 	case "getBalanceAvailableForRedelegation":
-		{
-			delegatorAddress, err := ParseAddressFromKey(args, "delegatorAddress")
-			if err != nil {
-				return nil, err
-			}
-			return &stakingTypes.ReadOnlyStakeMsg{
-				DelegatorAddress: delegatorAddress,
-				What:             method.Name[3:],
-			}, nil
-		}
+		return makeRoStakeMsgWithDelegator(args, method.Name[3:])
+	case "getBalanceDelegatedByDelegator":
+		return makeRoStakeMsgWithDelegator(args, method.Name[3:])
+	case "getTotalStakingSnapshot":
+		return &stakingTypes.ReadOnlyStakeMsg{
+			What: method.Name[3:],
+		}, nil
+	case "getMedianRawStakeSnapshot":
+		return &stakingTypes.ReadOnlyStakeMsg{
+			What: method.Name[3:],
+		}, nil
 	}
 	return nil, errors.New("invalid method name")
 }
@@ -448,6 +473,19 @@ func makeRoStakeMsgWithValidator(args map[string]interface{}, what string) (
 	}
 	return &stakingTypes.ReadOnlyStakeMsg{
 		ValidatorAddress: validatorAddress,
+		What:             what,
+	}, nil
+}
+
+func makeRoStakeMsgWithDelegator(args map[string]interface{}, what string) (
+	*stakingTypes.ReadOnlyStakeMsg, error,
+) {
+	delegatorAddress, err := ParseAddressFromKey(args, "delegatorAddress")
+	if err != nil {
+		return nil, err
+	}
+	return &stakingTypes.ReadOnlyStakeMsg{
+		DelegatorAddress: delegatorAddress,
 		What:             what,
 	}, nil
 }

--- a/staking/precompile_test.go
+++ b/staking/precompile_test.go
@@ -222,6 +222,15 @@ var ParseRoStakeMsgTests = []parseRoTest{
 		},
 	},
 	{
+		input:         []byte{90, 112, 28, 167, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55},
+		name:          "getBalanceDelegatedByDelegator",
+		expectedError: nil,
+		expected: &stakingTypes.ReadOnlyStakeMsg{
+			DelegatorAddress: common.HexToAddress("0x1337"),
+			What:             "BalanceDelegatedByDelegator",
+		},
+	},
+	{
 		input:         []byte{55, 162, 85, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56},
 		name:          "getDelegationByDelegatorAndValidatorSuccess",
 		expectedError: nil,
@@ -250,13 +259,28 @@ var ParseRoStakeMsgTests = []parseRoTest{
 		},
 	},
 	{
-		input:         []byte{41, 202, 19, 238, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 53},
-		name:          "getSlashingHeightFromBlockForValidator",
+		input:         []byte{163, 16, 98, 79, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56},
+		name:          "getValidatorStatus",
 		expectedError: nil,
 		expected: &stakingTypes.ReadOnlyStakeMsg{
 			ValidatorAddress: common.HexToAddress("0x1338"),
-			What:             "SlashingHeightFromBlockForValidator",
-			BlockNumber:      big.NewInt(53),
+			What:             "ValidatorStatus",
+		},
+	},
+	{
+		input:         []byte{75, 21, 53, 214},
+		name:          "getTotalStakingSnapshot",
+		expectedError: nil,
+		expected: &stakingTypes.ReadOnlyStakeMsg{
+			What: "TotalStakingSnapshot",
+		},
+	},
+	{
+		input:         []byte{255, 69, 95, 178},
+		name:          "getMedianRawStakeSnapshot",
+		expectedError: nil,
+		expected: &stakingTypes.ReadOnlyStakeMsg{
+			What: "MedianRawStakeSnapshot",
 		},
 	},
 	{
@@ -265,7 +289,7 @@ var ParseRoStakeMsgTests = []parseRoTest{
 		expectedError: errors.New("no method with id: 0x29cabfee"),
 	},
 	{
-		input:         []byte{41, 202, 19, 238},
+		input:         []byte{62, 128, 166, 177},
 		name:          "MissingDataFailure",
 		expectedError: errors.New("abi: attempting to unmarshall an empty string while arguments are expected"),
 	},
@@ -314,6 +338,7 @@ func testParseRoStakeMsg(test parseRoTest, t *testing.T) {
 					}
 				} else if strings.Compare(test.expected.What, "ValidatorMaxTotalDelegation") == 0 ||
 					strings.Compare(test.expected.What, "ValidatorTotalDelegation") == 0 ||
+					strings.Compare(test.expected.What, "ValidatorStatus") == 0 ||
 					strings.Compare(test.expected.What, "ValidatorCommissionRate") == 0 {
 					if !bytes.Equal(test.expected.ValidatorAddress[:], res.ValidatorAddress[:]) {
 						t.Errorf(
@@ -322,7 +347,8 @@ func testParseRoStakeMsg(test parseRoTest, t *testing.T) {
 							res.ValidatorAddress.Hex(),
 						)
 					}
-				} else if strings.Compare(test.expected.What, "BalanceAvailableForRedelegation") == 0 {
+				} else if strings.Compare(test.expected.What, "BalanceAvailableForRedelegation") == 0 ||
+					strings.Compare(test.expected.What, "BalanceDelegatedByDelegator") == 0 {
 					if !bytes.Equal(test.expected.DelegatorAddress[:], res.DelegatorAddress[:]) {
 						t.Errorf(
 							"Unequal value for delegator address %s and %s",
@@ -338,13 +364,8 @@ func testParseRoStakeMsg(test parseRoTest, t *testing.T) {
 							res.ValidatorAddress.Hex(),
 						)
 					}
-					if test.expected.BlockNumber.Cmp(res.BlockNumber) != 0 {
-						t.Errorf(
-							"Unequal value for block number %d and %d",
-							test.expected.BlockNumber,
-							res.BlockNumber,
-						)
-					}
+				} else if strings.Compare(test.expected.What, "TotalStakingSnapshot") == 0 ||
+					strings.Compare(test.expected.What, "MedianRawStakeSnapshot") == 0 {
 				} else {
 					t.Fatalf("Got %s as what", test.expected.What)
 				}

--- a/staking/types/messages.go
+++ b/staking/types/messages.go
@@ -263,3 +263,10 @@ func (v MigrationMsg) Copy() MigrationMsg {
 func (v MigrationMsg) Equals(s MigrationMsg) bool {
 	return v.From == s.From && v.To == s.To
 }
+
+type ReadOnlyStakeMsg struct {
+	DelegatorAddress common.Address
+	ValidatorAddress common.Address
+	What             string
+	BlockNumber      *big.Int
+}

--- a/staking/types/messages.go
+++ b/staking/types/messages.go
@@ -268,5 +268,4 @@ type ReadOnlyStakeMsg struct {
 	DelegatorAddress common.Address
 	ValidatorAddress common.Address
 	What             string
-	BlockNumber      *big.Int
 }


### PR DESCRIPTION
## Issue
https://talk.harmony.one/t/harmony-read-only-staking-precompile/12720

## Test

### Unit Test Coverage

Before:

```
?   	github.com/harmony-one/harmony/internal/params	[no test files]
ok  	github.com/harmony-one/harmony/core	(cached)	coverage: 30.8% of statements
ok  	github.com/harmony-one/harmony/core/vm	(cached)	coverage: 42.4% of statements
ok  	github.com/harmony-one/harmony/staking	(cached)	coverage: 89.1% of statements
ok  	github.com/harmony-one/harmony/staking/types	(cached)	coverage: 60.7% of statements
```

After:

```
?   	github.com/harmony-one/harmony/internal/params	[no test files]
ok  	github.com/harmony-one/harmony/core	(cached)	coverage: 31.4% of statements
ok  	github.com/harmony-one/harmony/core/vm	(cached)	coverage: 42.6% of statements
ok  	github.com/harmony-one/harmony/staking	(cached)	coverage: 81.4% of statements
ok  	github.com/harmony-one/harmony/staking/types	(cached)	coverage: 60.7% of statements
```

### Test/Run Logs
Integration tests were run from [here](https://github.com/MaxMustermann2/harmony-staking-precompiles/pull/3/files)
```
Node is booted up
Creating the validator at one155jp2y76nazx8uw5sa94fr0m4s5aj8e5xm6fu3 using pyhmy
Funding spare addresses
Delegating from spare addresses
Waiting for one epoch to close
Undelegating from spare addresses
Waiting for one epoch to close
tests/test_ro_staking.py::test_getBalanceAvailableForRedelegation PASSED
tests/test_ro_staking.py::test_getDelegationByDelegatorAndValidator PASSED
tests/test_ro_staking.py::test_getValidatorTotalDelegation PASSED
tests/test_ro_staking.py::test_getValidatorTotalDelegationFail PASSED
tests/test_ro_staking.py::test_getValidatorMaxTotalDelegation PASSED
tests/test_ro_staking.py::test_getSlashingHeightFromBlockForValidator PASSED

```

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)
No.

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)
No.

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**
No.
