### PR TITLE
fix max height issue

### DIFF
--- a/api/service/legacysync/helpers.go
+++ b/api/service/legacysync/helpers.go
@@ -14,7 +14,7 @@ import (
 )
 
 // getMaxPeerHeight gets the maximum blockchain heights from peers
-func getMaxPeerHeight(syncConfig *SyncConfig) uint64 {
+func getMaxPeerHeight(syncConfig *SyncConfig) (uint64, error) {
 	maxHeight := uint64(math.MaxUint64)
 	var (
 		wg   sync.WaitGroup
@@ -49,7 +49,12 @@ func getMaxPeerHeight(syncConfig *SyncConfig) uint64 {
 		return
 	})
 	wg.Wait()
-	return maxHeight
+
+	if maxHeight == uint64(math.MaxUint64) {
+		return 0, fmt.Errorf("[SYNC] get max peer height failed")
+	}
+
+	return maxHeight, nil
 }
 
 func createSyncConfig(syncConfig *SyncConfig, peers []p2p.Peer, shardID uint32, selfPeerID libp2p_peer.ID, waitForEachPeerToConnect bool) (*SyncConfig, error) {

--- a/api/service/stagedsync/sync_status.go
+++ b/api/service/stagedsync/sync_status.go
@@ -1,6 +1,7 @@
 package stagedsync
 
 import (
+	"math"
 	"sync"
 	"time"
 
@@ -75,7 +76,9 @@ func (status *syncStatus) Get(fallback func() SyncCheckResult) SyncCheckResult {
 	defer status.lock.Unlock()
 	if status.expired() {
 		result := fallback()
-		status.update(result)
+		if result.OtherHeight > 0 && result.OtherHeight < uint64(math.MaxUint64) {
+			status.update(result)
+		}
 	}
 	return status.lastResult
 }


### PR DESCRIPTION
## Issue
This PR fixes the eth_syncing rpc, which sometimes returns the wrong maximum height, and makes the rpc result exactly the same as Ethereum's. The issue was that some nodes were not able to query other nodes for block height. It's mostly because of the instability of the network connection or not getting proper responses on time from other peers. This PR tries to keep the last sync status in cache for 6s, and it only updates it if the returned height is valid; otherwise, it uses the last valid sync status.

## Test
Call the rpc and check the max block height:
`curl -X POST --data '{"jsonrpc":"2.0","method":"eth_syncing","params":[],"id":1}'`

