### PR TITLE
[build] github action update

### DIFF
--- a/.github/workflows/ci-tag.yaml
+++ b/.github/workflows/ci-tag.yaml
@@ -47,9 +47,9 @@ jobs:
     steps:
       - name: Import GPG key
         if: join(matrix.os, '-') != 'self-hosted-linux-ARM64'
-        uses: crazy-max/ghaction-import-gpg@v3
+        uses: crazy-max/ghaction-import-gpg@v5
         with:
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASS }}
 
       - name: Checkout dependence repo
@@ -104,7 +104,7 @@ jobs:
         working-directory: harmony
 
       - name: Build harmony binary and packages for MacOS
-        if: matrix.os == 'macos-10.15'
+        if: matrix.os == 'macos-12'
         run: |
           brew install bash
           sudo rm -f /usr/local/opt/openssl
@@ -182,9 +182,9 @@ jobs:
 
     steps:
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v3
+        uses: crazy-max/ghaction-import-gpg@v5
         with:
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASS }}
 
       - name: Checkout harmony core code

--- a/.github/workflows/ci-tag.yaml
+++ b/.github/workflows/ci-tag.yaml
@@ -10,14 +10,14 @@ on:
 jobs:
   check:
     name: Per-check for current tag
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     continue-on-error: false
     outputs:
       tag_annotated: ${{ steps.check-tag-annotated.outputs.tag_annotated }}
 
     steps:
       - name: Checkout harmony core code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: harmony
           ref: ${{ github.event.inputs.tag }}
@@ -42,7 +42,7 @@ jobs:
     if: needs.check.outputs.tag_annotated == 'true'
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15, [self-hosted, linux, ARM64]]
+        os: [ubuntu-22.04, macos-10.15, [self-hosted, linux, ARM64]]
 
     steps:
       - name: Import GPG key
@@ -52,29 +52,29 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASS }}
 
-      - name: Set up Go 1.14
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.14.14
-
       - name: Checkout dependence repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: harmony-one/mcl
           path: mcl
 
       - name: Checkout dependence repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: harmony-one/bls
           path: bls
 
       - name: Checkout harmony core code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: harmony
           ref: ${{ github.event.inputs.tag }}
           fetch-depth: 0
+
+      - name: Set up Go go.mod
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'harmony/go.mod'
 
       - name: Get latest version and release
         run: |
@@ -85,7 +85,7 @@ jobs:
         working-directory: harmony
 
       - name: Build harmony binary and packages for Linux
-        if: matrix.os == 'ubuntu-18.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           make linux_static
           make deb
@@ -126,12 +126,12 @@ jobs:
   docker-build:
     name: Build and push harmony docker image
     needs: [check, build]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     if: needs.check.outputs.tag_annotated == 'true'
 
     steps:
       - name: Checkout harmony core code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: harmony
           ref: ${{ github.event.inputs.tag }}
@@ -177,7 +177,7 @@ jobs:
   release-page:
     name: Sign binary and create and publish release page
     needs: [check, build]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     if: needs.check.outputs.tag_annotated == 'true'
 
     steps:
