### PR TITLE
Decider no longer requires public keys as a dependency.

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/harmony-one/harmony/consensus/quorum"
 	"github.com/harmony-one/harmony/internal/shardchain/tikv_manage"
 	"github.com/harmony-one/harmony/internal/tikv/redis_helper"
 	"github.com/harmony-one/harmony/internal/tikv/statedb_cache"
@@ -40,7 +41,6 @@ import (
 	"github.com/harmony-one/harmony/common/fdlimit"
 	"github.com/harmony-one/harmony/common/ntp"
 	"github.com/harmony-one/harmony/consensus"
-	"github.com/harmony-one/harmony/consensus/quorum"
 	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/hmy/downloader"
 	"github.com/harmony-one/harmony/internal/cli"
@@ -650,13 +650,8 @@ func setupConsensusAndNode(hc harmonyconfig.HarmonyConfig, nodeConfig *nodeconfi
 	// Consensus object.
 	// TODO: consensus object shouldn't start here
 	decider := quorum.NewDecider(quorum.SuperMajorityVote, uint32(hc.General.ShardID))
-
 	currentConsensus, err := consensus.New(
-		myHost, nodeConfig.ShardID, p2p.Peer{}, nodeConfig.ConsensusPriKey, decider,
-	)
-	currentConsensus.Decider.SetMyPublicKeyProvider(func() (multibls.PublicKeys, error) {
-		return currentConsensus.GetPublicKeys(), nil
-	})
+		myHost, nodeConfig.ShardID, nodeConfig.ConsensusPriKey, decider)
 
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Error :%v \n", err)

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -210,7 +210,7 @@ func (consensus *Consensus) BlockNum() uint64 {
 
 // New create a new Consensus record
 func New(
-	host p2p.Host, shard uint32, leader p2p.Peer, multiBLSPriKey multibls.PrivateKeys,
+	host p2p.Host, shard uint32, multiBLSPriKey multibls.PrivateKeys,
 	Decider quorum.Decider,
 ) (*Consensus, error) {
 	consensus := Consensus{}

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -19,7 +19,6 @@ import (
 	"github.com/harmony-one/harmony/crypto/hash"
 	"github.com/harmony-one/harmony/internal/chain"
 	"github.com/harmony-one/harmony/internal/utils"
-	"github.com/harmony-one/harmony/multibls"
 	"github.com/harmony-one/harmony/shard"
 	"github.com/harmony-one/harmony/shard/committee"
 	"github.com/pkg/errors"
@@ -299,9 +298,6 @@ func (consensus *Consensus) UpdateConsensusInformation() Mode {
 	// Only happens once, the flip-over to a new Decider policy
 	if isFirstTimeStaking || haventUpdatedDecider {
 		decider := quorum.NewDecider(quorum.SuperMajorityStake, consensus.ShardID)
-		decider.SetMyPublicKeyProvider(func() (multibls.PublicKeys, error) {
-			return consensus.GetPublicKeys(), nil
-		})
 		consensus.Decider = decider
 	}
 

--- a/consensus/consensus_service_test.go
+++ b/consensus/consensus_service_test.go
@@ -25,9 +25,7 @@ func TestSignAndMarshalConsensusMessage(t *testing.T) {
 	}
 	decider := quorum.NewDecider(quorum.SuperMajorityVote, shard.BeaconChainShardID)
 	blsPriKey := bls.RandPrivateKey()
-	consensus, err := New(
-		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(blsPriKey), decider,
-	)
+	consensus, err := New(host, shard.BeaconChainShardID, multibls.GetPrivateKeys(blsPriKey), decider)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
 	}
@@ -60,7 +58,7 @@ func TestSetViewID(t *testing.T) {
 	)
 	blsPriKey := bls.RandPrivateKey()
 	consensus, err := New(
-		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(blsPriKey), decider,
+		host, shard.BeaconChainShardID, multibls.GetPrivateKeys(blsPriKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -87,12 +87,10 @@ func GenerateConsensusForTesting() (p2p.Host, multibls.PrivateKeys, *Consensus, 
 		return nil, nil, nil, nil, err
 	}
 
-	peer := host.GetSelfPeer()
-
 	decider := quorum.NewDecider(quorum.SuperMajorityVote, shard.BeaconChainShardID)
 	multiBLSPrivateKey := multibls.GetPrivateKeys(bls.RandPrivateKey())
 
-	consensus, err := New(host, shard.BeaconChainShardID, peer, multiBLSPrivateKey, decider)
+	consensus, err := New(host, shard.BeaconChainShardID, multiBLSPrivateKey, decider)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/consensus/construct_test.go
+++ b/consensus/construct_test.go
@@ -31,9 +31,7 @@ func TestConstructAnnounceMessage(test *testing.T) {
 		quorum.SuperMajorityVote, shard.BeaconChainShardID,
 	)
 	blsPriKey := bls.RandPrivateKey()
-	consensus, err := New(
-		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(blsPriKey), decider,
-	)
+	consensus, err := New(host, shard.BeaconChainShardID, multibls.GetPrivateKeys(blsPriKey), decider)
 	if err != nil {
 		test.Fatalf("Cannot create consensus: %v", err)
 	}
@@ -66,7 +64,7 @@ func TestConstructPreparedMessage(test *testing.T) {
 	)
 	blsPriKey := bls.RandPrivateKey()
 	consensus, err := New(
-		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(blsPriKey), decider,
+		host, shard.BeaconChainShardID, multibls.GetPrivateKeys(blsPriKey), decider,
 	)
 	if err != nil {
 		test.Fatalf("Cannot craeate consensus: %v", err)
@@ -147,7 +145,7 @@ func TestConstructPrepareMessage(test *testing.T) {
 	)
 
 	consensus, err := New(
-		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(blsPriKey1), decider,
+		host, shard.BeaconChainShardID, multibls.GetPrivateKeys(blsPriKey1), decider,
 	)
 	if err != nil {
 		test.Fatalf("Cannot create consensus: %v", err)
@@ -238,9 +236,7 @@ func TestConstructCommitMessage(test *testing.T) {
 		quorum.SuperMajorityStake, shard.BeaconChainShardID,
 	)
 
-	consensus, err := New(
-		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(blsPriKey1), decider,
-	)
+	consensus, err := New(host, shard.BeaconChainShardID, multibls.GetPrivateKeys(blsPriKey1), decider)
 	if err != nil {
 		test.Fatalf("Cannot create consensus: %v", err)
 	}
@@ -322,7 +318,7 @@ func TestPopulateMessageFields(t *testing.T) {
 		quorum.SuperMajorityVote, shard.BeaconChainShardID,
 	)
 	consensus, err := New(
-		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(blsPriKey), decider,
+		host, shard.BeaconChainShardID, multibls.GetPrivateKeys(blsPriKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)

--- a/consensus/quorum/one-node-one-vote.go
+++ b/consensus/quorum/one-node-one-vote.go
@@ -19,8 +19,6 @@ import (
 )
 
 type uniformVoteWeight struct {
-	DependencyInjectionWriter
-	DependencyInjectionReader
 	SignatureReader
 
 	lastPowerSignersCountCache map[Phase]int64
@@ -108,23 +106,6 @@ func (v *uniformVoteWeight) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(t{v.Policy().String(), len(keys), keys})
-}
-
-func (v *uniformVoteWeight) AmIMemberOfCommitee() bool {
-	pubKeyFunc := v.MyPublicKey()
-	if pubKeyFunc == nil {
-		return false
-	}
-	identity, _ := pubKeyFunc()
-	everyone := v.Participants()
-	for _, key := range identity {
-		for i := range everyone {
-			if key.Object.IsEqual(everyone[i].Object) {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func (v *uniformVoteWeight) ResetPrepareAndCommitVotes() {

--- a/consensus/quorum/one-node-staked-vote.go
+++ b/consensus/quorum/one-node-staked-vote.go
@@ -6,7 +6,6 @@ import (
 	"math/big"
 
 	"github.com/harmony-one/harmony/crypto/bls"
-
 	"github.com/harmony-one/harmony/internal/utils"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -45,8 +44,6 @@ type VoteTally struct {
 
 type stakedVoteWeight struct {
 	SignatureReader
-	DependencyInjectionWriter
-	DependencyInjectionReader
 	roster    votepower.Roster
 	voteTally VoteTally
 	lastPower map[Phase]numeric.Dec
@@ -300,21 +297,6 @@ func (v *stakedVoteWeight) MarshalJSON() ([]byte, error) {
 		totalRaw.String(),
 		v.roster.TotalEffectiveStake.String(),
 	})
-}
-
-func (v *stakedVoteWeight) AmIMemberOfCommitee() bool {
-	pubKeyFunc := v.MyPublicKey()
-	if pubKeyFunc == nil {
-		return false
-	}
-	identity, _ := pubKeyFunc()
-	for _, key := range identity {
-		_, ok := v.roster.Voters[key.Bytes]
-		if ok {
-			return true
-		}
-	}
-	return false
 }
 
 func newVoteTally() VoteTally {

--- a/node/node_handler_test.go
+++ b/node/node_handler_test.go
@@ -33,7 +33,7 @@ func TestAddNewBlock(t *testing.T) {
 		quorum.SuperMajorityVote, shard.BeaconChainShardID,
 	)
 	consensus, err := consensus.New(
-		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(blsKey), decider,
+		host, shard.BeaconChainShardID, multibls.GetPrivateKeys(blsKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
@@ -80,7 +80,7 @@ func TestVerifyNewBlock(t *testing.T) {
 		quorum.SuperMajorityVote, shard.BeaconChainShardID,
 	)
 	consensus, err := consensus.New(
-		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(blsKey), decider,
+		host, shard.BeaconChainShardID, multibls.GetPrivateKeys(blsKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
@@ -126,7 +126,7 @@ func TestVerifyVRF(t *testing.T) {
 		quorum.SuperMajorityVote, shard.BeaconChainShardID,
 	)
 	consensus, err := consensus.New(
-		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(blsKey), decider,
+		host, shard.BeaconChainShardID, multibls.GetPrivateKeys(blsKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)

--- a/node/node_newblock_test.go
+++ b/node/node_newblock_test.go
@@ -34,7 +34,7 @@ func TestFinalizeNewBlockAsync(t *testing.T) {
 		quorum.SuperMajorityVote, shard.BeaconChainShardID,
 	)
 	consensus, err := consensus.New(
-		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(blsKey), decider,
+		host, shard.BeaconChainShardID, multibls.GetPrivateKeys(blsKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -34,7 +34,7 @@ func TestNewNode(t *testing.T) {
 		quorum.SuperMajorityVote, shard.BeaconChainShardID,
 	)
 	consensus, err := consensus.New(
-		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(blsKey), decider,
+		host, shard.BeaconChainShardID, multibls.GetPrivateKeys(blsKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)
@@ -207,7 +207,7 @@ func TestAddBeaconPeer(t *testing.T) {
 		quorum.SuperMajorityVote, shard.BeaconChainShardID,
 	)
 	consensus, err := consensus.New(
-		host, shard.BeaconChainShardID, leader, multibls.GetPrivateKeys(blsKey), decider,
+		host, shard.BeaconChainShardID, multibls.GetPrivateKeys(blsKey), decider,
 	)
 	if err != nil {
 		t.Fatalf("Cannot craeate consensus: %v", err)


### PR DESCRIPTION
It was required by method that no one uses, removing this method allows us simplify Decider dependencies.  