### PR TITLE
add new config to set local accounts from harmony config

### DIFF
--- a/cmd/harmony/config_migrations_test.go
+++ b/cmd/harmony/config_migrations_test.go
@@ -67,6 +67,7 @@ Version = "1.0.2"
 
 [TxPool]
   BlacklistFile = "./.hmy/blacklist.txt"
+  LocalAccountsFile = "./.hmy/locals.txt"
 
 [WS]
   Enabled = true
@@ -132,6 +133,7 @@ Version = "1.0.3"
 
 [TxPool]
   BlacklistFile = "./.hmy/blacklist.txt"
+  LocalAccountsFile = "./.hmy/locals.txt"
 
 [WS]
   Enabled = true
@@ -209,6 +211,7 @@ Version = "1.0.4"
 
 [TxPool]
   BlacklistFile = "./.hmy/blacklist.txt"
+  LocalAccountsFile = "./.hmy/locals.txt"
 
 [WS]
   Enabled = true
@@ -293,6 +296,7 @@ Version = "1.0.4"
 
 [TxPool]
   BlacklistFile = "./.hmy/blacklist.txt"
+  LocalAccountsFile = "./.hmy/locals.txt"
 
 [WS]
   Enabled = true

--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -83,6 +83,7 @@ Version = "1.0.4"
 
 [TxPool]
   BlacklistFile = "./.hmy/blacklist.txt"
