### PR TITLE
staking: enable migration precompile

### DIFF
--- a/core/evm.go
+++ b/core/evm.go
@@ -97,6 +97,7 @@ func NewEVMContext(msg Message, header *block.Header, chain ChainContext, author
 		Delegate:              DelegateFn(header, chain),
 		Undelegate:            UndelegateFn(header, chain),
 		CollectRewards:        CollectRewardsFn(header, chain),
+		MigrateDelegations:    MigrateDelegationsFn(header, chain),
 		CalculateMigrationGas: CalculateMigrationGasFn(chain),
 		ShardID:               chain.ShardID(),
 		NumShards:             shard.Schedule.InstanceForEpoch(header.Epoch()).NumShards(),
@@ -320,27 +321,27 @@ func CollectRewardsFn(ref *block.Header, chain ChainContext) vm.CollectRewardsFu
 	}
 }
 
-//func MigrateDelegationsFn(ref *block.Header, chain ChainContext) vm.MigrateDelegationsFunc {
-//	return func(db vm.StateDB, migrationMsg *stakingTypes.MigrationMsg) ([]interface{}, error) {
-//		// get existing delegations
-//		fromDelegations, err := chain.ReadDelegationsByDelegator(migrationMsg.From)
-//		if err != nil {
-//			return nil, err
-//		}
-//		// get list of modified wrappers
-//		wrappers, delegates, err := VerifyAndMigrateFromMsg(db, migrationMsg, fromDelegations)
-//		if err != nil {
-//			return nil, err
-//		}
-//		// add to state db
-//		for _, wrapper := range wrappers {
-//			if err := db.UpdateValidatorWrapperWithRevert(wrapper.Address, wrapper); err != nil {
-//				return nil, err
-//			}
-//		}
-//		return delegates, nil
-//	}
-//}
+func MigrateDelegationsFn(ref *block.Header, chain ChainContext) vm.MigrateDelegationsFunc {
+	return func(db vm.StateDB, migrationMsg *stakingTypes.MigrationMsg) ([]interface{}, error) {
+		// get existing delegations
+		fromDelegations, err := chain.ReadDelegationsByDelegator(migrationMsg.From)
+		if err != nil {
+			return nil, err
+		}
+		// get list of modified wrappers
+		wrappers, delegates, err := VerifyAndMigrateFromMsg(db, migrationMsg, fromDelegations)
+		if err != nil {
+			return nil, err
+		}
+		// add to state db
+		for _, wrapper := range wrappers {
+			if err := db.UpdateValidatorWrapperWithRevert(wrapper.Address, wrapper); err != nil {
+				return nil, err
+			}
+		}
+		return delegates, nil
+	}
+}
 
 // calculate the gas for migration; no checks done here similar to other functions
 // the checks are handled by staking_verifier.go, ex, if you try to delegate to an address

