### PR TITLE
[params] testnet hard fork for cross shard xfer

### DIFF
--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -104,7 +104,7 @@ var (
 		StakingPrecompileEpoch:        big.NewInt(75175),
 		ChainIdFixEpoch:               big.NewInt(75877), // around Fri, 10 Jun 2022 06:10:18 GMT with average block time 2.0065s
 		SlotsLimitedEpoch:             big.NewInt(75684), // epoch to enable HIP-16, around Mon, 02 May 2022 08:18:45 UTC with 2s block time
-		CrossShardXferPrecompileEpoch: EpochTBD,
+		CrossShardXferPrecompileEpoch: big.NewInt(75877),
 		AllowlistEpoch:                big.NewInt(75877), // around Fri, 10 Jun 2022 06:10:18 GMT with average block time 2.0065s
 	}
 


### PR DESCRIPTION
Set testnet epoch for cross shard transfer precompile (#4165) hard fork to be the same as that of HIP18 and `chainId` fix.