### PR TITLE
change testnet epoch number for appying fixes of unexpected chain id

### DIFF
--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -100,7 +100,7 @@ var (
 		SHA3Epoch:                  big.NewInt(74570),
 		HIP6And8Epoch:              big.NewInt(74570),
 		StakingPrecompileEpoch:     big.NewInt(75175),
-		ChainIdFixEpoch:            EpochTBD,
+		ChainIdFixEpoch:            big.NewInt(75769), // around Fri, 20 May 2022 07:51:02 UTC with 2s block time
 		SlotsLimitedEpoch:          big.NewInt(75684), // epoch to enable HIP-16, around Mon, 02 May 2022 08:18:45 UTC with 2s block time
 	}
 


### PR DESCRIPTION
update the epoch number for the chain id fix to be the same as HIP-18