### PR TITLE
internal/params: set validator code fix hard forks

### DIFF
--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -278,7 +278,7 @@ var (
 		AllowlistEpoch:                         EpochTBD,
 		LeaderRotationExternalNonBeaconLeaders: big.NewInt(5),
 		LeaderRotationExternalBeaconLeaders:    big.NewInt(6),
-		FeeCollectEpoch:                        big.NewInt(5),
+		FeeCollectEpoch:                        big.NewInt(2),
 		ValidatorCodeFixEpoch:                  big.NewInt(2),
 	}
 

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -113,7 +113,7 @@ var (
 		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
 		LeaderRotationExternalBeaconLeaders:    EpochTBD,
 		FeeCollectEpoch:                        big.NewInt(1296), // 2023-04-28 07:14:20+00:00
-		ValidatorCodeFixEpoch:                  EpochTBD,
+		ValidatorCodeFixEpoch:                  big.NewInt(1296), // 2023-04-28 07:14:20+00:00
 	}
 	// PangaeaChainConfig contains the chain parameters for the Pangaea network.
 	// All features except for CrossLink are enabled at launch.
@@ -193,9 +193,9 @@ var (
 		SlotsLimitedEpoch:                      EpochTBD, // epoch to enable HIP-16
 		CrossShardXferPrecompileEpoch:          big.NewInt(1),
 		AllowlistEpoch:                         EpochTBD,
-		FeeCollectEpoch:                        big.NewInt(848), // 2023-04-28 04:33:33+00:00
 		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
 		LeaderRotationExternalBeaconLeaders:    EpochTBD,
+		FeeCollectEpoch:                        big.NewInt(848), // 2023-04-28 04:33:33+00:00
 		ValidatorCodeFixEpoch:                  big.NewInt(848),
 	}
 
@@ -278,8 +278,8 @@ var (
 		AllowlistEpoch:                         EpochTBD,
 		LeaderRotationExternalNonBeaconLeaders: big.NewInt(5),
 		LeaderRotationExternalBeaconLeaders:    big.NewInt(6),
-		FeeCollectEpoch:                        big.NewInt(2),
-		ValidatorCodeFixEpoch:                  EpochTBD,
+		FeeCollectEpoch:                        big.NewInt(5),
+		ValidatorCodeFixEpoch:                  big.NewInt(2),
 	}
 
 	// AllProtocolChanges ...
@@ -548,16 +548,25 @@ func (c *ChainConfig) mustValid() {
 			panic(err)
 		}
 	}
+	// before staking epoch, fees were sent to coinbase
 	require(c.FeeCollectEpoch.Cmp(c.StakingEpoch) >= 0,
 		"must satisfy: FeeCollectEpoch >= StakingEpoch")
+	// obvious
 	require(c.PreStakingEpoch.Cmp(c.StakingEpoch) < 0,
 		"must satisfy: PreStakingEpoch < StakingEpoch")
+	// delegations can be made starting at PreStakingEpoch
 	require(c.StakingPrecompileEpoch.Cmp(c.PreStakingEpoch) >= 0,
 		"must satisfy: StakingPrecompileEpoch >= PreStakingEpoch")
+	// main functionality must come before the precompile
+	// see AcceptsCrossTx for why > and not >=
 	require(c.CrossShardXferPrecompileEpoch.Cmp(c.CrossTxEpoch) > 0,
 		"must satisfy: CrossShardXferPrecompileEpoch > CrossTxEpoch")
+	// the fix is applied only on the Solidity level, so you need eth compat
 	require(c.ValidatorCodeFixEpoch.Cmp(c.EthCompatibleEpoch) >= 0,
 		"must satisfy: ValidatorCodeFixEpoch >= EthCompatibleEpoch")
+	// we accept validator creation transactions starting at PreStakingEpoch
+	require(c.ValidatorCodeFixEpoch.Cmp(c.PreStakingEpoch) >= 0,
+		"must satisfy: ValidatorCodeFixEpoch >= PreStakingEpoch")
 }
 
 // IsEIP155 returns whether epoch is either equal to the EIP155 fork epoch or greater.


