### PR TITLE
fix: make localnet sharding structure consistent

### DIFF
--- a/internal/configs/sharding/localnet.go
+++ b/internal/configs/sharding/localnet.go
@@ -125,8 +125,8 @@ func (ls localnetSchedule) GetShardingStructure(numShard, shardID int) []map[str
 		res = append(res, map[string]interface{}{
 			"current": int(shardID) == i,
 			"shardID": i,
-			"http":    fmt.Sprintf("http://127.0.0.1:%d", 9500+i),
-			"ws":      fmt.Sprintf("ws://127.0.0.1:%d", 9800+i),
+			"http":    fmt.Sprintf("http://127.0.0.1:%d", 9500+2*i),
+			"ws":      fmt.Sprintf("ws://127.0.0.1:%d", 9800+2*i),
 		})
 	}
 	return res


### PR DESCRIPTION
As a follow up to #4270, ensure that all localnet URLs returned as part of the sharding structure are accurate.

Signed-off-by: MaxMustermann2 <82761650+MaxMustermann2@users.noreply.github.com>

## Issue
Before this change, `hmy balances <addr>` would produce the same balance on shards 0 and 1 because the first query was port 9500 and the next one was 9501 (the auth http port).
```json
[
  {
    "shard": 0,
    "amount": 4999.469240800000000000
  },
  {
    "shard": 1,
    "amount": 4999.469240800000000000
  },
  {
    "shard": 2,
    "amount": 0.000000000000000000
  },
  {
    "shard": 3,
    "amount": 0.000000000000000000
  }
]
```

After this change, `hmy balances <addr>` produces the expected result.
```json
[
  {
    "shard": 0,
    "amount": 4999.469240800000000000
  },
  {
    "shard": 1,
    "amount": 0.000000000000000000
  },
  {
    "shard": 2,
    "amount": 0.000000000000000000
  },
  {
    "shard": 3,
    "amount": 0.000000000000000000
  }
]
```