### PR TITLE
return error if call is reverted by EVM

### DIFF
--- a/rpc/contract.go
+++ b/rpc/contract.go
@@ -83,6 +83,10 @@ func (s *PublicContractService) Call(
 		return nil, err
 	}
 
+	// If the result contains a revert reason, try to unpack and return it.
+	if len(result.Revert()) > 0 {
+		return nil, newRevertError(&result)
+	}
 	// If VM returns error, still return the ReturnData, which is the contract error message
 	return result.ReturnData, nil
 }


### PR DESCRIPTION
## Issue
In Ethereum, when a contract is called via RPC eth_call, an error is returned if the contract throws an error, but Harmony does not. This pr fixed this isssue.
