### PR TITLE
Minor: removed time.Sleep from tests. 

### DIFF
--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -402,7 +402,7 @@ func (consensus *Consensus) tick() {
 				continue
 			}
 		}
-		if !v.CheckExpire() {
+		if !v.CheckExpire(time.Now()) {
 			continue
 		}
 		if k != timeoutViewChange {

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -402,7 +402,7 @@ func (consensus *Consensus) tick() {
 				continue
 			}
 		}
-		if !v.CheckExpire(time.Now()) {
+		if !v.Expired(time.Now()) {
 			continue
 		}
 		if k != timeoutViewChange {

--- a/internal/utils/timer.go
+++ b/internal/utils/timer.go
@@ -40,8 +40,8 @@ func (timeout *Timeout) Stop() {
 }
 
 // CheckExpire checks whether the timeout is reached/expired
-func (timeout *Timeout) CheckExpire() bool {
-	if timeout.state == Active && time.Since(timeout.start) > timeout.d {
+func (timeout *Timeout) CheckExpire(now time.Time) bool {
+	if timeout.state == Active && now.Sub(timeout.start) > timeout.d {
 		timeout.state = Expired
 	}
 	if timeout.state == Expired {

--- a/internal/utils/timer.go
+++ b/internal/utils/timer.go
@@ -39,8 +39,8 @@ func (timeout *Timeout) Stop() {
 	timeout.start = time.Now()
 }
 
-// CheckExpire checks whether the timeout is reached/expired
-func (timeout *Timeout) CheckExpire(now time.Time) bool {
+// Expired checks whether the timeout is reached/expired
+func (timeout *Timeout) Expired(now time.Time) bool {
 	if timeout.state == Active && now.Sub(timeout.start) > timeout.d {
 		timeout.state = Expired
 	}

--- a/internal/utils/timer_test.go
+++ b/internal/utils/timer_test.go
@@ -15,16 +15,27 @@ func TestNewTimeout(t *testing.T) {
 func TestCheckExpire(t *testing.T) {
 	timer := NewTimeout(time.Second)
 	timer.Start()
-	now := time.Now().Add(2 * time.Second)
-	if timer.CheckExpire(now) == false {
-		t.Fatalf("CheckExpire should be true")
+	now := time.Now()
+	if timer.Expired(now) {
+		t.Fatalf("Timer shouldn't be expired")
 	}
+	if !timer.Expired(now.Add(2 * time.Second)) {
+		t.Fatalf("Timer should be expired")
+	}
+	// start again
 	timer.Start()
-	if timer.CheckExpire(now) == true {
-		t.Fatalf("CheckExpire should be false")
+	if timer.Expired(now) {
+		t.Fatalf("Timer shouldn't be expired")
 	}
+	if !timer.Expired(now.Add(2 * time.Second)) {
+		t.Fatalf("Timer should be expired")
+	}
+	// stop
 	timer.Stop()
-	if timer.CheckExpire(now) == true {
-		t.Fatalf("CheckExpire should be false")
+	if timer.Expired(now) {
+		t.Fatalf("Expired shouldn't be expired because it is stopped")
+	}
+	if timer.Expired(now.Add(2 * time.Second)) {
+		t.Fatalf("Expired shouldn't be expired because it is stopped")
 	}
 }

--- a/internal/utils/timer_test.go
+++ b/internal/utils/timer_test.go
@@ -15,17 +15,16 @@ func TestNewTimeout(t *testing.T) {
 func TestCheckExpire(t *testing.T) {
 	timer := NewTimeout(time.Second)
 	timer.Start()
-	time.Sleep(2 * time.Second)
-	if timer.CheckExpire() == false {
+	now := time.Now().Add(2 * time.Second)
+	if timer.CheckExpire(now) == false {
 		t.Fatalf("CheckExpire should be true")
 	}
 	timer.Start()
-	if timer.CheckExpire() == true {
+	if timer.CheckExpire(now) == true {
 		t.Fatalf("CheckExpire should be false")
 	}
 	timer.Stop()
-	if timer.CheckExpire() == true {
+	if timer.CheckExpire(now) == true {
 		t.Fatalf("CheckExpire should be false")
 	}
-
 }

--- a/internal/utils/timer_test.go
+++ b/internal/utils/timer_test.go
@@ -33,9 +33,9 @@ func TestCheckExpire(t *testing.T) {
 	// stop
 	timer.Stop()
 	if timer.Expired(now) {
-		t.Fatalf("Expired shouldn't be expired because it is stopped")
+		t.Fatalf("Timer shouldn't be expired because it is stopped")
 	}
 	if timer.Expired(now.Add(2 * time.Second)) {
-		t.Fatalf("Expired shouldn't be expired because it is stopped")
+		t.Fatalf("Timer shouldn't be expired because it is stopped")
 	}
 }


### PR DESCRIPTION
Timeout can accept current time as argument, which makes it more convenient to use. 