### PR TITLE
fix: tikv graceful shutdown on close

### DIFF
--- a/internal/tikv/statedb_cache/statedb_cache_database.go
+++ b/internal/tikv/statedb_cache/statedb_cache_database.go
@@ -282,11 +282,12 @@ func (c *StateDBCacheDatabase) Close() error {
 		}
 
 		if !c.l2ReadOnly {
+			time.Sleep(time.Second)
+			close(c.l2ExpiredRefresh)
+
 			for range c.l2ExpiredRefresh {
 				// nop, clear chan
 			}
-
-			defer close(c.l2ExpiredRefresh)
 		}
 	}
 

--- a/internal/tikv/statedb_cache/statedb_cache_database.go
+++ b/internal/tikv/statedb_cache/statedb_cache_database.go
@@ -273,23 +273,21 @@ func (c *StateDBCacheDatabase) NewIterator(start, end []byte) ethdb.Iterator {
 // Close disconnect the redis and save memory cache to file
 func (c *StateDBCacheDatabase) Close() error {
 	if atomic.CompareAndSwapUint64(&c.isClose, 0, 1) {
+		defer c.remoteDB.Close()
+		defer c.l2Cache.Close()
+
 		err := c.l1Cache.SaveToFileConcurrent(c.config.CachePersistencePath, runtime.NumCPU())
 		if err != nil {
 			log.Printf("save file to '%s' error: %v", c.config.CachePersistencePath, err)
 		}
 
 		if !c.l2ReadOnly {
-			close(c.l2ExpiredRefresh)
-			time.Sleep(time.Second)
-
 			for range c.l2ExpiredRefresh {
 				// nop, clear chan
 			}
+
+			defer close(c.l2ExpiredRefresh)
 		}
-
-		_ = c.l2Cache.Close()
-
-		return c.remoteDB.Close()
 	}
 
 	return nil


### PR DESCRIPTION
## Issue

Sometimes when the writer is shutdown, panics because the channel **l2ExpiredRefresh** is closed before and there might still be some data being pushed to it, preventing the tikv and redis connection to close. In this PR I'm defering the close to make sure the connections are closed even if it panics, also moving the wait before the channel is closed to give some time to the cache to stop pushing messages to the channel 

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

2. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**