+  LocalAccountsFile = "./.hmy/locals.txt"
 
 [Sync]
   Downloader = false

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -65,9 +65,10 @@ var defaultConfig = harmonyconfig.HarmonyConfig{
 		KMSConfigFile:    "",
 	},
 	TxPool: harmonyconfig.TxPoolConfig{
-		BlacklistFile:  "./.hmy/blacklist.txt",
-		RosettaFixFile: "",
-		AccountSlots:   16,
+		BlacklistFile:     "./.hmy/blacklist.txt",
+		RosettaFixFile:    "",
+		AccountSlots:      16,
+		LocalAccountsFile: "./.hmy/locals.txt",
 	},
 	Sync: getDefaultSyncConfig(defNetworkType),
 	Pprof: harmonyconfig.PprofConfig{

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -130,6 +130,7 @@ var (
 		rosettaFixFileFlag,
 		tpBlacklistFileFlag,
 		legacyTPBlacklistFileFlag,
+		localAccountsFileFlag,
 	}
 
 	pprofFlags = []cli.Flag{
@@ -1030,6 +1031,11 @@ var (
 		DefValue:   defaultConfig.TxPool.BlacklistFile,
 		Deprecated: "use --txpool.blacklist",
 	}
+	localAccountsFileFlag = cli.StringFlag{
+		Name:     "txpool.locals",
+		Usage:    "file of local wallet addresses",
+		DefValue: defaultConfig.TxPool.LocalAccountsFile,
+	}
 )
 
 func applyTxPoolFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
@@ -1047,6 +1053,11 @@ func applyTxPoolFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 		config.TxPool.BlacklistFile = cli.GetStringFlagValue(cmd, tpBlacklistFileFlag)
 	} else if cli.IsFlagChanged(cmd, legacyTPBlacklistFileFlag) {
 		config.TxPool.BlacklistFile = cli.GetStringFlagValue(cmd, legacyTPBlacklistFileFlag)
+	}
+	if cli.IsFlagChanged(cmd, localAccountsFileFlag) {
+		config.TxPool.LocalAccountsFile = cli.GetStringFlagValue(cmd, localAccountsFileFlag)
+	} else if cli.IsFlagChanged(cmd, localAccountsFileFlag) {
+		config.TxPool.LocalAccountsFile = cli.GetStringFlagValue(cmd, localAccountsFileFlag)
 	}
 }
 

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -101,9 +101,10 @@ func TestHarmonyFlags(t *testing.T) {
 					KMSConfigFile:    "config.json",
 				},
 				TxPool: harmonyconfig.TxPoolConfig{
-					BlacklistFile:  "./.hmy/blacklist.txt",
-					RosettaFixFile: "",
-					AccountSlots:   16,
+					BlacklistFile:     "./.hmy/blacklist.txt",
+					RosettaFixFile:    "",
+					AccountSlots:      16,
+					LocalAccountsFile: "./.hmy/locals.txt",
 				},
 				Pprof: harmonyconfig.PprofConfig{
 					Enabled:            false,
@@ -801,9 +802,10 @@ func TestTxPoolFlags(t *testing.T) {
 		{
 			args: []string{},
 			expConfig: harmonyconfig.TxPoolConfig{
-				BlacklistFile:  defaultConfig.TxPool.BlacklistFile,
-				RosettaFixFile: defaultConfig.TxPool.RosettaFixFile,
-				AccountSlots:   defaultConfig.TxPool.AccountSlots,
+				BlacklistFile:     defaultConfig.TxPool.BlacklistFile,
+				RosettaFixFile:    defaultConfig.TxPool.RosettaFixFile,
+				AccountSlots:      defaultConfig.TxPool.AccountSlots,
+				LocalAccountsFile: defaultConfig.TxPool.LocalAccountsFile,
 			},
 		},
 		{
@@ -812,6 +814,7 @@ func TestTxPoolFlags(t *testing.T) {
 				BlacklistFile:  "blacklist.file",
 				RosettaFixFile: "rosettafix.file",
 				AccountSlots:   16, // default
+				LocalAccountsFile: defaultConfig.TxPool.LocalAccountsFile,
 			},
 		},
 		{
@@ -820,6 +823,7 @@ func TestTxPoolFlags(t *testing.T) {
 				BlacklistFile:  "blacklist.file",
 				RosettaFixFile: "rosettafix.file",
 				AccountSlots:   16, // default
+				LocalAccountsFile: defaultConfig.TxPool.LocalAccountsFile,
 			},
 		},
 		{
@@ -828,6 +832,16 @@ func TestTxPoolFlags(t *testing.T) {
 				AccountSlots:   5,
 				BlacklistFile:  "blacklist.file",
 				RosettaFixFile: "rosettafix.file",
+				LocalAccountsFile: defaultConfig.TxPool.LocalAccountsFile,
+			},
+		},
+		{
+			args: []string{"--txpool.locals", "locals.txt"},
+			expConfig: harmonyconfig.TxPoolConfig{
+				BlacklistFile:     defaultConfig.TxPool.BlacklistFile,
+				RosettaFixFile:    defaultConfig.TxPool.RosettaFixFile,
+				AccountSlots:      defaultConfig.TxPool.AccountSlots,
+				LocalAccountsFile: "locals.txt",
 			},
 		},
 	}

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -662,6 +662,11 @@ func setupConsensusAndNode(hc harmonyconfig.HarmonyConfig, nodeConfig *nodeconfi
 		utils.Logger().Warn().Msgf("Blacklist setup error: %s", err.Error())
 	}
 
+	localAccounts, err := setupLocalAccounts(hc, blacklist)
+	if err != nil {
+		utils.Logger().Warn().Msgf("local accounts setup error: %s", err.Error())
+	}
+
 	// Current node.
 	var chainDBFactory shardchain.DBFactory
 	if hc.ShardData.EnableShardData {
@@ -676,7 +681,7 @@ func setupConsensusAndNode(hc harmonyconfig.HarmonyConfig, nodeConfig *nodeconfi
 		chainDBFactory = &shardchain.LDBFactory{RootDir: nodeConfig.DBDir}
 	}
 
-	currentNode := node.New(myHost, currentConsensus, chainDBFactory, blacklist, nodeConfig.ArchiveModes(), &hc)
+	currentNode := node.New(myHost, currentConsensus, chainDBFactory, blacklist, localAccounts, nodeConfig.ArchiveModes(), &hc)
 
 	if hc.Legacy != nil && hc.Legacy.TPBroadcastInvalidTxn != nil {
 		currentNode.BroadcastInvalidTx = *hc.Legacy.TPBroadcastInvalidTxn
@@ -839,6 +844,52 @@ func setupBlacklist(hc harmonyconfig.HarmonyConfig) (map[ethCommon.Address]struc
 		}
 	}
 	return addrMap, nil
+}
+
+func setupLocalAccounts(hc harmonyconfig.HarmonyConfig, blacklist map[ethCommon.Address]struct{}) ([]ethCommon.Address, error) {
+	file := hc.TxPool.LocalAccountsFile
+	// check if file exist
+	var fileData string
+	if _, err := os.Stat(file); err == nil {
+		b, err := ioutil.ReadFile(file)
+		if err != nil {
+			return nil, err
+		}
+		fileData = string(b)
+	} else if errors.Is(err, os.ErrNotExist) {
+		// file path does not exist
+		return []ethCommon.Address{}, nil
+	} else {
+		// some other errors happened
+		return nil, err
+	}
+
+	localAccounts := make(map[ethCommon.Address]struct{})
+	lines := strings.Split(fileData, "\n")
+	for _, line := range lines {
+		if len(line) != 0 { // the file may have trailing empty string line
+			trimmedLine := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmedLine, "#") { //check the line is not commented
+				continue
+			}
+			addr, err := common.Bech32ToAddress(trimmedLine)
+			if err != nil {
+				return nil, err
+			}
+			// skip the blacklisted addresses
+			if _, exists := blacklist[addr]; exists {
+				utils.Logger().Warn().Msgf("local account with address %s is blacklisted", addr.String())
+				continue
+			}
+			localAccounts[addr] = struct{}{}
+		}
+	}
+	uniqueAddresses := make([]ethCommon.Address, 0, len(localAccounts))
+	for addr := range localAccounts {
+		uniqueAddresses = append(uniqueAddresses, addr)
+	}
+
+	return uniqueAddresses, nil
 }
 
 func listenOSSigAndShutDown(node *node.Node) {

--- a/internal/configs/harmony/harmony.go
+++ b/internal/configs/harmony/harmony.go
@@ -97,9 +97,10 @@ type BlsConfig struct {
 }
 
 type TxPoolConfig struct {
-	BlacklistFile  string
-	RosettaFixFile string
-	AccountSlots   uint64
+	BlacklistFile     string
+	RosettaFixFile    string
+	AccountSlots      uint64
+	LocalAccountsFile string
 }
 
 type PprofConfig struct {

--- a/node/node.go
+++ b/node/node.go
@@ -954,6 +954,7 @@ func New(
 	consensusObj *consensus.Consensus,
 	chainDBFactory shardchain.DBFactory,
 	blacklist map[common.Address]struct{},
+	localAccounts []common.Address,
 	isArchival map[uint32]bool,
 	harmonyconfig *harmonyconfig.HarmonyConfig,
 ) *Node {
@@ -1024,6 +1025,7 @@ func New(
 		}
 		if harmonyconfig != nil {
 			txPoolConfig.AccountSlots = harmonyconfig.TxPool.AccountSlots
+			txPoolConfig.Locals = append(txPoolConfig.Locals, localAccounts...)
 		}
 
 		txPoolConfig.Blacklist = blacklist

--- a/node/node_handler_test.go
+++ b/node/node_handler_test.go
@@ -39,7 +39,7 @@ func TestAddNewBlock(t *testing.T) {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
 	nodeconfig.SetNetworkType(nodeconfig.Devnet)
-	node := New(host, consensus, testDBFactory, nil, nil, nil)
+	node := New(host, consensus, testDBFactory, nil, nil, nil, nil)
 
 	txs := make(map[common.Address]types.Transactions)
 	stks := staking.StakingTransactions{}
@@ -88,7 +88,7 @@ func TestVerifyNewBlock(t *testing.T) {
 	archiveMode := make(map[uint32]bool)
 	archiveMode[0] = true
 	archiveMode[1] = false
-	node := New(host, consensus, testDBFactory, nil, archiveMode, nil)
+	node := New(host, consensus, testDBFactory, nil, nil, archiveMode, nil)
 
 	txs := make(map[common.Address]types.Transactions)
 	stks := staking.StakingTransactions{}
@@ -134,7 +134,7 @@ func TestVerifyVRF(t *testing.T) {
 	archiveMode := make(map[uint32]bool)
 	archiveMode[0] = true
 	archiveMode[1] = false
-	node := New(host, consensus, testDBFactory, nil, archiveMode, nil)
+	node := New(host, consensus, testDBFactory, nil, nil, archiveMode, nil)
 
 	consensus.Blockchain = node.Blockchain()
 	txs := make(map[common.Address]types.Transactions)

--- a/node/node_newblock_test.go
+++ b/node/node_newblock_test.go
@@ -40,7 +40,7 @@ func TestFinalizeNewBlockAsync(t *testing.T) {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
 	var testDBFactory = &shardchain.MemDBFactory{}
-	node := New(host, consensus, testDBFactory, nil, nil, nil)
+	node := New(host, consensus, testDBFactory, nil, nil, nil, nil)
 
 	node.Worker.UpdateCurrent()
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -39,7 +39,7 @@ func TestNewNode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
-	node := New(host, consensus, testDBFactory, nil, nil, nil)
+	node := New(host, consensus, testDBFactory, nil, nil, nil, nil)
 	if node.Consensus == nil {
 		t.Error("Consensus is not initialized for the node")
 	}
@@ -216,7 +216,7 @@ func TestAddBeaconPeer(t *testing.T) {
 	archiveMode := make(map[uint32]bool)
 	archiveMode[0] = true
 	archiveMode[1] = false
-	node := New(host, consensus, testDBFactory, nil, archiveMode, nil)
+	node := New(host, consensus, testDBFactory, nil, nil, archiveMode, nil)
 	for _, p := range peers1 {
 		ret := node.AddBeaconPeer(p)
 		if ret {

--- a/rosetta/infra/harmony-mainnet.conf
+++ b/rosetta/infra/harmony-mainnet.conf
@@ -92,6 +92,7 @@ Version = "2.5.2"
   BlacklistFile = "./.hmy/blacklist.txt"
   RosettaFixFile = "./rosetta_local_fix.csv"
   AccountSlots = 16
+  LocalAccountsFile = "./.hmy/locals.txt"
 
 [ShardData]
   EnableShardData = true

--- a/rosetta/infra/harmony-pstn.conf
+++ b/rosetta/infra/harmony-pstn.conf
@@ -91,6 +91,7 @@ Version = "2.5.2"
 [TxPool]
   BlacklistFile = "./.hmy/blacklist.txt"
   AccountSlots = 16
+  LocalAccountsFile = "./.hmy/locals.txt"
 
 [ShardData]
   EnableShardData = false


### PR DESCRIPTION
## Issue

Need to be able to set the local accounts through harmony configuration.

## Test

We added a new option called **LocalAccountsFile** under **TxPool** to set a file path which includes the local account. The default path for local accounts file is: **_./.hmy/locals.txt_**. In order to test, just set the local accounts file path in configuration and run a local test net by custom configuration. Send a transaction using one of the local accounts. If the transaction is under priced, it should still go through.  

The local accounts file supports comment lines using "#". The comment helps us to make it more readable and it helps maintenance and debugging. An example of this file is shown below:

```
# Harmony Local Account
one1m6m0ll3q7ljdqgmth2t5j7dfe6stykucpj2nr5

# Binanace Withdrawal Account
one1fdv7u7rll9epgcqv9xxh9lhwq427nsqlr5wca5
```