### PR TITLE
fix: add go-eth metrics flags

### DIFF
--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -233,6 +233,11 @@ var (
 		cacheTimeFlag,
 		cacheSizeFlag,
 	}
+
+	metricsFlags = []cli.Flag{
+		metricsETHFlag,
+		metricsExpensiveETHFlag,
+	}
 )
 
 var (
@@ -339,6 +344,7 @@ func getRootFlags() []cli.Flag {
 	flags = append(flags, prometheusFlags...)
 	flags = append(flags, syncFlags...)
 	flags = append(flags, shardDataFlags...)
+	flags = append(flags, metricsFlags...)
 
 	return flags
 }
@@ -1751,6 +1757,22 @@ var (
 		Name:     "sharddata.cache_size",
 		Usage:    "local cache storage size (MB)",
 		DefValue: defaultConfig.ShardData.CacheSize,
+	}
+)
+
+// metrics flags required for the go-eth library
+// https://github.com/ethereum/go-ethereum/blob/master/metrics/metrics.go#L35-L55
+var (
+	metricsETHFlag = cli.BoolFlag{
+		Name:     "metrics", // https://github.com/ethereum/go-ethereum/blob/master/metrics/metrics.go#L30
+		Usage:    "flag required to enable the eth metrics",
+		DefValue: false,
+	}
+
+	metricsExpensiveETHFlag = cli.BoolFlag{
+		Name:     "metrics.expensive", // https://github.com/ethereum/go-ethereum/blob/master/metrics/metrics.go#L33
+		Usage:    "flag required to enable the expensive eth metrics",
+		DefValue: false,
 	}
 )
 


### PR DESCRIPTION
## Issue

The Go-ETH metrics are [disabled by default](https://github.com/ethereum/go-ethereum/blob/master/metrics/metrics.go#L17-L22), even when we pass the correct config since this is embedded in the go-eth code. If the flag is not enabled then every time you create a metric the Go-ETH code will give you a NilCollector which will return zero all the time. Our binary does not support this flag, so I'm adding the support for this flag in our flag list so that can be read by the eth metrics code ([here](https://github.com/ethereum/go-ethereum/blob/master/metrics/metrics.go#L35-L55)).

The reason of why that was coded that way is written [here](https://geth.ethereum.org/docs/interface/metrics).
## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

2. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **NO**
