### PR TITLE
fix epoch chain initialization issue

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -718,7 +718,7 @@ func setupConsensusAndNode(hc harmonyconfig.HarmonyConfig, nodeConfig *nodeconfi
 
 	// We are not beacon chain, make sure beacon already initialized.
 	if nodeConfig.ShardID != shard.BeaconChainShardID {
-		_, err = collection.ShardChain(shard.BeaconChainShardID)
+		_, err = collection.ShardChain(shard.BeaconChainShardID, core.Options{EpochChain: true})
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Error :%v \n", err)
 			os.Exit(1)


### PR DESCRIPTION
## Issue
If the node is not a beacon validator, we make sure the beacon already initialized. Even if we are only checking, calling ShardChain function can initialise blockchain for a node. So, this checking line is blocking epoch chain initialization. Because it sets a normal beacon chain for shard 0, while it has to be EpochChain if the node is a shard node. This could create a couple of issues for syncing.