### PR TITLE
[rpc] use latest block as default params of EstimateGas

### DIFF
--- a/rpc/transaction.go
+++ b/rpc/transaction.go
@@ -167,7 +167,7 @@ func (s *PublicTransactionService) EstimateGas(
 ) (hexutil.Uint64, error) {
 	timer := DoMetricRPCRequest(RpcEstimateGas)
 	defer DoRPCRequestDuration(RpcEstimateGas, timer)
-	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 	if blockNrOrHash != nil {
 		bNrOrHash = *blockNrOrHash
 	}


### PR DESCRIPTION
because harmony does not support the pending block, it should use the latest block as default.