### PR TITLE
fix: erpc raw transaction error handling

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"math/big"
 	"os"
 	"runtime/pprof"
@@ -235,12 +234,6 @@ func (node *Node) addPendingTransactions(newTxs types.Transactions) []error {
 	// 		Msg("[addPendingTransactions] Node out of sync, ignoring transactions")
 	// 	return nil
 	// }
-
-	// in tikv mode, reader only accept the pending transaction from writer node, ignore the p2p message
-	if node.HarmonyConfig.General.RunElasticMode && node.HarmonyConfig.TiKV.Role == tikv.RoleReader {
-		log.Printf("skip reader addPendingTransactions: %#v", newTxs)
-		return nil
-	}
 
 	poolTxs := types.PoolTransactions{}
 	errs := []error{}


### PR DESCRIPTION
## Issue

Initially the erpc reader was thought to only listen to existing tx from the reader, so any new transaction coming from a client would get broadcasted to the network by the reader without any validation, then the client would get a valid tx hash for every transaction even if that transaction could be discarded by the validator afterwards. 
We did this because we didn't want the reader to get tx from the p2p network and only from the writer. But we then decided to run the reader in offline mode which discarded that issue but we never enabled the readers to process and validate pending transactions. In this PR im removing the lines of code that prevented just that, now the reader can validate a transaction and only if valid then it will broadcasting it, giving timely feedback to the client, the writer will still catch up with that transaction eventually and notify the other readers about it.

