### PR TITLE
Prune state trie in run-time

### DIFF
--- a/core/blockchain_impl.go
+++ b/core/blockchain_impl.go
@@ -3145,11 +3145,16 @@ func (bc *BlockChainImpl) tikvCleanCache() {
 			if err != nil {
 				continue
 			}
-
-			// build current block statedb
-			toBlock := bc.GetBlockByNumber(i + 1)
-			toTrie, err := state.New(toBlock.Root(), bc.stateCache)
-			if err != nil {
+			var toTrie *state.DB
+			// find next state trie
+			for j := i + 1; j <= to+1; j++ {
+				toBlock := bc.GetBlockByNumber(j)
+				toTrie, err = state.New(toBlock.Root(), bc.stateCache)
+				if err != nil {
+					continue
+				}
+			}
+			if toTrie == nil {
 				continue
 			}
 

--- a/core/blockchain_impl.go
+++ b/core/blockchain_impl.go
@@ -219,7 +219,7 @@ func newBlockChainWithOptions(
 	engine consensus_engine.Engine, vmConfig vm.Config, options Options) (*BlockChainImpl, error) {
 	if cacheConfig == nil {
 		cacheConfig = &CacheConfig{
-			TrieNodeLimit: 256 * 1024 * 1024,
+			TrieNodeLimit: 256,
 			TrieTimeLimit: 2 * time.Minute,
 		}
 	}
@@ -1214,7 +1214,7 @@ func (bc *BlockChainImpl) WriteBlockWithState(
 
 	// Flush trie state into disk if it's archival node or the block is epoch block
 	triedb := bc.stateCache.TrieDB()
-	if bc.cacheConfig.Disabled || block.IsLastBlockInEpoch() {
+	if bc.cacheConfig.Disabled {
 		if err := triedb.Commit(root, false); err != nil {
 			if isUnrecoverableErr(err) {
 				fmt.Printf("Unrecoverable error when committing triedb: %v\nExitting\n", err)
@@ -3282,6 +3282,7 @@ var (
 //  3. Corrupted db data. (leveldb.errors.ErrCorrupted)
 //  4. OS error when open file (too many open files, ...)
 //  5. OS error when write file (read-only, not enough disk space, ...)
+//
 // Among all the above leveldb errors, only `too many open files` error is known to be recoverable,
 // thus the unrecoverable errors refers to error that is
 //  1. The error is from the lower storage level (from module leveldb)

--- a/core/state/state_prune.go
+++ b/core/state/state_prune.go
@@ -1,0 +1,63 @@
+package state
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/harmony-one/harmony/core/rawdb"
+)
+
+// DiffAndPrune deletes data exists in oldDB, but not in newDB
+func DiffAndPrune(oldDB *DB, newDB *DB, batch rawdb.DatabaseDeleter) (int, error) {
+	// create difference iterator
+	differIt, _ := trie.NewDifferenceIterator(newDB.trie.NodeIterator(nil), oldDB.trie.NodeIterator(nil))
+
+	count := 0
+	for differIt.Next(true) {
+		if !differIt.Leaf() {
+			count++
+			batch.Delete(differIt.Hash().Bytes())
+		} else {
+			// build account data
+			addrBytes := oldDB.trie.GetKey(differIt.LeafKey())
+			addr := common.BytesToAddress(addrBytes)
+
+			var oldAccount, newAccount Account
+			if err := rlp.DecodeBytes(differIt.LeafBlob(), &oldAccount); err != nil {
+				continue
+			}
+
+			if accountBytes, err := newDB.trie.TryGet(addrBytes); err != nil {
+				continue
+			} else if err := rlp.DecodeBytes(accountBytes, &newAccount); err != nil {
+				continue
+			}
+
+			// if account not changed, skip
+			if oldAccount.Root == newAccount.Root {
+				continue
+			}
+			// if old state is empty, skip
+			if oldAccount.Root == emptyRoot || oldAccount.Root == (common.Hash{}) {
+				continue
+			}
+
+			// create account difference iterator
+			oldAccountTrie := newObject(oldDB, addr, oldAccount).getTrie(oldDB.db)
+			newAccountTrie := newObject(newDB, addr, newAccount).getTrie(newDB.db)
+			newTrieIt := newAccountTrie.NodeIterator(nil)
+			oldTrieIt := oldAccountTrie.NodeIterator(nil)
+			accountDifferIt, _ := NewDifferenceIterator(newTrieIt, oldTrieIt)
+
+			for accountDifferIt.Next(true) {
+				if !accountDifferIt.Leaf() {
+					count++
+					batch.Delete(accountDifferIt.Hash().Bytes())
+				} else if !newTrieIt.Leaf() {
+					batch.Delete(append(append([]byte{}, secureKeyPrefix...), accountDifferIt.LeafKey()...))
+				}
+			}
+		}
+	}
+	return count, nil
+}

--- a/core/state/state_prune_test.go
+++ b/core/state/state_prune_test.go
@@ -1,0 +1,73 @@
+package state
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+func generateTestData(mod int64) map[common.Hash]common.Hash {
+	data := make(map[common.Hash]common.Hash)
+	for i := int64(0); i < 1000; i++ {
+		key := common.BigToHash(big.NewInt(i))
+		val := common.BigToHash(big.NewInt(i + mod))
+		data[key] = val
+	}
+	return data
+}
+
+func writeTestData(s *stateTest, data map[common.Hash]common.Hash) {
+	obj := s.state.GetOrNewStateObject(common.BytesToAddress([]byte{0x01}))
+	obj.SetNonce(uint64(len(data)))
+	for k, v := range data {
+		s.state.SetState(obj.address, k, v)
+	}
+	root, _ := s.state.Commit(true)
+	s.state.db.TrieDB().Commit(root, false)
+}
+
+func compare(db1, db2 ethdb.Database) bool {
+	it1 := db1.NewIterator()
+	it2 := db2.NewIterator()
+	for it1.Next() {
+		if !it2.Next() {
+			return false
+		}
+		key1, val1 := it1.Key(), it1.Value()
+		key2, val2 := it2.Key(), it2.Value()
+		if !bytes.Equal(key1, key2) {
+			return false
+		}
+		if !bytes.Equal(val1, val2) {
+			return false
+		}
+	}
+	return !it2.Next()
+}
+
+func newState(root common.Hash, db ethdb.Database) *stateTest {
+	sdb, _ := New(root, NewDatabase(db))
+	return &stateTest{db: db, state: sdb}
+}
+
+func TestDiffAndPrune2(t *testing.T) {
+	db1State1 := newStateTest()
+	writeTestData(db1State1, generateTestData(0))
+	db1State2 := newState(db1State1.state.trie.Hash(), db1State1.db)
+	writeTestData(db1State2, generateTestData(10000))
+	db2State := newStateTest()
+	writeTestData(db2State, generateTestData(10000))
+	prune := func(old *stateTest, new *stateTest) {
+		batch := old.db.NewBatch()
+		DiffAndPrune(old.state, new.state, batch)
+		batch.Write()
+	}
+	prune(db1State1, db1State2)
+	if !compare(db1State2.db, db2State.db) {
+		t.Error("db state not equal")
+	}
+
+}

--- a/core/state/state_prune_test.go
+++ b/core/state/state_prune_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 )
 
-func generateTestData(mod int64) map[common.Hash]common.Hash {
+func generateTestData(base int64) map[common.Hash]common.Hash {
 	data := make(map[common.Hash]common.Hash)
 	for i := int64(0); i < 1000; i++ {
 		key := common.BigToHash(big.NewInt(i))
-		val := common.BigToHash(big.NewInt(i + mod))
+		val := common.BigToHash(big.NewInt(i + base))
 		data[key] = val
 	}
 	return data


### PR DESCRIPTION
This pr is designed to prune the state-tree in run-time to slow down the growth of disk usage for non-archival nodes.
When a new state-tree is written to disk, it compares the old state-tree with the new state-tree, and deletes data exists in old state-tree but not in the new state-tree.