### PR TITLE
Fix/filter new tikv

### DIFF
--- a/core/blockchain_impl.go
+++ b/core/blockchain_impl.go
@@ -1601,7 +1601,7 @@ func (bc *BlockChainImpl) insertChain(chain types.Blocks, verifyHeaders bool) (i
 			if bc.isInitTiKV() {
 				err = redis_helper.PublishShardUpdate(bc.ShardID(), block.NumberU64(), logs)
 				if err != nil {
-					utils.Logger().Info().Err(err).Msg("redis publish shard update error")
+					utils.Logger().Warn().Err(err).Msg("redis publish shard update error")
 				}
 			}
 

--- a/internal/tikv/redis_helper/pubsub.go
+++ b/internal/tikv/redis_helper/pubsub.go
@@ -5,18 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math/big"
 
 	"github.com/ethereum/go-ethereum"
-
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/internal/utils"
 	stakingTypes "github.com/harmony-one/harmony/staking/types"
 	"github.com/pkg/errors"
 )
-
-var big0 = big.NewInt(0)
 
 // BlockUpdate block update event
 type BlockUpdate struct {

--- a/internal/tikv/redis_helper/pubsub.go
+++ b/internal/tikv/redis_helper/pubsub.go
@@ -74,9 +74,10 @@ func SubscribeNewFilterLogEvent(shardID uint32, namespace string, cb func(id str
 			query.FilterCriteria.ToBlock.Neg(query.FilterCriteria.ToBlock)
 		}
 
+		fmt.Printf("filter: new message id='%s' from=%d to=%d", query.ID, query.FilterCriteria.FromBlock.Int64(), query.FilterCriteria.ToBlock.Int64())
 		err := rlp.DecodeBytes([]byte(message.Payload), &query)
 		if err != nil {
-			utils.Logger().Info().Err(err).Msg("redis subscribe new_filter_log_ error")
+			utils.Logger().Info().Err(err).Msg("redis subscribe new_filter_log error")
 			continue
 		}
 		cb(query.ID, query.FilterCriteria)
@@ -88,6 +89,8 @@ func PublishNewFilterLogEvent(shardID uint32, namespace, id string, crit ethereu
 	if redisInstance == nil {
 		return nil
 	}
+
+	fmt.Printf("filter: send message id='%s' from=%d to=%d", id, crit.FromBlock.Int64(), crit.ToBlock.Int64())
 
 	ev := NewFilterUpdated{
 		ID:                id,

--- a/internal/tikv/redis_helper/pubsub.go
+++ b/internal/tikv/redis_helper/pubsub.go
@@ -41,12 +41,26 @@ func SubscribeShardUpdate(shardID uint32, cb func(blkNum uint64, logs []*types.L
 			utils.Logger().Warn().Err(err).Msg("redis subscribe shard update error")
 			continue
 		}
+		for _, l := range block.Logs {
+			if l != nil {
+				log.Printf("subs hash='%s', num='%d'\n", l.TxHash, l.BlockNumber)
+			} else {
+				log.Println("subs log nil")
+			}
+		}
 		cb(block.BlkNum, block.Logs)
 	}
 }
 
 // PublishShardUpdate publish block update event
 func PublishShardUpdate(shardID uint32, blkNum uint64, logs []*types.Log) error {
+	for _, l := range logs {
+		if l != nil {
+			log.Printf("publish hash='%s', num='%d'\n", l.TxHash, l.BlockNumber)
+		} else {
+			log.Println("publish log nil")
+		}
+	}
 	msg, err := rlp.EncodeToBytes(&BlockUpdate{
 		BlkNum: blkNum,
 		Logs:   logs,

--- a/internal/tikv/redis_helper/pubsub.go
+++ b/internal/tikv/redis_helper/pubsub.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum"
@@ -74,7 +75,7 @@ func SubscribeNewFilterLogEvent(shardID uint32, namespace string, cb func(id str
 			query.FilterCriteria.ToBlock.Neg(query.FilterCriteria.ToBlock)
 		}
 
-		fmt.Printf("filter: new message id='%s' from=%d to=%d", query.ID, getInt(query.FilterCriteria.FromBlock), getInt(query.FilterCriteria.ToBlock))
+		log.Printf("filter: new message id='%s' from=%d to=%d\n", query.ID, getInt(query.FilterCriteria.FromBlock), getInt(query.FilterCriteria.ToBlock))
 		err := rlp.DecodeBytes([]byte(message.Payload), &query)
 		if err != nil {
 			utils.Logger().Info().Err(err).Msg("redis subscribe new_filter_log error")
@@ -90,7 +91,7 @@ func PublishNewFilterLogEvent(shardID uint32, namespace, id string, crit ethereu
 		return nil
 	}
 
-	fmt.Printf("filter: send message id='%s' from=%d to=%d", id, getInt(crit.FromBlock), getInt(crit.ToBlock))
+	log.Printf("filter: send message id='%s' from=%d to=%d\n", id, getInt(crit.FromBlock), getInt(crit.ToBlock))
 
 	ev := NewFilterUpdated{
 		ID:                id,

--- a/internal/tikv/redis_helper/pubsub.go
+++ b/internal/tikv/redis_helper/pubsub.go
@@ -39,7 +39,7 @@ func SubscribeShardUpdate(shardID uint32, cb func(blkNum uint64, logs []*types.L
 		block := &BlockUpdate{}
 		err := rlp.DecodeBytes([]byte(message.Payload), block)
 		if err != nil {
-			utils.Logger().Info().Err(err).Msg("redis subscribe shard update error")
+			utils.Logger().Warn().Err(err).Msg("redis subscribe shard update error")
 			continue
 		}
 		cb(block.BlkNum, block.Logs)
@@ -69,7 +69,7 @@ func SubscribeNewFilterLogEvent(shardID uint32, namespace string, cb func(id str
 		query := NewFilterUpdated{}
 
 		if err := rlp.DecodeBytes([]byte(message.Payload), &query); err != nil {
-			utils.Logger().Info().Err(err).Msg("redis subscribe new_filter_log error")
+			utils.Logger().Warn().Err(err).Msg("redis subscribe new_filter_log error")
 			continue
 		}
 
@@ -183,7 +183,7 @@ func SubscribeTxPoolUpdate(shardID uint32, cb func(tx types.PoolTransaction, loc
 		txu := &TxPoolUpdate{}
 		err := rlp.DecodeBytes([]byte(message.Payload), &txu)
 		if err != nil {
-			utils.Logger().Info().Err(err).Msg("redis subscribe shard update error")
+			utils.Logger().Warn().Err(err).Msg("redis subscribe shard update error")
 			continue
 		}
 		cb(txu.Tx, txu.Local)

--- a/internal/tikv/redis_helper/pubsub.go
+++ b/internal/tikv/redis_helper/pubsub.go
@@ -74,7 +74,7 @@ func SubscribeNewFilterLogEvent(shardID uint32, namespace string, cb func(id str
 			query.FilterCriteria.ToBlock.Neg(query.FilterCriteria.ToBlock)
 		}
 
-		fmt.Printf("filter: new message id='%s' from=%d to=%d", query.ID, query.FilterCriteria.FromBlock.Int64(), query.FilterCriteria.ToBlock.Int64())
+		fmt.Printf("filter: new message id='%s' from=%d to=%d", query.ID, getInt(query.FilterCriteria.FromBlock), getInt(query.FilterCriteria.ToBlock))
 		err := rlp.DecodeBytes([]byte(message.Payload), &query)
 		if err != nil {
 			utils.Logger().Info().Err(err).Msg("redis subscribe new_filter_log error")
@@ -90,7 +90,7 @@ func PublishNewFilterLogEvent(shardID uint32, namespace, id string, crit ethereu
 		return nil
 	}
 
-	fmt.Printf("filter: send message id='%s' from=%d to=%d", id, crit.FromBlock.Int64(), crit.ToBlock.Int64())
+	fmt.Printf("filter: send message id='%s' from=%d to=%d", id, getInt(crit.FromBlock), getInt(crit.ToBlock))
 
 	ev := NewFilterUpdated{
 		ID:                id,
@@ -204,4 +204,12 @@ func isBigNegative(i *big.Int) bool {
 		return false
 	}
 	return i.Cmp(big0) == -1
+}
+
+func getInt(i *big.Int) int64 {
+	if i == nil {
+		return 0
+	}
+
+	return i.Int64()
 }

--- a/node/api.go
+++ b/node/api.go
@@ -5,6 +5,7 @@ import (
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/eth/rpc"
 	"github.com/harmony-one/harmony/hmy"
+	"github.com/harmony-one/harmony/internal/tikv"
 	"github.com/harmony-one/harmony/rosetta"
 	hmy_rpc "github.com/harmony-one/harmony/rpc"
 	rpc_common "github.com/harmony-one/harmony/rpc/common"
@@ -95,7 +96,7 @@ func (node *Node) APIs(harmony *hmy.Harmony) []rpc.API {
 	hmyFilter := filters.NewPublicFilterAPI(harmony, false, "hmy", harmony.ShardID)
 	ethFilter := filters.NewPublicFilterAPI(harmony, false, "eth", harmony.ShardID)
 
-	if node.HarmonyConfig.General.RunElasticMode {
+	if node.HarmonyConfig.General.RunElasticMode && node.HarmonyConfig.TiKV.Role == tikv.RoleReader {
 		hmyFilter.Service.(*filters.PublicFilterAPI).SyncNewFilterFromOtherReaders()
 		ethFilter.Service.(*filters.PublicFilterAPI).SyncNewFilterFromOtherReaders()
 	}

--- a/node/api.go
+++ b/node/api.go
@@ -92,14 +92,22 @@ func (node *Node) StopRosetta() error {
 // APIs return the collection of local RPC services.
 // NOTE, some of these services probably need to be moved to somewhere else.
 func (node *Node) APIs(harmony *hmy.Harmony) []rpc.API {
+	hmyFilter := filters.NewPublicFilterAPI(harmony, false, "hmy", harmony.ShardID)
+	ethFilter := filters.NewPublicFilterAPI(harmony, false, "eth", harmony.ShardID)
+
+	if node.HarmonyConfig.General.RunElasticMode {
+		hmyFilter.Service.(*filters.PublicFilterAPI).SyncNewFilterFromOtherReaders()
+		ethFilter.Service.(*filters.PublicFilterAPI).SyncNewFilterFromOtherReaders()
+	}
+
 	// Append all the local APIs and return
 	return []rpc.API{
 		hmy_rpc.NewPublicNetAPI(node.host, harmony.ChainID, hmy_rpc.V1),
 		hmy_rpc.NewPublicNetAPI(node.host, harmony.ChainID, hmy_rpc.V2),
 		hmy_rpc.NewPublicNetAPI(node.host, harmony.ChainID, hmy_rpc.Eth),
 		hmy_rpc.NewPublicWeb3API(),
-		filters.NewPublicFilterAPI(harmony, false, "hmy"),
-		filters.NewPublicFilterAPI(harmony, false, "eth"),
+		hmyFilter,
+		ethFilter,
 	}
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -1436,13 +1436,13 @@ func (node *Node) syncFromTiKVWriter() {
 			select {
 			case <-doneChan:
 				return
-			case <-time.After(5 * time.Minute):
+			case <-time.After(2 * time.Minute):
 				buf := bytes.NewBuffer(nil)
 				err := pprof.Lookup("goroutine").WriteTo(buf, 1)
 				if err != nil {
 					panic(err)
 				}
-				err = ioutil.WriteFile(fmt.Sprintf("/tmp/%s", time.Now().Format("hmy_0102150405.error.log")), buf.Bytes(), 0644)
+				err = ioutil.WriteFile(fmt.Sprintf("/local/%s", time.Now().Format("hmy_0102150405.error.log")), buf.Bytes(), 0644)
 				if err != nil {
 					panic(err)
 				}
@@ -1452,8 +1452,7 @@ func (node *Node) syncFromTiKVWriter() {
 		}()
 		defer close(doneChan)
 
-		err := bc.SyncFromTiKVWriter(blkNum, logs)
-		if err != nil {
+		if err := bc.SyncFromTiKVWriter(blkNum, logs); err != nil {
 			utils.Logger().Warn().
 				Err(err).
 				Msg("cannot sync block from tikv writer")

--- a/node/node.go
+++ b/node/node.go
@@ -1090,7 +1090,7 @@ func New(
 			if node.Blockchain().IsTikvWriterMaster() {
 				err := redis_helper.PublishTxPoolUpdate(uint32(harmonyconfig.General.ShardID), tx, local)
 				if err != nil {
-					utils.Logger().Info().Err(err).Msg("redis publish txpool update error")
+					utils.Logger().Warn().Err(err).Msg("redis publish txpool update error")
 				}
 			}
 		}

--- a/rpc/filters/api.go
+++ b/rpc/filters/api.go
@@ -3,6 +3,7 @@ package filters
 import (
 	"context"
 	"fmt"
+	"log"
 	"sync"
 	"time"
 
@@ -399,7 +400,7 @@ func (api *PublicFilterAPI) createFilter(crit ethereum.FilterQuery, customId rpc
 		}
 	}()
 
-	fmt.Printf("filter: logs created id='%s'", logsSub.ID)
+	log.Printf("filter: logs created id='%s'\n", logsSub.ID)
 
 	return logsSub.ID, nil
 }

--- a/rpc/filters/api.go
+++ b/rpc/filters/api.go
@@ -402,7 +402,7 @@ func (api *PublicFilterAPI) createFilter(crit ethereum.FilterQuery) (rpc.ID, err
 }
 
 func (api *PublicFilterAPI) SyncNewFilterFromOtherReaders() {
-	redis_helper.SubscribeNewFilterLogEvent(api.shardID, api.namespace, func(crit ethereum.FilterQuery) {
+	go redis_helper.SubscribeNewFilterLogEvent(api.shardID, api.namespace, func(crit ethereum.FilterQuery) {
 		if _, err := api.createFilter(crit); err != nil {
 			utils.Logger().Warn().
 				Uint32("shardID", api.shardID).

--- a/rpc/filters/api.go
+++ b/rpc/filters/api.go
@@ -360,7 +360,7 @@ func (api *PublicFilterAPI) NewFilter(crit FilterCriteria) (rpc.ID, error) {
 		return "", fmt.Errorf("sending filter logs to other readers: %w", err)
 	}
 
-	time.Sleep(time.Millisecond * 70) // to give time to the other writers to catch up
+	time.Sleep(time.Millisecond * 70) // to give time to the other readers to catch up
 	return api.createFilter(ethereum.FilterQuery(crit), id)
 }
 

--- a/rpc/filters/api.go
+++ b/rpc/filters/api.go
@@ -3,7 +3,6 @@ package filters
 import (
 	"context"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
@@ -399,8 +398,6 @@ func (api *PublicFilterAPI) createFilter(crit ethereum.FilterQuery, customId rpc
 			}
 		}
 	}()
-
-	log.Printf("filter: logs created id='%s'\n", logsSub.ID)
 
 	return logsSub.ID, nil
 }

--- a/rpc/filters/api.go
+++ b/rpc/filters/api.go
@@ -399,6 +399,8 @@ func (api *PublicFilterAPI) createFilter(crit ethereum.FilterQuery, customId rpc
 		}
 	}()
 
+	fmt.Printf("filter: logs created id='%s'", logsSub.ID)
+
 	return logsSub.ID, nil
 }
 

--- a/rpc/filters/api.go
+++ b/rpc/filters/api.go
@@ -355,6 +355,7 @@ func (api *PublicFilterAPI) NewFilter(crit FilterCriteria) (rpc.ID, error) {
 	timer := hmy_rpc.DoMetricRPCRequest(hmy_rpc.NewFilter)
 	defer hmy_rpc.DoRPCRequestDuration(hmy_rpc.NewFilter, timer)
 
+	time.Sleep(time.Millisecond * 50) // to give time to the other writers to catch up
 	if err := redis_helper.PublishNewFilterLogEvent(api.shardID, api.namespace, ethereum.FilterQuery(crit)); err != nil {
 		return "", fmt.Errorf("sending filter logs to other readers: %w", err)
 	}

--- a/rpc/filters/filter_system.go
+++ b/rpc/filters/filter_system.go
@@ -193,7 +193,7 @@ func (es *EventSystem) subscribe(sub *subscription) *Subscription {
 // SubscribeLogs creates a subscription that will write all logs matching the
 // given criteria to the given logs channel. Default value for the from and to
 // block is "latest". If the fromBlock > toBlock an error is returned.
-func (es *EventSystem) SubscribeLogs(crit ethereum.FilterQuery, logs chan []*types.Log) (*Subscription, error) {
+func (es *EventSystem) SubscribeLogs(crit ethereum.FilterQuery, logs chan []*types.Log, customID *rpc.ID) (*Subscription, error) {
 	var from, to rpc.BlockNumber
 	if crit.FromBlock == nil {
 		from = rpc.LatestBlockNumber
@@ -208,32 +208,36 @@ func (es *EventSystem) SubscribeLogs(crit ethereum.FilterQuery, logs chan []*typ
 
 	// only interested in pending logs
 	if from == rpc.PendingBlockNumber && to == rpc.PendingBlockNumber {
-		return es.subscribePendingLogs(crit, logs), nil
+		return es.subscribePendingLogs(crit, logs, customID), nil
 	}
 	// only interested in new mined logs
 	if from == rpc.LatestBlockNumber && to == rpc.LatestBlockNumber {
-		return es.subscribeLogs(crit, logs), nil
+		return es.subscribeLogs(crit, logs, customID), nil
 	}
 	// only interested in mined logs within a specific block range
 	if from >= 0 && to >= 0 && to >= from {
-		return es.subscribeLogs(crit, logs), nil
+		return es.subscribeLogs(crit, logs, customID), nil
 	}
 	// interested in mined logs from a specific block number, new logs and pending logs
 	if from >= rpc.LatestBlockNumber && to == rpc.PendingBlockNumber {
-		return es.subscribeMinedPendingLogs(crit, logs), nil
+		return es.subscribeMinedPendingLogs(crit, logs, customID), nil
 	}
 	// interested in logs from a specific block number to new mined blocks
 	if from >= 0 && to == rpc.LatestBlockNumber {
-		return es.subscribeLogs(crit, logs), nil
+		return es.subscribeLogs(crit, logs, customID), nil
 	}
 	return nil, fmt.Errorf("invalid from and to block combination: from > to")
 }
 
 // subscribeMinedPendingLogs creates a subscription that returned mined and
 // pending logs that match the given criteria.
-func (es *EventSystem) subscribeMinedPendingLogs(crit ethereum.FilterQuery, logs chan []*types.Log) *Subscription {
+func (es *EventSystem) subscribeMinedPendingLogs(crit ethereum.FilterQuery, logs chan []*types.Log, customID *rpc.ID) *Subscription {
+	id := rpc.NewID()
+	if customID != nil {
+		id = *customID
+	}
 	sub := &subscription{
-		id:        rpc.NewID(),
+		id:        id,
 		typ:       MinedAndPendingLogsSubscription,
 		logsCrit:  crit,
 		created:   time.Now(),
@@ -248,9 +252,13 @@ func (es *EventSystem) subscribeMinedPendingLogs(crit ethereum.FilterQuery, logs
 
 // subscribeLogs creates a subscription that will write all logs matching the
 // given criteria to the given logs channel.
-func (es *EventSystem) subscribeLogs(crit ethereum.FilterQuery, logs chan []*types.Log) *Subscription {
+func (es *EventSystem) subscribeLogs(crit ethereum.FilterQuery, logs chan []*types.Log, customID *rpc.ID) *Subscription {
+	id := rpc.NewID()
+	if customID != nil {
+		id = *customID
+	}
 	sub := &subscription{
-		id:        rpc.NewID(),
+		id:        id,
 		typ:       LogsSubscription,
 		logsCrit:  crit,
 		created:   time.Now(),
@@ -265,9 +273,13 @@ func (es *EventSystem) subscribeLogs(crit ethereum.FilterQuery, logs chan []*typ
 
 // subscribePendingLogs creates a subscription that writes transaction hashes for
 // transactions that enter the transaction pool.
-func (es *EventSystem) subscribePendingLogs(crit ethereum.FilterQuery, logs chan []*types.Log) *Subscription {
+func (es *EventSystem) subscribePendingLogs(crit ethereum.FilterQuery, logs chan []*types.Log, customID *rpc.ID) *Subscription {
+	id := rpc.NewID()
+	if customID != nil {
+		id = *customID
+	}
 	sub := &subscription{
-		id:        rpc.NewID(),
+		id:        id,
 		typ:       PendingLogsSubscription,
 		logsCrit:  crit,
 		created:   time.Now(),

--- a/rpc/filters/filter_system.go
+++ b/rpc/filters/filter_system.go
@@ -232,9 +232,11 @@ func (es *EventSystem) SubscribeLogs(crit ethereum.FilterQuery, logs chan []*typ
 // subscribeMinedPendingLogs creates a subscription that returned mined and
 // pending logs that match the given criteria.
 func (es *EventSystem) subscribeMinedPendingLogs(crit ethereum.FilterQuery, logs chan []*types.Log, customID *rpc.ID) *Subscription {
-	id := rpc.NewID()
+	var id rpc.ID
 	if customID != nil {
 		id = *customID
+	} else {
+		id = rpc.NewID()
 	}
 	sub := &subscription{
 		id:        id,
@@ -253,9 +255,11 @@ func (es *EventSystem) subscribeMinedPendingLogs(crit ethereum.FilterQuery, logs
 // subscribeLogs creates a subscription that will write all logs matching the
 // given criteria to the given logs channel.
 func (es *EventSystem) subscribeLogs(crit ethereum.FilterQuery, logs chan []*types.Log, customID *rpc.ID) *Subscription {
-	id := rpc.NewID()
+	var id rpc.ID
 	if customID != nil {
 		id = *customID
+	} else {
+		id = rpc.NewID()
 	}
 	sub := &subscription{
 		id:        id,
@@ -274,9 +278,11 @@ func (es *EventSystem) subscribeLogs(crit ethereum.FilterQuery, logs chan []*typ
 // subscribePendingLogs creates a subscription that writes transaction hashes for
 // transactions that enter the transaction pool.
 func (es *EventSystem) subscribePendingLogs(crit ethereum.FilterQuery, logs chan []*types.Log, customID *rpc.ID) *Subscription {
-	id := rpc.NewID()
+	var id rpc.ID
 	if customID != nil {
 		id = *customID
+	} else {
+		id = rpc.NewID()
 	}
 	sub := &subscription{
 		id:        id,


### PR DESCRIPTION
## Issue

Two issues were found:

First: when creating a new filter, the filters are stored in memory so you would create the filter in one reader but then when you would like to pull the result of that filter and your request was routed to a different node then you would get "filter not found error". This PR makes it so other readers are notified about new filters created so they can create one with the same filter ID. This is done via redis channels

Second: the writer sends the newst blocks and logs to the readers, so they can keep them in memory and run in-memory feeds. The issue was that when serializing the data some fields where cut off from the [serialized output ](https://github.com/harmony-one/harmony/blob/da3c93fb58371b5355923ede044ab0ad398d15e6/core/types/log.go#L83).  So we needed to wrap the Log struct with LogForStorage [which includes all the fields](https://github.com/harmony-one/harmony/blob/da3c93fb58371b5355923ede044ab0ad398d15e6/core/types/log.go#L102).


Update: tested it on a non-erpc node and it works fine too.
