### PR TITLE
Fix for consensus stuck.

### DIFF
--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -62,15 +62,12 @@ func (consensus *Consensus) onAnnounce(msg *msg_pb.Message) {
 	consensus.switchPhase("Announce", FBFTPrepare)
 
 	if len(recvMsg.Block) > 0 {
-		go func() {
-			// Best effort check, no need to error out.
-			_, err := consensus.validateNewBlock(recvMsg)
-
-			if err == nil {
-				consensus.getLogger().Info().
-					Msg("[Announce] Block verified")
-			}
-		}()
+		_, err := consensus.validateNewBlock(recvMsg)
+		if err != nil {
+			consensus.getLogger().Warn().Err(err).Msg("[OnAnnounce] Failed to validate new block")
+			consensus.startViewChange()
+			return
+		}
 	}
 }
 

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -62,12 +62,15 @@ func (consensus *Consensus) onAnnounce(msg *msg_pb.Message) {
 	consensus.switchPhase("Announce", FBFTPrepare)
 
 	if len(recvMsg.Block) > 0 {
-		_, err := consensus.validateNewBlock(recvMsg)
-		if err != nil {
-			consensus.getLogger().Warn().Err(err).Msg("[OnAnnounce] Failed to validate new block")
-			consensus.startViewChange()
-			return
-		}
+		go func() {
+			// Best effort check, no need to error out.
+			_, err := consensus.validateNewBlock(recvMsg)
+
+			if err == nil {
+				consensus.getLogger().Info().
+					Msg("[Announce] Block verified")
+			}
+		}()
 	}
 }
 

--- a/consensus/view_change_construct.go
+++ b/consensus/view_change_construct.go
@@ -109,6 +109,10 @@ func (vc *viewChange) GetPreparedBlock(fbftlog *FBFTLog) ([]byte, []byte) {
 	// First 32 bytes of m1 payload is the correct block hash
 	copy(blockHash[:], vc.GetM1Payload())
 
+	if !fbftlog.IsBlockVerified(blockHash) {
+		return nil, nil
+	}
+
 	if block := fbftlog.GetBlockByHash(blockHash); block != nil {
 		encodedBlock, err := rlp.EncodeToBytes(block)
 		if err != nil || len(encodedBlock) == 0 {


### PR DESCRIPTION
We can see that error happened on `onNewView`:

`{"level":"warn","myBlock":33980416,"myViewID":33984024,"phase":"Commit","mode":"ViewChanging","error":"Block verification failed: crosslink already exist","caller":"/home/sp/harmony/harmony/consen
sus/view_change.go:496","time":"2022-11-15T05:44:05.852088781Z","message":"[onNewView] Verify New View Msg Failed"}`

`onNewView` is final step of view change mechanism, and block is already invalid. Previous step is `startNewView`, so i added check there for no unchecked blocks sending.