--- a/core/evm.go
+++ b/core/evm.go
@@ -305,7 +305,7 @@ func CollectRewardsFn(ref *block.Header, chain ChainContext) vm.CollectRewardsFu
 			db.AddLog(&types.Log{
 				Address:     collectRewards.DelegatorAddress,
 				Topics:      []common.Hash{staking.CollectRewardsTopicV2},
-				Data:        totalRewards.Bytes(),
+				Data:        common.LeftPadBytes(totalRewards.Bytes(), 32),
 				BlockNumber: ref.Number().Uint64(),
 			})
 		} else {

--- a/core/evm.go
+++ b/core/evm.go
@@ -298,12 +298,24 @@ func CollectRewardsFn(ref *block.Header, chain ChainContext) vm.CollectRewardsFu
 		db.AddBalance(collectRewards.DelegatorAddress, totalRewards)
 
 		// Add log if everything is good
-		db.AddLog(&types.Log{
-			Address:     collectRewards.DelegatorAddress,
-			Topics:      []common.Hash{staking.CollectRewardsTopic},
-			Data:        totalRewards.Bytes(),
-			BlockNumber: ref.Number().Uint64(),
-		})
+		if chain.Config().IsMigrationPrecompile(ref.Epoch()) {
+			// The standard way to calculate the topic hash
+			// is the full signature, including parameter types
+			// https://github.com/harmony-one/harmony/pull/3906#issuecomment-1080256104
+			db.AddLog(&types.Log{
+				Address:     collectRewards.DelegatorAddress,
+				Topics:      []common.Hash{staking.CollectRewardsTopicV2},
+				Data:        totalRewards.Bytes(),
+				BlockNumber: ref.Number().Uint64(),
+			})
+		} else {
+			db.AddLog(&types.Log{
+				Address:     collectRewards.DelegatorAddress,
+				Topics:      []common.Hash{staking.CollectRewardsTopic},
+				Data:        totalRewards.Bytes(),
+				BlockNumber: ref.Number().Uint64(),
+			})
+		}
 
 		//add rosetta log
 		if rosettaTracer != nil {

--- a/core/evm_test.go
+++ b/core/evm_test.go
@@ -24,7 +24,9 @@ import (
 	chain2 "github.com/harmony-one/harmony/internal/chain"
 	"github.com/harmony-one/harmony/internal/params"
 	"github.com/harmony-one/harmony/numeric"
+	"github.com/harmony-one/harmony/staking/effective"
 	staking "github.com/harmony-one/harmony/staking/types"
+	staketest "github.com/harmony-one/harmony/staking/types/test"
 )
 
 func getTestEnvironment(testBankKey ecdsa.PrivateKey) (*BlockChainImpl, *state.DB, *block.Header, ethdb.Database) {
@@ -129,201 +131,201 @@ func TestEVMStaking(t *testing.T) {
 		t.Errorf("Got error %v in CollectRewards", err)
 	}
 
-	//// migration test - when from has no delegations
-	//toKey, _ := crypto.GenerateKey()
-	//migration := sampleMigrationMsg(*toKey, *key)
-	//delegates, err := ctx.MigrateDelegations(db, &migration)
-	//expectedError := errors.New("No delegations to migrate")
-	//if err != nil && expectedError.Error() != err.Error() {
-	//	t.Errorf("Got error %v in MigrateDelegations but expected %v", err, expectedError)
-	//}
-	//if len(delegates) > 0 {
-	//	t.Errorf("Got delegates to migrate when none were expected")
-	//}
-	//// migration test - when from == to
-	//migration = sampleMigrationMsg(*toKey, *toKey)
-	//delegates, err = ctx.MigrateDelegations(db, &migration)
-	//expectedError = errors.New("From and To are the same address")
-	//if err != nil && expectedError.Error() != err.Error() {
-	//	t.Errorf("Got error %v in MigrateDelegations but expected %v", err, expectedError)
-	//}
-	//if len(delegates) > 0 {
-	//	t.Errorf("Got delegates to migrate when none were expected")
-	//}
-	//// migration test - when `to` has no delegations
-	//snapshot := db.Snapshot()
-	//migration = sampleMigrationMsg(*key, *toKey)
-	//wrapper, _ = db.ValidatorWrapper(wrapper.Address, true, false)
-	//expectedAmount := wrapper.Delegations[0].Amount
-	//delegates, err = ctx.MigrateDelegations(db, &migration)
-	//if err != nil {
-	//	t.Errorf("Got error %v in MigrateDelegations", err)
-	//}
-	//if len(delegates) != 1 {
-	//	t.Errorf("Got %d delegations to migrate, expected just 1", len(delegates))
-	//}
-	//wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, false, true)
-	//if wrapper.Delegations[0].Amount.Cmp(common.Big0) != 0 {
-	//	t.Errorf("Expected delegation at index 0 to have amount 0, but it has amount %d",
-	//		wrapper.Delegations[0].Amount)
-	//}
-	//if wrapper.Delegations[1].Amount.Cmp(expectedAmount) != 0 {
-	//	t.Errorf("Expected delegation at index 1 to have amount %d, but it has amount %d",
-	//		expectedAmount, wrapper.Delegations[1].Amount)
-	//}
-	//db.RevertToSnapshot(snapshot)
-	//snapshot = db.Snapshot()
-	//// migration test - when `from` delegation amount = 0 and no undelegations
-	//wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, false, true)
-	//wrapper.Delegations[0].Undelegations = make([]staking.Undelegation, 0)
-	//wrapper.Delegations[0].Amount = common.Big0
-	//wrapper.Status = effective.Inactive
-	//err = db.UpdateValidatorWrapperWithRevert(wrapper.Address, wrapper)
-	//if err != nil {
-	//	t.Errorf("Got error %v in UpdateValidatorWrapperWithRevert", err)
-	//}
-	//delegates, err = ctx.MigrateDelegations(db, &migration)
-	//if err != nil {
-	//	t.Errorf("Got error %v in MigrateDelegations", err)
-	//}
-	//if len(delegates) != 0 {
-	//	t.Errorf("Got %d delegations to migrate, expected none", len(delegates))
-	//}
-	//db.RevertToSnapshot(snapshot)
-	//snapshot = db.Snapshot()
-	//// migration test - when `to` has one delegation
-	//wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, false, true)
-	//wrapper.Delegations = append(wrapper.Delegations, staking.NewDelegation(
-	//	migration.To, new(big.Int).Mul(big.NewInt(denominations.One), big.NewInt(100))))
-	//expectedAmount = big.NewInt(0).Add(
-	//	wrapper.Delegations[0].Amount, wrapper.Delegations[1].Amount,
-	//)
-	//err = db.UpdateValidatorWrapperWithRevert(wrapper.Address, wrapper)
-	//if err != nil {
-	//	t.Errorf("Got error %v in UpdateValidatorWrapperWithRevert", err)
-	//}
-	//delegates, err = ctx.MigrateDelegations(db, &migration)
-	//if err != nil {
-	//	t.Errorf("Got error %v in MigrateDelegations", err)
-	//}
-	//if len(delegates) != 1 {
-	//	t.Errorf("Got %d delegations to migrate, expected just 1", len(delegates))
-	//}
-	//// read from updated wrapper
-	//wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, true, false)
-	//if wrapper.Delegations[0].Amount.Cmp(common.Big0) != 0 {
-	//	t.Errorf("Expected delegation at index 0 to have amount 0, but it has amount %d",
-	//		wrapper.Delegations[0].Amount)
-	//}
-	//if wrapper.Delegations[1].Amount.Cmp(expectedAmount) != 0 {
-	//	t.Errorf("Expected delegation at index 1 to have amount %d, but it has amount %d",
-	//		expectedAmount, wrapper.Delegations[1].Amount)
-	//}
-	//db.RevertToSnapshot(snapshot)
-	//snapshot = db.Snapshot()
-	//// migration test - when `to` has one undelegation in the current epoch and so does `from`
-	//wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, false, true)
-	//delegation := staking.NewDelegation(migration.To, big.NewInt(0))
-	//delegation.Undelegations = []staking.Undelegation{
-	//	staking.Undelegation{
-	//		Amount: new(big.Int).Mul(big.NewInt(denominations.One), big.NewInt(100)),
-	//		Epoch:  common.Big0,
-	//	},
-	//}
-	//wrapper.Delegations[0].Undelegate(
-	//	big.NewInt(0), new(big.Int).Mul(big.NewInt(denominations.One), big.NewInt(100)),
-	//)
-	//expectedAmount = big.NewInt(0).Add(
-	//	wrapper.Delegations[0].Amount, big.NewInt(0),
-	//)
-	//wrapper.Delegations = append(wrapper.Delegations, delegation)
-	//expectedDelegations := []staking.Delegation{
-	//	staking.Delegation{
-	//		DelegatorAddress: wrapper.Address,
-	//		Amount:           big.NewInt(0),
-	//		Reward:           big.NewInt(0),
-	//		Undelegations:    []staking.Undelegation{},
-	//	},
-	//	staking.Delegation{
-	//		DelegatorAddress: crypto.PubkeyToAddress(toKey.PublicKey),
-	//		Amount:           expectedAmount,
-	//		Undelegations: []staking.Undelegation{
-	//			staking.Undelegation{
-	//				Amount: new(big.Int).Mul(big.NewInt(denominations.One), big.NewInt(200)),
-	//				Epoch:  common.Big0,
-	//			},
-	//		},
-	//	},
-	//}
-	//err = db.UpdateValidatorWrapperWithRevert(wrapper.Address, wrapper)
-	//if err != nil {
-	//	t.Errorf("Got error %v in UpdateValidatorWrapperWithRevert", err)
-	//}
-	//delegates, err = ctx.MigrateDelegations(db, &migration)
-	//if err != nil {
-	//	t.Errorf("Got error %v in MigrateDelegations", err)
-	//}
-	//if len(delegates) != 1 {
-	//	t.Errorf("Got %d delegations to migrate, expected just 1", len(delegates))
-	//}
-	//// read from updated wrapper
-	//wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, true, false)
-	//// and finally the check for delegations being equal
-	//if err := staketest.CheckDelegationsEqual(
-	//	wrapper.Delegations,
-	//	expectedDelegations,
-	//); err != nil {
-	//	t.Errorf("Got error %s in CheckDelegationsEqual", err)
-	//}
+	// migration test - when from has no delegations
+	toKey, _ := crypto.GenerateKey()
+	migration := sampleMigrationMsg(*toKey, *key)
+	delegates, err := ctx.MigrateDelegations(db, &migration)
+	expectedError := errors.New("No delegations to migrate")
+	if err != nil && expectedError.Error() != err.Error() {
+		t.Errorf("Got error %v in MigrateDelegations but expected %v", err, expectedError)
+	}
+	if len(delegates) > 0 {
+		t.Errorf("Got delegates to migrate when none were expected")
+	}
+	// migration test - when from == to
+	migration = sampleMigrationMsg(*toKey, *toKey)
+	delegates, err = ctx.MigrateDelegations(db, &migration)
+	expectedError = errors.New("From and To are the same address")
+	if err != nil && expectedError.Error() != err.Error() {
+		t.Errorf("Got error %v in MigrateDelegations but expected %v", err, expectedError)
+	}
+	if len(delegates) > 0 {
+		t.Errorf("Got delegates to migrate when none were expected")
+	}
+	// migration test - when `to` has no delegations
+	snapshot := db.Snapshot()
+	migration = sampleMigrationMsg(*key, *toKey)
+	wrapper, _ = db.ValidatorWrapper(wrapper.Address, true, false)
+	expectedAmount := wrapper.Delegations[0].Amount
+	delegates, err = ctx.MigrateDelegations(db, &migration)
+	if err != nil {
+		t.Errorf("Got error %v in MigrateDelegations", err)
+	}
+	if len(delegates) != 1 {
+		t.Errorf("Got %d delegations to migrate, expected just 1", len(delegates))
+	}
+	wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, false, true)
+	if wrapper.Delegations[0].Amount.Cmp(common.Big0) != 0 {
+		t.Errorf("Expected delegation at index 0 to have amount 0, but it has amount %d",
+			wrapper.Delegations[0].Amount)
+	}
+	if wrapper.Delegations[1].Amount.Cmp(expectedAmount) != 0 {
+		t.Errorf("Expected delegation at index 1 to have amount %d, but it has amount %d",
+			expectedAmount, wrapper.Delegations[1].Amount)
+	}
+	db.RevertToSnapshot(snapshot)
+	snapshot = db.Snapshot()
+	// migration test - when `from` delegation amount = 0 and no undelegations
+	wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, false, true)
+	wrapper.Delegations[0].Undelegations = make([]staking.Undelegation, 0)
+	wrapper.Delegations[0].Amount = common.Big0
+	wrapper.Status = effective.Inactive
+	err = db.UpdateValidatorWrapperWithRevert(wrapper.Address, wrapper)
+	if err != nil {
+		t.Errorf("Got error %v in UpdateValidatorWrapperWithRevert", err)
+	}
+	delegates, err = ctx.MigrateDelegations(db, &migration)
+	if err != nil {
+		t.Errorf("Got error %v in MigrateDelegations", err)
+	}
+	if len(delegates) != 0 {
+		t.Errorf("Got %d delegations to migrate, expected none", len(delegates))
+	}
+	db.RevertToSnapshot(snapshot)
+	snapshot = db.Snapshot()
+	// migration test - when `to` has one delegation
+	wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, false, true)
+	wrapper.Delegations = append(wrapper.Delegations, staking.NewDelegation(
+		migration.To, new(big.Int).Mul(big.NewInt(denominations.One), big.NewInt(100))))
+	expectedAmount = big.NewInt(0).Add(
+		wrapper.Delegations[0].Amount, wrapper.Delegations[1].Amount,
+	)
+	err = db.UpdateValidatorWrapperWithRevert(wrapper.Address, wrapper)
+	if err != nil {
+		t.Errorf("Got error %v in UpdateValidatorWrapperWithRevert", err)
+	}
+	delegates, err = ctx.MigrateDelegations(db, &migration)
+	if err != nil {
+		t.Errorf("Got error %v in MigrateDelegations", err)
+	}
+	if len(delegates) != 1 {
+		t.Errorf("Got %d delegations to migrate, expected just 1", len(delegates))
+	}
+	// read from updated wrapper
+	wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, true, false)
+	if wrapper.Delegations[0].Amount.Cmp(common.Big0) != 0 {
+		t.Errorf("Expected delegation at index 0 to have amount 0, but it has amount %d",
+			wrapper.Delegations[0].Amount)
+	}
+	if wrapper.Delegations[1].Amount.Cmp(expectedAmount) != 0 {
+		t.Errorf("Expected delegation at index 1 to have amount %d, but it has amount %d",
+			expectedAmount, wrapper.Delegations[1].Amount)
+	}
+	db.RevertToSnapshot(snapshot)
+	snapshot = db.Snapshot()
+	// migration test - when `to` has one undelegation in the current epoch and so does `from`
+	wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, false, true)
+	delegation := staking.NewDelegation(migration.To, big.NewInt(0))
+	delegation.Undelegations = []staking.Undelegation{
+		{
+			Amount: new(big.Int).Mul(big.NewInt(denominations.One), big.NewInt(100)),
+			Epoch:  common.Big0,
+		},
+	}
+	wrapper.Delegations[0].Undelegate(
+		big.NewInt(0), new(big.Int).Mul(big.NewInt(denominations.One), big.NewInt(100)),
+	)
+	expectedAmount = big.NewInt(0).Add(
+		wrapper.Delegations[0].Amount, big.NewInt(0),
+	)
+	wrapper.Delegations = append(wrapper.Delegations, delegation)
+	expectedDelegations := []staking.Delegation{
+		{
+			DelegatorAddress: wrapper.Address,
+			Amount:           big.NewInt(0),
+			Reward:           big.NewInt(0),
+			Undelegations:    []staking.Undelegation{},
+		},
+		{
+			DelegatorAddress: crypto.PubkeyToAddress(toKey.PublicKey),
+			Amount:           expectedAmount,
+			Undelegations: []staking.Undelegation{
+				{
+					Amount: new(big.Int).Mul(big.NewInt(denominations.One), big.NewInt(200)),
+					Epoch:  common.Big0,
+				},
+			},
+		},
+	}
+	err = db.UpdateValidatorWrapperWithRevert(wrapper.Address, wrapper)
+	if err != nil {
+		t.Errorf("Got error %v in UpdateValidatorWrapperWithRevert", err)
+	}
+	delegates, err = ctx.MigrateDelegations(db, &migration)
+	if err != nil {
+		t.Errorf("Got error %v in MigrateDelegations", err)
+	}
+	if len(delegates) != 1 {
+		t.Errorf("Got %d delegations to migrate, expected just 1", len(delegates))
+	}
+	// read from updated wrapper
+	wrapper, _ = db.ValidatorWrapper(createValidator.ValidatorAddress, true, false)
+	// and finally the check for delegations being equal
+	if err := staketest.CheckDelegationsEqual(
+		wrapper.Delegations,
+		expectedDelegations,
+	); err != nil {
+		t.Errorf("Got error %s in CheckDelegationsEqual", err)
+	}
 
