### PR TITLE
Add logging for `NthNextHmy` panic

### DIFF
--- a/consensus/quorum/one-node-staked-vote.go
+++ b/consensus/quorum/one-node-staked-vote.go
@@ -157,6 +157,9 @@ func (v *stakedVoteWeight) IsQuorumAchievedByMask(mask *bls_cosi.Mask) bool {
 	if currentTotalPower == nil {
 		return false
 	}
+	const msg = "[IsQuorumAchievedByMask] Voting power: need %+v, have %+v"
+	utils.Logger().Debug().
+		Msgf(msg, threshold, currentTotalPower)
 	return (*currentTotalPower).GT(threshold)
 }
 

--- a/consensus/quorum/quorum.go
+++ b/consensus/quorum/quorum.go
@@ -12,6 +12,7 @@ import (
 	"github.com/harmony-one/harmony/consensus/votepower"
 	bls_cosi "github.com/harmony-one/harmony/crypto/bls"
 	shardingconfig "github.com/harmony-one/harmony/internal/configs/sharding"
+	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/multibls"
 	"github.com/harmony-one/harmony/numeric"
 	"github.com/harmony-one/harmony/shard"
@@ -224,6 +225,10 @@ func (s *cIdentities) NthNextHmy(instance shardingconfig.Instance, pubKey *bls.P
 	idx := s.IndexOf(pubKey.Bytes)
 	if idx != -1 {
 		found = true
+	} else {
+		utils.Logger().Error().
+			Str("key", pubKey.Bytes.Hex()).
+			Msg("[NthNextHmy] pubKey not found")
 	}
 	numNodes := instance.NumHarmonyOperatedNodesPerShard()
 	// sanity check to avoid out of bound access

--- a/consensus/quorum/quorum.go
+++ b/consensus/quorum/quorum.go
@@ -230,7 +230,14 @@ func (s *cIdentities) NthNextHmy(instance shardingconfig.Instance, pubKey *bls.P
 	if numNodes <= 0 || numNodes > len(s.publicKeys) {
 		numNodes = len(s.publicKeys)
 	}
-	idx = (idx + next) % numNodes
+	// numNodes is always positive
+	// next can be negative
+	// idx can be negative only when previous public key is not found
+	// if both idx and next are negative, (idx + next) % numNodes < 0 => error
+	// think -1, -10 and 3 => -11 % 3 => -2
+	// to fix, add back numNodes and do modulo again
+	// (-2 + 3) % 3 => 1
+	idx = ((idx+next)%numNodes + numNodes) % numNodes
 	return found, &s.publicKeys[idx]
 }
 

--- a/consensus/quorum/quorum.go
+++ b/consensus/quorum/quorum.go
@@ -230,14 +230,7 @@ func (s *cIdentities) NthNextHmy(instance shardingconfig.Instance, pubKey *bls.P
 	if numNodes <= 0 || numNodes > len(s.publicKeys) {
 		numNodes = len(s.publicKeys)
 	}
-	// numNodes is always positive
-	// next can be negative
-	// idx can be negative only when previous public key is not found
-	// if both idx and next are negative, (idx + next) % numNodes < 0 => error
-	// think -1, -10 and 3 => -11 % 3 => -2
-	// to fix, add back numNodes and do modulo again
-	// (-2 + 3) % 3 => 1
-	idx = ((idx+next)%numNodes + numNodes) % numNodes
+	idx = (idx + next) % numNodes
 	return found, &s.publicKeys[idx]
 }
 

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -142,6 +142,10 @@ func (consensus *Consensus) getNextViewID() (uint64, time.Duration) {
 
 	// timestamp messed up in current validator node
 	if curTimestamp <= blockTimestamp {
+		consensus.getLogger().Error().
+			Int64("curTimestamp", curTimestamp).
+			Int64("blockTimestamp", blockTimestamp).
+			Msg("[getNextViewID] timestamp of block too high")
 		return consensus.fallbackNextViewID()
 	}
 	// diff only increases, since view change timeout is shorter than

--- a/consensus/view_change_construct.go
+++ b/consensus/view_change_construct.go
@@ -444,7 +444,8 @@ func (vc *viewChange) InitPayload(
 					vc.nilBitmap[viewID] = nilBitmap
 				}
 				if err := vc.nilBitmap[viewID].SetKey(key.Pub.Bytes, true); err != nil {
-					vc.getLogger().Warn().Str("key", key.Pub.Bytes.Hex()).Msg("[InitPayload] nilBitmap setkey failed")
+					vc.getLogger().Warn().Err(err).
+						Str("key", key.Pub.Bytes.Hex()).Msg("[InitPayload] nilBitmap setkey failed")
 					continue
 				}
 				if _, ok := vc.nilSigs[viewID]; !ok {
@@ -475,7 +476,8 @@ func (vc *viewChange) InitPayload(
 				vc.viewIDBitmap[viewID] = viewIDBitmap
 			}
 			if err := vc.viewIDBitmap[viewID].SetKey(key.Pub.Bytes, true); err != nil {
-				vc.getLogger().Warn().Str("key", key.Pub.Bytes.Hex()).Msg("[InitPayload] viewIDBitmap setkey failed")
+				vc.getLogger().Warn().Err(err).
+					Str("key", key.Pub.Bytes.Hex()).Msg("[InitPayload] viewIDBitmap setkey failed")
 				continue
 			}
 			if _, ok := vc.viewIDSigs[viewID]; !ok {

--- a/core/blockchain_impl.go
+++ b/core/blockchain_impl.go
@@ -428,6 +428,7 @@ func (bc *BlockChainImpl) ValidateNewBlock(block *types.Block, beaconChain Block
 		bc, block.Header(),
 	); err != nil {
 		utils.Logger().Error().
+			Uint64("blockNum", block.NumberU64()).
 			Str("blockHash", block.Hash().Hex()).
 			Err(err).
 			Msg("[ValidateNewBlock] Cannot verify vrf for the new block")

--- a/core/rawdb/accessors_offchain.go
+++ b/core/rawdb/accessors_offchain.go
@@ -21,7 +21,9 @@ func ReadShardState(
 ) (*shard.State, error) {
 	data, err := db.Get(shardStateKey(epoch))
 	if err != nil {
-		return nil, errors.New(MsgNoShardStateFromDB)
+		return nil, errors.Errorf(
+			MsgNoShardStateFromDB, "epoch: %d", epoch,
+		)
 	}
 	ss, err2 := shard.DecodeWrapper(data)
 	if err2 != nil {


### PR DESCRIPTION
Helps confirm that #4340 is caused by time drift. 

 - The crash occurred due to an index out of bounds error on the list of leader public keys. 
 - The index in question was negative.
 - The index represented the location of the next leader's index in the list. 
 - The index is calculated as `(gap in view ids + current leader index) % number of internal keys`. The gap acts as an offset parameter, and can be negative.
 - _However_, if the gap becomes too negative (such that the numerator is less than 0), we will get a negative number. [For Go, `a % b` is negative if `a` is negative.](https://stackoverflow.com/questions/43018206/modulo-of-negative-integers-in-go).
 - Most of the times, the gap is positive, except when the fallback mechanism for view id calculation is used.
 - The fallback mechanism of the gap calculation is triggered when the timestamp of the current block is larger than that of the current validator. This means, that either the current node is behind in time, or the proposer of the current block is ahead. In our case it was the latter.

[See private Discord thread here for logs](https://discord.com/channels/532383335348043777/1064798171835936879).

### Solution
On all nodes which could potentially have this issue, install and enable the `systemd` service to synchronize time with NTP servers.
```bash
apt install -y systemd-timesyncd
cat<<-EOF > /etc/systemd/timesyncd.conf.d/99-working.conf
[Time]
NTP=pool.ntp.org
EOF
systemctl unmask systemd-timesyncd.service
systemctl enable --now systemd-timesyncd.service
timedatectl timesync-status
```