### PR TITLE
[rpc] fix: cascade send raw tx error

### DIFF
--- a/rpc/pool.go
+++ b/rpc/pool.go
@@ -106,7 +106,7 @@ func (s *PublicPoolService) SendRawTransaction(
 	// Submit transaction
 	if err := s.hmy.SendTx(ctx, tx); err != nil {
 		utils.Logger().Warn().Err(err).Msg("Could not submit transaction")
-		return txHash, err
+		return common.Hash{}, err
 	}
 
 	// Log submission


### PR DESCRIPTION
Temporary patch to be reverted later once error checking is prioritized on Elastic RPC level