### PR TITLE
[config] change default localnet sync config...

### DIFF
--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -169,13 +169,13 @@ var (
 	defaultLocalNetSyncConfig = harmonyconfig.SyncConfig{
 		Enabled:        true,
 		Downloader:     true,
-		Concurrency:    2,
-		MinPeers:       2,
-		InitStreams:    2,
-		DiscSoftLowCap: 2,
-		DiscHardLowCap: 2,
+		Concurrency:    4,
+		MinPeers:       5,
+		InitStreams:    5,
+		DiscSoftLowCap: 5,
+		DiscHardLowCap: 5,
 		DiscHighCap:    1024,
-		DiscBatch:      3,
+		DiscBatch:      8,
 	}
 
 	defaultElseSyncConfig = harmonyconfig.SyncConfig{


### PR DESCRIPTION
...to allow localnet cross shard tests to pass. It has been observed
that the epoch block from shard 0, which contains the `ShardState` does
not reach shard 1 on localnet in time. This leads to the cross shard
receipt not being validated, and thus, the block is not signed by one
node (8.5% vote power) in some cases. This change makes the sync
parameters a bit aggressive (only on localnet) to reduce the number of
times the test can fail.

See [here](https://app.travis-ci.com/github/harmony-one/harmony/jobs/574745237) for an example of the flaky test case failing.
