### PR TITLE
add inspectdb to cli

### DIFF
--- a/cmd/harmony/inspectdb.go
+++ b/cmd/harmony/inspectdb.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/harmony-one/harmony/core/rawdb"
+	"github.com/harmony-one/harmony/internal/cli"
+)
+
+var prefixFlag = cli.StringFlag{
+	Name:      "prefix",
+	Shorthand: "p",
+	Usage:     "key prefix",
+	DefValue:  "",
+}
+
+var startKeyFlag = cli.StringFlag{
+	Name:      "start_key",
+	Shorthand: "s",
+	Usage:     "start key",
+	DefValue:  "",
+}
+
+var inspectDBCmd = &cobra.Command{
+	Use:     "inspectdb srcdb prefix startKey",
+	Short:   "inspect a db.",
+	Long:    "inspect a db.",
+	Example: "harmony inspectdb /srcDir/harmony_db_0",
+	Args:    cobra.RangeArgs(1, 3),
+	Run: func(cmd *cobra.Command, args []string) {
+		srcDBDir := args[0]
+		prefix := cli.GetStringFlagValue(cmd, prefixFlag)
+		startKey := cli.GetStringFlagValue(cmd, startKeyFlag)
+		fmt.Println("db path: ", srcDBDir)
+		inspectDB(srcDBDir, prefix, startKey)
+		os.Exit(0)
+	},
+}
+
+func registerInspectionFlags() error {
+	return cli.RegisterFlags(inspectDBCmd, []cli.Flag{prefixFlag, startKeyFlag})
+
+}
+
+func inspectDB(srcDBDir, prefix, startKey string) {
+	fmt.Println("===inspectDB===")
+	srcDB, err := rawdb.NewLevelDBDatabase(srcDBDir, LEVELDB_CACHE_SIZE, LEVELDB_HANDLES, "", false)
+	if err != nil {
+		fmt.Println("open src db error:", err)
+		os.Exit(-1)
+	}
+
+	rawdb.InspectDatabase(srcDB, []byte(prefix), []byte(startKey))
+
+	fmt.Println("database inspection completed!")
+}

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -111,6 +111,7 @@ func init() {
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(dumpConfigLegacyCmd)
 	rootCmd.AddCommand(dumpDBCmd)
+	rootCmd.AddCommand(inspectDBCmd)
 
 	if err := registerRootCmdFlags(); err != nil {
 		os.Exit(2)
@@ -119,6 +120,9 @@ func init() {
 		os.Exit(2)
 	}
 	if err := registerDumpDBFlags(); err != nil {
+		os.Exit(2)
+	}
+	if err := registerInspectionFlags(); err != nil {
 		os.Exit(2)
 	}
 }

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -332,6 +331,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		// Meta- and unaccounted data
 		metadata    stat
 		unaccounted stat
+		zeroval     stat
 
 		// Totals
 		total common.StorageSize
@@ -342,6 +342,9 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 			key  = it.Key()
 			size = common.StorageSize(len(key) + len(it.Value()))
 		)
+		if len(it.Value()) == 0 {
+			zeroval.Add(1)
+		}
 		total += size
 		switch {
 		case bytes.HasPrefix(key, headerPrefix) && len(key) == (len(headerPrefix)+8+common.HashLength):
@@ -433,30 +436,22 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		{"Key-Value store", "Beacon sync headers", beaconHeaders.Size(), beaconHeaders.Count()},
 		{"Key-Value store", "Clique snapshots", cliqueSnaps.Size(), cliqueSnaps.Count()},
 		{"Key-Value store", "Singleton metadata", metadata.Size(), metadata.Count()},
+		{"Key-Value store", "Zero value keys", zeroval.Size(), zeroval.Count()},
+		{"Key-Value store", "Unaccounted", unaccounted.Size(), unaccounted.Count()},
 		{"Light client", "CHT trie nodes", chtTrieNodes.Size(), chtTrieNodes.Count()},
 		{"Light client", "Bloom trie nodes", bloomTrieNodes.Size(), bloomTrieNodes.Count()},
-	}
-	// Inspect all registered append-only file store then.
-	ancients, err := inspectFreezers(db)
-	if err != nil {
-		return err
-	}
-	for _, ancient := range ancients {
-		for _, table := range ancient.sizes {
-			stats = append(stats, []string{
-				fmt.Sprintf("Ancient store (%s)", strings.Title(ancient.name)),
-				strings.Title(table.name),
-				table.size.String(),
-				fmt.Sprintf("%d", ancient.count()),
-			})
-		}
-		total += ancient.size()
 	}
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"Database", "Category", "Size", "Items"})
 	table.SetFooter([]string{"", "Total", total.String(), " "})
 	table.AppendBulk(stats)
 	table.Render()
+
+	if zeroval.count > 0 {
+		utils.Logger().Error().
+			Interface("count", zeroval).
+			Msg("Database contains zero value keys")
+	}
 
 	if unaccounted.size > 0 {
 		utils.Logger().Error().

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -296,7 +296,6 @@ func (s *stat) Count() string {
 
 // InspectDatabase traverses the entire database and checks the size
 // of all different categories of data.
-// This function is NOT used, just ported over from the Ethereum
 func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 	it := db.NewIterator(keyPrefix, keyStart)
 	defer it.Release()


### PR DESCRIPTION
## feature

This PR adds inspectdb to the list of supported commands. It traverses the entire database and checks the size of all different categories of data. It records number of zero-value entries as well. Once the inspection is done, the report will be shown in a table.

## Test
`harmony inspectdb ./harmony_db_0`