-	//// test for migration gas
-	//db.RevertToSnapshot(snapshot)
-	//// to calculate gas we need to test 0 / 1 / 2 delegations to migrate as per ReadDelegationsByDelegator
-	//// case 0
-	//evm := vm.NewEVM(ctx, db, params.TestChainConfig, vm.Config{})
-	//gas, err := ctx.CalculateMigrationGas(db, &staking.MigrationMsg{
-	//	From: crypto.PubkeyToAddress(toKey.PublicKey),
-	//	To:   crypto.PubkeyToAddress(key.PublicKey),
-	//}, evm.ChainConfig().IsS3(evm.EpochNumber), evm.ChainConfig().IsS3(evm.EpochNumber))
-	//var expectedGasMin uint64 = params.TxGas
-	//if err != nil {
-	//	t.Errorf("Gas error %s", err)
-	//}
-	//if gas < expectedGasMin {
-	//	t.Errorf("Gas for 0 migration was expected to be at least %d but got %d", expectedGasMin, gas)
-	//}
-	//// case 1
-	//gas, err = ctx.CalculateMigrationGas(db, &migration,
-	//	evm.ChainConfig().IsS3(evm.EpochNumber), evm.ChainConfig().IsS3(evm.EpochNumber))
-	//expectedGasMin = params.TxGas
-	//if err != nil {
-	//	t.Errorf("Gas error %s", err)
-	//}
-	//if gas < expectedGasMin {
-	//	t.Errorf("Gas for 1 migration was expected to be at least %d but got %d", expectedGasMin, gas)
-	//}
-	//// case 2
-	//createValidator = sampleCreateValidator(*toKey)
-	//db.AddBalance(createValidator.ValidatorAddress, createValidator.Amount)
-	//err = ctx.CreateValidator(db, &createValidator)
-	//delegate = sampleDelegate(*toKey)
-	//delegate.DelegatorAddress = crypto.PubkeyToAddress(key.PublicKey)
-	//_ = ctx.Delegate(db, &delegate)
-	//delegationIndex := staking.DelegationIndex{
-	//	ValidatorAddress: crypto.PubkeyToAddress(toKey.PublicKey),
-	//	Index:            uint64(1),
-	//	BlockNum:         common.Big0,
-	//}
-	//err = chain.writeDelegationsByDelegator(batch, migration.From, []staking.DelegationIndex{selfIndex, delegationIndex})
-	//gas, err = ctx.CalculateMigrationGas(db, &migration,
-	//	evm.ChainConfig().IsS3(evm.EpochNumber), evm.ChainConfig().IsS3(evm.EpochNumber))
-	//expectedGasMin = 2 * params.TxGas
-	//if err != nil {
-	//	t.Errorf("Gas error %s", err)
-	//}
-	//if gas < expectedGasMin {
-	//	t.Errorf("Gas for 2 migrations was expected to be at least %d but got %d", expectedGasMin, gas)
-	//}
+	// test for migration gas
+	db.RevertToSnapshot(snapshot)
+	// to calculate gas we need to test 0 / 1 / 2 delegations to migrate as per ReadDelegationsByDelegator
+	// case 0
+	evm := vm.NewEVM(ctx, db, params.TestChainConfig, vm.Config{})
+	gas, err := ctx.CalculateMigrationGas(db, &staking.MigrationMsg{
+		From: crypto.PubkeyToAddress(toKey.PublicKey),
+		To:   crypto.PubkeyToAddress(key.PublicKey),
+	}, evm.ChainConfig().IsS3(evm.EpochNumber), evm.ChainConfig().IsS3(evm.EpochNumber))
+	var expectedGasMin uint64 = params.TxGas
+	if err != nil {
+		t.Errorf("Gas error %s", err)
+	}
+	if gas < expectedGasMin {
+		t.Errorf("Gas for 0 migration was expected to be at least %d but got %d", expectedGasMin, gas)
+	}
+	// case 1
+	gas, err = ctx.CalculateMigrationGas(db, &migration,
+		evm.ChainConfig().IsS3(evm.EpochNumber), evm.ChainConfig().IsS3(evm.EpochNumber))
+	expectedGasMin = params.TxGas
+	if err != nil {
+		t.Errorf("Gas error %s", err)
+	}
+	if gas < expectedGasMin {
+		t.Errorf("Gas for 1 migration was expected to be at least %d but got %d", expectedGasMin, gas)
+	}
+	// case 2
+	createValidator = sampleCreateValidator(*toKey)
+	db.AddBalance(createValidator.ValidatorAddress, createValidator.Amount)
+	_ = ctx.CreateValidator(db, nil, &createValidator)
+	delegate = sampleDelegate(*toKey)
+	delegate.DelegatorAddress = crypto.PubkeyToAddress(key.PublicKey)
+	_ = ctx.Delegate(db, nil, &delegate)
+	delegationIndex := staking.DelegationIndex{
+		ValidatorAddress: crypto.PubkeyToAddress(toKey.PublicKey),
+		Index:            uint64(1),
+		BlockNum:         common.Big0,
+	}
+	_ = chain.writeDelegationsByDelegator(batch, migration.From, []staking.DelegationIndex{selfIndex, delegationIndex})
+	gas, err = ctx.CalculateMigrationGas(db, &migration,
+		evm.ChainConfig().IsS3(evm.EpochNumber), evm.ChainConfig().IsS3(evm.EpochNumber))
+	expectedGasMin = 2 * params.TxGas
+	if err != nil {
+		t.Errorf("Gas error %s", err)
+	}
+	if gas < expectedGasMin {
+		t.Errorf("Gas for 2 migrations was expected to be at least %d but got %d", expectedGasMin, gas)
+	}
 }
 
 func generateBLSKeyAndSig() (bls.SerializedPublicKey, bls.SerializedSignature) {
@@ -453,7 +455,7 @@ func TestWriteCapablePrecompilesIntegration(t *testing.T) {
 
 	// now add a validator, and send its address as caller
 	createValidator := sampleCreateValidator(*key)
-	err = ctx.CreateValidator(db, nil, &createValidator)
+	_ = ctx.CreateValidator(db, nil, &createValidator)
 	_, _, err = evm.Call(vm.AccountRef(common.Address{}),
 		createValidator.ValidatorAddress,
 		[]byte{},

--- a/core/vm/contracts_write.go
+++ b/core/vm/contracts_write.go
@@ -124,6 +124,13 @@ func (c *stakingPrecompile) RunWriteCapable(
 	if evm.Context.ShardID != shard.BeaconChainShardID {
 		return nil, errors.New("Staking not supported on this shard")
 	}
+	// disable payable contract
+	if evm.chainRules.IsMigrationPrecompile {
+		// prevent issues like https://github.com/harmony-one/harmony/issues/4152
+		if contract.Value().Cmp(common.Big0) > 0 {
+			return nil, errors.New("precompile does not accept funds")
+		}
+	}
 	stakeMsg, err := staking.ParseStakeMsg(contract.Caller(), input,
 		evm.chainRules.IsMigrationPrecompile)
 	if err != nil {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -61,7 +61,7 @@ type (
 	UndelegateFunc      func(db StateDB, rosettaTracer RosettaTracer, stakeMsg *stakingTypes.Undelegate) error
 	CollectRewardsFunc  func(db StateDB, rosettaTracer RosettaTracer, stakeMsg *stakingTypes.CollectRewards) error
 	// Used for migrating delegations via the staking precompile
-	//MigrateDelegationsFunc    func(db StateDB, migrationMsg *stakingTypes.MigrationMsg) ([]interface{}, error)
+	MigrateDelegationsFunc    func(db StateDB, migrationMsg *stakingTypes.MigrationMsg) ([]interface{}, error)
 	CalculateMigrationGasFunc func(db StateDB, migrationMsg *stakingTypes.MigrationMsg, homestead bool, istanbul bool) (uint64, error)
 )
 
@@ -177,6 +177,7 @@ type Context struct {
 	Delegate              DelegateFunc
 	Undelegate            UndelegateFunc
 	CollectRewards        CollectRewardsFunc
+	MigrateDelegations    MigrateDelegationsFunc
 	CalculateMigrationGas CalculateMigrationGasFunc
 
 	ShardID   uint32 // Used by staking and cross shard transfer precompile

--- a/staking/params.go
+++ b/staking/params.go
@@ -8,6 +8,7 @@ const (
 	isValidatorKeyStr     = "Harmony/IsValidator/Key/v1"
 	isValidatorStr        = "Harmony/IsValidator/Value/v1"
 	collectRewardsStr     = "Harmony/CollectRewards"
+	collectRewardsStrV2   = "Harmony/CollectRewards(uint256)"
 	delegateStr           = "Harmony/Delegate"
 	unDelegateStr         = "Harmony/UnDelegate"
 	firstElectionEpochStr = "Harmony/FirstElectionEpoch/Key/v1"
@@ -18,6 +19,7 @@ var (
 	IsValidatorKey        = crypto.Keccak256Hash([]byte(isValidatorKeyStr))
 	IsValidator           = crypto.Keccak256Hash([]byte(isValidatorStr))
 	CollectRewardsTopic   = crypto.Keccak256Hash([]byte(collectRewardsStr))
+	CollectRewardsTopicV2 = crypto.Keccak256Hash([]byte(collectRewardsStrV2))
 	DelegateTopic         = crypto.Keccak256Hash([]byte(delegateStr))
 	UnDelegateTopic       = crypto.Keccak256Hash([]byte(unDelegateStr))
 	FirstElectionEpochKey = crypto.Keccak256Hash([]byte(firstElectionEpochStr))

--- a/staking/precompile_test.go
+++ b/staking/precompile_test.go
@@ -2,8 +2,8 @@ package staking
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -96,44 +96,44 @@ var ParseStakeMsgTests = []parseTest{
 		expectedError: errors.New("[StakingPrecompile] Address mismatch, expected 0x0000000000000000000000000000000000001337 have 0x0000000000000000000000000000000000001338"),
 		name:          "undelegateAddressMismatch",
 	},
-	//{
-	//	input:         []byte{42, 5, 187, 113},
-	//	expectedError: errors.New("abi: attempting to unmarshall an empty string while arguments are expected"),
-	//	name:          "yesMethodNoData",
-	//},
-	//{
-	//	input:         []byte{0, 0},
-	//	expectedError: errors.New("data too short (2 bytes) for abi method lookup"),
-	//	name:          "malformedInput",
-	//},
-	//{
-	//	input: []byte{42, 5, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56},
-	//	expected: &stakingTypes.MigrationMsg{
-	//		From: common.HexToAddress("0x1337"),
-	//		To:   common.HexToAddress("0x1338"),
-	//	},
-	//	name: "migrationSuccess",
-	//},
-	//{
-	//	input:         []byte{42, 5, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55},
-	//	expectedError: errors.New("[StakingPrecompile] Address mismatch, expected 0x0000000000000000000000000000000000001337 have 0x0000000000000000000000000000000000001338"),
-	//	name:          "migrationAddressMismatch",
-	//},
-	//{
-	//	input:         []byte{42, 6, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55},
-	//	expectedError: errors.New("no method with id: 0x2a06bb71"),
-	//	name:          "migrationNoMatchingMethod",
-	//},
-	//{
-	//	input:         []byte{42, 5, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19},
-	//	expectedError: errors.New("abi: cannot marshal in to go type: length insufficient 63 require 64"),
-	//	name:          "migrationAddressMismatch",
-	//},
+	{
+		input:         []byte{42, 5, 187, 113},
+		expectedError: errors.New("abi: attempting to unmarshall an empty string while arguments are expected"),
+		name:          "yesMethodNoData",
+	},
+	{
+		input:         []byte{0, 0},
+		expectedError: errors.New("data too short (2 bytes) for abi method lookup"),
+		name:          "malformedInput",
+	},
+	{
+		input: []byte{42, 5, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56},
+		expected: &stakingTypes.MigrationMsg{
+			From: common.HexToAddress("0x1337"),
+			To:   common.HexToAddress("0x1338"),
+		},
+		name: "migrationSuccess",
+	},
+	{
+		input:         []byte{42, 5, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55},
+		expectedError: errors.New("[StakingPrecompile] Address mismatch, expected 0x0000000000000000000000000000000000001337 have 0x0000000000000000000000000000000000001338"),
+		name:          "migrationAddressMismatch",
+	},
+	{
+		input:         []byte{42, 6, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55},
+		expectedError: errors.New("no method with id: 0x2a06bb71"),
+		name:          "migrationNoMatchingMethod",
+	},
+	{
+		input:         []byte{42, 5, 187, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19},
+		expectedError: errors.New("abi: cannot marshal in to go type: length insufficient 63 require 64"),
+		name:          "migrationAddressMismatch",
+	},
 }
 
 func testParseStakeMsg(test parseTest, t *testing.T) {
-	t.Run(fmt.Sprintf("%s", test.name), func(t *testing.T) {
-		if res, err := ParseStakeMsg(common.HexToAddress("1337"), test.input); err != nil {
+	t.Run(test.name, func(t *testing.T) {
+		if res, err := ParseStakeMsg(common.HexToAddress("1337"), test.input, strings.Contains(test.name, "migrat")); err != nil {
 			if test.expectedError != nil {
 				if test.expectedError.Error() != err.Error() {
 					t.Errorf("Expected error %v, got %v", test.expectedError, err)


### PR DESCRIPTION
This change [re-](https://github.com/harmony-one/harmony/pull/3906#issuecomment-1014158304)adds support for staking migration to the staking precompile located at `0xFC`. Staking migration is defined as the transfer of all delegated balance, undelegated balance, and pending rewards from address A to address B. In the event that a wallet's private key is compromised, a single transaction can transfer all the staked balance (+ rewards) to a new, clean address. 

We have seen a few events where attackers undelegate the balances of compromised users, and wait for the 7 epoch period to end. A user who notices this transaction on time may redelegate their balance to save it, but no other transaction is possible because the malicious attacker can steal any unlocked funds. This ends up becoming a cat and mouse game where the attacker undelegates and the owner delegates, on repeat. This change is built to work around that, by allowing users to transfer their (locked) funds to a new address.