### PR TITLE
[node] fix: always broadcast cross links

### DIFF
--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -227,16 +227,15 @@ func (node *Node) doBeaconSyncing() {
 			for beaconBlock := range node.BeaconBlockChannel {
 				if node.beaconSync != nil {
 					if beaconBlock.NumberU64() >= node.Beaconchain().CurrentBlock().NumberU64()+1 {
+						// have crosslinks broadcasted by only leader or 1% of validators to avoid p2p spamming
+						if node.Consensus.IsLeader() || rand.Intn(100) == 0 {
+							node.BroadcastCrossLinkFromShardsToBeacon()
+						}
 						err := node.beaconSync.UpdateBlockAndStatus(
 							beaconBlock, node.Beaconchain(), true,
 						)
 						if err != nil {
 							node.beaconSync.AddLastMileBlock(beaconBlock)
-						} else if node.Consensus.IsLeader() || rand.Intn(100) == 0 {
-							// Only leader or 1% of validators broadcast crosslink to avoid spamming p2p
-							// if beaconBlock.NumberU64() == node.Beaconchain().CurrentBlock().NumberU64() {
-							node.BroadcastCrossLinkFromShardsToBeacon()
-							// }
 						}
 					}
 				}


### PR DESCRIPTION
Continuation of #4199 to always broadcast cross links even when beacon blocks channel is empty.