### PR TITLE
Fix canonical hash usages.

### DIFF
--- a/cmd/harmony/dumpdb.go
+++ b/cmd/harmony/dumpdb.go
@@ -87,6 +87,14 @@ type KakashiDB struct {
 	cache      *lru.Cache
 }
 
+func (db *KakashiDB) GetCanonicalHash(number uint64) common.Hash {
+	return rawdb.ReadCanonicalHash(db, number)
+}
+
+func (db *KakashiDB) ChainDb() ethdb.Database {
+	return db
+}
+
 const (
 	MB                 = 1024 * 1024
 	BLOCKS_DUMP        = 512 // must >= 256

--- a/core/blockchain_impl.go
+++ b/core/blockchain_impl.go
@@ -633,7 +633,7 @@ func (bc *BlockChainImpl) ExportN(w io.Writer, first uint64, last uint64) error 
 // writeHeadBlock writes a new head block
 func (bc *BlockChainImpl) writeHeadBlock(block *types.Block) error {
 	// If the block is on a side chain or an unknown one, force other heads onto it too
-	updateHeads := rawdb.ReadCanonicalHash(bc.db, block.NumberU64()) != block.Hash()
+	updateHeads := bc.GetCanonicalHash(block.NumberU64()) != block.Hash()
 
 	// Add the block to the canonical chain number scheme and mark as the head
 	batch := bc.ChainDb().NewBatch()
@@ -765,7 +765,7 @@ func (bc *BlockChainImpl) GetBlockByHash(hash common.Hash) *types.Block {
 }
 
 func (bc *BlockChainImpl) GetBlockByNumber(number uint64) *types.Block {
-	hash := rawdb.ReadCanonicalHash(bc.db, number)
+	hash := bc.GetCanonicalHash(number)
 	if hash == (common.Hash{}) {
 		return nil
 	}

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -348,9 +348,9 @@ func (hc *HeaderChain) GetAncestor(hash common.Hash, number, ancestor uint64, ma
 		return common.Hash{}, 0
 	}
 	for ancestor != 0 {
-		if rawdb.ReadCanonicalHash(hc.chainDb, number) == hash {
+		if hc.GetCanonicalHash(number) == hash {
 			number -= ancestor
-			return rawdb.ReadCanonicalHash(hc.chainDb, number), number
+			return hc.GetCanonicalHash(number), number
 		}
 		if *maxNonCanonical == 0 {
 			return common.Hash{}, 0
@@ -448,6 +448,10 @@ func (hc *HeaderChain) GetHeaderByNumber(number uint64) *block.Header {
 }
 
 func (hc *HeaderChain) getHashByNumber(number uint64) common.Hash {
+	return hc.GetCanonicalHash(number)
+}
+
+func (hc *HeaderChain) GetCanonicalHash(number uint64) common.Hash {
 	// Since canonical chain is immutable, it's safe to read header
 	// hash by number from cache.
 	if hash, ok := hc.canonicalCache.Get(number); ok {
@@ -458,10 +462,6 @@ func (hc *HeaderChain) getHashByNumber(number uint64) common.Hash {
 		hc.canonicalCache.Add(number, hash)
 	}
 	return hash
-}
-
-func (hc *HeaderChain) GetCanonicalHash(number uint64) common.Hash {
-	return rawdb.ReadCanonicalHash(hc.chainDb, number)
 }
 
 // CurrentHeader retrieves the current head header of the canonical chain. The

--- a/hmy/hmy.go
+++ b/hmy/hmy.go
@@ -123,12 +123,11 @@ type NodeAPI interface {
 func New(
 	nodeAPI NodeAPI, txPool *core.TxPool, cxPool *core.CxPool, shardID uint32,
 ) *Harmony {
-	chainDb := nodeAPI.Blockchain().ChainDb()
 	leaderCache, _ := lru.New(leaderCacheSize)
 	undelegationPayoutsCache, _ := lru.New(undelegationPayoutsCacheSize)
 	preStakingBlockRewardsCache, _ := lru.New(preStakingBlockRewardsCacheSize)
 	totalStakeCache := newTotalStakeCache(totalStakeCacheDuration)
-	bloomIndexer := NewBloomIndexer(chainDb, params.BloomBitsBlocks, params.BloomConfirms)
+	bloomIndexer := NewBloomIndexer(nodeAPI.Blockchain(), params.BloomBitsBlocks, params.BloomConfirms)
 	bloomIndexer.Start(nodeAPI.Blockchain())
 
 	backend := &Harmony{
@@ -140,7 +139,7 @@ func New(
 		TxPool:                      txPool,
 		CxPool:                      cxPool,
 		eventMux:                    new(event.TypeMux),
-		chainDb:                     chainDb,
+		chainDb:                     nodeAPI.Blockchain().ChainDb(),
 		NodeAPI:                     nodeAPI,
 		ChainID:                     nodeAPI.Blockchain().Config().ChainID.Uint64(),
 		EthChainID:                  nodeAPI.Blockchain().Config().EthCompatibleChainID.Uint64(),


### PR DESCRIPTION
Raw usages of `rawdb.ReadCanonicalHash` don't use cache and break encapsulation. It's still not perfect, but it's a good direction.

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**