### PR DESCRIPTION
## Test
The below code was run on `make debug` to confirm that everything works as expected. It must be run after epoch 1 begins so that the network accepts the staking transaction.
### Set up a validator
```python
from pyhmy import account, blockchain, staking, transaction, validator as validator_module, numbers
import time

pk = "1f84c95ac16e6a50f08d44c7bde7aff8742212fda6e4321fde48bf83bef266dc"
validator_address = "one155jp2y76nazx8uw5sa94fr0m4s5aj8e5xm6fu3"
protocol_min_delegation = int( numbers.convert_one_to_atto( 100 ) )
validator_info = {
    "name": "Alice",
    "identity": "alice",
    "website": "alice.harmony.one",
    "security-contact": "Bob",
    "details": "Are you even reading this?",
    "min-self-delegation": int( numbers.convert_one_to_atto( 10000 ) ),
    "max-total-delegation": int( numbers.convert_one_to_atto( 100000 ) ),
    "rate": "0.1",
    "max-rate": "0.9",
    "max-change-rate": "0.05",
    "bls-public-keys": [
        "0xa20e70089664a874b00251c5e85d35a73871531306f3af43e02138339d294e6bb9c4eb82162199c6a852afeaa8d68712",
    ],
    "amount": int( numbers.convert_one_to_atto( 10000 ) ),
    "bls-key-sigs": [
        "0xef2c49a2f31fbbd23c21bc176eaf05cd0bebe6832033075d81fea7cff6f9bc1ab42f3b6895c5493fe645d8379d2eaa1413de55a9d3ce412a4f747cb57d52cc4da4754bfb2583ec9a41fe5dd48287f964f276336699959a5fcef3391dc24df00d",
    ]
}
endpoint = 'http://localhost:9500'
def create_validator( address, info, private_key ):
    # address must be a bech32 (one...) address
    validators = staking.get_all_validator_addresses( endpoint = endpoint )
    if address in validators:
        return
    balance = account.get_balance( address, endpoint = endpoint )
    assert( balance >= numbers.convert_one_to_atto( 10050 ) )
    print( "Creating the validator at {} using pyhmy".format( address ) )
    validators = staking.get_all_validator_addresses( endpoint = endpoint )
    original_count = len( validators )
    validator = validator_module.Validator( address )
    validator.load( info )
    nonce = account.get_account_nonce( address, 'latest', endpoint = endpoint )
    # nonce, gas_price, gas_limit, private_key, chain_id
    signed_tx = validator.sign_create_validator_transaction(
        nonce,
        int( 1e9 ),
        55000000,   # gas limit
        private_key,
        2           # chain id
    )
    hash = transaction.send_raw_staking_transaction(
        signed_tx.rawTransaction.hex(),
        endpoint = endpoint
    )
    # wait for tx to get processed
    while ( True ):
        tx = transaction.get_staking_transaction_by_hash(
            hash,
            endpoint = endpoint
        )
        if tx is not None:
            block_hash = tx.get( "blockHash", "0x00" )
            unique_chars = "".join( set( list( block_hash[ 2 : ] ) ) )
            if unique_chars != "0":  # meaning non 0 block hash
                break  # out of the while loop
        time.sleep( 0.5 )
    # ensure it is created
    validators = staking.get_all_validator_addresses( endpoint = endpoint )
    assert ( len( validators ) > original_count )
    # ensure it has correct info
    loaded_info = staking.get_validator_information(
        address,
        endpoint = endpoint
    )
    assert ( loaded_info[ 'validator' ][ 'name' ] == info[ 'name' ] )
    assert ( loaded_info[ 'validator' ][ 'identity' ] == info[ 'identity' ] )
create_validator( validator_address, validator_info, pk )
```
### Contract to be deployed
```solidity
//SPDX-License-Identifier: Unlicense
pragma solidity ^0.8.17;

contract Checker {
    function extCodeSizeCall(address addr) view public returns (uint256 size) {
        assembly {
            size := extcodesize(addr)
        }
    }

    function extCodeSize(address addr) view public returns (uint256 size) {
        return addr.code.length;
    }

    function extCodeCopy(address addr) view public returns (bytes memory) {
        return addr.code;
    }

    function extCodeCopyCall(address addr) view public returns (bytes memory o_code) {
        assembly {
            let size := extcodesize(addr)
             o_code := mload(0x40)
             mstore(0x40, add(o_code, and(add(add(size, 0x20), 0x1f), not(0x1f))))
             mstore(o_code, size)
             extcodecopy(addr, add(o_code, 0x20), 0, size)
        }
    }
}
```
### Checking
Run `brownie console --network hmyLocal`
```python
>>> from pyhmy import blockchain
>>> accounts.add( pk )
>>> contract = Checker.deploy( { 'from': accounts[ 0 ] } )
>>> # Before the code fix epoch
>>> blockchain.get_current_epoch()
1
>>> contract.extCodeCopy( accounts[ 0 ].address )
0xf8e9f8bf94a5241513da9f4463f1d4874b548dfbac29d91f34f1b0a20e70089664a874b00251c5e85d35a73871531306f3af43e02138339d294e6bb9c4eb82162199c6a852afeaa8d68712808a021e19e0c9bab24000008a152d02c7e14af680000001dfddc988016345785d8a0000c9880c7d713b49da0000c887b1a2bc2ec5000013f83d85416c69636585616c69636591616c6963652e6861726d6f6e792e6f6e6583426f629a41726520796f75206576656e2072656164696e6720746869733f13e3e294a5241513da9f4463f1d4874b548dfbac29d91f348a021e19e0c9bab240000080c0c2808080
>>> contract.extCodeCopyCall( accounts[ 0 ].address )
0xf8e9f8bf94a5241513da9f4463f1d4874b548dfbac29d91f34f1b0a20e70089664a874b00251c5e85d35a73871531306f3af43e02138339d294e6bb9c4eb82162199c6a852afeaa8d68712808a021e19e0c9bab24000008a152d02c7e14af680000001dfddc988016345785d8a0000c9880c7d713b49da0000c887b1a2bc2ec5000013f83d85416c69636585616c69636591616c6963652e6861726d6f6e792e6f6e6583426f629a41726520796f75206576656e2072656164696e6720746869733f13e3e294a5241513da9f4463f1d4874b548dfbac29d91f348a021e19e0c9bab240000080c0c2808080
>>> contract.extCodeSize( accounts[ 0 ].address )
235
>>> contract.extCodeSizeCall( accounts[ 0 ].address )
235
>>> # after the code fix epoch
>>> blockchain.get_current_epoch()
2
>>> contract.extCodeCopy( accounts[ 0 ].address )
0x
>>> contract.extCodeCopyCall( accounts[ 0 ].address )
0x
>>> contract.extCodeSize( accounts[ 0 ].address )
0
>>> contract.extCodeSizeCall( accounts[ 0 ].address )
0
```