### PR TITLE
[rpc] fix: catch ErrAddressNotPresent old block

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -808,7 +808,7 @@ func (db *DB) Commit(deleteEmptyObjects bool) (root common.Hash, err error) {
 }
 
 var (
-	errAddressNotPresent = errors.New("address not present in state")
+	ErrAddressNotPresent = errors.New("address not present in state")
 )
 
 // ValidatorWrapper retrieves the existing validator in the cache, if sendOriginal
@@ -834,7 +834,7 @@ func (db *DB) ValidatorWrapper(
 
 	by := db.GetCode(addr)
 	if len(by) == 0 {
-		return nil, errAddressNotPresent
+		return nil, ErrAddressNotPresent
 	}
 	val := stk.ValidatorWrapper{}
 	if err := rlp.DecodeBytes(by, &val); err != nil {
@@ -897,7 +897,7 @@ func (db *DB) UpdateValidatorWrapperWithRevert(
 	// a copy of the existing store can be used for revert
 	// since we are replacing the existing with the new anyway
 	prev, err := db.ValidatorWrapper(addr, true, false)
-	if err != nil && err != errAddressNotPresent {
+	if err != nil && err != ErrAddressNotPresent {
 		return err
 	}
 	if err := db.UpdateValidatorWrapper(addr, val); err != nil {

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -1019,7 +1019,7 @@ func verifyValidatorWrapperRevert(
 ) {
 	state.RevertToSnapshot(snapshot)
 	loadedWrapper, err := state.ValidatorWrapper(wrapperAddress, true, false)
-	if err != nil && !(err == errAddressNotPresent && allowErrAddressNotPresent) {
+	if err != nil && !(err == ErrAddressNotPresent && allowErrAddressNotPresent) {
 		t.Fatalf("Could not load wrapper %v\n", err)
 	}
 	if expectedWrapper != nil {

--- a/rpc/staking.go
+++ b/rpc/staking.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/harmony-one/harmony/core/state"
 	"github.com/harmony-one/harmony/eth/rpc"
 	"github.com/harmony-one/harmony/hmy"
 	internal_common "github.com/harmony-one/harmony/internal/common"
@@ -366,7 +367,14 @@ func (s *PublicStakingService) getAllValidatorInformation(
 	for i := start; i < start+validatorsNum; i++ {
 		validatorInfo, err := s.hmy.GetValidatorInformation(addresses[i], blk)
 		if err != nil {
-			return nil, err
+			if errors.Cause(err) != state.ErrAddressNotPresent {
+				return nil, err
+			} else {
+				// GetAllValidatorAddresses is as of current block
+				// but we are querying state as of prior block
+				// which means we can ignore ErrAddressNotPresent
+				continue
+			}
 		}
 		// Response output is the same for all versions
 		validators = append(validators, validatorInfo)


### PR DESCRIPTION
The validator list is not per block, while the information being sought
is. Therefore, do not return error if validator address is not present
in state.

Fixes #4202