### PR TITLE
Revert testnet hard fork for unexpected chainId.

### DIFF
--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -100,7 +100,7 @@ var (
 		SHA3Epoch:                  big.NewInt(74570),
 		HIP6And8Epoch:              big.NewInt(74570),
 		StakingPrecompileEpoch:     big.NewInt(75175),
-		ChainIdFixEpoch:            big.NewInt(75769), // around Fri, 20 May 2022 07:51:02 UTC with 2s block time
+		ChainIdFixEpoch:            EpochTBD,
 		SlotsLimitedEpoch:          big.NewInt(75684), // epoch to enable HIP-16, around Mon, 02 May 2022 08:18:45 UTC with 2s block time
 	}
 


### PR DESCRIPTION
This reverts commit aa30288dcef9fc732dd7527174f1535de51d6f80. The commit
will be remade when #4146 is merged with the same epoch as that of HIP18
to make a combined hard fork for both features.

CC: @GheisMohammadi
