### PR TITLE
[ops] github action and docker image update

### DIFF
--- a/.github/workflows/ci-tag.yaml
+++ b/.github/workflows/ci-tag.yaml
@@ -146,7 +146,7 @@ jobs:
         working-directory: harmony
 
       - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: harmony
 
@@ -156,16 +156,16 @@ jobs:
         working-directory: harmony
   
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./harmony/scripts/docker
           file: ./harmony/scripts/docker/Dockerfile
@@ -205,7 +205,7 @@ jobs:
         working-directory: harmony
 
       - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: harmony
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,7 +148,7 @@ jobs:
         working-directory: harmony
 
       - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: harmony
 
@@ -158,16 +158,16 @@ jobs:
         working-directory: harmony
   
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./harmony/scripts/docker
           file: ./harmony/scripts/docker/Dockerfile
@@ -207,7 +207,7 @@ jobs:
         working-directory: harmony
 
       - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: harmony
 

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -39,7 +39,7 @@ ARG HARMONY_USER_GID=1000
 ENV HARMONY_HOME=/harmony
 ENV HOME=${HARMONY_HOME}
 
-RUN apk add --no-cache bash~=5.1.16-r2 bind-tools~=9.16.29-r0 tini~=0.19.0 curl==7.83.1-r2 sed~=4.8-r0 \
+RUN apk add --no-cache bash~=5.1.16-r2 bind-tools~=9.16.37-r0 tini~=0.19.0 curl==7.83.1-r5 sed~=4.8-r0 \
     && rm -rf /var/cache/apk/* \
     && addgroup -g ${HARMONY_USER_GID} ${HARMONY_USER} \
     && adduser -u ${HARMONY_USER_UID} -G ${HARMONY_USER} --shell /sbin/nologin --no-create-home -D ${HARMONY_USER} \


### PR DESCRIPTION
This is a PR going direct to main as there are no harmony code changes, and dev has been updated with the same changes already.

## Issue

- fix issue https://github.com/harmony-one/harmony/actions/runs/4014263067/jobs/6894656037
- update github action tasks

## Test

### Test/Run Logs

github action run showing the build now works (only the push to the harmony docker repo is failing since it is done from my personal account)
https://github.com/sophoah/harmony/actions/runs/4023250279/jobs/6914199451
