### PR TITLE
[pool] make GlobalSlots configurable

### DIFF
--- a/cmd/harmony/config_migrations.go
+++ b/cmd/harmony/config_migrations.go
@@ -266,5 +266,12 @@ func init() {
 		confTree.Set("Version", "2.5.4")
 		return confTree
 	}
+	migrations["2.5.4"] = func(confTree *toml.Tree) *toml.Tree {
+		if confTree.Get("TxPool.GlobalSlots") == nil {
+			confTree.Set("TxPool.GlobalSlots", defaultConfig.TxPool.GlobalSlots)
+		}
+		confTree.Set("Version", "2.5.5")
+		return confTree
+	}
 
 }

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -5,7 +5,7 @@ import (
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 )
 
-const tomlConfigVersion = "2.5.4" // bump from 2.5.2 for rpc filters
+const tomlConfigVersion = "2.5.5"
 
 const (
 	defNetworkType = nodeconfig.Mainnet
@@ -74,6 +74,7 @@ var defaultConfig = harmonyconfig.HarmonyConfig{
 		RosettaFixFile:    "",
 		AccountSlots:      16,
 		LocalAccountsFile: "./.hmy/locals.txt",
+		GlobalSlots:       5120,
 	},
 	Sync: getDefaultSyncConfig(defNetworkType),
 	Pprof: harmonyconfig.PprofConfig{

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -136,6 +136,7 @@ var (
 		legacyTPBlacklistFileFlag,
 		localAccountsFileFlag,
 		allowedTxsFileFlag,
+		tpGlobalSlotsFlag,
 	}
 
 	pprofFlags = []cli.Flag{
@@ -1086,6 +1087,11 @@ var (
 		Usage:    "file of allowed transactions",
 		DefValue: defaultConfig.TxPool.AllowedTxsFile,
 	}
+	tpGlobalSlotsFlag = cli.IntFlag{
+		Name:     "txpool.globalslots",
+		Usage:    "maximum global number of non-executable transactions in the pool",
+		DefValue: int(defaultConfig.TxPool.GlobalSlots),
+	}
 )
 
 func applyTxPoolFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
@@ -1097,7 +1103,14 @@ func applyTxPoolFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 		if value <= 0 {
 			panic("Must provide positive for txpool.accountslots")
 		}
-		config.TxPool.AccountSlots = uint64(cli.GetIntFlagValue(cmd, tpAccountSlotsFlag))
+		config.TxPool.AccountSlots = uint64(value)
+	}
+	if cli.IsFlagChanged(cmd, tpGlobalSlotsFlag) {
+		value := cli.GetIntFlagValue(cmd, tpGlobalSlotsFlag)
+		if value <= 0 {
+			panic("Must provide positive value for txpool.globalslots")
+		}
+		config.TxPool.GlobalSlots = uint64(value)
 	}
 	if cli.IsFlagChanged(cmd, tpBlacklistFileFlag) {
 		config.TxPool.BlacklistFile = cli.GetStringFlagValue(cmd, tpBlacklistFileFlag)

--- a/cmd/harmony/flags_test.go
+++ b/cmd/harmony/flags_test.go
@@ -109,6 +109,7 @@ func TestHarmonyFlags(t *testing.T) {
 					AllowedTxsFile:    "./.hmy/allowedtxs.txt",
 					RosettaFixFile:    "",
 					AccountSlots:      16,
+					GlobalSlots:       5120,
 					LocalAccountsFile: "./.hmy/locals.txt",
 				},
 				Pprof: harmonyconfig.PprofConfig{
@@ -880,6 +881,7 @@ func TestTxPoolFlags(t *testing.T) {
 				RosettaFixFile:    defaultConfig.TxPool.RosettaFixFile,
 				AccountSlots:      defaultConfig.TxPool.AccountSlots,
 				LocalAccountsFile: defaultConfig.TxPool.LocalAccountsFile,
+				GlobalSlots:       defaultConfig.TxPool.GlobalSlots,
 			},
 		},
 		{
@@ -888,7 +890,8 @@ func TestTxPoolFlags(t *testing.T) {
 				BlacklistFile:     "blacklist.file",
 				AllowedTxsFile:    "allowedtxs.txt",
 				RosettaFixFile:    "rosettafix.file",
-				AccountSlots:      16, // default
+				AccountSlots:      defaultConfig.TxPool.AccountSlots,
+				GlobalSlots:       defaultConfig.TxPool.GlobalSlots,
 				LocalAccountsFile: defaultConfig.TxPool.LocalAccountsFile,
 			},
 		},
@@ -898,7 +901,8 @@ func TestTxPoolFlags(t *testing.T) {
 				BlacklistFile:     "blacklist.file",
 				RosettaFixFile:    "rosettafix.file",
 				AllowedTxsFile:    defaultConfig.TxPool.AllowedTxsFile,
-				AccountSlots:      16, // default
+				AccountSlots:      defaultConfig.TxPool.AccountSlots,
+				GlobalSlots:       defaultConfig.TxPool.GlobalSlots,
 				LocalAccountsFile: defaultConfig.TxPool.LocalAccountsFile,
 			},
 		},
@@ -910,6 +914,7 @@ func TestTxPoolFlags(t *testing.T) {
 				AllowedTxsFile:    defaultConfig.TxPool.AllowedTxsFile,
 				RosettaFixFile:    "rosettafix.file",
 				LocalAccountsFile: defaultConfig.TxPool.LocalAccountsFile,
+				GlobalSlots:       defaultConfig.TxPool.GlobalSlots,
 			},
 		},
 		{
@@ -920,6 +925,18 @@ func TestTxPoolFlags(t *testing.T) {
 				RosettaFixFile:    defaultConfig.TxPool.RosettaFixFile,
 				AccountSlots:      defaultConfig.TxPool.AccountSlots,
 				LocalAccountsFile: "locals.txt",
+				GlobalSlots:       defaultConfig.TxPool.GlobalSlots,
+			},
+		},
+		{
+			args: []string{"--txpool.globalslots", "10240"},
+			expConfig: harmonyconfig.TxPoolConfig{
+				BlacklistFile:     defaultConfig.TxPool.BlacklistFile,
+				AllowedTxsFile:    defaultConfig.TxPool.AllowedTxsFile,
+				RosettaFixFile:    defaultConfig.TxPool.RosettaFixFile,
+				AccountSlots:      defaultConfig.TxPool.AccountSlots,
+				LocalAccountsFile: defaultConfig.TxPool.LocalAccountsFile,
+				GlobalSlots:       10240,
 			},
 		},
 	}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -234,6 +234,13 @@ func (config *TxPoolConfig) sanitize() TxPoolConfig {
 			Msg("Sanitizing invalid txpool account slots")
 		conf.AccountSlots = DefaultTxPoolConfig.AccountSlots
 	}
