### PR TITLE
Feature peers storage.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ exe:
 	bash ./scripts/go_executable_build.sh -S
 
 race:
-	bash ./scripts/go_executable_build.sh -r
+	bash ./scripts/go_executable_build.sh -Sr
 
 trace-pointer:
 	bash ./scripts/go_executable_build.sh -t

--- a/api/service/legacysync/helpers.go
+++ b/api/service/legacysync/helpers.go
@@ -27,11 +27,11 @@ func getMaxPeerHeight(syncConfig *SyncConfig) uint64 {
 			// utils.Logger().Debug().Bool("isBeacon", isBeacon).Str("peerIP", peerConfig.ip).Str("peerPort", peerConfig.port).Msg("[Sync]getMaxPeerHeight")
 			response, err := peerConfig.client.GetBlockChainHeight()
 			if err != nil {
-				utils.Logger().Warn().Err(err).Str("peerIP", peerConfig.ip).Str("peerPort", peerConfig.port).Msg("[Sync]GetBlockChainHeight failed")
+				utils.Logger().Warn().Err(err).Str("peerIP", peerConfig.peer.IP).Str("peerPort", peerConfig.peer.Port).Msg("[Sync]GetBlockChainHeight failed")
 				syncConfig.RemovePeer(peerConfig, fmt.Sprintf("failed getMaxPeerHeight for shard %d with message: %s", syncConfig.ShardID(), err.Error()))
 				return
 			}
-			utils.Logger().Info().Str("peerIP", peerConfig.ip).Uint64("blockHeight", response.BlockHeight).
+			utils.Logger().Info().Str("peerIP", peerConfig.peer.IP).Uint64("blockHeight", response.BlockHeight).
 				Msg("[SYNC] getMaxPeerHeight")
 
 			lock.Lock()
@@ -60,7 +60,7 @@ func createSyncConfig(syncConfig *SyncConfig, provider SyncingPeerProvider, shar
 	storage.AddPeers(peers)
 
 	// limit the number of dns peers to connect
-	peers = storage.GetPeersN(limitNumPeersNum())
+	peers = storage.GetPeersN(limitPeersNum())
 
 	utils.Logger().Debug().
 		Int("len", len(peers)).
@@ -86,8 +86,7 @@ func createSyncConfig(syncConfig *SyncConfig, provider SyncingPeerProvider, shar
 				return
 			}
 			peerConfig := &SyncPeerConfig{
-				ip:     peer.IP,
-				port:   peer.Port,
+				peer:   peer,
 				client: client,
 			}
 			ch <- peerConfig

--- a/api/service/legacysync/helpers.go
+++ b/api/service/legacysync/helpers.go
@@ -95,6 +95,7 @@ func createSyncConfig(syncConfig *SyncConfig, provider SyncingPeerProvider, shar
 	wg.Wait()
 	close(ch)
 	for v := range ch {
+		storage.SetSuccess(v.peer)
 		syncConfig.AddPeer(v)
 	}
 	utils.Logger().Info().

--- a/api/service/legacysync/helpers.go
+++ b/api/service/legacysync/helpers.go
@@ -60,7 +60,7 @@ func createSyncConfig(syncConfig *SyncConfig, provider SyncingPeerProvider, shar
 	storage.AddPeers(peers)
 
 	// limit the number of dns peers to connect
-	peers = storage.GetPeersN(limitPeersNum())
+	peers = storage.GetPeers(limitPeersNum())
 
 	utils.Logger().Debug().
 		Int("len", len(peers)).

--- a/api/service/legacysync/storage.go
+++ b/api/service/legacysync/storage.go
@@ -1,0 +1,68 @@
+package legacysync
+
+import "github.com/harmony-one/harmony/p2p"
+
+type peerDupID struct {
+	ip   string
+	port string
+}
+
+type Storage struct {
+	succ map[peerDupID]p2p.Peer
+	fail map[peerDupID]p2p.Peer
+}
+
+func (s *Storage) Contains(p p2p.Peer) bool {
+	d := peerDupID{p.IP, p.Port}
+	return s.contains(d)
+}
+
+func (s *Storage) contains(d peerDupID) bool {
+	_, ok := s.succ[d]
+	if ok {
+		return true
+	}
+	_, ok = s.fail[d]
+	return ok
+}
+
+func (s *Storage) AddPeers(peers []p2p.Peer) {
+	for _, p := range peers {
+		s.AddPeer(p)
+	}
+}
+
+func (s *Storage) GetPeersN(n int) []p2p.Peer {
+	peers := make([]p2p.Peer, 0, n)
+	for _, p := range s.succ {
+		peers = append(peers, p)
+		if len(peers) >= n {
+			break
+		}
+	}
+	return peers
+}
+
+func (s *Storage) AddPeer(p p2p.Peer) {
+	d := peerDupID{p.IP, p.Port}
+	if s.contains(d) {
+		return
+	}
+	s.succ[d] = p
+}
+
+func (s *Storage) Fail(p p2p.Peer) {
+	d := peerDupID{p.IP, p.Port}
+	delete(s.succ, d)
+	s.fail[d] = p
+}
+
+func (s *Storage) Success(p p2p.Peer) {
+	d := peerDupID{p.IP, p.Port}
+	delete(s.fail, d)
+	s.succ[d] = p
+}
+
+func NewStorage() *Storage {
+	return &Storage{}
+}

--- a/api/service/legacysync/storage.go
+++ b/api/service/legacysync/storage.go
@@ -27,7 +27,7 @@ func (s *Storage) Contains(p p2p.Peer) bool {
 }
 
 func (s *Storage) contains(d peerDupID) bool {
-	return s.isSuccess(d) || s.isFail(d)
+	return s.isSuccess(d) || s.isFailure(d)
 }
 
 func (s *Storage) AddPeers(peers []p2p.Peer) {
@@ -66,7 +66,7 @@ func (s *Storage) AddPeer(p p2p.Peer) {
 	s.succ.Add(d, p)
 }
 
-func (s *Storage) Fail(p p2p.Peer) {
+func (s *Storage) SetFailure(p p2p.Peer) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	d := peerDupID{p.IP, p.Port}
@@ -74,17 +74,17 @@ func (s *Storage) Fail(p p2p.Peer) {
 	s.fail.Add(d, p)
 }
 
-func (s *Storage) IsFail(p p2p.Peer) bool {
+func (s *Storage) IsFailure(p p2p.Peer) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.isFail(peerDupID{p.IP, p.Port})
+	return s.isFailure(peerDupID{p.IP, p.Port})
 }
 
-func (s *Storage) isFail(d peerDupID) bool {
+func (s *Storage) isFailure(d peerDupID) bool {
 	return s.fail.Contains(d)
 }
 
-func (s *Storage) Success(p p2p.Peer) {
+func (s *Storage) SetSuccess(p p2p.Peer) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	d := peerDupID{p.IP, p.Port}

--- a/api/service/legacysync/storage.go
+++ b/api/service/legacysync/storage.go
@@ -11,6 +11,7 @@ type peerDupID struct {
 	port string
 }
 
+// Storage keeps successful and failed peers.
 type Storage struct {
 	mu   sync.Mutex
 	succ map[peerDupID]p2p.Peer
@@ -34,6 +35,7 @@ func (s *Storage) AddPeers(peers []p2p.Peer) {
 	}
 }
 
+// GetPeers returns no more than `n` peers. First `succ` then `fail`.
 func (s *Storage) GetPeers(n int) []p2p.Peer {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/api/service/legacysync/storage.go
+++ b/api/service/legacysync/storage.go
@@ -63,12 +63,27 @@ func (s *Storage) Fail(p p2p.Peer) {
 	s.fail[d] = p
 }
 
+func (s *Storage) IsFail(p p2p.Peer) bool {
+	d := peerDupID{p.IP, p.Port}
+	_, ok := s.fail[d]
+	return ok
+}
+
 func (s *Storage) Success(p p2p.Peer) {
 	d := peerDupID{p.IP, p.Port}
 	delete(s.fail, d)
 	s.succ[d] = p
 }
 
+func (s *Storage) IsSuccess(p p2p.Peer) bool {
+	d := peerDupID{p.IP, p.Port}
+	_, ok := s.succ[d]
+	return ok
+}
+
 func NewStorage() *Storage {
-	return &Storage{}
+	return &Storage{
+		succ: make(map[peerDupID]p2p.Peer),
+		fail: make(map[peerDupID]p2p.Peer),
+	}
 }

--- a/api/service/legacysync/storage.go
+++ b/api/service/legacysync/storage.go
@@ -40,6 +40,12 @@ func (s *Storage) GetPeersN(n int) []p2p.Peer {
 			break
 		}
 	}
+	for _, p := range s.fail {
+		peers = append(peers, p)
+		if len(peers) >= n {
+			break
+		}
+	}
 	return peers
 }
 

--- a/api/service/legacysync/storage_test.go
+++ b/api/service/legacysync/storage_test.go
@@ -15,7 +15,7 @@ func TestStorage(t *testing.T) {
 	s.AddPeer(p1)
 	require.True(t, s.Contains(p1))
 
-	peers := s.GetPeersN(1)
+	peers := s.GetPeers(1)
 	require.Equal(t, 1, len(peers))
 
 	require.True(t, s.IsSuccess(p1))
@@ -26,5 +26,5 @@ func TestStorage(t *testing.T) {
 	require.False(t, s.IsSuccess(p1))
 	require.True(t, s.IsFail(p1))
 
-	require.Equal(t, 1, len(s.GetPeersN(1)))
+	require.Equal(t, 1, len(s.GetPeers(1)))
 }

--- a/api/service/legacysync/storage_test.go
+++ b/api/service/legacysync/storage_test.go
@@ -1,0 +1,30 @@
+package legacysync
+
+import (
+	"testing"
+
+	"github.com/harmony-one/harmony/p2p"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorage(t *testing.T) {
+	s := NewStorage()
+	p1 := p2p.Peer{IP: "127.0.0.1", Port: "1"}
+	require.False(t, s.Contains(p1))
+
+	s.AddPeer(p1)
+	require.True(t, s.Contains(p1))
+
+	peers := s.GetPeersN(1)
+	require.Equal(t, 1, len(peers))
+
+	require.True(t, s.IsSuccess(p1))
+	require.False(t, s.IsFail(p1))
+
+	s.Fail(p1)
+
+	require.False(t, s.IsSuccess(p1))
+	require.True(t, s.IsFail(p1))
+
+	require.Equal(t, 1, len(s.GetPeersN(1)))
+}

--- a/api/service/legacysync/storage_test.go
+++ b/api/service/legacysync/storage_test.go
@@ -19,12 +19,12 @@ func TestStorage(t *testing.T) {
 	require.Equal(t, 1, len(peers))
 
 	require.True(t, s.IsSuccess(p1))
-	require.False(t, s.IsFail(p1))
+	require.False(t, s.IsFailure(p1))
 
-	s.Fail(p1)
+	s.SetFailure(p1)
 
 	require.False(t, s.IsSuccess(p1))
-	require.True(t, s.IsFail(p1))
+	require.True(t, s.IsFailure(p1))
 
 	require.Equal(t, 1, len(s.GetPeers(1)))
 }

--- a/api/service/legacysync/syncing.go
+++ b/api/service/legacysync/syncing.go
@@ -191,7 +191,7 @@ func (sc *SyncConfig) RemovePeer(peer *SyncPeerConfig, reason string) {
 			break
 		}
 	}
-	sc.storage.Fail(peer.peer)
+	sc.storage.SetFailure(peer.peer)
 	utils.Logger().Info().
 		Str("peerIP", peer.peer.IP).
 		Str("peerPortMsg", peer.peer.Port).

--- a/api/service/legacysync/syncing_test.go
+++ b/api/service/legacysync/syncing_test.go
@@ -29,34 +29,46 @@ func TestSyncPeerConfig_IsEqual(t *testing.T) {
 	}{
 		{
 			p1: &SyncPeerConfig{
-				ip:   "0.0.0.1",
-				port: "1",
+				peer: p2p.Peer{
+					IP:   "0.0.0.1",
+					Port: "1",
+				},
 			},
 			p2: &SyncPeerConfig{
-				ip:   "0.0.0.1",
-				port: "2",
+				peer: p2p.Peer{
+					IP:   "0.0.0.1",
+					Port: "2",
+				},
 			},
 			exp: false,
 		},
 		{
 			p1: &SyncPeerConfig{
-				ip:   "0.0.0.1",
-				port: "1",
+				peer: p2p.Peer{
+					IP:   "0.0.0.1",
+					Port: "1",
+				},
 			},
 			p2: &SyncPeerConfig{
-				ip:   "0.0.0.2",
-				port: "1",
+				peer: p2p.Peer{
+					IP:   "0.0.0.2",
+					Port: "1",
+				},
 			},
 			exp: false,
 		},
 		{
 			p1: &SyncPeerConfig{
-				ip:   "0.0.0.1",
-				port: "1",
+				peer: p2p.Peer{
+					IP:   "0.0.0.1",
+					Port: "1",
+				},
 			},
 			p2: &SyncPeerConfig{
-				ip:   "0.0.0.1",
-				port: "1",
+				peer: p2p.Peer{
+					IP:   "0.0.0.1",
+					Port: "1",
+				},
 			},
 			exp: true,
 		},

--- a/internal/linkedhashmap/entry.go
+++ b/internal/linkedhashmap/entry.go
@@ -1,0 +1,6 @@
+package linkedhashmap
+
+type Entry[K, V any] struct {
+	Key   K
+	Value V
+}

--- a/internal/linkedhashmap/hashmap.go
+++ b/internal/linkedhashmap/hashmap.go
@@ -1,0 +1,74 @@
+package linkedhashmap
+
+import "fmt"
+
+type internal[K, V any] struct {
+	key   *DoubleLinkedListNode[K]
+	value V
+}
+
+type HashMap[K comparable, V any] struct {
+	m          map[K]internal[K, V]
+	linkedList DoubleLinkedList[K]
+}
+
+func New[K comparable, V any]() *HashMap[K, V] {
+	return &HashMap[K, V]{
+		m:          make(map[K]internal[K, V]),
+		linkedList: DoubleLinkedList[K]{},
+	}
+}
+
+func (a *HashMap[K, V]) Add(k K, v V) {
+	if node, ok := a.m[k]; ok {
+		a.linkedList.RemoveNode(node.key)
+	}
+
+	a.m[k] = internal[K, V]{
+		key:   a.linkedList.PushBack(k),
+		value: v,
+	}
+}
+
+func (a *HashMap[K, V]) Count() int {
+	return len(a.m)
+}
+
+func (a *HashMap[K, V]) Pop() *Entry[K, V] {
+	if len(a.m) == 0 {
+		return nil
+	}
+	key := a.linkedList.PopFront()
+	if v, ok := a.m[*key]; ok {
+		delete(a.m, *key)
+		return &Entry[K, V]{*key, v.value}
+	}
+	panic(fmt.Sprintf("key %v not found", *key))
+}
+
+func (a *HashMap[K, V]) HasNext() bool {
+	return len(a.m) > 0
+}
+
+func (a *HashMap[K, V]) Next() *Entry[K, V] {
+	if len(a.m) == 0 {
+		return nil
+	}
+	key := a.linkedList.Front()
+	if v, ok := a.m[key.Value]; ok {
+		return &Entry[K, V]{key.Value, v.value}
+	}
+	panic(fmt.Sprintf("key %v not found", *key))
+}
+
+func (a *HashMap[K, V]) Remove(key K) {
+	if v, ok := a.m[key]; ok {
+		a.linkedList.RemoveNode(v.key)
+		delete(a.m, key)
+	}
+}
+
+func (a *HashMap[K, V]) Contains(key K) bool {
+	_, ok := a.m[key]
+	return ok
+}

--- a/internal/linkedhashmap/hashmap_test.go
+++ b/internal/linkedhashmap/hashmap_test.go
@@ -1,0 +1,31 @@
+package linkedhashmap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type value struct {
+	v int
+}
+
+func TestHashMap(t *testing.T) {
+	h := New[int, *value]()
+	for i := 0; i < 3; i++ {
+		require.Equal(t, 0, h.Count())
+		require.Nil(t, h.Next())
+		require.False(t, h.HasNext())
+
+		h.Add(1, &value{1})
+		require.Equal(t, 1, h.Count())
+
+		h.Add(2, &value{2})
+		require.Equal(t, 2, h.Count())
+
+		require.Equal(t, &value{1}, h.Pop().Value)
+		require.Equal(t, 1, h.Count())
+		require.Equal(t, &value{2}, h.Next().Value)
+		h.Remove(h.Next().Key)
+	}
+}

--- a/internal/linkedhashmap/hashmap_test.go
+++ b/internal/linkedhashmap/hashmap_test.go
@@ -11,21 +11,42 @@ type value struct {
 }
 
 func TestHashMap(t *testing.T) {
-	h := New[int, *value]()
-	for i := 0; i < 3; i++ {
-		require.Equal(t, 0, h.Count())
-		require.Nil(t, h.Next())
-		require.False(t, h.HasNext())
+	t.Run("test_methods", func(t *testing.T) {
+		h := New[int, *value]()
+		for i := 0; i < 3; i++ {
+			require.Equal(t, 0, h.Count())
+			require.Nil(t, h.Next())
+			require.False(t, h.HasNext())
 
+			h.Add(1, &value{1})
+			require.Equal(t, 1, h.Count())
+
+			h.Add(2, &value{2})
+			require.Equal(t, 2, h.Count())
+
+			require.Equal(t, &value{1}, h.Pop().Value)
+			require.Equal(t, 1, h.Count())
+			require.Equal(t, &value{2}, h.Next().Value)
+			h.Remove(h.Next().Key)
+		}
+	})
+	t.Run("test_add_duplicate_peer", func(t *testing.T) {
+		h := New[int, *value]()
+		h.Add(1, &value{1})
 		h.Add(1, &value{1})
 		require.Equal(t, 1, h.Count())
+	})
 
-		h.Add(2, &value{2})
-		require.Equal(t, 2, h.Count())
+	t.Run("test_contains", func(t *testing.T) {
+		h := New[int, *value]()
+		require.False(t, h.Contains(1))
 
-		require.Equal(t, &value{1}, h.Pop().Value)
-		require.Equal(t, 1, h.Count())
-		require.Equal(t, &value{2}, h.Next().Value)
-		h.Remove(h.Next().Key)
-	}
+		h.Add(1, &value{1})
+		require.True(t, h.Contains(1))
+	})
+
+	t.Run("test_pop_empty_map", func(t *testing.T) {
+		h := New[int, *value]()
+		require.Nil(t, h.Pop())
+	})
 }

--- a/internal/linkedhashmap/list.go
+++ b/internal/linkedhashmap/list.go
@@ -1,0 +1,87 @@
+package linkedhashmap
+
+type DoubleLinkedList[T any] struct {
+	first *DoubleLinkedListNode[T] // pust only to front
+	last  *DoubleLinkedListNode[T]
+	count int
+}
+
+type DoubleLinkedListNode[T any] struct {
+	Front *DoubleLinkedListNode[T]
+	Back  *DoubleLinkedListNode[T]
+	Value T
+}
+
+func (a *DoubleLinkedList[T]) Count() int {
+	return a.count
+}
+
+func (a *DoubleLinkedList[T]) PushBack(value T) *DoubleLinkedListNode[T] {
+	newNode := &DoubleLinkedListNode[T]{Value: value}
+	if a.count == 0 {
+		a.last = newNode
+		a.first = newNode
+	} else {
+		back := a.last
+		a.last = newNode
+		newNode.Front = back
+		back.Back = newNode
+	}
+
+	a.count++
+	return newNode
+}
+
+func (a *DoubleLinkedList[T]) PopFront() *T {
+	if a.count == 0 {
+		return nil
+	}
+	first := a.first
+	a.first = a.first.Back
+	a.count--
+	return &first.Value
+}
+
+func (a *DoubleLinkedList[T]) PopBack() *T {
+	if a.count == 0 {
+		return nil
+	}
+	last := a.last
+	a.last = a.last.Front
+	a.count--
+	return &last.Value
+}
+
+func (a *DoubleLinkedList[T]) Front() *DoubleLinkedListNode[T] {
+	if a.count == 0 {
+		return nil
+	}
+	return a.first
+}
+
+func (a *DoubleLinkedList[T]) Back() *DoubleLinkedListNode[T] {
+	if a.count == 0 {
+		return nil
+	}
+	return a.last
+}
+
+func (a *DoubleLinkedList[T]) RemoveNode(node *DoubleLinkedListNode[T]) {
+	if a.count == 0 || node == nil {
+		return
+	}
+
+	if node.Front != nil && node.Front.Back != nil {
+		node.Front.Back = node.Back
+	}
+	if node.Back != nil && node.Back.Front != nil {
+		node.Back.Front = node.Front
+	}
+	if node == a.first { // first node
+		a.first = a.first.Back
+	}
+	if node == a.last {
+		a.last = a.last.Front
+	}
+	a.count--
+}

--- a/internal/linkedhashmap/list_test.go
+++ b/internal/linkedhashmap/list_test.go
@@ -1,0 +1,40 @@
+package linkedhashmap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDoubleLinkedList(t *testing.T) {
+	l := DoubleLinkedList[*value]{}
+	for i := 0; i < 3; i++ { // to be sure previous iterations didn't break something
+		require.Equal(t, 0, l.Count())
+
+		l.PushBack(&value{1})
+		l.PushBack(&value{2})
+		l.PushBack(&value{3})
+		l.PushBack(&value{4})
+
+		require.Equal(t, 4, l.Count())
+
+		require.Equal(t, &value{1}, *l.PopFront())
+		require.Equal(t, 3, l.Count())
+
+		require.Equal(t, &value{4}, *l.PopBack())
+		require.Equal(t, 2, l.Count())
+
+		require.Equal(t, &value{2}, l.Front().Value)
+		l.RemoveNode(l.Front())
+
+		require.Equal(t, &value{3}, l.Back().Value)
+		l.RemoveNode(l.Back())
+
+		// this methods shouldn't affect
+		require.Empty(t, l.Front())
+		require.Empty(t, l.Back())
+		require.Empty(t, l.PopFront())
+		require.Empty(t, l.PopBack())
+		l.RemoveNode(nil)
+	}
+}

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -276,18 +276,9 @@ func (node *Node) DoSyncing(bc core.BlockChain, worker *worker.Worker, willJoinC
 func (node *Node) doSync(bc core.BlockChain, worker *worker.Worker, willJoinConsensus bool) {
 	if node.stateSync.GetActivePeerNumber() < legacysync.NumPeersLowBound {
 		shardID := bc.ShardID()
-		peers, err := node.SyncingPeerProvider.SyncingPeers(shardID)
-		if err != nil {
+		if err := node.stateSync.CreateSyncConfig(node.SyncingPeerProvider, shardID); err != nil {
 			utils.Logger().Warn().
 				Err(err).
-				Uint32("shard_id", shardID).
-				Msg("cannot retrieve syncing peers")
-			return
-		}
-		if err := node.stateSync.CreateSyncConfig(peers, shardID); err != nil {
-			utils.Logger().Warn().
-				Err(err).
-				Interface("peers", peers).
 				Msg("[SYNC] create peers error")
 			return
 		}


### PR DESCRIPTION
`Storage` is struct where we keep 2 types of peers: valid peers and invalid. When we ask storage to give us peers to connect, first we get them from valid peers, and if it's not enough then from invalid in hope, that somehow we will succeed to connect to them. If it happens, we move peer from invalid to valid and vice versa for valid peers. 
The difference is that currently we get all peers, shuffle them and get N (probably 3) of them. We have no clue are those peers have ever been valid, and we have chance not to connect to even 1 peer from that list. With `storage` we have same chance too, but it's less probably. 

Actually, it contains more cleanup than logic, `storage` is really simple.