### PR TITLE
Rotate external validators for non-beacon shards. 

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -218,6 +218,8 @@ func (consensus *Consensus) getConsensusLeaderPrivateKey() (*bls.PrivateKeyWrapp
 
 // SetBlockVerifier sets the block verifier
 func (consensus *Consensus) SetBlockVerifier(verifier VerifyBlockFunc) {
+	consensus.mutex.Lock()
+	defer consensus.mutex.Unlock()
 	consensus.BlockVerifier = verifier
 	consensus.vc.SetVerifyBlock(consensus.verifyBlock)
 }

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -547,7 +547,7 @@ func (consensus *Consensus) GetFinality() int64 {
 	return consensus.finality
 }
 
-// switchPhase will switch FBFTPhase to nextPhase if the desirePhase equals the nextPhase
+// switchPhase will switch FBFTPhase to desired phase.
 func (consensus *Consensus) switchPhase(subject string, desired FBFTPhase) {
 	consensus.getLogger().Info().
 		Str("from:", consensus.phase.String()).

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -689,16 +689,12 @@ func (consensus *Consensus) commitBlock(blk *types.Block, committedMsg *FBFTMess
 // rotateLeader rotates the leader to the next leader in the committee.
 // This function must be called with enabled leader rotation.
 func (consensus *Consensus) rotateLeader(epoch *big.Int) {
-	// Feature activated only for non-beacon shards.
-	if consensus.ShardID == shard.BeaconChainShardID {
-		return
-	}
 	var (
 		bc     = consensus.Blockchain()
 		prev   = consensus.getLeaderPubKey()
 		leader = consensus.getLeaderPubKey()
 	)
-	utils.Logger().Info().Msgf("[Rotating leader] epoch: %v rotation:%v ", epoch.Uint64(), bc.Config().IsNonBeaconLeaderRotation(epoch))
+	utils.Logger().Info().Msgf("[Rotating leader] epoch: %v rotation:%v external rotation %v", epoch.Uint64(), bc.Config().IsLeaderRotation(epoch), bc.Config().IsLeaderRotationExternalValidatorsAllowed(epoch, consensus.ShardID))
 	ss, err := bc.ReadShardState(epoch)
 	if err != nil {
 		utils.Logger().Error().Err(err).Msg("Failed to read shard state")
@@ -750,7 +746,15 @@ func (consensus *Consensus) rotateLeader(epoch *big.Int) {
 	// Passed all checks, we can change leader.
 	// NthNext will move the leader to the next leader in the committee.
 	// It does not know anything about external or internal validators.
-	wasFound, next := consensus.Decider.NthNext(leader, 1)
+	var (
+		wasFound bool
+		next     *bls.PublicKeyWrapper
+	)
+	if bc.Config().IsLeaderRotationExternalValidatorsAllowed(epoch, consensus.ShardID) {
+		wasFound, next = consensus.Decider.NthNext(leader, 1)
+	} else {
+		wasFound, next = consensus.Decider.NthNextHmy(shard.Schedule.InstanceForEpoch(epoch), leader, 1)
+	}
 	if !wasFound {
 		utils.Logger().Error().Msg("Failed to get next leader")
 		return
@@ -776,7 +780,7 @@ func (consensus *Consensus) setupForNewConsensus(blk *types.Block, committedMsg 
 	} else {
 		epoch = blk.Epoch()
 	}
-	if consensus.Blockchain().Config().IsNonBeaconLeaderRotation(epoch) {
+	if consensus.Blockchain().Config().IsLeaderRotation(epoch) {
 		consensus.rotateLeader(epoch)
 	}
 

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -63,9 +63,8 @@ func (consensus *Consensus) onAnnounce(msg *msg_pb.Message) {
 		go func() {
 			// Best effort check, no need to error out.
 			_, err := consensus.ValidateNewBlock(recvMsg)
-
 			if err == nil {
-				consensus.getLogger().Info().
+				consensus.GetLogger().Info().
 					Msg("[Announce] Block verified")
 			}
 		}()

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -202,14 +202,14 @@ func (consensus *Consensus) getNextLeaderKey(viewID uint64) *bls.PublicKeyWrappe
 	// FIXME: rotate leader on harmony nodes only before fully externalization
 	var wasFound bool
 	var next *bls.PublicKeyWrapper
-	if blockchain != nil && blockchain.Config().IsNonBeaconLeaderRotation(epoch) {
-		if consensus.ShardID == shard.BeaconChainShardID {
-			wasFound, next = consensus.Decider.NthNextHmy(
-				shard.Schedule.InstanceForEpoch(epoch),
+	if blockchain != nil && blockchain.Config().IsLeaderRotation(epoch) {
+		if blockchain.Config().IsLeaderRotationExternalValidatorsAllowed(epoch, consensus.ShardID) {
+			wasFound, next = consensus.Decider.NthNext(
 				lastLeaderPubKey,
 				gap)
 		} else {
-			wasFound, next = consensus.Decider.NthNext(
+			wasFound, next = consensus.Decider.NthNextHmy(
+				shard.Schedule.InstanceForEpoch(epoch),
 				lastLeaderPubKey,
 				gap)
 		}

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -202,14 +202,14 @@ func (consensus *Consensus) getNextLeaderKey(viewID uint64) *bls.PublicKeyWrappe
 	// FIXME: rotate leader on harmony nodes only before fully externalization
 	var wasFound bool
 	var next *bls.PublicKeyWrapper
-	if blockchain != nil && blockchain.Config().IsLeaderRotation(epoch) {
-		if blockchain.Config().IsLeaderRotationExternalValidatorsAllowed(epoch, consensus.ShardID) {
-			wasFound, next = consensus.Decider.NthNext(
+	if blockchain != nil && blockchain.Config().IsNonBeaconLeaderRotation(epoch) {
+		if consensus.ShardID == shard.BeaconChainShardID {
+			wasFound, next = consensus.Decider.NthNextHmy(
+				shard.Schedule.InstanceForEpoch(epoch),
 				lastLeaderPubKey,
 				gap)
 		} else {
-			wasFound, next = consensus.Decider.NthNextHmy(
-				shard.Schedule.InstanceForEpoch(epoch),
+			wasFound, next = consensus.Decider.NthNext(
 				lastLeaderPubKey,
 				gap)
 		}

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -202,7 +202,7 @@ func (consensus *Consensus) getNextLeaderKey(viewID uint64) *bls.PublicKeyWrappe
 	// FIXME: rotate leader on harmony nodes only before fully externalization
 	var wasFound bool
 	var next *bls.PublicKeyWrapper
-	if blockchain != nil && blockchain.Config().IsLeaderRotation(epoch) {
+	if blockchain != nil && blockchain.Config().IsNonBeaconLeaderRotation(epoch) {
 		if consensus.ShardID == shard.BeaconChainShardID {
 			wasFound, next = consensus.Decider.NthNextHmy(
 				shard.Schedule.InstanceForEpoch(epoch),

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -107,6 +107,8 @@ type BlockChain interface {
 	//
 	// After insertion is done, all accumulated events will be fired.
 	InsertChain(chain types.Blocks, verifyHeaders bool) (int, error)
+	// LeaderContinuousBlocksCount returns the number of continuous blocks by the leader.
+	LeaderContinuousBlocksCount() (publicKeyBytes []byte, epoch uint64, count uint64, err error)
 	// BadBlocks returns a list of the last 'bad blocks' that
 	// the client has seen on the network.
 	BadBlocks() []BadBlock

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -107,8 +107,8 @@ type BlockChain interface {
 	//
 	// After insertion is done, all accumulated events will be fired.
 	InsertChain(chain types.Blocks, verifyHeaders bool) (int, error)
-	// LeaderContinuousBlocksCount returns the number of continuous blocks by the leader.
-	LeaderContinuousBlocksCount() (publicKeyBytes []byte, epoch uint64, count uint64, err error)
+	// LeaderRotationMeta returns the number of continuous blocks by the leader.
+	LeaderRotationMeta() (publicKeyBytes []byte, epoch, count, shifts uint64, err error)
 	// BadBlocks returns a list of the last 'bad blocks' that
 	// the client has seen on the network.
 	BadBlocks() []BadBlock

--- a/core/blockchain_impl.go
+++ b/core/blockchain_impl.go
@@ -114,6 +114,7 @@ const (
 	validatorListByDelegatorCacheLimit = 128
 	pendingCrossLinksCacheLimit        = 2
 	blockAccumulatorCacheLimit         = 64
+	leaderPubKeyFromCoinbaseLimit      = 8
 	maxPendingSlashes                  = 256
 	// BlockChainVersion ensures that an incompatible database forces a resync from scratch.
 	BlockChainVersion = 3
@@ -240,7 +241,7 @@ func newBlockChainWithOptions(
 	validatorListByDelegatorCache, _ := lru.New(validatorListByDelegatorCacheLimit)
 	pendingCrossLinksCache, _ := lru.New(pendingCrossLinksCacheLimit)
 	blockAccumulatorCache, _ := lru.New(blockAccumulatorCacheLimit)
-	leaderPubKeyFromCoinbase, _ := lru.New(chainConfig.LeaderRotationBlocksCount + 2)
+	leaderPubKeyFromCoinbase, _ := lru.New(leaderPubKeyFromCoinbaseLimit)
 
 	bc := &BlockChainImpl{
 		chainConfig:                   chainConfig,
@@ -1522,11 +1523,53 @@ func (bc *BlockChainImpl) InsertChain(chain types.Blocks, verifyHeaders bool) (i
 
 	n, events, logs, err := bc.insertChain(chain, verifyHeaders)
 	bc.PostChainEvents(events, logs)
+	if err == nil {
+		// there should be only 1 block.
+		for _, b := range chain {
+			err := bc.saveLeaderContinuousBlocksCount(b.Header())
+			if err != nil {
+				utils.Logger().Error().Err(err).Msg("save leader continuous blocks count error")
+				return n, err
+			}
+		}
+	}
 	if bc.isInitTiKV() && err != nil {
 		// if has some error, master writer node will release the permission
 		_, _ = bc.redisPreempt.Unlock()
 	}
 	return n, err
+}
+
+func (bc *BlockChainImpl) saveLeaderContinuousBlocksCount(h *block.Header) error {
+	blockPubKey, err := bc.getLeaderPubKeyFromCoinbase(h)
+	if err != nil {
+		return err
+	}
+	type stored struct {
+		pub   []byte
+		epoch uint64
+		count uint64
+	}
+	var s stored
+	// error is possible here only on the first iteration, so we can ignore it
+	s.pub, s.epoch, s.count, _ = rawdb.ReadLeaderContinuousBlocksCount(bc.db)
+
+	cnt := s.count
+	// so, increase counter only if the same leader and epoch
+	if bytes.Equal(s.pub, blockPubKey.Bytes[:]) && s.epoch == h.Epoch().Uint64() {
+		cnt++
+	} else {
+		cnt = 1
+	}
+	err = rawdb.WriteLeaderContinuousBlocksCount(bc.db, blockPubKey.Bytes[:], h.Epoch().Uint64(), cnt)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (bc *BlockChainImpl) LeaderContinuousBlocksCount() (publicKeyBytes []byte, epoch uint64, count uint64, err error) {
+	return rawdb.ReadLeaderContinuousBlocksCount(bc.db)
 }
 
 // insertChain will execute the actual chain insertion and event aggregation. The

--- a/core/blockchain_impl.go
+++ b/core/blockchain_impl.go
@@ -1526,10 +1526,12 @@ func (bc *BlockChainImpl) InsertChain(chain types.Blocks, verifyHeaders bool) (i
 	if err == nil {
 		// there should be only 1 block.
 		for _, b := range chain {
-			err := bc.saveLeaderContinuousBlocksCount(b.Header())
-			if err != nil {
-				utils.Logger().Error().Err(err).Msg("save leader continuous blocks count error")
-				return n, err
+			if b.Epoch().Uint64() > 0 {
+				err := bc.saveLeaderContinuousBlocksCount(b.Header())
+				if err != nil {
+					utils.Logger().Error().Err(err).Msg("save leader continuous blocks count error")
+					return n, err
+				}
 			}
 		}
 	}

--- a/core/blockchain_stub.go
+++ b/core/blockchain_stub.go
@@ -423,3 +423,7 @@ func (a Stub) SyncFromTiKVWriter(newBlkNum uint64, logs []*types.Log) error {
 func (a Stub) InitTiKV(conf *harmonyconfig.TiKVConfig) {
 	return
 }
+
+func (a Stub) LeaderContinuousBlocksCount() ([]byte, uint64, uint64, error) {
+	return nil, 0, 0, errors.Errorf("method LeaderContinuousBlocksCount not implemented for %s", a.Name)
+}

--- a/core/blockchain_stub.go
+++ b/core/blockchain_stub.go
@@ -424,6 +424,6 @@ func (a Stub) InitTiKV(conf *harmonyconfig.TiKVConfig) {
 	return
 }
 
-func (a Stub) LeaderContinuousBlocksCount() ([]byte, uint64, uint64, error) {
-	return nil, 0, 0, errors.Errorf("method LeaderContinuousBlocksCount not implemented for %s", a.Name)
+func (a Stub) LeaderRotationMeta() (publicKeyBytes []byte, epoch, count, shifts uint64, err error) {
+	return nil, 0, 0, 0, errors.Errorf("method LeaderRotationMeta not implemented for %s", a.Name)
 }

--- a/core/rawdb/accessors_metadata.go
+++ b/core/rawdb/accessors_metadata.go
@@ -195,7 +195,8 @@ func WriteTransitionStatus(db ethdb.KeyValueWriter, data []byte) {
 	}
 }
 
-func WriteLeaderContinuousBlocksCount(db DatabaseWriter, leader []byte, count uint64, epoch uint64) error {
+// WriteLeaderContinuousBlocksCount writes the leader continuous blocks count to the database.
+func WriteLeaderContinuousBlocksCount(db DatabaseWriter, leader []byte, epoch uint64, count uint64) error {
 	if len(leader) != bls.PublicKeySizeInBytes {
 		return errors.New("invalid leader public key size")
 	}
@@ -210,6 +211,7 @@ func WriteLeaderContinuousBlocksCount(db DatabaseWriter, leader []byte, count ui
 	return nil
 }
 
+// ReadLeaderContinuousBlocksCount retrieves the leader continuous blocks count from the database.
 func ReadLeaderContinuousBlocksCount(db DatabaseReader) (pubKeyBytes []byte, epoch uint64, count uint64, err error) {
 	data, _ := db.Get(leaderContinuousBlocksCountKey())
 	if len(data) != bls.PublicKeySizeInBytes+16 {

--- a/core/rawdb/accessors_metadata.go
+++ b/core/rawdb/accessors_metadata.go
@@ -17,12 +17,14 @@
 package rawdb
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/harmony-one/harmony/crypto/bls"
 	"github.com/harmony-one/harmony/internal/params"
 	"github.com/harmony-one/harmony/internal/utils"
 )
@@ -191,4 +193,32 @@ func WriteTransitionStatus(db ethdb.KeyValueWriter, data []byte) {
 	if err := db.Put(transitionStatusKey, data); err != nil {
 		utils.Logger().Error().Err(err).Msg("Failed to store the eth2 transition status")
 	}
+}
+
+func WriteLeaderContinuousBlocksCount(db DatabaseWriter, leader []byte, count uint64, epoch uint64) error {
+	if len(leader) != bls.PublicKeySizeInBytes {
+		return errors.New("invalid leader public key size")
+	}
+	value := make([]byte, bls.PublicKeySizeInBytes+16)
+	copy(value, leader)
+	binary.LittleEndian.PutUint64(value[len(leader):], epoch)
+	binary.LittleEndian.PutUint64(value[len(leader)+8:], count)
+	if err := db.Put(leaderContinuousBlocksCountKey(), value); err != nil {
+		utils.Logger().Error().Err(err).Msg("Failed to store leader continuous blocks count")
+		return err
+	}
+	return nil
+}
+
+func ReadLeaderContinuousBlocksCount(db DatabaseReader) (pubKeyBytes []byte, epoch uint64, count uint64, err error) {
+	data, _ := db.Get(leaderContinuousBlocksCountKey())
+	if len(data) != bls.PublicKeySizeInBytes+16 {
+		return nil, 0, 0, errors.New("invalid leader continuous blocks count")
+	}
+
+	pubKeyBytes = data[:bls.PublicKeySizeInBytes]
+	epoch = binary.LittleEndian.Uint64(data[bls.PublicKeySizeInBytes:])
+	count = binary.LittleEndian.Uint64(data[bls.PublicKeySizeInBytes+8:])
+
+	return pubKeyBytes, epoch, count, nil
 }

--- a/core/rawdb/accessors_metadata.go
+++ b/core/rawdb/accessors_metadata.go
@@ -27,6 +27,7 @@ import (
 	"github.com/harmony-one/harmony/crypto/bls"
 	"github.com/harmony-one/harmony/internal/params"
 	"github.com/harmony-one/harmony/internal/utils"
+	"github.com/pkg/errors"
 )
 
 // ReadDatabaseVersion retrieves the version number of the database.

--- a/core/rawdb/accessors_metadata_test.go
+++ b/core/rawdb/accessors_metadata_test.go
@@ -1,0 +1,29 @@
+package rawdb
+
+import (
+	"testing"
+
+	ethRawDB "github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/harmony-one/harmony/crypto/bls"
+)
+
+func TestLeaderContinuousBlocksCount(t *testing.T) {
+	db := ethRawDB.NewMemoryDatabase()
+	err := WriteLeaderContinuousBlocksCount(db, make([]byte, bls.PublicKeySizeInBytes), 1, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub, epoch, count, err := ReadLeaderContinuousBlocksCount(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pub) != bls.PublicKeySizeInBytes {
+		t.Fatal("invalid leader public key size")
+	}
+	if epoch != 1 {
+		t.Fatal("invalid epoch")
+	}
+	if count != 2 {
+		t.Fatal("invalid count")
+	}
+}

--- a/core/rawdb/accessors_metadata_test.go
+++ b/core/rawdb/accessors_metadata_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/harmony-one/harmony/crypto/bls"
 )
 
-func TestLeaderContinuousBlocksCount(t *testing.T) {
+func TestLeaderRotationMeta(t *testing.T) {
 	db := ethRawDB.NewMemoryDatabase()
-	err := WriteLeaderContinuousBlocksCount(db, make([]byte, bls.PublicKeySizeInBytes), 1, 2)
+	err := WriteLeaderRotationMeta(db, make([]byte, bls.PublicKeySizeInBytes), 1, 2, 3)
 	if err != nil {
 		t.Fatal(err)
 	}
-	pub, epoch, count, err := ReadLeaderContinuousBlocksCount(db)
+	pub, epoch, count, shifts, err := ReadLeaderRotationMeta(db)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,5 +25,8 @@ func TestLeaderContinuousBlocksCount(t *testing.T) {
 	}
 	if count != 2 {
 		t.Fatal("invalid count")
+	}
+	if shifts != 3 {
+		t.Fatal("invalid shifts")
 	}
 }

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -100,6 +100,7 @@ var (
 	pendingCrosslinkKey          = []byte("pendingCL")        // prefix for shard last pending crosslink
 	pendingSlashingKey           = []byte("pendingSC")        // prefix for shard last pending slashing record
 	preimagePrefix               = []byte("secure-key-")      // preimagePrefix + hash -> preimage
+	continuousBlocksCountKey     = []byte("continuous")       // key for continuous blocks count
 	configPrefix                 = []byte("ethereum-config-") // config prefix for the db
 	crosslinkPrefix              = []byte("cl")               // prefix for crosslink
 	delegatorValidatorListPrefix = []byte("dvl")              // prefix for delegator's validator list
@@ -283,6 +284,10 @@ func bloomBitsKey(bit uint, section uint64, hash common.Hash) []byte {
 // preimageKey = preimagePrefix + hash
 func preimageKey(hash common.Hash) []byte {
 	return append(preimagePrefix, hash.Bytes()...)
+}
+
+func leaderContinuousBlocksCountKey() []byte {
+	return continuousBlocksCountKey
 }
 
 // configKey = configPrefix + hash

--- a/internal/configs/sharding/shardingconfig.go
+++ b/internal/configs/sharding/shardingconfig.go
@@ -72,8 +72,9 @@ type Instance interface {
 	// ReshardingEpoch returns a list of Epoch while off-chain resharding happens
 	ReshardingEpoch() []*big.Int
 
-	// Count of blocks per epoch
+	// BlocksPerEpoch returns the number of blocks per epoch.
 	BlocksPerEpoch() uint64
+
 	// HIP-16: The absolute number of maximum effective slots per shard limit for each validator. 0 means no limit.
 	SlotsLimit() int
 

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -36,243 +36,249 @@ var once sync.Once
 var (
 	// MainnetChainConfig is the chain parameters to run a node on the main network.
 	MainnetChainConfig = &ChainConfig{
-		ChainID:                       MainnetChainID,
-		EthCompatibleChainID:          EthMainnetShard0ChainID,
-		EthCompatibleShard0ChainID:    EthMainnetShard0ChainID,
-		EthCompatibleEpoch:            big.NewInt(442), // Around Thursday Feb 4th 2020, 10AM PST
-		CrossTxEpoch:                  big.NewInt(28),
-		CrossLinkEpoch:                big.NewInt(186),
-		AggregatedRewardEpoch:         big.NewInt(689), // Around Wed Sept 15th 2021 with 3.5s block time
-		StakingEpoch:                  big.NewInt(186),
-		PreStakingEpoch:               big.NewInt(185),
-		QuickUnlockEpoch:              big.NewInt(191),
-		FiveSecondsEpoch:              big.NewInt(230),
-		TwoSecondsEpoch:               big.NewInt(366), // Around Tuesday Dec 8th 2020, 8AM PST
-		SixtyPercentEpoch:             big.NewInt(530), // Around Monday Apr 12th 2021, 22:30 UTC
-		RedelegationEpoch:             big.NewInt(290),
-		NoEarlyUnlockEpoch:            big.NewInt(530), // Around Monday Apr 12th 2021, 22:30 UTC
-		VRFEpoch:                      big.NewInt(631), // Around Wed July 7th 2021
-		PrevVRFEpoch:                  big.NewInt(689), // Around Wed Sept 15th 2021 with 3.5s block time
-		MinDelegation100Epoch:         big.NewInt(631), // Around Wed July 7th 2021
-		MinCommissionRateEpoch:        big.NewInt(631), // Around Wed July 7th 2021
-		MinCommissionPromoPeriod:      big.NewInt(100),
-		EPoSBound35Epoch:              big.NewInt(631), // Around Wed July 7th 2021
-		EIP155Epoch:                   big.NewInt(28),
-		S3Epoch:                       big.NewInt(28),
-		DataCopyFixEpoch:              big.NewInt(689), // Around Wed Sept 15th 2021 with 3.5s block time
-		IstanbulEpoch:                 big.NewInt(314),
-		ReceiptLogEpoch:               big.NewInt(101),
-		SHA3Epoch:                     big.NewInt(725),  // Around Mon Oct 11 2021, 19:00 UTC
-		HIP6And8Epoch:                 big.NewInt(725),  // Around Mon Oct 11 2021, 19:00 UTC
-		StakingPrecompileEpoch:        big.NewInt(871),  // Around Tue Feb 11 2022
-		ChainIdFixEpoch:               big.NewInt(1323), // Around Wed 8 Feb 11:30PM UTC
-		SlotsLimitedEpoch:             big.NewInt(999),  // Around Fri, 27 May 2022 09:41:02 UTC with 2s block time
-		CrossShardXferPrecompileEpoch: big.NewInt(1323), // Around Wed 8 Feb 11:30PM UTC
-		AllowlistEpoch:                EpochTBD,
-		FeeCollectEpoch:               EpochTBD,
-		NonBeaconLeaderRotation:       EpochTBD,
+		ChainID:                                MainnetChainID,
+		EthCompatibleChainID:                   EthMainnetShard0ChainID,
+		EthCompatibleShard0ChainID:             EthMainnetShard0ChainID,
+		EthCompatibleEpoch:                     big.NewInt(442), // Around Thursday Feb 4th 2020, 10AM PST
+		CrossTxEpoch:                           big.NewInt(28),
+		CrossLinkEpoch:                         big.NewInt(186),
+		AggregatedRewardEpoch:                  big.NewInt(689), // Around Wed Sept 15th 2021 with 3.5s block time
+		StakingEpoch:                           big.NewInt(186),
+		PreStakingEpoch:                        big.NewInt(185),
+		QuickUnlockEpoch:                       big.NewInt(191),
+		FiveSecondsEpoch:                       big.NewInt(230),
+		TwoSecondsEpoch:                        big.NewInt(366), // Around Tuesday Dec 8th 2020, 8AM PST
+		SixtyPercentEpoch:                      big.NewInt(530), // Around Monday Apr 12th 2021, 22:30 UTC
+		RedelegationEpoch:                      big.NewInt(290),
+		NoEarlyUnlockEpoch:                     big.NewInt(530), // Around Monday Apr 12th 2021, 22:30 UTC
+		VRFEpoch:                               big.NewInt(631), // Around Wed July 7th 2021
+		PrevVRFEpoch:                           big.NewInt(689), // Around Wed Sept 15th 2021 with 3.5s block time
+		MinDelegation100Epoch:                  big.NewInt(631), // Around Wed July 7th 2021
+		MinCommissionRateEpoch:                 big.NewInt(631), // Around Wed July 7th 2021
+		MinCommissionPromoPeriod:               big.NewInt(100),
+		EPoSBound35Epoch:                       big.NewInt(631), // Around Wed July 7th 2021
+		EIP155Epoch:                            big.NewInt(28),
+		S3Epoch:                                big.NewInt(28),
+		DataCopyFixEpoch:                       big.NewInt(689), // Around Wed Sept 15th 2021 with 3.5s block time
+		IstanbulEpoch:                          big.NewInt(314),
+		ReceiptLogEpoch:                        big.NewInt(101),
+		SHA3Epoch:                              big.NewInt(725),  // Around Mon Oct 11 2021, 19:00 UTC
+		HIP6And8Epoch:                          big.NewInt(725),  // Around Mon Oct 11 2021, 19:00 UTC
+		StakingPrecompileEpoch:                 big.NewInt(871),  // Around Tue Feb 11 2022
+		ChainIdFixEpoch:                        big.NewInt(1323), // Around Wed 8 Feb 11:30PM UTC
+		SlotsLimitedEpoch:                      big.NewInt(999),  // Around Fri, 27 May 2022 09:41:02 UTC with 2s block time
+		CrossShardXferPrecompileEpoch:          big.NewInt(1323), // Around Wed 8 Feb 11:30PM UTC
+		AllowlistEpoch:                         EpochTBD,
+		FeeCollectEpoch:                        EpochTBD,
+		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
+		LeaderRotationExternalBeaconLeaders:    EpochTBD,
 		ValidatorCodeFixEpoch:         EpochTBD,
 	}
 
 	// TestnetChainConfig contains the chain parameters to run a node on the harmony test network.
 	TestnetChainConfig = &ChainConfig{
-		ChainID:                       TestnetChainID,
-		EthCompatibleChainID:          EthTestnetShard0ChainID,
-		EthCompatibleShard0ChainID:    EthTestnetShard0ChainID,
-		EthCompatibleEpoch:            big.NewInt(0),
-		CrossTxEpoch:                  big.NewInt(0),
-		CrossLinkEpoch:                big.NewInt(2),
-		AggregatedRewardEpoch:         big.NewInt(2),
-		StakingEpoch:                  big.NewInt(2),
-		PreStakingEpoch:               big.NewInt(1),
-		QuickUnlockEpoch:              big.NewInt(0),
-		FiveSecondsEpoch:              big.NewInt(0),
-		TwoSecondsEpoch:               big.NewInt(2),
-		SixtyPercentEpoch:             big.NewInt(2),
-		RedelegationEpoch:             big.NewInt(2),
-		NoEarlyUnlockEpoch:            big.NewInt(2),
-		VRFEpoch:                      big.NewInt(2),
-		PrevVRFEpoch:                  big.NewInt(2),
-		MinDelegation100Epoch:         big.NewInt(2),
-		MinCommissionRateEpoch:        big.NewInt(2),
-		MinCommissionPromoPeriod:      big.NewInt(2),
-		EPoSBound35Epoch:              big.NewInt(2),
-		EIP155Epoch:                   big.NewInt(0),
-		S3Epoch:                       big.NewInt(0),
-		DataCopyFixEpoch:              big.NewInt(0),
-		IstanbulEpoch:                 big.NewInt(0),
-		ReceiptLogEpoch:               big.NewInt(0),
-		SHA3Epoch:                     big.NewInt(0),
-		HIP6And8Epoch:                 big.NewInt(2),
-		StakingPrecompileEpoch:        big.NewInt(2),
-		SlotsLimitedEpoch:             big.NewInt(2),
-		ChainIdFixEpoch:               big.NewInt(0),
-		CrossShardXferPrecompileEpoch: big.NewInt(2),
-		AllowlistEpoch:                big.NewInt(2),
-		NonBeaconLeaderRotation:       EpochTBD,
-		FeeCollectEpoch:               EpochTBD,
+		ChainID:                                TestnetChainID,
+		EthCompatibleChainID:                   EthTestnetShard0ChainID,
+		EthCompatibleShard0ChainID:             EthTestnetShard0ChainID,
+		EthCompatibleEpoch:                     big.NewInt(0),
+		CrossTxEpoch:                           big.NewInt(0),
+		CrossLinkEpoch:                         big.NewInt(2),
+		AggregatedRewardEpoch:                  big.NewInt(2),
+		StakingEpoch:                           big.NewInt(2),
+		PreStakingEpoch:                        big.NewInt(1),
+		QuickUnlockEpoch:                       big.NewInt(0),
+		FiveSecondsEpoch:                       big.NewInt(0),
+		TwoSecondsEpoch:                        big.NewInt(2),
+		SixtyPercentEpoch:                      big.NewInt(2),
+		RedelegationEpoch:                      big.NewInt(2),
+		NoEarlyUnlockEpoch:                     big.NewInt(2),
+		VRFEpoch:                               big.NewInt(2),
+		PrevVRFEpoch:                           big.NewInt(2),
+		MinDelegation100Epoch:                  big.NewInt(2),
+		MinCommissionRateEpoch:                 big.NewInt(2),
+		MinCommissionPromoPeriod:               big.NewInt(2),
+		EPoSBound35Epoch:                       big.NewInt(2),
+		EIP155Epoch:                            big.NewInt(0),
+		S3Epoch:                                big.NewInt(0),
+		DataCopyFixEpoch:                       big.NewInt(0),
+		IstanbulEpoch:                          big.NewInt(0),
+		ReceiptLogEpoch:                        big.NewInt(0),
+		SHA3Epoch:                              big.NewInt(0),
+		HIP6And8Epoch:                          big.NewInt(2),
+		StakingPrecompileEpoch:                 big.NewInt(2),
+		SlotsLimitedEpoch:                      big.NewInt(2),
+		ChainIdFixEpoch:                        big.NewInt(0),
+		CrossShardXferPrecompileEpoch:          big.NewInt(2),
+		AllowlistEpoch:                         big.NewInt(2),
+		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
+		LeaderRotationExternalBeaconLeaders:    EpochTBD,
+		FeeCollectEpoch:                        EpochTBD,
 		ValidatorCodeFixEpoch:         EpochTBD,
 	}
 	// PangaeaChainConfig contains the chain parameters for the Pangaea network.
 	// All features except for CrossLink are enabled at launch.
 	PangaeaChainConfig = &ChainConfig{
-		ChainID:                       PangaeaChainID,
-		EthCompatibleChainID:          EthPangaeaShard0ChainID,
-		EthCompatibleShard0ChainID:    EthPangaeaShard0ChainID,
-		EthCompatibleEpoch:            big.NewInt(0),
-		CrossTxEpoch:                  big.NewInt(0),
-		CrossLinkEpoch:                big.NewInt(2),
-		AggregatedRewardEpoch:         big.NewInt(3),
-		StakingEpoch:                  big.NewInt(2),
-		PreStakingEpoch:               big.NewInt(1),
-		QuickUnlockEpoch:              big.NewInt(0),
-		FiveSecondsEpoch:              big.NewInt(0),
-		TwoSecondsEpoch:               big.NewInt(0),
-		SixtyPercentEpoch:             big.NewInt(0),
-		RedelegationEpoch:             big.NewInt(0),
-		NoEarlyUnlockEpoch:            big.NewInt(0),
-		VRFEpoch:                      big.NewInt(0),
-		PrevVRFEpoch:                  big.NewInt(0),
-		MinDelegation100Epoch:         big.NewInt(0),
-		MinCommissionRateEpoch:        big.NewInt(0),
-		MinCommissionPromoPeriod:      big.NewInt(10),
-		EPoSBound35Epoch:              big.NewInt(0),
-		EIP155Epoch:                   big.NewInt(0),
-		S3Epoch:                       big.NewInt(0),
-		DataCopyFixEpoch:              big.NewInt(0),
-		IstanbulEpoch:                 big.NewInt(0),
-		ReceiptLogEpoch:               big.NewInt(0),
-		SHA3Epoch:                     big.NewInt(0),
-		HIP6And8Epoch:                 big.NewInt(0),
-		StakingPrecompileEpoch:        big.NewInt(2), // same as staking
-		ChainIdFixEpoch:               big.NewInt(0),
-		SlotsLimitedEpoch:             EpochTBD, // epoch to enable HIP-16
-		CrossShardXferPrecompileEpoch: big.NewInt(1),
-		AllowlistEpoch:                EpochTBD,
-		NonBeaconLeaderRotation:       EpochTBD,
-		FeeCollectEpoch:               EpochTBD,
+		ChainID:                                PangaeaChainID,
+		EthCompatibleChainID:                   EthPangaeaShard0ChainID,
+		EthCompatibleShard0ChainID:             EthPangaeaShard0ChainID,
+		EthCompatibleEpoch:                     big.NewInt(0),
+		CrossTxEpoch:                           big.NewInt(0),
+		CrossLinkEpoch:                         big.NewInt(2),
+		AggregatedRewardEpoch:                  big.NewInt(3),
+		StakingEpoch:                           big.NewInt(2),
+		PreStakingEpoch:                        big.NewInt(1),
+		QuickUnlockEpoch:                       big.NewInt(0),
+		FiveSecondsEpoch:                       big.NewInt(0),
+		TwoSecondsEpoch:                        big.NewInt(0),
+		SixtyPercentEpoch:                      big.NewInt(0),
+		RedelegationEpoch:                      big.NewInt(0),
+		NoEarlyUnlockEpoch:                     big.NewInt(0),
+		VRFEpoch:                               big.NewInt(0),
+		PrevVRFEpoch:                           big.NewInt(0),
+		MinDelegation100Epoch:                  big.NewInt(0),
+		MinCommissionRateEpoch:                 big.NewInt(0),
+		MinCommissionPromoPeriod:               big.NewInt(10),
+		EPoSBound35Epoch:                       big.NewInt(0),
+		EIP155Epoch:                            big.NewInt(0),
+		S3Epoch:                                big.NewInt(0),
+		DataCopyFixEpoch:                       big.NewInt(0),
+		IstanbulEpoch:                          big.NewInt(0),
+		ReceiptLogEpoch:                        big.NewInt(0),
+		SHA3Epoch:                              big.NewInt(0),
+		HIP6And8Epoch:                          big.NewInt(0),
+		StakingPrecompileEpoch:                 big.NewInt(2), // same as staking
+		ChainIdFixEpoch:                        big.NewInt(0),
+		SlotsLimitedEpoch:                      EpochTBD, // epoch to enable HIP-16
+		CrossShardXferPrecompileEpoch:          big.NewInt(1),
+		AllowlistEpoch:                         EpochTBD,
+		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
+		LeaderRotationExternalBeaconLeaders:    EpochTBD,
+		FeeCollectEpoch:                        EpochTBD,
 		ValidatorCodeFixEpoch:         EpochTBD,
 	}
 
 	// PartnerChainConfig contains the chain parameters for the Partner network.
 	// This is the Devnet config
 	PartnerChainConfig = &ChainConfig{
-		ChainID:                       PartnerChainID,
-		EthCompatibleChainID:          EthPartnerShard0ChainID,
-		EthCompatibleShard0ChainID:    EthPartnerShard0ChainID,
-		EthCompatibleEpoch:            big.NewInt(0),
-		CrossTxEpoch:                  big.NewInt(0),
-		CrossLinkEpoch:                big.NewInt(2),
-		AggregatedRewardEpoch:         big.NewInt(3),
-		StakingEpoch:                  big.NewInt(2),
-		PreStakingEpoch:               big.NewInt(1),
-		QuickUnlockEpoch:              big.NewInt(0),
-		FiveSecondsEpoch:              big.NewInt(0),
-		TwoSecondsEpoch:               big.NewInt(0),
-		SixtyPercentEpoch:             big.NewInt(4),
-		RedelegationEpoch:             big.NewInt(0),
-		NoEarlyUnlockEpoch:            big.NewInt(0),
-		VRFEpoch:                      big.NewInt(0),
-		PrevVRFEpoch:                  big.NewInt(0),
-		MinDelegation100Epoch:         big.NewInt(0),
-		MinCommissionRateEpoch:        big.NewInt(0),
-		MinCommissionPromoPeriod:      big.NewInt(10),
-		EPoSBound35Epoch:              big.NewInt(0),
-		EIP155Epoch:                   big.NewInt(0),
-		S3Epoch:                       big.NewInt(0),
-		DataCopyFixEpoch:              big.NewInt(0),
-		IstanbulEpoch:                 big.NewInt(0),
-		ReceiptLogEpoch:               big.NewInt(0),
-		SHA3Epoch:                     big.NewInt(0),
-		HIP6And8Epoch:                 big.NewInt(0),
-		StakingPrecompileEpoch:        big.NewInt(2),
-		ChainIdFixEpoch:               big.NewInt(0),
-		SlotsLimitedEpoch:             EpochTBD, // epoch to enable HIP-16
-		CrossShardXferPrecompileEpoch: big.NewInt(1),
-		AllowlistEpoch:                EpochTBD,
-		FeeCollectEpoch:               big.NewInt(574),
-		NonBeaconLeaderRotation:       EpochTBD,
+		ChainID:                                PartnerChainID,
+		EthCompatibleChainID:                   EthPartnerShard0ChainID,
+		EthCompatibleShard0ChainID:             EthPartnerShard0ChainID,
+		EthCompatibleEpoch:                     big.NewInt(0),
+		CrossTxEpoch:                           big.NewInt(0),
+		CrossLinkEpoch:                         big.NewInt(2),
+		AggregatedRewardEpoch:                  big.NewInt(3),
+		StakingEpoch:                           big.NewInt(2),
+		PreStakingEpoch:                        big.NewInt(1),
+		QuickUnlockEpoch:                       big.NewInt(0),
+		FiveSecondsEpoch:                       big.NewInt(0),
+		TwoSecondsEpoch:                        big.NewInt(0),
+		SixtyPercentEpoch:                      big.NewInt(4),
+		RedelegationEpoch:                      big.NewInt(0),
+		NoEarlyUnlockEpoch:                     big.NewInt(0),
+		VRFEpoch:                               big.NewInt(0),
+		PrevVRFEpoch:                           big.NewInt(0),
+		MinDelegation100Epoch:                  big.NewInt(0),
+		MinCommissionRateEpoch:                 big.NewInt(0),
+		MinCommissionPromoPeriod:               big.NewInt(10),
+		EPoSBound35Epoch:                       big.NewInt(0),
+		EIP155Epoch:                            big.NewInt(0),
+		S3Epoch:                                big.NewInt(0),
+		DataCopyFixEpoch:                       big.NewInt(0),
+		IstanbulEpoch:                          big.NewInt(0),
+		ReceiptLogEpoch:                        big.NewInt(0),
+		SHA3Epoch:                              big.NewInt(0),
+		HIP6And8Epoch:                          big.NewInt(0),
+		StakingPrecompileEpoch:                 big.NewInt(2),
+		ChainIdFixEpoch:                        big.NewInt(0),
+		SlotsLimitedEpoch:                      EpochTBD, // epoch to enable HIP-16
+		CrossShardXferPrecompileEpoch:          big.NewInt(1),
+		AllowlistEpoch:                         EpochTBD,
+		FeeCollectEpoch:                        big.NewInt(574),
+		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
+		LeaderRotationExternalBeaconLeaders:    EpochTBD,
 		ValidatorCodeFixEpoch:         EpochTBD,
 	}
 
 	// StressnetChainConfig contains the chain parameters for the Stress test network.
 	// All features except for CrossLink are enabled at launch.
 	StressnetChainConfig = &ChainConfig{
-		ChainID:                       StressnetChainID,
-		EthCompatibleChainID:          EthStressnetShard0ChainID,
-		EthCompatibleShard0ChainID:    EthStressnetShard0ChainID,
-		EthCompatibleEpoch:            big.NewInt(0),
-		CrossTxEpoch:                  big.NewInt(0),
-		CrossLinkEpoch:                big.NewInt(2),
-		AggregatedRewardEpoch:         big.NewInt(3),
-		StakingEpoch:                  big.NewInt(2),
-		PreStakingEpoch:               big.NewInt(1),
-		QuickUnlockEpoch:              big.NewInt(0),
-		FiveSecondsEpoch:              big.NewInt(0),
-		TwoSecondsEpoch:               big.NewInt(0),
-		SixtyPercentEpoch:             big.NewInt(10),
-		RedelegationEpoch:             big.NewInt(0),
-		NoEarlyUnlockEpoch:            big.NewInt(0),
-		VRFEpoch:                      big.NewInt(0),
-		PrevVRFEpoch:                  big.NewInt(0),
-		MinDelegation100Epoch:         big.NewInt(0),
-		MinCommissionRateEpoch:        big.NewInt(0),
-		MinCommissionPromoPeriod:      big.NewInt(10),
-		EPoSBound35Epoch:              big.NewInt(0),
-		EIP155Epoch:                   big.NewInt(0),
-		S3Epoch:                       big.NewInt(0),
-		DataCopyFixEpoch:              big.NewInt(0),
-		IstanbulEpoch:                 big.NewInt(0),
-		ReceiptLogEpoch:               big.NewInt(0),
-		SHA3Epoch:                     big.NewInt(0),
-		HIP6And8Epoch:                 big.NewInt(0),
-		StakingPrecompileEpoch:        big.NewInt(2),
-		ChainIdFixEpoch:               big.NewInt(0),
-		SlotsLimitedEpoch:             EpochTBD, // epoch to enable HIP-16
-		CrossShardXferPrecompileEpoch: big.NewInt(1),
-		AllowlistEpoch:                EpochTBD,
-		FeeCollectEpoch:               EpochTBD,
-		NonBeaconLeaderRotation:       EpochTBD,
+		ChainID:                                StressnetChainID,
+		EthCompatibleChainID:                   EthStressnetShard0ChainID,
+		EthCompatibleShard0ChainID:             EthStressnetShard0ChainID,
+		EthCompatibleEpoch:                     big.NewInt(0),
+		CrossTxEpoch:                           big.NewInt(0),
+		CrossLinkEpoch:                         big.NewInt(2),
+		AggregatedRewardEpoch:                  big.NewInt(3),
+		StakingEpoch:                           big.NewInt(2),
+		PreStakingEpoch:                        big.NewInt(1),
+		QuickUnlockEpoch:                       big.NewInt(0),
+		FiveSecondsEpoch:                       big.NewInt(0),
+		TwoSecondsEpoch:                        big.NewInt(0),
+		SixtyPercentEpoch:                      big.NewInt(10),
+		RedelegationEpoch:                      big.NewInt(0),
+		NoEarlyUnlockEpoch:                     big.NewInt(0),
+		VRFEpoch:                               big.NewInt(0),
+		PrevVRFEpoch:                           big.NewInt(0),
+		MinDelegation100Epoch:                  big.NewInt(0),
+		MinCommissionRateEpoch:                 big.NewInt(0),
+		MinCommissionPromoPeriod:               big.NewInt(10),
+		EPoSBound35Epoch:                       big.NewInt(0),
+		EIP155Epoch:                            big.NewInt(0),
+		S3Epoch:                                big.NewInt(0),
+		DataCopyFixEpoch:                       big.NewInt(0),
+		IstanbulEpoch:                          big.NewInt(0),
+		ReceiptLogEpoch:                        big.NewInt(0),
+		SHA3Epoch:                              big.NewInt(0),
+		HIP6And8Epoch:                          big.NewInt(0),
+		StakingPrecompileEpoch:                 big.NewInt(2),
+		ChainIdFixEpoch:                        big.NewInt(0),
+		SlotsLimitedEpoch:                      EpochTBD, // epoch to enable HIP-16
+		CrossShardXferPrecompileEpoch:          big.NewInt(1),
+		AllowlistEpoch:                         EpochTBD,
+		FeeCollectEpoch:                        EpochTBD,
+		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
+		LeaderRotationExternalBeaconLeaders:    EpochTBD,
 		ValidatorCodeFixEpoch:         EpochTBD,
 	}
 
 	// LocalnetChainConfig contains the chain parameters to run for local development.
 	LocalnetChainConfig = &ChainConfig{
-		ChainID:                       TestnetChainID,
-		EthCompatibleChainID:          EthTestnetShard0ChainID,
-		EthCompatibleShard0ChainID:    EthTestnetShard0ChainID,
-		EthCompatibleEpoch:            big.NewInt(0),
-		CrossTxEpoch:                  big.NewInt(0),
-		CrossLinkEpoch:                big.NewInt(2),
-		AggregatedRewardEpoch:         big.NewInt(3),
-		StakingEpoch:                  big.NewInt(2),
-		PreStakingEpoch:               big.NewInt(0),
-		QuickUnlockEpoch:              big.NewInt(0),
-		FiveSecondsEpoch:              big.NewInt(0),
-		TwoSecondsEpoch:               big.NewInt(0),
-		SixtyPercentEpoch:             EpochTBD, // Never enable it for localnet as localnet has no external validator setup
-		RedelegationEpoch:             big.NewInt(0),
-		NoEarlyUnlockEpoch:            big.NewInt(0),
-		VRFEpoch:                      big.NewInt(0),
-		PrevVRFEpoch:                  big.NewInt(0),
-		MinDelegation100Epoch:         big.NewInt(0),
-		MinCommissionRateEpoch:        big.NewInt(0),
-		MinCommissionPromoPeriod:      big.NewInt(10),
-		EPoSBound35Epoch:              big.NewInt(0),
-		EIP155Epoch:                   big.NewInt(0),
-		S3Epoch:                       big.NewInt(0),
-		DataCopyFixEpoch:              big.NewInt(0),
-		IstanbulEpoch:                 big.NewInt(0),
-		ReceiptLogEpoch:               big.NewInt(0),
-		SHA3Epoch:                     big.NewInt(0),
-		HIP6And8Epoch:                 EpochTBD, // Never enable it for localnet as localnet has no external validator setup
-		StakingPrecompileEpoch:        big.NewInt(2),
-		ChainIdFixEpoch:               big.NewInt(0),
-		SlotsLimitedEpoch:             EpochTBD, // epoch to enable HIP-16
-		CrossShardXferPrecompileEpoch: big.NewInt(1),
-		AllowlistEpoch:                EpochTBD,
-		NonBeaconLeaderRotation:       EpochTBD,
-		FeeCollectEpoch:               big.NewInt(5),
+		ChainID:                                TestnetChainID,
+		EthCompatibleChainID:                   EthTestnetShard0ChainID,
+		EthCompatibleShard0ChainID:             EthTestnetShard0ChainID,
+		EthCompatibleEpoch:                     big.NewInt(0),
+		CrossTxEpoch:                           big.NewInt(0),
+		CrossLinkEpoch:                         big.NewInt(2),
+		AggregatedRewardEpoch:                  big.NewInt(3),
+		StakingEpoch:                           big.NewInt(2),
+		PreStakingEpoch:                        big.NewInt(0),
+		QuickUnlockEpoch:                       big.NewInt(0),
+		FiveSecondsEpoch:                       big.NewInt(0),
+		TwoSecondsEpoch:                        big.NewInt(0),
+		SixtyPercentEpoch:                      EpochTBD, // Never enable it for localnet as localnet has no external validator setup
+		RedelegationEpoch:                      big.NewInt(0),
+		NoEarlyUnlockEpoch:                     big.NewInt(0),
+		VRFEpoch:                               big.NewInt(0),
+		PrevVRFEpoch:                           big.NewInt(0),
+		MinDelegation100Epoch:                  big.NewInt(0),
+		MinCommissionRateEpoch:                 big.NewInt(0),
+		MinCommissionPromoPeriod:               big.NewInt(10),
+		EPoSBound35Epoch:                       big.NewInt(0),
+		EIP155Epoch:                            big.NewInt(0),
+		S3Epoch:                                big.NewInt(0),
+		DataCopyFixEpoch:                       big.NewInt(0),
+		IstanbulEpoch:                          big.NewInt(0),
+		ReceiptLogEpoch:                        big.NewInt(0),
+		SHA3Epoch:                              big.NewInt(0),
+		HIP6And8Epoch:                          EpochTBD, // Never enable it for localnet as localnet has no external validator setup
+		StakingPrecompileEpoch:                 big.NewInt(2),
+		ChainIdFixEpoch:                        big.NewInt(0),
+		SlotsLimitedEpoch:                      EpochTBD, // epoch to enable HIP-16
+		CrossShardXferPrecompileEpoch:          big.NewInt(1),
+		AllowlistEpoch:                         EpochTBD,
+		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
+		LeaderRotationExternalBeaconLeaders:    EpochTBD,
+		FeeCollectEpoch:                        big.NewInt(5),
 		ValidatorCodeFixEpoch:         EpochTBD,
 	}
 
@@ -313,7 +319,8 @@ var (
 		big.NewInt(0),                      // SlotsLimitedEpoch
 		big.NewInt(1),                      // CrossShardXferPrecompileEpoch
 		big.NewInt(0),                      // AllowlistEpoch
-		big.NewInt(1),                      // LeaderRotationEpoch
+		big.NewInt(1),                      // LeaderRotationExternalNonBeaconLeaders
+		big.NewInt(1),                      // LeaderRotationExternalBeaconLeaders
 		big.NewInt(0),                      // FeeCollectEpoch
 		big.NewInt(0),                      // ValidatorCodeFixEpoch
 	}
@@ -355,7 +362,8 @@ var (
 		big.NewInt(0),        // SlotsLimitedEpoch
 		big.NewInt(1),        // CrossShardXferPrecompileEpoch
 		big.NewInt(0),        // AllowlistEpoch
-		big.NewInt(1),        // LeaderRotationEpoch
+		big.NewInt(1),        // LeaderRotationExternalNonBeaconLeaders
+		big.NewInt(1),        // LeaderRotationExternalBeaconLeaders
 		big.NewInt(0),        // FeeCollectEpoch
 		big.NewInt(0),        // ValidatorCodeFixEpoch
 	}
@@ -497,7 +505,9 @@ type ChainConfig struct {
 	// AllowlistEpoch is the first epoch to support allowlist of HIP18
 	AllowlistEpoch *big.Int
 
-	NonBeaconLeaderRotation *big.Int `json:"non-beacon-leader-rotation-epoch,omitempty"`
+	LeaderRotationExternalNonBeaconLeaders *big.Int `json:"non-beacon-leader-rotation-epoch,omitempty"`
+
+	LeaderRotationExternalBeaconLeaders *big.Int `json:"non-beacon-leader-rotation-epoch,omitempty"`
 
 	// FeeCollectEpoch is the first epoch that enables txn fees to be collected into the community-managed account.
 	// It should >= StakingEpoch.
@@ -714,8 +724,18 @@ func (c *ChainConfig) IsAllowlistEpoch(epoch *big.Int) bool {
 	return isForked(c.AllowlistEpoch, epoch)
 }
 
-func (c *ChainConfig) IsNonBeaconLeaderRotation(epoch *big.Int) bool {
-	return isForked(c.NonBeaconLeaderRotation, epoch)
+func (c *ChainConfig) IsLeaderRotation(epoch *big.Int) bool {
+	return isForked(c.LeaderRotationExternalNonBeaconLeaders, epoch)
+}
+
+func (c *ChainConfig) IsLeaderRotationExternalValidatorsAllowed(epoch *big.Int, shardID uint32) bool {
+	if !c.IsLeaderRotation(epoch) {
+		return false
+	}
+	if shardID == 0 {
+		return isForked(c.LeaderRotationExternalBeaconLeaders, epoch)
+	}
+	return true
 }
 
 // IsFeeCollectEpoch determines whether Txn Fees will be collected into the community-managed account.

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -70,8 +70,7 @@ var (
 		CrossShardXferPrecompileEpoch: big.NewInt(1323), // Around Wed 8 Feb 11:30PM UTC
 		AllowlistEpoch:                EpochTBD,
 		FeeCollectEpoch:               EpochTBD,
-		LeaderRotationEpoch:           EpochTBD,
-		LeaderRotationBlocksCount:     64,
+		NonBeaconLeaderRotation:       EpochTBD,
 		ValidatorCodeFixEpoch:         EpochTBD,
 	}
 
@@ -110,8 +109,7 @@ var (
 		ChainIdFixEpoch:               big.NewInt(0),
 		CrossShardXferPrecompileEpoch: big.NewInt(2),
 		AllowlistEpoch:                big.NewInt(2),
-		LeaderRotationEpoch:           EpochTBD,
-		LeaderRotationBlocksCount:     64,
+		NonBeaconLeaderRotation:       EpochTBD,
 		FeeCollectEpoch:               EpochTBD,
 		ValidatorCodeFixEpoch:         EpochTBD,
 	}
@@ -151,8 +149,7 @@ var (
 		SlotsLimitedEpoch:             EpochTBD, // epoch to enable HIP-16
 		CrossShardXferPrecompileEpoch: big.NewInt(1),
 		AllowlistEpoch:                EpochTBD,
-		LeaderRotationEpoch:           EpochTBD,
-		LeaderRotationBlocksCount:     64,
+		NonBeaconLeaderRotation:       EpochTBD,
 		FeeCollectEpoch:               EpochTBD,
 		ValidatorCodeFixEpoch:         EpochTBD,
 	}
@@ -194,8 +191,7 @@ var (
 		CrossShardXferPrecompileEpoch: big.NewInt(1),
 		AllowlistEpoch:                EpochTBD,
 		FeeCollectEpoch:               big.NewInt(574),
-		LeaderRotationEpoch:           EpochTBD,
-		LeaderRotationBlocksCount:     64,
+		NonBeaconLeaderRotation:       EpochTBD,
 		ValidatorCodeFixEpoch:         EpochTBD,
 	}
 
@@ -236,8 +232,7 @@ var (
 		CrossShardXferPrecompileEpoch: big.NewInt(1),
 		AllowlistEpoch:                EpochTBD,
 		FeeCollectEpoch:               EpochTBD,
-		LeaderRotationEpoch:           EpochTBD,
-		LeaderRotationBlocksCount:     64,
+		NonBeaconLeaderRotation:       EpochTBD,
 		ValidatorCodeFixEpoch:         EpochTBD,
 	}
 
@@ -276,8 +271,7 @@ var (
 		SlotsLimitedEpoch:             EpochTBD, // epoch to enable HIP-16
 		CrossShardXferPrecompileEpoch: big.NewInt(1),
 		AllowlistEpoch:                EpochTBD,
-		LeaderRotationEpoch:           EpochTBD,
-		LeaderRotationBlocksCount:     5,
+		NonBeaconLeaderRotation:       EpochTBD,
 		FeeCollectEpoch:               big.NewInt(5),
 		ValidatorCodeFixEpoch:         EpochTBD,
 	}
@@ -320,7 +314,6 @@ var (
 		big.NewInt(1),                      // CrossShardXferPrecompileEpoch
 		big.NewInt(0),                      // AllowlistEpoch
 		big.NewInt(1),                      // LeaderRotationEpoch
-		64,                                 // LeaderRotationBlocksCount
 		big.NewInt(0),                      // FeeCollectEpoch
 		big.NewInt(0),                      // ValidatorCodeFixEpoch
 	}
@@ -363,7 +356,6 @@ var (
 		big.NewInt(1),        // CrossShardXferPrecompileEpoch
 		big.NewInt(0),        // AllowlistEpoch
 		big.NewInt(1),        // LeaderRotationEpoch
-		64,                   // LeaderRotationBlocksCount
 		big.NewInt(0),        // FeeCollectEpoch
 		big.NewInt(0),        // ValidatorCodeFixEpoch
 	}
@@ -505,9 +497,7 @@ type ChainConfig struct {
 	// AllowlistEpoch is the first epoch to support allowlist of HIP18
 	AllowlistEpoch *big.Int
 
-	LeaderRotationEpoch *big.Int `json:"leader-rotation-epoch,omitempty"`
-
-	LeaderRotationBlocksCount int `json:"leader-rotation-blocks-count,omitempty"`
+	NonBeaconLeaderRotation *big.Int `json:"non-beacon-leader-rotation-epoch,omitempty"`
 
 	// FeeCollectEpoch is the first epoch that enables txn fees to be collected into the community-managed account.
 	// It should >= StakingEpoch.
@@ -724,8 +714,8 @@ func (c *ChainConfig) IsAllowlistEpoch(epoch *big.Int) bool {
 	return isForked(c.AllowlistEpoch, epoch)
 }
 
-func (c *ChainConfig) IsLeaderRotation(epoch *big.Int) bool {
-	return isForked(c.LeaderRotationEpoch, epoch)
+func (c *ChainConfig) IsNonBeaconLeaderRotation(epoch *big.Int) bool {
+	return isForked(c.NonBeaconLeaderRotation, epoch)
 }
 
 // IsFeeCollectEpoch determines whether Txn Fees will be collected into the community-managed account.

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -36,249 +36,243 @@ var once sync.Once
 var (
 	// MainnetChainConfig is the chain parameters to run a node on the main network.
 	MainnetChainConfig = &ChainConfig{
-		ChainID:                                MainnetChainID,
-		EthCompatibleChainID:                   EthMainnetShard0ChainID,
-		EthCompatibleShard0ChainID:             EthMainnetShard0ChainID,
-		EthCompatibleEpoch:                     big.NewInt(442), // Around Thursday Feb 4th 2020, 10AM PST
-		CrossTxEpoch:                           big.NewInt(28),
-		CrossLinkEpoch:                         big.NewInt(186),
-		AggregatedRewardEpoch:                  big.NewInt(689), // Around Wed Sept 15th 2021 with 3.5s block time
-		StakingEpoch:                           big.NewInt(186),
-		PreStakingEpoch:                        big.NewInt(185),
-		QuickUnlockEpoch:                       big.NewInt(191),
-		FiveSecondsEpoch:                       big.NewInt(230),
-		TwoSecondsEpoch:                        big.NewInt(366), // Around Tuesday Dec 8th 2020, 8AM PST
-		SixtyPercentEpoch:                      big.NewInt(530), // Around Monday Apr 12th 2021, 22:30 UTC
-		RedelegationEpoch:                      big.NewInt(290),
-		NoEarlyUnlockEpoch:                     big.NewInt(530), // Around Monday Apr 12th 2021, 22:30 UTC
-		VRFEpoch:                               big.NewInt(631), // Around Wed July 7th 2021
-		PrevVRFEpoch:                           big.NewInt(689), // Around Wed Sept 15th 2021 with 3.5s block time
-		MinDelegation100Epoch:                  big.NewInt(631), // Around Wed July 7th 2021
-		MinCommissionRateEpoch:                 big.NewInt(631), // Around Wed July 7th 2021
-		MinCommissionPromoPeriod:               big.NewInt(100),
-		EPoSBound35Epoch:                       big.NewInt(631), // Around Wed July 7th 2021
-		EIP155Epoch:                            big.NewInt(28),
-		S3Epoch:                                big.NewInt(28),
-		DataCopyFixEpoch:                       big.NewInt(689), // Around Wed Sept 15th 2021 with 3.5s block time
-		IstanbulEpoch:                          big.NewInt(314),
-		ReceiptLogEpoch:                        big.NewInt(101),
-		SHA3Epoch:                              big.NewInt(725),  // Around Mon Oct 11 2021, 19:00 UTC
-		HIP6And8Epoch:                          big.NewInt(725),  // Around Mon Oct 11 2021, 19:00 UTC
-		StakingPrecompileEpoch:                 big.NewInt(871),  // Around Tue Feb 11 2022
-		ChainIdFixEpoch:                        big.NewInt(1323), // Around Wed 8 Feb 11:30PM UTC
-		SlotsLimitedEpoch:                      big.NewInt(999),  // Around Fri, 27 May 2022 09:41:02 UTC with 2s block time
-		CrossShardXferPrecompileEpoch:          big.NewInt(1323), // Around Wed 8 Feb 11:30PM UTC
-		AllowlistEpoch:                         EpochTBD,
-		FeeCollectEpoch:                        EpochTBD,
-		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
-		LeaderRotationExternalBeaconLeaders:    EpochTBD,
+		ChainID:                       MainnetChainID,
+		EthCompatibleChainID:          EthMainnetShard0ChainID,
+		EthCompatibleShard0ChainID:    EthMainnetShard0ChainID,
+		EthCompatibleEpoch:            big.NewInt(442), // Around Thursday Feb 4th 2020, 10AM PST
+		CrossTxEpoch:                  big.NewInt(28),
+		CrossLinkEpoch:                big.NewInt(186),
+		AggregatedRewardEpoch:         big.NewInt(689), // Around Wed Sept 15th 2021 with 3.5s block time
+		StakingEpoch:                  big.NewInt(186),
+		PreStakingEpoch:               big.NewInt(185),
+		QuickUnlockEpoch:              big.NewInt(191),
+		FiveSecondsEpoch:              big.NewInt(230),
+		TwoSecondsEpoch:               big.NewInt(366), // Around Tuesday Dec 8th 2020, 8AM PST
+		SixtyPercentEpoch:             big.NewInt(530), // Around Monday Apr 12th 2021, 22:30 UTC
+		RedelegationEpoch:             big.NewInt(290),
+		NoEarlyUnlockEpoch:            big.NewInt(530), // Around Monday Apr 12th 2021, 22:30 UTC
+		VRFEpoch:                      big.NewInt(631), // Around Wed July 7th 2021
+		PrevVRFEpoch:                  big.NewInt(689), // Around Wed Sept 15th 2021 with 3.5s block time
+		MinDelegation100Epoch:         big.NewInt(631), // Around Wed July 7th 2021
+		MinCommissionRateEpoch:        big.NewInt(631), // Around Wed July 7th 2021
+		MinCommissionPromoPeriod:      big.NewInt(100),
+		EPoSBound35Epoch:              big.NewInt(631), // Around Wed July 7th 2021
+		EIP155Epoch:                   big.NewInt(28),
+		S3Epoch:                       big.NewInt(28),
+		DataCopyFixEpoch:              big.NewInt(689), // Around Wed Sept 15th 2021 with 3.5s block time
+		IstanbulEpoch:                 big.NewInt(314),
+		ReceiptLogEpoch:               big.NewInt(101),
+		SHA3Epoch:                     big.NewInt(725),  // Around Mon Oct 11 2021, 19:00 UTC
+		HIP6And8Epoch:                 big.NewInt(725),  // Around Mon Oct 11 2021, 19:00 UTC
+		StakingPrecompileEpoch:        big.NewInt(871),  // Around Tue Feb 11 2022
+		ChainIdFixEpoch:               big.NewInt(1323), // Around Wed 8 Feb 11:30PM UTC
+		SlotsLimitedEpoch:             big.NewInt(999),  // Around Fri, 27 May 2022 09:41:02 UTC with 2s block time
+		CrossShardXferPrecompileEpoch: big.NewInt(1323), // Around Wed 8 Feb 11:30PM UTC
+		AllowlistEpoch:                EpochTBD,
+		FeeCollectEpoch:               EpochTBD,
+		NonBeaconLeaderRotation:       EpochTBD,
 		ValidatorCodeFixEpoch:         EpochTBD,
 	}
 
 	// TestnetChainConfig contains the chain parameters to run a node on the harmony test network.
 	TestnetChainConfig = &ChainConfig{
-		ChainID:                                TestnetChainID,
-		EthCompatibleChainID:                   EthTestnetShard0ChainID,
-		EthCompatibleShard0ChainID:             EthTestnetShard0ChainID,
-		EthCompatibleEpoch:                     big.NewInt(0),
-		CrossTxEpoch:                           big.NewInt(0),
-		CrossLinkEpoch:                         big.NewInt(2),
-		AggregatedRewardEpoch:                  big.NewInt(2),
-		StakingEpoch:                           big.NewInt(2),
-		PreStakingEpoch:                        big.NewInt(1),
-		QuickUnlockEpoch:                       big.NewInt(0),
-		FiveSecondsEpoch:                       big.NewInt(0),
-		TwoSecondsEpoch:                        big.NewInt(2),
-		SixtyPercentEpoch:                      big.NewInt(2),
-		RedelegationEpoch:                      big.NewInt(2),
-		NoEarlyUnlockEpoch:                     big.NewInt(2),
-		VRFEpoch:                               big.NewInt(2),
-		PrevVRFEpoch:                           big.NewInt(2),
-		MinDelegation100Epoch:                  big.NewInt(2),
-		MinCommissionRateEpoch:                 big.NewInt(2),
-		MinCommissionPromoPeriod:               big.NewInt(2),
-		EPoSBound35Epoch:                       big.NewInt(2),
-		EIP155Epoch:                            big.NewInt(0),
-		S3Epoch:                                big.NewInt(0),
-		DataCopyFixEpoch:                       big.NewInt(0),
-		IstanbulEpoch:                          big.NewInt(0),
-		ReceiptLogEpoch:                        big.NewInt(0),
-		SHA3Epoch:                              big.NewInt(0),
-		HIP6And8Epoch:                          big.NewInt(2),
-		StakingPrecompileEpoch:                 big.NewInt(2),
-		SlotsLimitedEpoch:                      big.NewInt(2),
-		ChainIdFixEpoch:                        big.NewInt(0),
-		CrossShardXferPrecompileEpoch:          big.NewInt(2),
-		AllowlistEpoch:                         big.NewInt(2),
-		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
-		LeaderRotationExternalBeaconLeaders:    EpochTBD,
-		FeeCollectEpoch:                        EpochTBD,
+		ChainID:                       TestnetChainID,
+		EthCompatibleChainID:          EthTestnetShard0ChainID,
+		EthCompatibleShard0ChainID:    EthTestnetShard0ChainID,
+		EthCompatibleEpoch:            big.NewInt(0),
+		CrossTxEpoch:                  big.NewInt(0),
+		CrossLinkEpoch:                big.NewInt(2),
+		AggregatedRewardEpoch:         big.NewInt(2),
+		StakingEpoch:                  big.NewInt(2),
+		PreStakingEpoch:               big.NewInt(1),
+		QuickUnlockEpoch:              big.NewInt(0),
+		FiveSecondsEpoch:              big.NewInt(0),
+		TwoSecondsEpoch:               big.NewInt(2),
+		SixtyPercentEpoch:             big.NewInt(2),
+		RedelegationEpoch:             big.NewInt(2),
+		NoEarlyUnlockEpoch:            big.NewInt(2),
+		VRFEpoch:                      big.NewInt(2),
+		PrevVRFEpoch:                  big.NewInt(2),
+		MinDelegation100Epoch:         big.NewInt(2),
+		MinCommissionRateEpoch:        big.NewInt(2),
+		MinCommissionPromoPeriod:      big.NewInt(2),
+		EPoSBound35Epoch:              big.NewInt(2),
+		EIP155Epoch:                   big.NewInt(0),
+		S3Epoch:                       big.NewInt(0),
+		DataCopyFixEpoch:              big.NewInt(0),
+		IstanbulEpoch:                 big.NewInt(0),
+		ReceiptLogEpoch:               big.NewInt(0),
+		SHA3Epoch:                     big.NewInt(0),
+		HIP6And8Epoch:                 big.NewInt(2),
+		StakingPrecompileEpoch:        big.NewInt(2),
+		SlotsLimitedEpoch:             big.NewInt(2),
+		ChainIdFixEpoch:               big.NewInt(0),
+		CrossShardXferPrecompileEpoch: big.NewInt(2),
+		AllowlistEpoch:                big.NewInt(2),
+		NonBeaconLeaderRotation:       EpochTBD,
+		FeeCollectEpoch:               EpochTBD,
 		ValidatorCodeFixEpoch:         EpochTBD,
 	}
 	// PangaeaChainConfig contains the chain parameters for the Pangaea network.
 	// All features except for CrossLink are enabled at launch.
 	PangaeaChainConfig = &ChainConfig{
-		ChainID:                                PangaeaChainID,
-		EthCompatibleChainID:                   EthPangaeaShard0ChainID,
-		EthCompatibleShard0ChainID:             EthPangaeaShard0ChainID,
-		EthCompatibleEpoch:                     big.NewInt(0),
-		CrossTxEpoch:                           big.NewInt(0),
-		CrossLinkEpoch:                         big.NewInt(2),
-		AggregatedRewardEpoch:                  big.NewInt(3),
-		StakingEpoch:                           big.NewInt(2),
-		PreStakingEpoch:                        big.NewInt(1),
-		QuickUnlockEpoch:                       big.NewInt(0),
-		FiveSecondsEpoch:                       big.NewInt(0),
-		TwoSecondsEpoch:                        big.NewInt(0),
-		SixtyPercentEpoch:                      big.NewInt(0),
-		RedelegationEpoch:                      big.NewInt(0),
-		NoEarlyUnlockEpoch:                     big.NewInt(0),
-		VRFEpoch:                               big.NewInt(0),
-		PrevVRFEpoch:                           big.NewInt(0),
-		MinDelegation100Epoch:                  big.NewInt(0),
-		MinCommissionRateEpoch:                 big.NewInt(0),
-		MinCommissionPromoPeriod:               big.NewInt(10),
-		EPoSBound35Epoch:                       big.NewInt(0),
-		EIP155Epoch:                            big.NewInt(0),
-		S3Epoch:                                big.NewInt(0),
-		DataCopyFixEpoch:                       big.NewInt(0),
-		IstanbulEpoch:                          big.NewInt(0),
-		ReceiptLogEpoch:                        big.NewInt(0),
-		SHA3Epoch:                              big.NewInt(0),
-		HIP6And8Epoch:                          big.NewInt(0),
-		StakingPrecompileEpoch:                 big.NewInt(2), // same as staking
-		ChainIdFixEpoch:                        big.NewInt(0),
-		SlotsLimitedEpoch:                      EpochTBD, // epoch to enable HIP-16
-		CrossShardXferPrecompileEpoch:          big.NewInt(1),
-		AllowlistEpoch:                         EpochTBD,
-		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
-		LeaderRotationExternalBeaconLeaders:    EpochTBD,
-		FeeCollectEpoch:                        EpochTBD,
+		ChainID:                       PangaeaChainID,
+		EthCompatibleChainID:          EthPangaeaShard0ChainID,
+		EthCompatibleShard0ChainID:    EthPangaeaShard0ChainID,
+		EthCompatibleEpoch:            big.NewInt(0),
+		CrossTxEpoch:                  big.NewInt(0),
+		CrossLinkEpoch:                big.NewInt(2),
+		AggregatedRewardEpoch:         big.NewInt(3),
+		StakingEpoch:                  big.NewInt(2),
+		PreStakingEpoch:               big.NewInt(1),
+		QuickUnlockEpoch:              big.NewInt(0),
+		FiveSecondsEpoch:              big.NewInt(0),
+		TwoSecondsEpoch:               big.NewInt(0),
+		SixtyPercentEpoch:             big.NewInt(0),
+		RedelegationEpoch:             big.NewInt(0),
+		NoEarlyUnlockEpoch:            big.NewInt(0),
+		VRFEpoch:                      big.NewInt(0),
+		PrevVRFEpoch:                  big.NewInt(0),
+		MinDelegation100Epoch:         big.NewInt(0),
+		MinCommissionRateEpoch:        big.NewInt(0),
+		MinCommissionPromoPeriod:      big.NewInt(10),
+		EPoSBound35Epoch:              big.NewInt(0),
+		EIP155Epoch:                   big.NewInt(0),
+		S3Epoch:                       big.NewInt(0),
+		DataCopyFixEpoch:              big.NewInt(0),
+		IstanbulEpoch:                 big.NewInt(0),
+		ReceiptLogEpoch:               big.NewInt(0),
+		SHA3Epoch:                     big.NewInt(0),
+		HIP6And8Epoch:                 big.NewInt(0),
+		StakingPrecompileEpoch:        big.NewInt(2), // same as staking
+		ChainIdFixEpoch:               big.NewInt(0),
+		SlotsLimitedEpoch:             EpochTBD, // epoch to enable HIP-16
+		CrossShardXferPrecompileEpoch: big.NewInt(1),
+		AllowlistEpoch:                EpochTBD,
+		NonBeaconLeaderRotation:       EpochTBD,
+		FeeCollectEpoch:               EpochTBD,
 		ValidatorCodeFixEpoch:         EpochTBD,
 	}
 
 	// PartnerChainConfig contains the chain parameters for the Partner network.
 	// This is the Devnet config
 	PartnerChainConfig = &ChainConfig{
-		ChainID:                                PartnerChainID,
-		EthCompatibleChainID:                   EthPartnerShard0ChainID,
-		EthCompatibleShard0ChainID:             EthPartnerShard0ChainID,
-		EthCompatibleEpoch:                     big.NewInt(0),
-		CrossTxEpoch:                           big.NewInt(0),
-		CrossLinkEpoch:                         big.NewInt(2),
-		AggregatedRewardEpoch:                  big.NewInt(3),
-		StakingEpoch:                           big.NewInt(2),
-		PreStakingEpoch:                        big.NewInt(1),
-		QuickUnlockEpoch:                       big.NewInt(0),
-		FiveSecondsEpoch:                       big.NewInt(0),
-		TwoSecondsEpoch:                        big.NewInt(0),
-		SixtyPercentEpoch:                      big.NewInt(4),
-		RedelegationEpoch:                      big.NewInt(0),
-		NoEarlyUnlockEpoch:                     big.NewInt(0),
-		VRFEpoch:                               big.NewInt(0),
-		PrevVRFEpoch:                           big.NewInt(0),
-		MinDelegation100Epoch:                  big.NewInt(0),
-		MinCommissionRateEpoch:                 big.NewInt(0),
-		MinCommissionPromoPeriod:               big.NewInt(10),
-		EPoSBound35Epoch:                       big.NewInt(0),
-		EIP155Epoch:                            big.NewInt(0),
-		S3Epoch:                                big.NewInt(0),
-		DataCopyFixEpoch:                       big.NewInt(0),
-		IstanbulEpoch:                          big.NewInt(0),
-		ReceiptLogEpoch:                        big.NewInt(0),
-		SHA3Epoch:                              big.NewInt(0),
-		HIP6And8Epoch:                          big.NewInt(0),
-		StakingPrecompileEpoch:                 big.NewInt(2),
-		ChainIdFixEpoch:                        big.NewInt(0),
-		SlotsLimitedEpoch:                      EpochTBD, // epoch to enable HIP-16
-		CrossShardXferPrecompileEpoch:          big.NewInt(1),
-		AllowlistEpoch:                         EpochTBD,
-		FeeCollectEpoch:                        big.NewInt(574),
-		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
-		LeaderRotationExternalBeaconLeaders:    EpochTBD,
+		ChainID:                       PartnerChainID,
+		EthCompatibleChainID:          EthPartnerShard0ChainID,
+		EthCompatibleShard0ChainID:    EthPartnerShard0ChainID,
+		EthCompatibleEpoch:            big.NewInt(0),
+		CrossTxEpoch:                  big.NewInt(0),
+		CrossLinkEpoch:                big.NewInt(2),
+		AggregatedRewardEpoch:         big.NewInt(3),
+		StakingEpoch:                  big.NewInt(2),
+		PreStakingEpoch:               big.NewInt(1),
+		QuickUnlockEpoch:              big.NewInt(0),
+		FiveSecondsEpoch:              big.NewInt(0),
+		TwoSecondsEpoch:               big.NewInt(0),
+		SixtyPercentEpoch:             big.NewInt(4),
+		RedelegationEpoch:             big.NewInt(0),
+		NoEarlyUnlockEpoch:            big.NewInt(0),
+		VRFEpoch:                      big.NewInt(0),
+		PrevVRFEpoch:                  big.NewInt(0),
+		MinDelegation100Epoch:         big.NewInt(0),
+		MinCommissionRateEpoch:        big.NewInt(0),
+		MinCommissionPromoPeriod:      big.NewInt(10),
+		EPoSBound35Epoch:              big.NewInt(0),
+		EIP155Epoch:                   big.NewInt(0),
+		S3Epoch:                       big.NewInt(0),
+		DataCopyFixEpoch:              big.NewInt(0),
+		IstanbulEpoch:                 big.NewInt(0),
+		ReceiptLogEpoch:               big.NewInt(0),
+		SHA3Epoch:                     big.NewInt(0),
+		HIP6And8Epoch:                 big.NewInt(0),
+		StakingPrecompileEpoch:        big.NewInt(2),
+		ChainIdFixEpoch:               big.NewInt(0),
+		SlotsLimitedEpoch:             EpochTBD, // epoch to enable HIP-16
+		CrossShardXferPrecompileEpoch: big.NewInt(1),
+		AllowlistEpoch:                EpochTBD,
+		FeeCollectEpoch:               big.NewInt(574),
+		NonBeaconLeaderRotation:       EpochTBD,
 		ValidatorCodeFixEpoch:         EpochTBD,
 	}
 
 	// StressnetChainConfig contains the chain parameters for the Stress test network.
 	// All features except for CrossLink are enabled at launch.
 	StressnetChainConfig = &ChainConfig{
-		ChainID:                                StressnetChainID,
-		EthCompatibleChainID:                   EthStressnetShard0ChainID,
-		EthCompatibleShard0ChainID:             EthStressnetShard0ChainID,
-		EthCompatibleEpoch:                     big.NewInt(0),
-		CrossTxEpoch:                           big.NewInt(0),
-		CrossLinkEpoch:                         big.NewInt(2),
-		AggregatedRewardEpoch:                  big.NewInt(3),
-		StakingEpoch:                           big.NewInt(2),
-		PreStakingEpoch:                        big.NewInt(1),
-		QuickUnlockEpoch:                       big.NewInt(0),
-		FiveSecondsEpoch:                       big.NewInt(0),
-		TwoSecondsEpoch:                        big.NewInt(0),
-		SixtyPercentEpoch:                      big.NewInt(10),
-		RedelegationEpoch:                      big.NewInt(0),
-		NoEarlyUnlockEpoch:                     big.NewInt(0),
-		VRFEpoch:                               big.NewInt(0),
-		PrevVRFEpoch:                           big.NewInt(0),
-		MinDelegation100Epoch:                  big.NewInt(0),
-		MinCommissionRateEpoch:                 big.NewInt(0),
-		MinCommissionPromoPeriod:               big.NewInt(10),
-		EPoSBound35Epoch:                       big.NewInt(0),
-		EIP155Epoch:                            big.NewInt(0),
-		S3Epoch:                                big.NewInt(0),
-		DataCopyFixEpoch:                       big.NewInt(0),
-		IstanbulEpoch:                          big.NewInt(0),
-		ReceiptLogEpoch:                        big.NewInt(0),
-		SHA3Epoch:                              big.NewInt(0),
-		HIP6And8Epoch:                          big.NewInt(0),
-		StakingPrecompileEpoch:                 big.NewInt(2),
-		ChainIdFixEpoch:                        big.NewInt(0),
-		SlotsLimitedEpoch:                      EpochTBD, // epoch to enable HIP-16
-		CrossShardXferPrecompileEpoch:          big.NewInt(1),
-		AllowlistEpoch:                         EpochTBD,
-		FeeCollectEpoch:                        EpochTBD,
-		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
-		LeaderRotationExternalBeaconLeaders:    EpochTBD,
+		ChainID:                       StressnetChainID,
+		EthCompatibleChainID:          EthStressnetShard0ChainID,
+		EthCompatibleShard0ChainID:    EthStressnetShard0ChainID,
+		EthCompatibleEpoch:            big.NewInt(0),
+		CrossTxEpoch:                  big.NewInt(0),
+		CrossLinkEpoch:                big.NewInt(2),
+		AggregatedRewardEpoch:         big.NewInt(3),
+		StakingEpoch:                  big.NewInt(2),
+		PreStakingEpoch:               big.NewInt(1),
+		QuickUnlockEpoch:              big.NewInt(0),
+		FiveSecondsEpoch:              big.NewInt(0),
+		TwoSecondsEpoch:               big.NewInt(0),
+		SixtyPercentEpoch:             big.NewInt(10),
+		RedelegationEpoch:             big.NewInt(0),
+		NoEarlyUnlockEpoch:            big.NewInt(0),
+		VRFEpoch:                      big.NewInt(0),
+		PrevVRFEpoch:                  big.NewInt(0),
+		MinDelegation100Epoch:         big.NewInt(0),
+		MinCommissionRateEpoch:        big.NewInt(0),
+		MinCommissionPromoPeriod:      big.NewInt(10),
+		EPoSBound35Epoch:              big.NewInt(0),
+		EIP155Epoch:                   big.NewInt(0),
+		S3Epoch:                       big.NewInt(0),
+		DataCopyFixEpoch:              big.NewInt(0),
+		IstanbulEpoch:                 big.NewInt(0),
+		ReceiptLogEpoch:               big.NewInt(0),
+		SHA3Epoch:                     big.NewInt(0),
+		HIP6And8Epoch:                 big.NewInt(0),
+		StakingPrecompileEpoch:        big.NewInt(2),
+		ChainIdFixEpoch:               big.NewInt(0),
+		SlotsLimitedEpoch:             EpochTBD, // epoch to enable HIP-16
+		CrossShardXferPrecompileEpoch: big.NewInt(1),
+		AllowlistEpoch:                EpochTBD,
+		FeeCollectEpoch:               EpochTBD,
+		NonBeaconLeaderRotation:       EpochTBD,
 		ValidatorCodeFixEpoch:         EpochTBD,
 	}
 
 	// LocalnetChainConfig contains the chain parameters to run for local development.
 	LocalnetChainConfig = &ChainConfig{
-		ChainID:                                TestnetChainID,
-		EthCompatibleChainID:                   EthTestnetShard0ChainID,
-		EthCompatibleShard0ChainID:             EthTestnetShard0ChainID,
-		EthCompatibleEpoch:                     big.NewInt(0),
-		CrossTxEpoch:                           big.NewInt(0),
-		CrossLinkEpoch:                         big.NewInt(2),
-		AggregatedRewardEpoch:                  big.NewInt(3),
-		StakingEpoch:                           big.NewInt(2),
-		PreStakingEpoch:                        big.NewInt(0),
-		QuickUnlockEpoch:                       big.NewInt(0),
-		FiveSecondsEpoch:                       big.NewInt(0),
-		TwoSecondsEpoch:                        big.NewInt(0),
-		SixtyPercentEpoch:                      EpochTBD, // Never enable it for localnet as localnet has no external validator setup
-		RedelegationEpoch:                      big.NewInt(0),
-		NoEarlyUnlockEpoch:                     big.NewInt(0),
-		VRFEpoch:                               big.NewInt(0),
-		PrevVRFEpoch:                           big.NewInt(0),
-		MinDelegation100Epoch:                  big.NewInt(0),
-		MinCommissionRateEpoch:                 big.NewInt(0),
-		MinCommissionPromoPeriod:               big.NewInt(10),
-		EPoSBound35Epoch:                       big.NewInt(0),
-		EIP155Epoch:                            big.NewInt(0),
-		S3Epoch:                                big.NewInt(0),
-		DataCopyFixEpoch:                       big.NewInt(0),
-		IstanbulEpoch:                          big.NewInt(0),
-		ReceiptLogEpoch:                        big.NewInt(0),
-		SHA3Epoch:                              big.NewInt(0),
-		HIP6And8Epoch:                          EpochTBD, // Never enable it for localnet as localnet has no external validator setup
-		StakingPrecompileEpoch:                 big.NewInt(2),
-		ChainIdFixEpoch:                        big.NewInt(0),
-		SlotsLimitedEpoch:                      EpochTBD, // epoch to enable HIP-16
-		CrossShardXferPrecompileEpoch:          big.NewInt(1),
-		AllowlistEpoch:                         EpochTBD,
-		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
-		LeaderRotationExternalBeaconLeaders:    EpochTBD,
-		FeeCollectEpoch:                        big.NewInt(5),
+		ChainID:                       TestnetChainID,
+		EthCompatibleChainID:          EthTestnetShard0ChainID,
+		EthCompatibleShard0ChainID:    EthTestnetShard0ChainID,
+		EthCompatibleEpoch:            big.NewInt(0),
+		CrossTxEpoch:                  big.NewInt(0),
+		CrossLinkEpoch:                big.NewInt(2),
+		AggregatedRewardEpoch:         big.NewInt(3),
+		StakingEpoch:                  big.NewInt(2),
+		PreStakingEpoch:               big.NewInt(0),
+		QuickUnlockEpoch:              big.NewInt(0),
+		FiveSecondsEpoch:              big.NewInt(0),
+		TwoSecondsEpoch:               big.NewInt(0),
+		SixtyPercentEpoch:             EpochTBD, // Never enable it for localnet as localnet has no external validator setup
+		RedelegationEpoch:             big.NewInt(0),
+		NoEarlyUnlockEpoch:            big.NewInt(0),
+		VRFEpoch:                      big.NewInt(0),
+		PrevVRFEpoch:                  big.NewInt(0),
+		MinDelegation100Epoch:         big.NewInt(0),
+		MinCommissionRateEpoch:        big.NewInt(0),
+		MinCommissionPromoPeriod:      big.NewInt(10),
+		EPoSBound35Epoch:              big.NewInt(0),
+		EIP155Epoch:                   big.NewInt(0),
+		S3Epoch:                       big.NewInt(0),
+		DataCopyFixEpoch:              big.NewInt(0),
+		IstanbulEpoch:                 big.NewInt(0),
+		ReceiptLogEpoch:               big.NewInt(0),
+		SHA3Epoch:                     big.NewInt(0),
+		HIP6And8Epoch:                 EpochTBD, // Never enable it for localnet as localnet has no external validator setup
+		StakingPrecompileEpoch:        big.NewInt(2),
+		ChainIdFixEpoch:               big.NewInt(0),
+		SlotsLimitedEpoch:             EpochTBD, // epoch to enable HIP-16
+		CrossShardXferPrecompileEpoch: big.NewInt(1),
+		AllowlistEpoch:                EpochTBD,
+		NonBeaconLeaderRotation:       EpochTBD,
+		FeeCollectEpoch:               big.NewInt(5),
 		ValidatorCodeFixEpoch:         EpochTBD,
 	}
 
@@ -319,8 +313,7 @@ var (
 		big.NewInt(0),                      // SlotsLimitedEpoch
 		big.NewInt(1),                      // CrossShardXferPrecompileEpoch
 		big.NewInt(0),                      // AllowlistEpoch
-		big.NewInt(1),                      // LeaderRotationExternalNonBeaconLeaders
-		big.NewInt(1),                      // LeaderRotationExternalBeaconLeaders
+		big.NewInt(1),                      // LeaderRotationEpoch
 		big.NewInt(0),                      // FeeCollectEpoch
 		big.NewInt(0),                      // ValidatorCodeFixEpoch
 	}
@@ -362,8 +355,7 @@ var (
 		big.NewInt(0),        // SlotsLimitedEpoch
 		big.NewInt(1),        // CrossShardXferPrecompileEpoch
 		big.NewInt(0),        // AllowlistEpoch
-		big.NewInt(1),        // LeaderRotationExternalNonBeaconLeaders
-		big.NewInt(1),        // LeaderRotationExternalBeaconLeaders
+		big.NewInt(1),        // LeaderRotationEpoch
 		big.NewInt(0),        // FeeCollectEpoch
 		big.NewInt(0),        // ValidatorCodeFixEpoch
 	}
@@ -505,9 +497,7 @@ type ChainConfig struct {
 	// AllowlistEpoch is the first epoch to support allowlist of HIP18
 	AllowlistEpoch *big.Int
 
-	LeaderRotationExternalNonBeaconLeaders *big.Int `json:"non-beacon-leader-rotation-epoch,omitempty"`
-
-	LeaderRotationExternalBeaconLeaders *big.Int `json:"non-beacon-leader-rotation-epoch,omitempty"`
+	NonBeaconLeaderRotation *big.Int `json:"non-beacon-leader-rotation-epoch,omitempty"`
 
 	// FeeCollectEpoch is the first epoch that enables txn fees to be collected into the community-managed account.
 	// It should >= StakingEpoch.
@@ -724,18 +714,8 @@ func (c *ChainConfig) IsAllowlistEpoch(epoch *big.Int) bool {
 	return isForked(c.AllowlistEpoch, epoch)
 }
 
-func (c *ChainConfig) IsLeaderRotation(epoch *big.Int) bool {
-	return isForked(c.LeaderRotationExternalNonBeaconLeaders, epoch)
-}
-
-func (c *ChainConfig) IsLeaderRotationExternalValidatorsAllowed(epoch *big.Int, shardID uint32) bool {
-	if !c.IsLeaderRotation(epoch) {
-		return false
-	}
-	if shardID == 0 {
-		return isForked(c.LeaderRotationExternalBeaconLeaders, epoch)
-	}
-	return true
+func (c *ChainConfig) IsNonBeaconLeaderRotation(epoch *big.Int) bool {
+	return isForked(c.NonBeaconLeaderRotation, epoch)
 }
 
 // IsFeeCollectEpoch determines whether Txn Fees will be collected into the community-managed account.

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -505,9 +505,9 @@ type ChainConfig struct {
 	// AllowlistEpoch is the first epoch to support allowlist of HIP18
 	AllowlistEpoch *big.Int
 
-	LeaderRotationExternalNonBeaconLeaders *big.Int `json:"leader-rotation-external-non-beacon-leaders"`
+	LeaderRotationExternalNonBeaconLeaders *big.Int `json:"non-beacon-leader-rotation-epoch,omitempty"`
 
-	LeaderRotationExternalBeaconLeaders *big.Int `json:"leader-rotation-external-beacon-leaders"`
+	LeaderRotationExternalBeaconLeaders *big.Int `json:"non-beacon-leader-rotation-epoch,omitempty"`
 
 	// FeeCollectEpoch is the first epoch that enables txn fees to be collected into the community-managed account.
 	// It should >= StakingEpoch.

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -505,9 +505,9 @@ type ChainConfig struct {
 	// AllowlistEpoch is the first epoch to support allowlist of HIP18
 	AllowlistEpoch *big.Int
 
-	LeaderRotationExternalNonBeaconLeaders *big.Int `json:"non-beacon-leader-rotation-epoch,omitempty"`
+	LeaderRotationExternalNonBeaconLeaders *big.Int `json:"leader-rotation-external-non-beacon-leaders"`
 
-	LeaderRotationExternalBeaconLeaders *big.Int `json:"non-beacon-leader-rotation-epoch,omitempty"`
+	LeaderRotationExternalBeaconLeaders *big.Int `json:"leader-rotation-external-beacon-leaders"`
 
 	// FeeCollectEpoch is the first epoch that enables txn fees to be collected into the community-managed account.
 	// It should >= StakingEpoch.

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -72,7 +72,7 @@ var (
 		FeeCollectEpoch:                        EpochTBD,
 		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
 		LeaderRotationExternalBeaconLeaders:    EpochTBD,
-		ValidatorCodeFixEpoch:         EpochTBD,
+		ValidatorCodeFixEpoch:                  EpochTBD,
 	}
 
 	// TestnetChainConfig contains the chain parameters to run a node on the harmony test network.
@@ -113,7 +113,7 @@ var (
 		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
 		LeaderRotationExternalBeaconLeaders:    EpochTBD,
 		FeeCollectEpoch:                        EpochTBD,
-		ValidatorCodeFixEpoch:         EpochTBD,
+		ValidatorCodeFixEpoch:                  EpochTBD,
 	}
 	// PangaeaChainConfig contains the chain parameters for the Pangaea network.
 	// All features except for CrossLink are enabled at launch.
@@ -154,7 +154,7 @@ var (
 		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
 		LeaderRotationExternalBeaconLeaders:    EpochTBD,
 		FeeCollectEpoch:                        EpochTBD,
-		ValidatorCodeFixEpoch:         EpochTBD,
+		ValidatorCodeFixEpoch:                  EpochTBD,
 	}
 
 	// PartnerChainConfig contains the chain parameters for the Partner network.
@@ -196,7 +196,7 @@ var (
 		FeeCollectEpoch:                        big.NewInt(574),
 		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
 		LeaderRotationExternalBeaconLeaders:    EpochTBD,
-		ValidatorCodeFixEpoch:         EpochTBD,
+		ValidatorCodeFixEpoch:                  EpochTBD,
 	}
 
 	// StressnetChainConfig contains the chain parameters for the Stress test network.
@@ -238,7 +238,7 @@ var (
 		FeeCollectEpoch:                        EpochTBD,
 		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
 		LeaderRotationExternalBeaconLeaders:    EpochTBD,
-		ValidatorCodeFixEpoch:         EpochTBD,
+		ValidatorCodeFixEpoch:                  EpochTBD,
 	}
 
 	// LocalnetChainConfig contains the chain parameters to run for local development.
@@ -279,7 +279,7 @@ var (
 		LeaderRotationExternalNonBeaconLeaders: big.NewInt(5),
 		LeaderRotationExternalBeaconLeaders:    big.NewInt(6),
 		FeeCollectEpoch:                        big.NewInt(5),
-		ValidatorCodeFixEpoch:         EpochTBD,
+		ValidatorCodeFixEpoch:                  EpochTBD,
 	}
 
 	// AllProtocolChanges ...

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -276,8 +276,8 @@ var (
 		SlotsLimitedEpoch:                      EpochTBD, // epoch to enable HIP-16
 		CrossShardXferPrecompileEpoch:          big.NewInt(1),
 		AllowlistEpoch:                         EpochTBD,
-		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
-		LeaderRotationExternalBeaconLeaders:    EpochTBD,
+		LeaderRotationExternalNonBeaconLeaders: big.NewInt(5),
+		LeaderRotationExternalBeaconLeaders:    big.NewInt(6),
 		FeeCollectEpoch:                        big.NewInt(5),
 		ValidatorCodeFixEpoch:         EpochTBD,
 	}
@@ -505,9 +505,9 @@ type ChainConfig struct {
 	// AllowlistEpoch is the first epoch to support allowlist of HIP18
 	AllowlistEpoch *big.Int
 
-	LeaderRotationExternalNonBeaconLeaders *big.Int `json:"non-beacon-leader-rotation-epoch,omitempty"`
+	LeaderRotationExternalNonBeaconLeaders *big.Int `json:"leader-rotation-external-non-beacon-leaders,omitempty"`
 
-	LeaderRotationExternalBeaconLeaders *big.Int `json:"non-beacon-leader-rotation-epoch,omitempty"`
+	LeaderRotationExternalBeaconLeaders *big.Int `json:"leader-rotation-external-beacon-leaders,omitempty"`
 
 	// FeeCollectEpoch is the first epoch that enables txn fees to be collected into the community-managed account.
 	// It should >= StakingEpoch.

--- a/numeric/decimal.go
+++ b/numeric/decimal.go
@@ -202,6 +202,12 @@ func (d Dec) Copy() Dec {
 	}
 }
 
+func (d Dec) Div(d2 Dec) Dec {
+	return Dec{
+		new(big.Int).Div(d.Int, d2.Int),
+	}
+}
+
 // IsNil ...
 func (d Dec) IsNil() bool { return d.Int == nil } // is decimal nil
 // IsZero ...

--- a/numeric/decimal_test.go
+++ b/numeric/decimal_test.go
@@ -368,3 +368,27 @@ func TestDecCeil(t *testing.T) {
 		require.Equal(t, tc.expected, res, "unexpected result for test case %d, input: %v", i, tc.input)
 	}
 }
+
+func TestDiv(t *testing.T) {
+	tests := []struct {
+		d1, d2, exp Dec
+	}{
+		{mustNewDecFromStr(t, "0"), mustNewDecFromStr(t, "1"), ZeroDec()},
+		{mustNewDecFromStr(t, "1"), mustNewDecFromStr(t, "1"), NewDec(1)},
+		{mustNewDecFromStr(t, "1"), mustNewDecFromStr(t, "2"), mustNewDecFromStr(t, "0.5")},
+		{mustNewDecFromStr(t, "2"), mustNewDecFromStr(t, "1"), NewDec(2)},
+		{mustNewDecFromStr(t, "2"), mustNewDecFromStr(t, "3"), mustNewDecFromStr(t, "0.666666666666666667")},
+		{mustNewDecFromStr(t, "2"), mustNewDecFromStr(t, "4"), mustNewDecFromStr(t, "0.5")},
+		{mustNewDecFromStr(t, "2"), mustNewDecFromStr(t, "5"), mustNewDecFromStr(t, "0.4")},
+		{mustNewDecFromStr(t, "2"), mustNewDecFromStr(t, "6"), mustNewDecFromStr(t, "0.333333333333333333")},
+		{mustNewDecFromStr(t, "2"), mustNewDecFromStr(t, "7"), mustNewDecFromStr(t, "0.285714285714285714")},
+		{mustNewDecFromStr(t, "2"), mustNewDecFromStr(t, "8"), mustNewDecFromStr(t, "0.25")},
+		{mustNewDecFromStr(t, "2"), mustNewDecFromStr(t, "9"), mustNewDecFromStr(t, "0.222222222222222222")},
+		{mustNewDecFromStr(t, "2"), mustNewDecFromStr(t, "10"), mustNewDecFromStr(t, "0.2")},
+	}
+	for i, tc := range tests {
+		res := tc.d1.Quo(tc.d2)
+		require.True(t, res.Equal(tc.exp), "unexpected result for test case %d, input: %s %s %s", i, tc.d1, tc.d2, tc.exp)
+	}
+
+}


### PR DESCRIPTION
When the feature NonBeaconLeaderRotation is activated, the leaders will be rotated on shards 1-3 an equal amount of blocks depending on the epoch length and slots count. Shard 0 will rotate only the internal validators.