### PR TITLE
[dumpdb] ensure each cross link is dumped

### DIFF
--- a/core/offchain.go
+++ b/core/offchain.go
@@ -167,6 +167,8 @@ func (bc *BlockChainImpl) CommitOffChainData(
 
 			cl0, _ := bc.ReadShardLastCrossLink(crossLink.ShardID())
 			if cl0 == nil {
+				// make sure it is written at least once, so that it is overwritten below
+				// under "Roll up latest crosslinks"
 				rawdb.WriteShardLastCrossLink(batch, crossLink.ShardID(), crossLink.Serialize())
 			}
 		}


### PR DESCRIPTION
## Issue
This pull request fixes the root cause behind the recent consensus stuck issue.
 - `dumpdb` does not write the crosslink to disk.
 - a new node is set up with `snapdb` (obtained from `dumpdb` command).
 - it receives an old crosslink, likely over the wire, from a syncing s1/2/3 node.
 - it adds this crosslink to the store of pending crosslinks, while a valid node would have dropped such a crosslink. 
 - the pending crosslinks are saved to disk and reloaded each time the node restarts.
 - with time more invalid crosslinks are stored in the list, since the list is capped at 1000 of them.
 - when this node becomes a leader, it proposes a block with invalid crosslink.
 - other nodes, which already have this crosslink, reject the block - but do not trigger a view change.
 - some nodes, which were loaded from the same `snapdb` accept the block and return a `prepare` message. however, it does not have enough voting power for the block to be considered valid.
 - consensus times out, and the next leader broadcasts a view change message.
 - some nodes respond to the view change message but others still consider the previous block as valid and can ignore the view change.
 - view change times out as well.
 - repeat until a valid node has its view change proposal accepted. it then proposes a valid block, which restores consensus.
 