### PR TITLE
fix beacon-ness in legacy sync

### DIFF
--- a/api/service/legacysync/epoch_syncing.go
+++ b/api/service/legacysync/epoch_syncing.go
@@ -92,7 +92,7 @@ func (ss *EpochSync) SyncLoop(bc core.BlockChain, consensus *consensus.Consensus
 }
 
 func syncLoop(bc core.BlockChain, syncConfig *SyncConfig) (timeout int) {
-	isBeacon := bc.ShardID() == 0
+	isBeacon := bc.ShardID() == shard.BeaconChainShardID
 	maxHeight, errMaxHeight := getMaxPeerHeight(syncConfig)
 	if errMaxHeight != nil {
 		utils.Logger().Info().

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -314,7 +314,8 @@ func (node *Node) doSync(bc core.BlockChain, worker *worker.Worker, willJoinCons
 		if willJoinConsensus {
 			node.Consensus.BlocksNotSynchronized()
 		}
-		syncInstance.SyncLoop(bc, worker, false, node.Consensus, legacysync.LoopMinTime)
+		isBeacon := bc.ShardID() == shard.BeaconChainShardID
+		syncInstance.SyncLoop(bc, worker, isBeacon, node.Consensus, legacysync.LoopMinTime)
 		if willJoinConsensus {
 			node.IsSynchronized.Set()
 			node.Consensus.BlocksSynchronized()


### PR DESCRIPTION
## Issue

This PR fixes beacon-ness in legacy sync.

Previously, `isBeacon` parameter was hardcoded as `false` when called. Now, it is dynamic, based on the configuration. The parameter is only used in the logs.