### PR TITLE
Consensus doesn't require anymore `Node` as a circular dependency.

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -760,7 +760,8 @@ func setupConsensusAndNode(hc harmonyconfig.HarmonyConfig, nodeConfig *nodeconfi
 		Msg("Init Blockchain")
 
 	// Assign closure functions to the consensus object
-	currentConsensus.SetBlockVerifier(currentNode.VerifyNewBlock)
+	currentConsensus.SetBlockVerifier(
+		node.VerifyNewBlock(currentNode.NodeConfig, currentNode.Blockchain(), currentNode.Beaconchain()))
 	currentConsensus.PostConsensusJob = currentNode.PostConsensusProcessing
 	// update consensus information based on the blockchain
 	currentConsensus.SetMode(currentConsensus.UpdateConsensusInformation())

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -43,7 +43,7 @@ type Options struct {
 // canonical chain.
 type BlockChain interface {
 	// ValidateNewBlock validates new block.
-	ValidateNewBlock(block *types.Block) error
+	ValidateNewBlock(block *types.Block, beaconChain BlockChain) error
 	// SetHead rewinds the local chain to a new head. In the case of headers, everything
 	// above the new head will be deleted and the new one set. In the case of blocks
 	// though, the head may be further rewound if block bodies are missing (non-archive

--- a/core/blockchain_impl.go
+++ b/core/blockchain_impl.go
@@ -90,6 +90,8 @@ var (
 	// errExceedMaxPendingSlashes ..
 	errExceedMaxPendingSlashes = errors.New("exceeed max pending slashes")
 	errNilEpoch                = errors.New("nil epoch for voting power computation")
+	errAlreadyExist            = errors.New("crosslink already exist")
+	errDoubleSpent             = errors.New("[verifyIncomingReceipts] Double Spent")
 )
 
 const (
@@ -294,7 +296,154 @@ func newBlockChainWithOptions(
 	return bc, nil
 }
 
-func (bc *BlockChainImpl) ValidateNewBlock(block *types.Block) error {
+// VerifyBlockCrossLinks verifies the crosslinks of the block.
+// This function should be called from beacon chain.
+func VerifyBlockCrossLinks(blockchain BlockChain, block *types.Block) error {
+	cxLinksData := block.Header().CrossLinks()
+	if len(cxLinksData) == 0 {
+		utils.Logger().Debug().Msgf("[CrossLinkVerification] Zero CrossLinks in the header")
+		return nil
+	}
+
+	crossLinks := types.CrossLinks{}
+	err := rlp.DecodeBytes(cxLinksData, &crossLinks)
+	if err != nil {
+		return errors.Wrapf(
+			err, "[CrossLinkVerification] failed to decode cross links",
+		)
+	}
+
+	if !crossLinks.IsSorted() {
+		return errors.New("[CrossLinkVerification] cross links are not sorted")
+	}
+
+	for _, crossLink := range crossLinks {
+		// ReadCrossLink beacon chain usage.
+		cl, err := blockchain.ReadCrossLink(crossLink.ShardID(), crossLink.BlockNum())
+		if err == nil && cl != nil {
+			// Add slash for exist same blocknum but different crosslink
+			return errAlreadyExist
+		}
+		if err := VerifyCrossLink(blockchain, crossLink); err != nil {
+			return errors.Wrapf(err, "cannot VerifyBlockCrossLinks")
+		}
+	}
+	return nil
+}
+
+// VerifyCrossLink verifies the header is valid
+func VerifyCrossLink(blockchain BlockChain, cl types.CrossLink) error {
+	if blockchain.ShardID() != shard.BeaconChainShardID {
+		return errors.New("[VerifyCrossLink] Shard chains should not verify cross links")
+	}
+	engine := blockchain.Engine()
+
+	if err := engine.VerifyCrossLink(blockchain, cl); err != nil {
+		return errors.Wrap(err, "[VerifyCrossLink]")
+	}
+	return nil
+}
+
+func VerifyIncomingReceipts(blockchain BlockChain, block *types.Block) error {
+	m := make(map[common.Hash]struct{})
+	cxps := block.IncomingReceipts()
+	for _, cxp := range cxps {
+		// double spent
+		if blockchain.IsSpent(cxp) {
+			return errDoubleSpent
+		}
+		hash := cxp.MerkleProof.BlockHash
+		// duplicated receipts
+		if _, ok := m[hash]; ok {
+			return errDoubleSpent
+		}
+		m[hash] = struct{}{}
+
+		for _, item := range cxp.Receipts {
+			if s := blockchain.ShardID(); item.ToShardID != s {
+				return errors.Errorf(
+					"[verifyIncomingReceipts] Invalid ToShardID %d expectShardID %d",
+					s, item.ToShardID,
+				)
+			}
+		}
+
+		if err := blockchain.Validator().ValidateCXReceiptsProof(cxp); err != nil {
+			return errors.Wrapf(err, "[verifyIncomingReceipts] verification failed")
+		}
+	}
+
+	incomingReceiptHash := types.EmptyRootHash
+	if len(cxps) > 0 {
+		incomingReceiptHash = types.DeriveSha(cxps)
+	}
+	if incomingReceiptHash != block.Header().IncomingReceiptHash() {
+		return errors.New("[verifyIncomingReceipts] Invalid IncomingReceiptHash in block header")
+	}
+
+	return nil
+}
+
+func (bc *BlockChainImpl) ValidateNewBlock(block *types.Block, beaconChain BlockChain) error {
+	if block == nil || block.Header() == nil {
+		return errors.New("nil header or block asked to verify")
+	}
+
+	if block.ShardID() != bc.ShardID() {
+		utils.Logger().Error().
+			Uint32("my shard ID", bc.ShardID()).
+			Uint32("new block's shard ID", block.ShardID()).
+			Msg("[ValidateNewBlock] Wrong shard ID of the new block")
+		return errors.New("[ValidateNewBlock] Wrong shard ID of the new block")
+	}
+
+	if block.NumberU64() <= bc.CurrentBlock().NumberU64() {
+		return errors.Errorf("block with the same block number is already committed: %d", block.NumberU64())
+	}
+	if err := bc.Validator().ValidateHeader(block, true); err != nil {
+		utils.Logger().Error().
+			Str("blockHash", block.Hash().Hex()).
+			Err(err).
+			Msg("[ValidateNewBlock] Cannot validate header for the new block")
+		return err
+	}
+	if err := bc.Engine().VerifyVRF(
+		bc, block.Header(),
+	); err != nil {
+		utils.Logger().Error().
+			Str("blockHash", block.Hash().Hex()).
+			Err(err).
+			Msg("[ValidateNewBlock] Cannot verify vrf for the new block")
+		return errors.Wrap(err,
+			"[ValidateNewBlock] Cannot verify vrf for the new block",
+		)
+	}
+	err := bc.Engine().VerifyShardState(bc, beaconChain, block.Header())
+	if err != nil {
+		utils.Logger().Error().
+			Str("blockHash", block.Hash().Hex()).
+			Err(err).
+			Msg("[ValidateNewBlock] Cannot verify shard state for the new block")
+		return errors.Wrap(err,
+			"[ValidateNewBlock] Cannot verify shard state for the new block",
+		)
+	}
+	err = bc.validateNewBlock(block)
+	if err != nil {
+		return err
+	}
+	if bc.shardID == shard.BeaconChainShardID {
+		err = VerifyBlockCrossLinks(bc, block)
+		if err != nil {
+			utils.Logger().Debug().Err(err).Msg("ops2 VerifyBlockCrossLinks Failed")
+			return err
+		}
+	}
+
+	return VerifyIncomingReceipts(bc, block)
+}
+
+func (bc *BlockChainImpl) validateNewBlock(block *types.Block) error {
 	state, err := state.New(bc.CurrentBlock().Root(), bc.stateCache)
 	if err != nil {
 		return err

--- a/core/blockchain_stub.go
+++ b/core/blockchain_stub.go
@@ -29,7 +29,7 @@ type Stub struct {
 	Name string
 }
 
-func (a Stub) ValidateNewBlock(block *types.Block) error {
+func (a Stub) ValidateNewBlock(block *types.Block, beaconChain BlockChain) error {
 	return errors.Errorf("method ValidateNewBlock not implemented for %s", a.Name)
 }
 

--- a/node/node_cross_link.go
+++ b/node/node_cross_link.go
@@ -6,6 +6,7 @@ import (
 	common2 "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
 	ffi_bls "github.com/harmony-one/bls/ffi/go/bls"
+	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/shard"
@@ -17,46 +18,6 @@ const (
 	maxPendingCrossLinkSize = 1000
 	crossLinkBatchSize      = 3
 )
-
-var (
-	errAlreadyExist = errors.New("crosslink already exist")
-)
-
-// VerifyBlockCrossLinks verifies the crosslinks of the block.
-// This method should be called from beacon chain.
-func (node *Node) VerifyBlockCrossLinks(block *types.Block) error {
-	cxLinksData := block.Header().CrossLinks()
-	if len(cxLinksData) == 0 {
-		utils.Logger().Debug().Msgf("[CrossLinkVerification] Zero CrossLinks in the header")
-		return nil
-	}
-
-	crossLinks := types.CrossLinks{}
-	err := rlp.DecodeBytes(cxLinksData, &crossLinks)
-	if err != nil {
-		return errors.Wrapf(
-			err, "[CrossLinkVerification] failed to decode cross links",
-		)
-	}
-
-	if !crossLinks.IsSorted() {
-		return errors.New("[CrossLinkVerification] cross links are not sorted")
-	}
-
-	for _, crossLink := range crossLinks {
-		// ReadCrossLink beacon chain usage.
-		cl, err := node.Blockchain().ReadCrossLink(crossLink.ShardID(), crossLink.BlockNum())
-		if err == nil && cl != nil {
-			// Add slash for exist same blocknum but different crosslink
-			return errAlreadyExist
-		}
-		if err := node.VerifyCrossLink(crossLink); err != nil {
-			return errors.Wrapf(err, "cannot VerifyBlockCrossLinks")
-
-		}
-	}
-	return nil
-}
 
 // ProcessCrossLinkHeartbeatMessage process crosslink heart beat signal.
 // This function is only called on shards 1,2,3 when network message `CrosslinkHeartbeat` receiving.
@@ -187,7 +148,7 @@ func (node *Node) ProcessCrossLinkMessage(msgPayload []byte) {
 				continue
 			}
 
-			if err = node.VerifyCrossLink(cl); err != nil {
+			if err = core.VerifyCrossLink(node.Blockchain(), cl); err != nil {
 				nodeCrossLinkMessageCounterVec.With(prometheus.Labels{"type": "invalid_crosslink"}).Inc()
 				utils.Logger().Info().
 					Str("cross-link-issue", err.Error()).
@@ -207,17 +168,4 @@ func (node *Node) ProcessCrossLinkMessage(msgPayload []byte) {
 		utils.Logger().Debug().
 			Msgf("[ProcessingCrossLink] Add pending crosslinks,  total pending: %d", Len)
 	}
-}
-
-// VerifyCrossLink verifies the header is valid
-func (node *Node) VerifyCrossLink(cl types.CrossLink) error {
-	if node.Blockchain().ShardID() != shard.BeaconChainShardID {
-		return errors.New("[VerifyCrossLink] Shard chains should not verify cross links")
-	}
-	engine := node.Blockchain().Engine()
-
-	if err := engine.VerifyCrossLink(node.Blockchain(), cl); err != nil {
-		return errors.Wrap(err, "[VerifyCrossLink]")
-	}
-	return nil
 }

--- a/node/node_handler.go
+++ b/node/node_handler.go
@@ -52,11 +52,6 @@ func (node *Node) processSkippedMsgTypeByteValue(
 	}
 }
 
-var (
-	errInvalidPayloadSize = errors.New("invalid payload size")
-	errWrongBlockMsgSize  = errors.New("invalid block message size")
-)
-
 // HandleNodeMessage parses the message and dispatch the actions.
 func (node *Node) HandleNodeMessage(
 	ctx context.Context,
@@ -334,101 +329,34 @@ func getCrosslinkHeadersForShards(shardChain core.BlockChain, curBlock *types.Bl
 
 // VerifyNewBlock is called by consensus participants to verify the block (account model) they are
 // running consensus on.
-func (node *Node) VerifyNewBlock(newBlock *types.Block) error {
-	if newBlock == nil || newBlock.Header() == nil {
-		return errors.New("nil header or block asked to verify")
-	}
-
-	if newBlock.ShardID() != node.Blockchain().ShardID() {
-		utils.Logger().Error().
-			Uint32("my shard ID", node.Blockchain().ShardID()).
-			Uint32("new block's shard ID", newBlock.ShardID()).
-			Msg("[VerifyNewBlock] Wrong shard ID of the new block")
-		return errors.New("[VerifyNewBlock] Wrong shard ID of the new block")
-	}
-
-	if newBlock.NumberU64() <= node.Blockchain().CurrentBlock().NumberU64() {
-		return errors.Errorf("block with the same block number is already committed: %d", newBlock.NumberU64())
-	}
-	if err := node.Blockchain().Validator().ValidateHeader(newBlock, true); err != nil {
-		utils.Logger().Error().
-			Str("blockHash", newBlock.Hash().Hex()).
-			Err(err).
-			Msg("[VerifyNewBlock] Cannot validate header for the new block")
-		return err
-	}
-
-	if err := node.Blockchain().Engine().VerifyVRF(
-		node.Blockchain(), newBlock.Header(),
-	); err != nil {
-		utils.Logger().Error().
-			Str("blockHash", newBlock.Hash().Hex()).
-			Err(err).
-			Msg("[VerifyNewBlock] Cannot verify vrf for the new block")
-		return errors.Wrap(err,
-			"[VerifyNewBlock] Cannot verify vrf for the new block",
-		)
-	}
-
-	if err := node.Blockchain().Engine().VerifyShardState(
-		node.Blockchain(), node.Beaconchain(), newBlock.Header(),
-	); err != nil {
-		utils.Logger().Error().
-			Str("blockHash", newBlock.Hash().Hex()).
-			Err(err).
-			Msg("[VerifyNewBlock] Cannot verify shard state for the new block")
-		return errors.Wrap(err,
-			"[VerifyNewBlock] Cannot verify shard state for the new block",
-		)
-	}
-
-	if err := node.Blockchain().ValidateNewBlock(newBlock); err != nil {
-		if hooks := node.NodeConfig.WebHooks.Hooks; hooks != nil {
-			if p := hooks.ProtocolIssues; p != nil {
-				url := p.OnCannotCommit
-				go func() {
-					webhooks.DoPost(url, map[string]interface{}{
-						"bad-header": newBlock.Header(),
-						"reason":     err.Error(),
-					})
-				}()
+func VerifyNewBlock(nodeConfig *nodeconfig.ConfigType, blockChain core.BlockChain, beaconChain core.BlockChain) func(*types.Block) error {
+	return func(newBlock *types.Block) error {
+		if err := blockChain.ValidateNewBlock(newBlock, beaconChain); err != nil {
+			if hooks := nodeConfig.WebHooks.Hooks; hooks != nil {
+				if p := hooks.ProtocolIssues; p != nil {
+					url := p.OnCannotCommit
+					go func() {
+						webhooks.DoPost(url, map[string]interface{}{
+							"bad-header": newBlock.Header(),
+							"reason":     err.Error(),
+						})
+					}()
+				}
 			}
+			utils.Logger().Error().
+				Str("blockHash", newBlock.Hash().Hex()).
+				Int("numTx", len(newBlock.Transactions())).
+				Int("numStakingTx", len(newBlock.StakingTransactions())).
+				Err(err).
+				Msg("[VerifyNewBlock] Cannot Verify New Block!!!")
+			return errors.Errorf(
+				"[VerifyNewBlock] Cannot Verify New Block!!! block-hash %s txn-count %d",
+				newBlock.Hash().Hex(),
+				len(newBlock.Transactions()),
+			)
 		}
-		utils.Logger().Error().
-			Str("blockHash", newBlock.Hash().Hex()).
-			Int("numTx", len(newBlock.Transactions())).
-			Int("numStakingTx", len(newBlock.StakingTransactions())).
-			Err(err).
-			Msg("[VerifyNewBlock] Cannot Verify New Block!!!")
-		return errors.Errorf(
-			"[VerifyNewBlock] Cannot Verify New Block!!! block-hash %s txn-count %d",
-			newBlock.Hash().Hex(),
-			len(newBlock.Transactions()),
-		)
+		return nil
 	}
-
-	// Verify cross links
-	// TODO: move into ValidateNewBlock
-	if node.IsRunningBeaconChain() {
-		err := node.VerifyBlockCrossLinks(newBlock)
-		if err != nil {
-			utils.Logger().Debug().Err(err).Msg("ops2 VerifyBlockCrossLinks Failed")
-			return err
-		}
-	}
-
-	// TODO: move into ValidateNewBlock
-	if err := node.verifyIncomingReceipts(newBlock); err != nil {
-		utils.Logger().Error().
-			Str("blockHash", newBlock.Hash().Hex()).
-			Int("numIncomingReceipts", len(newBlock.IncomingReceipts())).
-			Err(err).
-			Msg("[VerifyNewBlock] Cannot ValidateNewBlock")
-		return errors.Wrapf(
-			err, "[VerifyNewBlock] Cannot ValidateNewBlock",
-		)
-	}
-	return nil
 }
 
 // PostConsensusProcessing is called by consensus participants, after consensus is done, to:


### PR DESCRIPTION
Resolved circular dependency 
`currentConsensus.SetBlockVerifier(currentNode.VerifyNewBlock)` 
where `*Node` method was provided as validator for new block. Checks from node were moved inside blockschain_impl.