### PR TITLE
[p2p] prevent dialing of private ips

### DIFF
--- a/p2p/discovery/option.go
+++ b/p2p/discovery/option.go
@@ -11,10 +11,9 @@ import (
 // DHTConfig is the configurable DHT options.
 // For normal nodes, only BootNodes field need to be specified.
 type DHTConfig struct {
-	BootNodes            []string
-	DataStoreFile        *string // File path to store DHT data. Shall be only used for bootstrap nodes.
-	DiscConcurrency      int
-	DisablePrivateIPScan bool
+	BootNodes       []string
+	DataStoreFile   *string // File path to store DHT data. Shall be only used for bootstrap nodes.
+	DiscConcurrency int
 }
 
 // getLibp2pRawOptions get the raw libp2p options as a slice.
@@ -39,13 +38,6 @@ func (opt DHTConfig) getLibp2pRawOptions() ([]libp2p_dht.Option, error) {
 	// the concurrency num meaning you can see Section 2.3 in the KAD paper https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf
 	if opt.DiscConcurrency > 0 {
 		opts = append(opts, libp2p_dht.Concurrency(opt.DiscConcurrency))
-	}
-
-	if opt.DisablePrivateIPScan {
-		// QueryFilter sets a function that approves which peers may be dialed in a query
-		// PublicQueryFilter returns true if the peer is suspected of being publicly accessible
-		// includes RFC1918 + some other ranges + a stricter definition for IPv6
-		opts = append(opts, libp2p_dht.QueryFilter(libp2p_dht.PublicQueryFilter))
 	}
 
 	return opts, nil

--- a/p2p/gater.go
+++ b/p2p/gater.go
@@ -1,0 +1,44 @@
+package p2p
+
+import (
+	"github.com/libp2p/go-libp2p-core/connmgr"
+	"github.com/libp2p/go-libp2p-core/control"
+	"github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/peer"
+	libp2p_dht "github.com/libp2p/go-libp2p-kad-dht"
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+type Gater struct{}
+
+func NewGater(disablePrivateIPScan bool) connmgr.ConnectionGater {
+	if !disablePrivateIPScan {
+		return nil
+	}
+	return Gater{}
+}
+
+func (gater Gater) InterceptPeerDial(p peer.ID) (allow bool) {
+	return true
+}
+
+// Blocking connections at this stage is typical for address filtering.
+func (gater Gater) InterceptAddrDial(p peer.ID, m ma.Multiaddr) (allow bool) {
+	return libp2p_dht.PublicQueryFilter(nil, peer.AddrInfo{
+		ID:    p,
+		Addrs: []ma.Multiaddr{m},
+	})
+}
+
+func (gater Gater) InterceptAccept(network.ConnMultiaddrs) (allow bool) {
+	return true
+}
+
+func (gater Gater) InterceptSecured(network.Direction, peer.ID, network.ConnMultiaddrs) (allow bool) {
+	return true
+}
+
+// NOTE: the go-libp2p implementation currently IGNORES the disconnect reason.
+func (gater Gater) InterceptUpgraded(network.Conn) (allow bool, reason control.DisconnectReason) {
+	return true, 0
+}

--- a/p2p/gater_test.go
+++ b/p2p/gater_test.go
@@ -8,10 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEmptyGater(t *testing.T) {
-	assert.Nil(t, NewGater(false))
-}
-
 func TestGaterBlocking(t *testing.T) {
 	gater := NewGater(true)
 	require.NotNil(t, &gater, "%s", &gater)
@@ -25,4 +21,19 @@ func TestGaterBlocking(t *testing.T) {
 	assert.Nil(t, err, "%s", err)
 	allowed = gater.InterceptAddrDial("somePeer", private)
 	assert.False(t, allowed, "%b", allowed)
+}
+
+func TestGaterNotBlocking(t *testing.T) {
+	gater := NewGater(false)
+	require.NotNil(t, &gater, "%s", &gater)
+
+	public, err := ma.NewMultiaddr("/ip4/1.1.1.1/udp/53")
+	assert.Nil(t, err, "%s", err)
+	allowed := gater.InterceptAddrDial("somePeer", public)
+	assert.True(t, allowed, "%b", allowed)
+
+	private, err := ma.NewMultiaddr("/ip4/192.168.1.1/tcp/80")
+	assert.Nil(t, err, "%s", err)
+	allowed = gater.InterceptAddrDial("somePeer", private)
+	assert.True(t, allowed, "%b", allowed)
 }

--- a/p2p/gater_test.go
+++ b/p2p/gater_test.go
@@ -1,0 +1,28 @@
+package p2p
+
+import (
+	"testing"
+
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmptyGater(t *testing.T) {
+	assert.Nil(t, NewGater(false))
+}
+
+func TestGaterBlocking(t *testing.T) {
+	gater := NewGater(true)
+	require.NotNil(t, &gater, "%s", &gater)
+
+	public, err := ma.NewMultiaddr("/ip4/1.1.1.1/udp/53")
+	assert.Nil(t, err, "%s", err)
+	allowed := gater.InterceptAddrDial("somePeer", public)
+	assert.True(t, allowed, "%b", allowed)
+
+	private, err := ma.NewMultiaddr("/ip4/192.168.1.1/tcp/80")
+	assert.Nil(t, err, "%s", err)
+	allowed = gater.InterceptAddrDial("somePeer", private)
+	assert.False(t, allowed, "%b", allowed)
+}

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -123,6 +123,8 @@ func NewHost(cfg HostConfig) (Host, error) {
 		libp2p.EnableNATService(),
 		libp2p.ForceReachabilityPublic(),
 		libp2p.BandwidthReporter(newCounter()),
+		// prevent dialing of public addresses
+		libp2p.ConnectionGater(NewGater(cfg.DisablePrivateIPScan)),
 	)
 	if err != nil {
 		cancel()
@@ -130,9 +132,12 @@ func NewHost(cfg HostConfig) (Host, error) {
 	}
 
 	disc, err := discovery.NewDHTDiscovery(p2pHost, discovery.DHTConfig{
-		BootNodes:            cfg.BootNodes,
-		DataStoreFile:        cfg.DataStoreFile,
-		DiscConcurrency:      cfg.DiscConcurrency,
+		BootNodes:       cfg.BootNodes,
+		DataStoreFile:   cfg.DataStoreFile,
+		DiscConcurrency: cfg.DiscConcurrency,
+		// prevent saving (for querying) peer's public IP
+		// TODO mm: remove this once blocking dialing is tested
+		// since it supersedes blocking querying
 		DisablePrivateIPScan: cfg.DisablePrivateIPScan,
 	})
 	if err != nil {

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -135,10 +135,6 @@ func NewHost(cfg HostConfig) (Host, error) {
 		BootNodes:       cfg.BootNodes,
 		DataStoreFile:   cfg.DataStoreFile,
 		DiscConcurrency: cfg.DiscConcurrency,
-		// prevent saving (for querying) peer's public IP
-		// TODO mm: remove this once blocking dialing is tested
-		// since it supersedes blocking querying
-		DisablePrivateIPScan: cfg.DisablePrivateIPScan,
 	})
 	if err != nil {
 		cancel()


### PR DESCRIPTION
The original feature (erroneously) prevents only querying of the private IPs. This change prevents dialing private IPs altogether when the flag is activated.

## Issue
One of our (newly added) internal nodes received a netscan abuse email even though the flag `DisablePrivateIPScan` was turned on.

## Test

### Unit Test Coverage

Before:
```
p2p: 15.7%
```

After:

```
p2p: 17.2%
```

### Test/Run Logs


## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)
No.

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)
No.

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**
No.