@@ -188,7 +188,7 @@ jobs:
           passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASS }}
 
       - name: Checkout harmony core code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: harmony
           ref: ${{ github.event.inputs.tag }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,10 +105,11 @@ jobs:
         if: matrix.os == 'macos-12'
         run: |
           brew install bash
-          ls /opt/homebrew/opt
-          ls /usr/local/opt/
           sudo rm -f /usr/local/opt/openssl
           sudo ln -sf /usr/local/opt/openssl@1.1 /usr/local/opt/openssl
+          # hack for older chip (macos)
+          mdkir -p /opt/homebrew/opt
+          sudo ln -sf /usr/local/opt/openssl@1.1 /opt/homebrew/opt/openssl@1.1
           make
           cd ./bin && mkdir ./lib && mv ./*.dylib ./lib && rm -f ./bootnode
           gpg --detach-sign harmony

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,14 +8,14 @@ on:
 jobs:
   check:
     name: Per-check for current tag
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     continue-on-error: false
     outputs:
       tag_annotated: ${{ steps.check-tag-annotated.outputs.tag_annotated }}
 
     steps:
       - name: Checkout harmony core code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: harmony
           ref: ${{ github.ref }}
@@ -40,7 +40,7 @@ jobs:
     if: needs.check.outputs.tag_annotated == 'true'
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-12, [self-hosted, linux, ARM64]]
+        os: [ubuntu-22.04, macos-12, [self-hosted, linux, ARM64]]
 
     steps:
       - name: Import GPG key
@@ -50,29 +50,29 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASS }}
 
-      - name: Set up Go 1.18
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.18.4
-
       - name: Checkout dependence repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: harmony-one/mcl
           path: mcl
 
       - name: Checkout dependence repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: harmony-one/bls
           path: bls
 
       - name: Checkout harmony core code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: harmony
           ref: ${{ github.ref }}
           fetch-depth: 0
+
+      - name: Set up Go with go.mod
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'harmony/go.mod'
 
       - name: Get latest version and release
         run: |
@@ -83,7 +83,7 @@ jobs:
         working-directory: harmony
 
       - name: Build harmony binary and packages for Linux
-        if: matrix.os == 'ubuntu-18.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           make linux_static
           make deb
@@ -124,12 +124,12 @@ jobs:
   docker-build:
     name: Build and push harmony docker image
     needs: [check, build]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     if: needs.check.outputs.tag_annotated == 'true'
 
     steps:
       - name: Checkout harmony core code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: harmony
           ref: ${{ github.ref }}
@@ -175,7 +175,7 @@ jobs:
   release-page:
     name: Sign binary and create and publish release page
     needs: [check, build]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     if: needs.check.outputs.tag_annotated == 'true'
 
     steps:
@@ -186,7 +186,7 @@ jobs:
           passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASS }}
 
       - name: Checkout harmony core code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: harmony
           ref: ${{ github.ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,7 @@ jobs:
           sudo rm -f /usr/local/opt/openssl
           sudo ln -sf /usr/local/opt/openssl@1.1 /usr/local/opt/openssl
           # hack for older chip (macos)
-          mdkir -p /opt/homebrew/opt
+          mkdir -p /opt/homebrew/opt
           sudo ln -sf /usr/local/opt/openssl@1.1 /opt/homebrew/opt/openssl@1.1
           make
           cd ./bin && mkdir ./lib && mv ./*.dylib ./lib && rm -f ./bootnode

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: Import GPG key
         if: join(matrix.os, '-') != 'self-hosted-linux-ARM64'
-        uses: crazy-max/ghaction-import-gpg@v3
+        uses: crazy-max/ghaction-import-gpg@v5
         with:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASS }}
@@ -105,6 +105,8 @@ jobs:
         if: matrix.os == 'macos-12'
         run: |
           brew install bash
+          ls /opt/homebrew/opt
+          ls /usr/local/opt/
           sudo rm -f /usr/local/opt/openssl
           sudo ln -sf /usr/local/opt/openssl@1.1 /usr/local/opt/openssl
           make
@@ -180,7 +182,7 @@ jobs:
 
     steps:
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v3
+        uses: crazy-max/ghaction-import-gpg@v5
         with:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASS }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
         if: join(matrix.os, '-') != 'self-hosted-linux-ARM64'
         uses: crazy-max/ghaction-import-gpg@v5
         with:
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASS }}
 
       - name: Checkout dependence repo
@@ -184,7 +184,7 @@ jobs:
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v5
         with:
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASS }}
 
       - name: Checkout harmony core code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,6 +110,7 @@ jobs:
           # hack for older chip (macos)
           sudo mkdir -p /opt/homebrew/opt
           sudo ln -sf /usr/local/opt/openssl@1.1 /opt/homebrew/opt/openssl@1.1
+          sudo ln -sf /usr/local/opt/gmp /opt/homebrew/opt/gmp
           make
           cd ./bin && mkdir ./lib && mv ./*.dylib ./lib && rm -f ./bootnode
           gpg --detach-sign harmony

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,7 @@ jobs:
           sudo rm -f /usr/local/opt/openssl
           sudo ln -sf /usr/local/opt/openssl@1.1 /usr/local/opt/openssl
           # hack for older chip (macos)
-          mkdir -p /opt/homebrew/opt
+          sudo mkdir -p /opt/homebrew/opt
           sudo ln -sf /usr/local/opt/openssl@1.1 /opt/homebrew/opt/openssl@1.1
           make
           cd ./bin && mkdir ./lib && mv ./*.dylib ./lib && rm -f ./bootnode


### PR DESCRIPTION
## Issue

macos build failed due to https://github.com/harmony-one/harmony/pull/4302
github action using ubuntu-18 ad node12 were deprecated
build failed as well due to harmony binary now using go1.19

### Test/Run Logs

[<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->]

(https://github.com/sophoah/harmony/actions/runs/3892477323/jobs/6645269414)

