### PR TITLE
Fix consensus concurrent map access.

### DIFF
--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -915,3 +915,24 @@ func (consensus *Consensus) ValidateVdfAndProof(headerObj *block.Header) bool {
 
 	return true
 }
+
+// DeleteBlocksLessThan deletes blocks less than given block number
+func (consensus *Consensus) DeleteBlocksLessThan(number uint64) {
+	consensus.mutex.Lock()
+	defer consensus.mutex.Unlock()
+	consensus.FBFTLog.deleteBlocksLessThan(number)
+}
+
+// DeleteMessagesLessThan deletes messages less than given block number.
+func (consensus *Consensus) DeleteMessagesLessThan(number uint64) {
+	consensus.mutex.Lock()
+	defer consensus.mutex.Unlock()
+	consensus.FBFTLog.deleteMessagesLessThan(number)
+}
+
+// DeleteBlockByNumber deletes block by given block number.
+func (consensus *Consensus) DeleteBlockByNumber(number uint64) {
+	consensus.mutex.Lock()
+	defer consensus.mutex.Unlock()
+	consensus.FBFTLog.deleteBlockByNumber(number)
+}

--- a/consensus/fbft_log.go
+++ b/consensus/fbft_log.go
@@ -147,7 +147,7 @@ func (log *FBFTLog) GetBlocksByNumber(number uint64) []*types.Block {
 }
 
 // DeleteBlocksLessThan deletes blocks less than given block number
-func (log *FBFTLog) DeleteBlocksLessThan(number uint64) {
+func (log *FBFTLog) deleteBlocksLessThan(number uint64) {
 	for h, block := range log.blocks {
 		if block.NumberU64() < number {
 			delete(log.blocks, h)
@@ -157,7 +157,7 @@ func (log *FBFTLog) DeleteBlocksLessThan(number uint64) {
 }
 
 // DeleteBlockByNumber deletes block of specific number
-func (log *FBFTLog) DeleteBlockByNumber(number uint64) {
+func (log *FBFTLog) deleteBlockByNumber(number uint64) {
 	for h, block := range log.blocks {
 		if block.NumberU64() == number {
 			delete(log.blocks, h)
@@ -167,7 +167,7 @@ func (log *FBFTLog) DeleteBlockByNumber(number uint64) {
 }
 
 // DeleteMessagesLessThan deletes messages less than given block number
-func (log *FBFTLog) DeleteMessagesLessThan(number uint64) {
+func (log *FBFTLog) deleteMessagesLessThan(number uint64) {
 	for h, msg := range log.messages {
 		if msg.BlockNum < number {
 			delete(log.messages, h)
@@ -357,6 +357,6 @@ func (log *FBFTLog) GetCommittedBlockAndMsgsFromNumber(bn uint64, logger *zerolo
 
 // PruneCacheBeforeBlock prune all blocks before bn
 func (log *FBFTLog) PruneCacheBeforeBlock(bn uint64) {
-	log.DeleteBlocksLessThan(bn - 1)
-	log.DeleteMessagesLessThan(bn - 1)
+	log.deleteBlocksLessThan(bn - 1)
+	log.deleteMessagesLessThan(bn - 1)
 }

--- a/node/node_explorer.go
+++ b/node/node_explorer.go
@@ -148,7 +148,7 @@ func (node *Node) TraceLoopForExplorer() {
 // AddNewBlockForExplorer add new block for explorer.
 func (node *Node) AddNewBlockForExplorer(block *types.Block) {
 	if node.HarmonyConfig.General.RunElasticMode && node.HarmonyConfig.TiKV.Role == tikv.RoleReader {
-		node.Consensus.FBFTLog.DeleteBlockByNumber(block.NumberU64())
+		node.Consensus.DeleteBlockByNumber(block.NumberU64())
 		return
 	}
 
@@ -159,7 +159,7 @@ func (node *Node) AddNewBlockForExplorer(block *types.Block) {
 			node.Consensus.UpdateConsensusInformation()
 		}
 		// Clean up the blocks to avoid OOM.
-		node.Consensus.FBFTLog.DeleteBlockByNumber(block.NumberU64())
+		node.Consensus.DeleteBlockByNumber(block.NumberU64())
 
 		// if in tikv mode, only master writer node need dump all explorer block
 		if !node.HarmonyConfig.General.RunElasticMode || node.Blockchain().IsTikvWriterMaster() {
@@ -216,8 +216,8 @@ func (node *Node) commitBlockForExplorer(block *types.Block) {
 
 	curNum := block.NumberU64()
 	if curNum-100 > 0 {
-		node.Consensus.FBFTLog.DeleteBlocksLessThan(curNum - 100)
-		node.Consensus.FBFTLog.DeleteMessagesLessThan(curNum - 100)
+		node.Consensus.DeleteBlocksLessThan(curNum - 100)
+		node.Consensus.DeleteMessagesLessThan(curNum - 100)
 	}
 }
 


### PR DESCRIPTION
concurrent map iteration and map write
May 04 11:06:14 mhe-explorer0-01 systemd-journald[359497]: Suppressed 17945 messages from harmony.service
May 04 11:06:14 mhe-explorer0-01 harmony-explorer-node[1457088]: goroutine 6812396 [running]:
May 04 11:06:14 mhe-explorer0-01 harmony-explorer-node[1457088]: github.com/harmony-one/harmony/consensus.(*FBFTLog).DeleteBlocksLessThan(...)
May 04 11:06:14 mhe-explorer0-01 harmony-explorer-node[1457088]:         /home/sp/harmony/harmony/consensus/fbft_log.go:151
May 04 11:06:14 mhe-explorer0-01 harmony-explorer-node[1457088]: github.com/harmony-one/harmony/node.(*Node).commitBlockForExplorer(0xc028ac0000, 0xc138e7f500)... 