### PR TITLE
[core] fix state handling of self destruct

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -542,7 +542,10 @@ func (db *DB) createObject(addr common.Address) (newobj, prev *Object) {
 		db.journal.append(resetObjectChange{prev: prev})
 	}
 	db.setStateObject(newobj)
-	return newobj, prev
+	if prev != nil && !prev.deleted {
+		return newobj, prev
+	}
+	return newobj, nil
 }
 
 // CreateAccount explicitly creates a state object. If a state object with the address


### PR DESCRIPTION
If a contract self destructs to self and then receives funds within the same transaction, it is possible for its stale state to be saved. This change removes that possibility by checking for deleted state objects before returning them.