### PR TITLE
Fix code hash conflicts

### DIFF
--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -412,7 +412,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		}
 		count++
 		if count%1000 == 0 && time.Since(logged) > 8*time.Second {
-			log.Info("Inspecting database", "count", count, "elapsed", common.PrettyDuration(time.Since(start)))
+			utils.Logger().Info().Int64("count", count).Interface("elapsed", common.PrettyDuration(time.Since(start))).Msg("Inspecting database")
 			logged = time.Now()
 		}
 	}

--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -165,7 +165,7 @@ func (s *DB) DumpToCollector(c DumpCollector, conf *DumpConfig) (nextKey []byte)
 		addr := common.BytesToAddress(addrBytes)
 		obj := newObject(s, addr, data)
 		if !conf.SkipCode {
-			account.Code = obj.Code(s.db, false)
+			account.Code = obj.Code(s.db)
 		}
 		if !conf.SkipStorage {
 			account.Storage = make(map[common.Hash]string)

--- a/core/state/prefeth.go
+++ b/core/state/prefeth.go
@@ -100,7 +100,7 @@ func (s *DB) prefetchWorker(job *prefetchJob, jobs chan *prefetchJob) {
 			addr := common.BytesToAddress(addrBytes)
 			obj := newObject(s, addr, data)
 			if data.CodeHash != nil {
-				obj.Code(s.db, false)
+				obj.Code(s.db)
 			}
 
 			// build account trie tree

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -32,7 +32,13 @@ import (
 	"github.com/harmony-one/harmony/staking"
 )
 
-var emptyCodeHash = crypto.Keccak256(nil)
+var (
+	// EmptyRootHash is the known root hash of an empty trie.
+	EmptyRootHash = common.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+
+	// EmptyCodeHash is the known hash of the empty EVM bytecode.
+	EmptyCodeHash = crypto.Keccak256Hash(nil) // c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
+)
 
 // Code ...
 type Code []byte
@@ -101,7 +107,7 @@ type Object struct {
 
 // empty returns whether the account is considered empty.
 func (s *Object) empty() bool {
-	return s.data.Nonce == 0 && s.data.Balance.Sign() == 0 && bytes.Equal(s.data.CodeHash, emptyCodeHash)
+	return s.data.Nonce == 0 && s.data.Balance.Sign() == 0 && bytes.Equal(s.data.CodeHash, EmptyCodeHash.Bytes())
 }
 
 // Account is the Ethereum consensus representation of accounts.
@@ -113,16 +119,29 @@ type Account struct {
 	CodeHash []byte
 }
 
+/*
+var emptyCodeHash = crypto.Keccak256(nil)
+crypto.Keccak256Hash(nil) // c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
+	// EmptyRootHash is the known root hash of an empty trie.
+	EmptyRootHash = common.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+
+	// EmptyUncleHash is the known hash of the empty uncle set.
+	EmptyUncleHash = rlpHash([]*Header(nil)) // 1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347
+
+	// EmptyCodeHash is the known hash of the empty EVM bytecode.
+	EmptyCodeHash = crypto.Keccak256Hash(nil) // c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
+*/
+
 // newObject creates a state object.
 func newObject(db *DB, address common.Address, data types.StateAccount) *Object {
 	if data.Balance == nil {
 		data.Balance = new(big.Int)
 	}
 	if data.CodeHash == nil {
-		data.CodeHash = types.EmptyCodeHash.Bytes()
+		data.CodeHash = EmptyCodeHash.Bytes()
 	}
 	if data.Root == (common.Hash{}) {
-		data.Root = types.EmptyRootHash
+		data.Root = EmptyRootHash
 	}
 	return &Object{
 		db:             db,
@@ -169,7 +188,7 @@ func (s *Object) getTrie(db Database) (Trie, error) {
 	if s.trie == nil {
 		// Try fetching from prefetcher first
 		// We don't prefetch empty tries
-		if s.data.Root != types.EmptyRootHash && s.db.prefetcher != nil {
+		if s.data.Root != EmptyRootHash && s.db.prefetcher != nil {
 			// When the miner is creating the pending state, there is no
 			// prefetcher
 			s.trie = s.db.prefetcher.trie(s.addrHash, s.data.Root)
@@ -316,7 +335,7 @@ func (s *Object) finalise(prefetch bool) {
 			slotsToPrefetch = append(slotsToPrefetch, common.CopyBytes(key[:])) // Copy needed for closure
 		}
 	}
-	if s.db.prefetcher != nil && prefetch && len(slotsToPrefetch) > 0 && s.data.Root != types.EmptyRootHash {
+	if s.db.prefetcher != nil && prefetch && len(slotsToPrefetch) > 0 && s.data.Root != EmptyRootHash {
 		s.db.prefetcher.prefetch(s.addrHash, s.data.Root, slotsToPrefetch)
 	}
 	if len(s.dirtyStorage) > 0 {
@@ -475,18 +494,18 @@ func (s *Object) setBalance(amount *big.Int) {
 func (s *Object) ReturnGas(gas *big.Int) {}
 
 func (s *Object) deepCopy(db *DB) *Object {
-	Object := newObject(db, s.address, s.data)
+	stateObject := newObject(db, s.address, s.data)
 	if s.trie != nil {
-		Object.trie = db.db.CopyTrie(s.trie)
+		stateObject.trie = db.db.CopyTrie(s.trie)
 	}
-	Object.code = s.code
-	Object.dirtyStorage = s.dirtyStorage.Copy()
-	Object.originStorage = s.originStorage.Copy()
-	Object.pendingStorage = s.pendingStorage.Copy()
-	Object.suicided = s.suicided
-	Object.dirtyCode = s.dirtyCode
-	Object.deleted = s.deleted
-	return Object
+	stateObject.code = s.code
+	stateObject.dirtyStorage = s.dirtyStorage.Copy()
+	stateObject.originStorage = s.originStorage.Copy()
+	stateObject.pendingStorage = s.pendingStorage.Copy()
+	stateObject.suicided = s.suicided
+	stateObject.dirtyCode = s.dirtyCode
+	stateObject.deleted = s.deleted
+	return stateObject
 }
 
 //
@@ -499,26 +518,33 @@ func (s *Object) Address() common.Address {
 }
 
 // Code returns the contract/validator code associated with this object, if any.
-func (s *Object) Code(db Database, isValidatorCode bool) []byte {
+func (s *Object) Code(db Database) []byte {
 	if s.code != nil {
 		return s.code
 	}
-	if bytes.Equal(s.CodeHash(), types.EmptyCodeHash.Bytes()) {
+	if bytes.Equal(s.CodeHash(), EmptyCodeHash.Bytes()) {
 		return nil
 	}
-	if s.validatorWrapper || isValidatorCode {
-		code, err := db.ValidatorCode(s.addrHash, common.BytesToHash(s.CodeHash()))
-		if err != nil {
-			s.setError(fmt.Errorf("can't load validator code hash %x: %v", s.CodeHash(), err))
-		}
-		if code != nil {
-			s.code = code
-			return code
-		}
+	var err error
+	code := []byte{}
+	// if it's set for validator wrapper, no need to check contract code
+	if !s.validatorWrapper {
+		code, err = db.ContractCode(s.addrHash, common.BytesToHash(s.CodeHash()))
 	}
-	code, err := db.ContractCode(s.addrHash, common.BytesToHash(s.CodeHash()))
-	if err != nil {
-		s.setError(fmt.Errorf("can't load code hash %x: %v", s.CodeHash(), err))
+	// if it's not set for validator wrapper, then it may be either contract code or validator wrapper (old version of db 
+	// don't have any prefix to differentiate between them)
+	// so if it couldn't load contract code or it is set to validator wrapper, then it tries to fetch validator wrapper code
+	if s.validatorWrapper || err != nil {
+		vCode, errVCode := db.ValidatorCode(s.addrHash, common.BytesToHash(s.CodeHash()))
+		if errVCode == nil && vCode != nil {
+			s.code = vCode
+			return vCode
+		}
+		if s.validatorWrapper {
+			s.setError(fmt.Errorf("can't load validator code hash %x : %v", s.CodeHash(), err))
+		} else {
+			s.setError(fmt.Errorf("can't load contract/validator code hash %x, contract code error: %v, validator code error: %v", s.CodeHash(), err, errVCode))
+		}
 	}
 	s.code = code
 	return code
@@ -527,31 +553,35 @@ func (s *Object) Code(db Database, isValidatorCode bool) []byte {
 // CodeSize returns the size of the contract/validator code associated with this object,
 // or zero if none. This method is an almost mirror of Code, but uses a cache
 // inside the database to avoid loading codes seen recently.
-func (s *Object) CodeSize(db Database, isValidatorCode bool) int {
+func (s *Object) CodeSize(db Database) int {
 	if s.code != nil {
 		return len(s.code)
 	}
-	if bytes.Equal(s.CodeHash(), types.EmptyCodeHash.Bytes()) {
+	if bytes.Equal(s.CodeHash(), EmptyCodeHash.Bytes()) {
 		return 0
 	}
-	if s.validatorWrapper || isValidatorCode {
-		size, err := db.ValidatorCodeSize(s.addrHash, common.BytesToHash(s.CodeHash()))
-		if err != nil {
-			s.setError(fmt.Errorf("can't load validator code size %x: %v", s.CodeHash(), err))
-		}
-		if size > 0 {
+	var err error
+	size := int(0)
+	if !s.validatorWrapper {
+		size, err = db.ContractCodeSize(s.addrHash, common.BytesToHash(s.CodeHash()))
+	}
+	if s.validatorWrapper || err != nil {
+		vcSize, errVCSize := db.ValidatorCodeSize(s.addrHash, common.BytesToHash(s.CodeHash()))
+		if errVCSize == nil && vcSize > 0 {
 			return size
 		}
-	}
-	size, err := db.ContractCodeSize(s.addrHash, common.BytesToHash(s.CodeHash()))
-	if err != nil {
-		s.setError(fmt.Errorf("can't load code size %x: %v", s.CodeHash(), err))
+		if s.validatorWrapper {
+			s.setError(fmt.Errorf("can't load validator code size %x : %v", s.CodeHash(), err))
+		} else {
+			s.setError(fmt.Errorf("can't load contract/validator code size %x, contract code size error: %v, validator code size error: %v", s.CodeHash(), err, errVCSize))
+		}
+		s.setError(fmt.Errorf("can't load code size %x (validator wrapper: %t): %v", s.CodeHash(), s.validatorWrapper, err))
 	}
 	return size
 }
 
 func (s *Object) SetCode(codeHash common.Hash, code []byte, isValidatorCode bool) {
-	prevcode := s.Code(s.db.db, isValidatorCode)
+	prevcode := s.Code(s.db.db)
 	s.db.journal.append(codeChange{
 		account:  &s.address,
 		prevhash: s.CodeHash(),

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -194,7 +194,7 @@ func TestSnapshot2(t *testing.T) {
 	so0Restored := state.getStateObject(stateobjaddr0)
 	// Update lazily-loaded values before comparing.
 	so0Restored.GetState(state.db, storageaddr)
-	so0Restored.Code(state.db, false)
+	so0Restored.Code(state.db)
 	// non-deleted is equal (restored)
 	compareStateObjects(so0Restored, so0, t)
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -342,18 +342,18 @@ func (db *DB) BlockHash() common.Hash {
 	return db.bhash
 }
 
-func (db *DB) GetCode(addr common.Address, isValidatorCode bool) []byte {
+func (db *DB) GetCode(addr common.Address) []byte {
 	Object := db.getStateObject(addr)
 	if Object != nil {
-		return Object.Code(db.db, isValidatorCode)
+		return Object.Code(db.db)
 	}
 	return nil
 }
 
-func (db *DB) GetCodeSize(addr common.Address, isValidatorCode bool) int {
+func (db *DB) GetCodeSize(addr common.Address) int {
 	Object := db.getStateObject(addr)
 	if Object != nil {
-		return Object.CodeSize(db.db, isValidatorCode)
+		return Object.CodeSize(db.db)
 	}
 	return 0
 }
@@ -1241,13 +1241,11 @@ func (db *DB) ValidatorWrapper(
 		return copyValidatorWrapperIfNeeded(cached, sendOriginal, copyDelegations), nil
 	}
 
-	by := db.GetCode(addr, true)
+	by := db.GetCode(addr)
 	if len(by) == 0 {
-		by = db.GetCode(addr, false)
-		if len(by) == 0 {
-			return nil, ErrAddressNotPresent
-		}
+		return nil, ErrAddressNotPresent
 	}
+
 	val := stk.ValidatorWrapper{}
 	if err := rlp.DecodeBytes(by, &val); err != nil {
 		return nil, errors.Wrapf(

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -452,9 +452,9 @@ func (test *snapshotTest) checkEqual(state, checkstate *DB) error {
 		checkeq("HasSuicided", state.HasSuicided(addr), checkstate.HasSuicided(addr))
 		checkeq("GetBalance", state.GetBalance(addr), checkstate.GetBalance(addr))
 		checkeq("GetNonce", state.GetNonce(addr), checkstate.GetNonce(addr))
-		checkeq("GetCode", state.GetCode(addr, false), checkstate.GetCode(addr, false))
+		checkeq("GetCode", state.GetCode(addr), checkstate.GetCode(addr))
 		checkeq("GetCodeHash", state.GetCodeHash(addr), checkstate.GetCodeHash(addr))
-		checkeq("GetCodeSize", state.GetCodeSize(addr, false), checkstate.GetCodeSize(addr, false))
+		checkeq("GetCodeSize", state.GetCodeSize(addr), checkstate.GetCodeSize(addr))
 		// Check storage.
 		if obj := state.getStateObject(addr); obj != nil {
 			state.ForEachStorage(addr, func(key, value common.Hash) bool {
@@ -532,7 +532,7 @@ func TestCopyCommitCopy(t *testing.T) {
 	if balance := state.GetBalance(addr); balance.Cmp(big.NewInt(42)) != 0 {
 		t.Fatalf("initial balance mismatch: have %v, want %v", balance, 42)
 	}
-	if code := state.GetCode(addr, false); !bytes.Equal(code, []byte("hello")) {
+	if code := state.GetCode(addr); !bytes.Equal(code, []byte("hello")) {
 		t.Fatalf("initial code mismatch: have %x, want %x", code, []byte("hello"))
 	}
 	if val := state.GetState(addr, skey); val != sval {
@@ -546,7 +546,7 @@ func TestCopyCommitCopy(t *testing.T) {
 	if balance := copyOne.GetBalance(addr); balance.Cmp(big.NewInt(42)) != 0 {
 		t.Fatalf("first copy pre-commit balance mismatch: have %v, want %v", balance, 42)
 	}
-	if code := copyOne.GetCode(addr, false); !bytes.Equal(code, []byte("hello")) {
+	if code := copyOne.GetCode(addr); !bytes.Equal(code, []byte("hello")) {
 		t.Fatalf("first copy pre-commit code mismatch: have %x, want %x", code, []byte("hello"))
 	}
 	if val := copyOne.GetState(addr, skey); val != sval {
@@ -560,7 +560,7 @@ func TestCopyCommitCopy(t *testing.T) {
 	if balance := copyOne.GetBalance(addr); balance.Cmp(big.NewInt(42)) != 0 {
 		t.Fatalf("first copy post-commit balance mismatch: have %v, want %v", balance, 42)
 	}
-	if code := copyOne.GetCode(addr, false); !bytes.Equal(code, []byte("hello")) {
+	if code := copyOne.GetCode(addr); !bytes.Equal(code, []byte("hello")) {
 		t.Fatalf("first copy post-commit code mismatch: have %x, want %x", code, []byte("hello"))
 	}
 	if val := copyOne.GetState(addr, skey); val != sval {
@@ -574,7 +574,7 @@ func TestCopyCommitCopy(t *testing.T) {
 	if balance := copyTwo.GetBalance(addr); balance.Cmp(big.NewInt(42)) != 0 {
 		t.Fatalf("second copy balance mismatch: have %v, want %v", balance, 42)
 	}
-	if code := copyTwo.GetCode(addr, false); !bytes.Equal(code, []byte("hello")) {
+	if code := copyTwo.GetCode(addr); !bytes.Equal(code, []byte("hello")) {
 		t.Fatalf("second copy code mismatch: have %x, want %x", code, []byte("hello"))
 	}
 	if val := copyTwo.GetState(addr, skey); val != sval {
@@ -604,7 +604,7 @@ func TestCopyCopyCommitCopy(t *testing.T) {
 	if balance := state.GetBalance(addr); balance.Cmp(big.NewInt(42)) != 0 {
 		t.Fatalf("initial balance mismatch: have %v, want %v", balance, 42)
 	}
-	if code := state.GetCode(addr, false); !bytes.Equal(code, []byte("hello")) {
+	if code := state.GetCode(addr); !bytes.Equal(code, []byte("hello")) {
 		t.Fatalf("initial code mismatch: have %x, want %x", code, []byte("hello"))
 	}
 	if val := state.GetState(addr, skey); val != sval {
@@ -618,7 +618,7 @@ func TestCopyCopyCommitCopy(t *testing.T) {
 	if balance := copyOne.GetBalance(addr); balance.Cmp(big.NewInt(42)) != 0 {
 		t.Fatalf("first copy balance mismatch: have %v, want %v", balance, 42)
 	}
-	if code := copyOne.GetCode(addr, false); !bytes.Equal(code, []byte("hello")) {
+	if code := copyOne.GetCode(addr); !bytes.Equal(code, []byte("hello")) {
 		t.Fatalf("first copy code mismatch: have %x, want %x", code, []byte("hello"))
 	}
 	if val := copyOne.GetState(addr, skey); val != sval {
@@ -632,7 +632,7 @@ func TestCopyCopyCommitCopy(t *testing.T) {
 	if balance := copyTwo.GetBalance(addr); balance.Cmp(big.NewInt(42)) != 0 {
 		t.Fatalf("second copy pre-commit balance mismatch: have %v, want %v", balance, 42)
 	}
-	if code := copyTwo.GetCode(addr, false); !bytes.Equal(code, []byte("hello")) {
+	if code := copyTwo.GetCode(addr); !bytes.Equal(code, []byte("hello")) {
 		t.Fatalf("second copy pre-commit code mismatch: have %x, want %x", code, []byte("hello"))
 	}
 	if val := copyTwo.GetState(addr, skey); val != sval {
@@ -645,7 +645,7 @@ func TestCopyCopyCommitCopy(t *testing.T) {
 	if balance := copyTwo.GetBalance(addr); balance.Cmp(big.NewInt(42)) != 0 {
 		t.Fatalf("second copy post-commit balance mismatch: have %v, want %v", balance, 42)
 	}
-	if code := copyTwo.GetCode(addr, false); !bytes.Equal(code, []byte("hello")) {
+	if code := copyTwo.GetCode(addr); !bytes.Equal(code, []byte("hello")) {
 		t.Fatalf("second copy post-commit code mismatch: have %x, want %x", code, []byte("hello"))
 	}
 	if val := copyTwo.GetState(addr, skey); val != sval {
@@ -659,7 +659,7 @@ func TestCopyCopyCommitCopy(t *testing.T) {
 	if balance := copyThree.GetBalance(addr); balance.Cmp(big.NewInt(42)) != 0 {
 		t.Fatalf("third copy balance mismatch: have %v, want %v", balance, 42)
 	}
-	if code := copyThree.GetCode(addr, false); !bytes.Equal(code, []byte("hello")) {
+	if code := copyThree.GetCode(addr); !bytes.Equal(code, []byte("hello")) {
 		t.Fatalf("third copy code mismatch: have %x, want %x", code, []byte("hello"))
 	}
 	if val := copyThree.GetState(addr, skey); val != sval {

--- a/core/vm/contracts_write.go
+++ b/core/vm/contracts_write.go
@@ -242,7 +242,7 @@ func (c *crossShardXferPrecompile) RunWriteCapable(
 		return nil, err
 	}
 	// validate not a contract (toAddress can still be a contract)
-	if len(evm.StateDB.GetCode(fromAddress, false)) > 0 && !evm.IsValidator(evm.StateDB, fromAddress) {
+	if len(evm.StateDB.GetCode(fromAddress)) > 0 && !evm.IsValidator(evm.StateDB, fromAddress) {
 		return nil, errors.New("cross shard xfer not yet implemented for contracts")
 	}
 	// can't have too many shards

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -336,7 +336,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	evm.Transfer(evm.StateDB, caller.Address(), to.Address(), value, txType)
 
 	codeHash := evm.StateDB.GetCodeHash(addr)
-	code := evm.StateDB.GetCode(addr, false)
+	code := evm.StateDB.GetCode(addr)
 	// If address is a validator address, then it's not a smart contract address
 	// we don't use its code and codeHash fields
 	if evm.Context.IsValidator(evm.StateDB, addr) {
@@ -402,7 +402,7 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 	// EVM. The contract is a scoped environment for this execution context
 	// only.
 	contract := NewContract(caller, to, value, gas)
-	contract.SetCallCode(&addr, evm.StateDB.GetCodeHash(addr), evm.StateDB.GetCode(addr, false))
+	contract.SetCallCode(&addr, evm.StateDB.GetCodeHash(addr), evm.StateDB.GetCode(addr))
 
 	ret, err = run(evm, contract, input, false)
 	if err != nil {
@@ -435,7 +435,7 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 
 	// Initialise a new contract and make initialise the delegate values
 	contract := NewContract(caller, to, nil, gas).AsDelegate()
-	contract.SetCallCode(&addr, evm.StateDB.GetCodeHash(addr), evm.StateDB.GetCode(addr, false))
+	contract.SetCallCode(&addr, evm.StateDB.GetCodeHash(addr), evm.StateDB.GetCode(addr))
 
 	ret, err = run(evm, contract, input, false)
 	if err != nil {
@@ -468,7 +468,7 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	// EVM. The contract is a scoped environment for this execution context
 	// only.
 	contract := NewContract(caller, to, new(big.Int), gas)
-	contract.SetCallCode(&addr, evm.StateDB.GetCodeHash(addr), evm.StateDB.GetCode(addr, false))
+	contract.SetCallCode(&addr, evm.StateDB.GetCodeHash(addr), evm.StateDB.GetCode(addr))
 
 	// We do an AddBalance of zero here, just in order to trigger a touch.
 	// This doesn't matter on Mainnet, where all empties are gone at the time of Byzantium,

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -488,7 +488,7 @@ func opExtCodeSize(pc *uint64, interpreter *EVMInterpreter, contract *Contract, 
 		slot.SetUint64(0)
 		return nil, nil
 	}
-	slot.SetUint64(uint64(interpreter.evm.StateDB.GetCodeSize(common.BigToAddress(slot), false)))
+	slot.SetUint64(uint64(interpreter.evm.StateDB.GetCodeSize(common.BigToAddress(slot))))
 
 	return nil, nil
 }
@@ -528,7 +528,7 @@ func opExtCodeCopy(pc *uint64, interpreter *EVMInterpreter, contract *Contract, 
 		// for EOAs that are not validators, statedb returns nil
 		code = nil
 	} else {
-		code = interpreter.evm.StateDB.GetCode(addr, false)
+		code = interpreter.evm.StateDB.GetCode(addr)
 	}
 	codeCopy := getDataBig(code, codeOffset, length)
 	memory.Set(memOffset.Uint64(), length.Uint64(), codeCopy)

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -38,9 +38,9 @@ type StateDB interface {
 	SetNonce(common.Address, uint64)
 
 	GetCodeHash(common.Address) common.Hash
-	GetCode(common.Address, bool) []byte
+	GetCode(common.Address) []byte
 	SetCode(common.Address, []byte, bool)
-	GetCodeSize(common.Address, bool) int
+	GetCodeSize(common.Address) int
 
 	ValidatorWrapper(common.Address, bool, bool) (*staking.ValidatorWrapper, error)
 	UpdateValidatorWrapper(common.Address, *staking.ValidatorWrapper) error

--- a/hmy/tracers/block_tracer.go
+++ b/hmy/tracers/block_tracer.go
@@ -353,7 +353,7 @@ func (jst *ParityBlockTracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode,
 			ret := stackPeek(0)
 			if ret.Sign() != 0 {
 				call.to = common.BigToAddress(ret)
-				call.output = env.StateDB.GetCode(call.to, false)
+				call.output = env.StateDB.GetCode(call.to)
 			} else if call.err == nil {
 				call.err = errors.New("internal failure")
 			}

--- a/hmy/tracers/tracer.go
+++ b/hmy/tracers/tracer.go
@@ -210,7 +210,7 @@ func (dw *dbWrapper) pushObject(vm *duktape.Context) {
 
 	// Push the wrapper for statedb.GetCode
 	vm.PushGoFunction(func(ctx *duktape.Context) int {
-		code := dw.db.GetCode(common.BytesToAddress(popSlice(ctx)), false)
+		code := dw.db.GetCode(common.BytesToAddress(popSlice(ctx)))
 
 		ptr := ctx.PushFixedBuffer(len(code))
 		copy(makeSlice(ptr, uint(len(code))), code)

--- a/rosetta/services/block.go
+++ b/rosetta/services/block.go
@@ -178,11 +178,11 @@ func (s *BlockAPI) BlockTransaction(
 			// check for contract related operations, if it is a plain transaction.
 			if txInfo.tx.To() != nil {
 				// possible call to existing contract so fetch relevant data
-				contractInfo.ContractCode = state.GetCode(*txInfo.tx.To(), false)
+				contractInfo.ContractCode = state.GetCode(*txInfo.tx.To())
 				contractInfo.ContractAddress = txInfo.tx.To()
 			} else {
 				// contract creation, so address is in receipt
-				contractInfo.ContractCode = state.GetCode(txInfo.receipt.ContractAddress, false)
+				contractInfo.ContractCode = state.GetCode(txInfo.receipt.ContractAddress)
 				contractInfo.ContractAddress = &txInfo.receipt.ContractAddress
 			}
 			contractInfo.ExecutionResult, rosettaError = s.getTransactionTrace(ctx, blk, txInfo)

--- a/rosetta/services/construction_check.go
+++ b/rosetta/services/construction_check.go
@@ -289,7 +289,7 @@ func (s *ConstructAPI) ConstructionMetadata(
 		GasPrice:        sugNativePrice,
 		GasLimit:        estGasUsed,
 		Transaction:     options.TransactionMetadata,
-		ContractCode:    state.GetCode(contractAddress, false),
+		ContractCode:    state.GetCode(contractAddress),
 		EvmErrorMessage: evmErrorMsg,
 		EvmReturn:       evmReturn,
 	})

--- a/rpc/contract.go
+++ b/rpc/contract.go
@@ -123,7 +123,7 @@ func (s *PublicContractService) GetCode(
 		DoMetricRPCQueryInfo(GetCode, FailedNumber)
 		return nil, err
 	}
-	code := state.GetCode(address, false)
+	code := state.GetCode(address)
 
 	// Response output is the same for all versions
 	return code, state.Error()


### PR DESCRIPTION
## Issue

The validator wrapper code is prefixed differently than contract codes. Prior to the current release (2023.2.0), neither of them used a prefix and both used a code hash as the key to store the code in the database. We used a flag called **isValidatorCode** to tell state object how to fetch code and which prefix to use, but this flag cannot be identified for old data because validator and contract codes do not have prefixes. So, it was using **false** by default in most parts of the code, which can cause problems if the code belongs to a validator wrapper and is stored by prefix. This PR removes that flag and tries to retrieve the code without and with all possible code prefixes.
