### PR TITLE
build: update pinned curl version

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -39,7 +39,7 @@ ARG HARMONY_USER_GID=1000
 ENV HARMONY_HOME=/harmony
 ENV HOME=${HARMONY_HOME}
 
-RUN apk add --no-cache bash~=5.1.16-r2 bind-tools~=9.16.37-r0 tini~=0.19.0 curl==7.83.1-r5 sed~=4.8-r0 \
+RUN apk add --no-cache bash~=5.1.16-r2 bind-tools~=9.16.37-r0 tini~=0.19.0 curl==7.83.1-r6 sed~=4.8-r0 \
     && rm -rf /var/cache/apk/* \
     && addgroup -g ${HARMONY_USER_GID} ${HARMONY_USER} \
     && adduser -u ${HARMONY_USER_UID} -G ${HARMONY_USER} --shell /sbin/nologin --no-create-home -D ${HARMONY_USER} \


### PR DESCRIPTION
Per the Alpine Linux package repositories, the version for cURL included with v3.16 has changed to revision 6

https://pkgs.alpinelinux.org/packages?name=curl&branch=v3.16&repo=&arch=&maintainer=
