### PR TITLE
Fix epoch sync: min bound, reconnect and additional checks.

### DIFF
--- a/api/service/legacysync/syncing.go
+++ b/api/service/legacysync/syncing.go
@@ -137,6 +137,14 @@ func (sc *SyncConfig) AddPeer(peer *SyncPeerConfig) {
 	sc.peers = append(sc.peers, peer)
 }
 
+func (sc *SyncConfig) GetPeers() []*SyncPeerConfig {
+	sc.mtx.RLock()
+	defer sc.mtx.RUnlock()
+	out := make([]*SyncPeerConfig, len(sc.peers))
+	copy(out, sc.peers)
+	return out
+}
+
 // ForEachPeer calls the given function with each peer.
 // It breaks the iteration iff the function returns true.
 func (sc *SyncConfig) ForEachPeer(f func(peer *SyncPeerConfig) (brk bool)) {


### PR DESCRIPTION
There were errors like 
`{"level":"info","caller":"/root/go/src/github.com/harmony-one/harmony/api/service/legacysync/epoch_syncing.go:106","time":"2022-08-06T06:15:06.313198608Z","message":"[EPOCHSYNC] Node is now IN SYNC! (isBeacon: true, ShardID: 0, otherEpoch: 1075, currentEpoch: 1078)"}`
That means, that it gets height from connected peers and their height less than my. Less height => no need to do sync.
Current pr gets rid of those stale peers and tries to get new ones. 





## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

    **NO**
