### PR TITLE
slow down the growth of statedb disk usage

### DIFF
--- a/core/blockchain_impl.go
+++ b/core/blockchain_impl.go
@@ -3145,11 +3145,16 @@ func (bc *BlockChainImpl) tikvCleanCache() {
 			if err != nil {
 				continue
 			}
-
-			// build current block statedb
-			toBlock := bc.GetBlockByNumber(i + 1)
-			toTrie, err := state.New(toBlock.Root(), bc.stateCache)
-			if err != nil {
+			var toTrie *state.DB
+			// find next state trie
+			for j := i + 1; j <= to+1; j++ {
+				toBlock := bc.GetBlockByNumber(j)
+				toTrie, err = state.New(toBlock.Root(), bc.stateCache)
+				if err != nil {
+					continue
+				}
+			}
+			if toTrie == nil {
 				continue
 			}
 

--- a/core/blockchain_impl.go
+++ b/core/blockchain_impl.go
@@ -219,7 +219,7 @@ func newBlockChainWithOptions(
 	engine consensus_engine.Engine, vmConfig vm.Config, options Options) (*BlockChainImpl, error) {
 	if cacheConfig == nil {
 		cacheConfig = &CacheConfig{
-			TrieNodeLimit: 256 * 1024 * 1024,
+			TrieNodeLimit: 256,
 			TrieTimeLimit: 2 * time.Minute,
 		}
 	}
@@ -1214,7 +1214,7 @@ func (bc *BlockChainImpl) WriteBlockWithState(
 
 	// Flush trie state into disk if it's archival node or the block is epoch block
 	triedb := bc.stateCache.TrieDB()
-	if bc.cacheConfig.Disabled || block.IsLastBlockInEpoch() {
+	if bc.cacheConfig.Disabled {
 		if err := triedb.Commit(root, false); err != nil {
 			if isUnrecoverableErr(err) {
 				fmt.Printf("Unrecoverable error when committing triedb: %v\nExitting\n", err)
@@ -3282,6 +3282,7 @@ var (
 //  3. Corrupted db data. (leveldb.errors.ErrCorrupted)
 //  4. OS error when open file (too many open files, ...)
 //  5. OS error when write file (read-only, not enough disk space, ...)
+//
 // Among all the above leveldb errors, only `too many open files` error is known to be recoverable,
 // thus the unrecoverable errors refers to error that is
 //  1. The error is from the lower storage level (from module leveldb)


### PR DESCRIPTION
## Issue
1. removed writing stateDB to disk once per epoch and now it only writes to disk when memory garbage collection happens.
2. fix minor bug of tikvCleanCache