+	if conf.GlobalSlots == 0 {
+		utils.Logger().Warn().
+			Uint64("provided", conf.GlobalSlots).
+			Uint64("updated", DefaultTxPoolConfig.GlobalSlots).
+			Msg("Sanitizing invalid txpool global slots")
+		conf.GlobalSlots = DefaultTxPoolConfig.GlobalSlots
+	}
 
 	return conf
 }

--- a/internal/configs/harmony/harmony.go
+++ b/internal/configs/harmony/harmony.go
@@ -102,6 +102,7 @@ type TxPoolConfig struct {
 	RosettaFixFile    string
 	AccountSlots      uint64
 	LocalAccountsFile string
+	GlobalSlots       uint64
 }
 
 type PprofConfig struct {

--- a/node/node.go
+++ b/node/node.go
@@ -1028,6 +1028,7 @@ func New(
 		}
 		if harmonyconfig != nil {
 			txPoolConfig.AccountSlots = harmonyconfig.TxPool.AccountSlots
+			txPoolConfig.GlobalSlots = harmonyconfig.TxPool.GlobalSlots
 			txPoolConfig.Locals = append(txPoolConfig.Locals, localAccounts...)
 		}
 

--- a/rosetta/infra/harmony-mainnet.conf
+++ b/rosetta/infra/harmony-mainnet.conf
@@ -1,4 +1,4 @@
-Version = "2.5.4"
+Version = "2.5.5"
 
 [BLSKeys]
   KMSConfigFile = ""
@@ -108,6 +108,7 @@ Version = "2.5.4"
   BlacklistFile = "./.hmy/blacklist.txt"
   LocalAccountsFile = "./.hmy/locals.txt"
   RosettaFixFile = "./rosetta_local_fix.csv"
+  GlobalSlots = 5120
 
 [WS]
   AuthPort = 9801

--- a/rosetta/infra/harmony-pstn.conf
+++ b/rosetta/infra/harmony-pstn.conf
@@ -108,6 +108,7 @@ Version = "2.5.4"
   BlacklistFile = "./.hmy/blacklist.txt"
   LocalAccountsFile = "./.hmy/locals.txt"
   RosettaFixFile = ""
+  GlobalSlots = 5120
 
 [WS]
   AuthPort = 9801


### PR DESCRIPTION
Test logs:
```bash
$ ./bin/harmony -c harmony.conf
Old config version detected 2.5.4
Do you want to update config to the latest version: [y/N]
y
Original config backed up to harmony.conf.backup
Successfully migrated harmony.conf from 2.5.4 to 2.5.5 
Started Explorer server at: 0.0.0.0:5000
Started RPC server at: 127.0.0.1:9500
Started Auth-RPC server at: 127.0.0.1:9501
Started WS server at: 127.0.0.1:9800
Started Auth-WS server at: 127.0.0.1:9801
^CGot interrupt signal. Gracefully shutting down...
Successfully shut down!
```

```diff
$ diff harmony.conf.backup harmony.conf
1c1
< Version = "2.5.4"
---
> Version = "2.5.5"
104a105
>   GlobalSlots = 5120
```