### PR TITLE
evm: don't return extcode for validators

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/internal/params"
+	"github.com/harmony-one/harmony/shard"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -477,6 +478,16 @@ func opReturnDataCopy(pc *uint64, interpreter *EVMInterpreter, contract *Contrac
 
 func opExtCodeSize(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	slot := stack.peek()
+	address := common.BigToAddress(slot)
+	fixValidatorCode := interpreter.evm.chainRules.IsValidatorCodeFix &&
+		interpreter.evm.ShardID == shard.BeaconChainShardID &&
+		interpreter.evm.StateDB.IsValidator(address)
+	if fixValidatorCode {
+		// https://github.com/ethereum/solidity/blob/develop/Changelog.md#081-2021-01-27
+		// per this link, <address>.code.length calls extcodesize on the address so this fix will work
+		slot.SetUint64(0)
+		return nil, nil
+	}
 	slot.SetUint64(uint64(interpreter.evm.StateDB.GetCodeSize(common.BigToAddress(slot))))
 
 	return nil, nil
@@ -509,7 +520,17 @@ func opExtCodeCopy(pc *uint64, interpreter *EVMInterpreter, contract *Contract, 
 		codeOffset = stack.pop()
 		length     = stack.pop()
 	)
-	codeCopy := getDataBig(interpreter.evm.StateDB.GetCode(addr), codeOffset, length)
+	var code []byte
+	fixValidatorCode := interpreter.evm.chainRules.IsValidatorCodeFix &&
+		interpreter.evm.ShardID == shard.BeaconChainShardID &&
+		interpreter.evm.StateDB.IsValidator(addr)
+	if fixValidatorCode {
+		// for EOAs that are not validators, statedb returns nil
+		code = nil
+	} else {
+		code = interpreter.evm.StateDB.GetCode(addr)
+	}
+	codeCopy := getDataBig(code, codeOffset, length)
 	memory.Set(memOffset.Uint64(), length.Uint64(), codeCopy)
 
 	interpreter.intPool.put(memOffset, codeOffset, length)
@@ -555,7 +576,14 @@ func opExtCodeHash(pc *uint64, interpreter *EVMInterpreter, contract *Contract, 
 	if interpreter.evm.StateDB.Empty(address) {
 		slot.SetUint64(0)
 	} else {
-		slot.SetBytes(interpreter.evm.StateDB.GetCodeHash(address).Bytes())
+		fixValidatorCode := interpreter.evm.chainRules.IsValidatorCodeFix &&
+			interpreter.evm.ShardID == shard.BeaconChainShardID &&
+			interpreter.evm.StateDB.IsValidator(address)
+		if fixValidatorCode {
+			slot.SetBytes(emptyCodeHash.Bytes())
+		} else {
+			slot.SetBytes(interpreter.evm.StateDB.GetCodeHash(address).Bytes())
+		}
 	}
 	return nil, nil
 }


### PR DESCRIPTION
Due to technical debt, validator information is stored in the code field of the address. The code field can be accessed in Solidity for an arbitrary address using `extcodesize`, `extcodehash`, and `extcodecopy` or helper commands (such as `address.code.Length`). The presence of this field is used by contract developers to (erroneously) deny smart contract access to other smart contracts (and therefore, validators). This PR fixes that oversight by returning the same values as other EOAs for known validator addresses. Obviously, it needs a hard fork that will be scheduled separately.