### PR TITLE
git: ignore the cache folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,4 +96,5 @@ explorer_storage_*
 profiles/*.pb.gz
 
 # cache db
+cache/
 cache_*_db


### PR DESCRIPTION
The cache folder is generated by code introduced in #4316 when using `make debug`