### PR TITLE
consensus: replace type assert with test

### DIFF
--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -538,8 +538,10 @@ func (consensus *Consensus) StartFinalityCount() {
 // FinishFinalityCount calculate the current finality
 func (consensus *Consensus) FinishFinalityCount() {
 	d := time.Now().UnixNano()
-	consensus.finality = (d - consensus.finalityCounter.Load().(int64)) / 1000000
-	consensusFinalityHistogram.Observe(float64(consensus.finality))
+	if prior, ok := consensus.finalityCounter.Load().(int64); ok {
+		consensus.finality = (d - prior) / 1000000
+		consensusFinalityHistogram.Observe(float64(consensus.finality))
+	}
 }
 
 // GetFinality returns the finality time in milliseconds of previous consensus


### PR DESCRIPTION
If `consensus.finalityCounter` does not have anything stored (for example in Syncing mode), the `Load()` returns an interface that cannot be automatically asserted to an `int64`. This results in the node crashing. This commit fixes that.

This pull request is made directly to the `main` branch intentionally.

## Issue
Systemd logs prior to the fix on release 09dba416
```
github.com/harmony-one/harmony/consensus.(*Consensus).FinishFinalityCount(0xc00323ea00)
/root/go/src/github.com/harmony-one/harmony/consensus/consensus_service.go:479 +0x127
github.com/harmony-one/harmony/consensus.(*Consensus).commitBlock(0xc00323ea00, 0xc003c72ee0, 0xc00063a700)
/root/go/src/github.com/harmony-one/harmony/consensus/consensus_v2.go:673 +0x177
github.com/harmony-one/harmony/consensus.(*Consensus).tryCatchup(0xc00323ea00)
/root/go/src/github.com/harmony-one/harmony/consensus/consensus_v2.go:643 +0x2eb
github.com/harmony-one/harmony/consensus.(*Consensus).onCommitted(0xc00323ea00, 0xc00063a700)
/root/go/src/github.com/harmony-one/harmony/consensus/validator.go:376 +0xbb2
github.com/harmony-one/harmony/consensus.(*Consensus).HandleMessageUpdate(0xc00323ea00, {0x22b9d8d4dcf2ba?, 0xc001471730?}, 0xc02be2a3c0, 0xc01e6f16e0)
/root/go/src/github.com/harmony-one/harmony/consensus/consensus_v2.go:114 +0x2c7
github.com/harmony-one/harmony/node.(*Node).StartPubSub.func2.1()
/root/go/src/github.com/harmony-one/harmony/node/node.go:896 +0x189
created by github.com/harmony-one/harmony/node.(*Node).StartPubSub.func2
/root/go/src/github.com/harmony-one/harmony/node/node.go:883 +0x70
```

Associated zero log:
```json
{"level":"warn","number":"40049751","hash":"0xaba9b5852cac0f20ce46969c52cc3b884a9b7fdaedbc9d7aba06210859cc5969","caller":"/root/go/src/github.com/harmony-one/harmony/core/blockchain_impl.go:528","time":"2023-04-04T20:19:15.435979943Z","message":"Head state missing, repairing chain"}
{"level":"info","number":"40046846","hash":"0xcefc08c572b4cd447b388f4b3a5aa922a0ad3c303ac49fed5d0b873eaf1b7be3","caller":"/root/go/src/github.com/harmony-one/harmony/core/blockchain_impl.go:746","time":"2023-04-04T20:19:15.873235963Z","message":"Rewound blockchain to past state"}
{"level":"info","number":"40046846","hash":"0xcefc08c572b4cd447b388f4b3a5aa922a0ad3c303ac49fed5d0b873eaf1b7be3","td":"<nil>","age":"1h37m33s","caller":"/root/go/src/github.com/harmony-one/harmony/core/blockchain_impl.go:573","time":"2023-04-04T20:19:15.87371855Z","message":"Loaded most recent local header"}
{"level":"info","number":"40046846","hash":"0xcefc08c572b4cd447b388f4b3a5aa922a0ad3c303ac49fed5d0b873eaf1b7be3","td":"<nil>","age":"1h37m33s","caller":"/root/go/src/github.com/harmony-one/harmony/core/blockchain_impl.go:579","time":"2023-04-04T20:19:15.873765169Z","message":"Loaded most recent local full block"}
{"level":"info","number":"40049751","hash":"0xaba9b5852cac0f20ce46969c52cc3b884a9b7fdaedbc9d7aba06210859cc5969","td":"<nil>","age":"4s","caller":"/root/go/src/github.com/harmony-one/harmony/core/blockchain_impl.go:585","time":"2023-04-04T20:19:15.873796156Z","message":"Loaded most recent local fast block"}
```