### PR TITLE
Add prefix for contract code

### DIFF
--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -183,8 +183,7 @@ func skeletonHeaderKey(number uint64) []byte {
 
 // codeKey = CodePrefix + hash
 func codeKey(hash common.Hash) []byte {
-	// We don't use any prefix for code key, otherwise we should return append(CodePrefix, hash.Bytes()...)
-	return hash.Bytes()
+	return append(CodePrefix, hash.Bytes()...)
 }
 
 // IsCodeKey reports whether the given byte slice is the key of contract code,


### PR DESCRIPTION
## Issue

This PR adds a prefix to contract code.
- To write contract code to db, we add prefix by default. 
- To retrieve contract code from db, first we check with prefix and then we check without prefix. Either of them give us the code, we return it as code. 

If a node starts from genesis block, it will save all codes with prefix. So it will have slightly different db with a node that has been working since long back ago. But both data are valid and all nodes can work with both DBs. 


## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

