### PR TITLE
hmy: Gas Price Oracle improvements

### DIFF
--- a/cmd/harmony/config_migrations.go
+++ b/cmd/harmony/config_migrations.go
@@ -378,6 +378,33 @@ func init() {
 		return confTree
 	}
 
+	migrations["2.5.14"] = func(confTree *toml.Tree) *toml.Tree {
+		if confTree.Get("GPO.Blocks") == nil {
+			confTree.Set("GPO.Blocks", defaultConfig.GPO.Blocks)
+		}
+		if confTree.Get("GPO.Transactions") == nil {
+			confTree.Set("GPO.Transactions", defaultConfig.GPO.Transactions)
+		}
+		if confTree.Get("GPO.Percentile") == nil {
+			confTree.Set("GPO.Percentile", defaultConfig.GPO.Percentile)
+		}
+		if confTree.Get("GPO.DefaultPrice") == nil {
+			confTree.Set("GPO.DefaultPrice", defaultConfig.GPO.DefaultPrice)
+		}
+		if confTree.Get("GPO.MaxPrice") == nil {
+			confTree.Set("GPO.MaxPrice", defaultConfig.GPO.MaxPrice)
+		}
+		if confTree.Get("GPO.LowUsageThreshold") == nil {
+			confTree.Set("GPO.LowUsageThreshold", defaultConfig.GPO.LowUsageThreshold)
+		}
+		if confTree.Get("GPO.BlockGasLimit") == nil {
+			confTree.Set("GPO.BlockGasLimit", defaultConfig.GPO.BlockGasLimit)
+		}
+		// upgrade minor version because of `GPO` section introduction
+		confTree.Set("Version", "2.6.0")
+		return confTree
+	}
+
 	// check that the latest version here is the same as in default.go
 	largestKey := getNextVersion(migrations)
 	if largestKey != tomlConfigVersion {

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"github.com/harmony-one/harmony/core"
+	"github.com/harmony-one/harmony/hmy"
 	harmonyconfig "github.com/harmony-one/harmony/internal/configs/harmony"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 )
 
-const tomlConfigVersion = "2.5.14"
+const tomlConfigVersion = "2.6.0"
 
 const (
 	defNetworkType = nodeconfig.Mainnet
@@ -119,6 +120,15 @@ var defaultConfig = harmonyconfig.HarmonyConfig{
 		ShardCount:      4,
 		CacheTime:       10,
 		CacheSize:       512,
+	},
+	GPO: harmonyconfig.GasPriceOracleConfig{
+		Blocks:            hmy.DefaultGPOConfig.Blocks,
+		Transactions:      hmy.DefaultGPOConfig.Transactions,
+		Percentile:        hmy.DefaultGPOConfig.Percentile,
+		DefaultPrice:      hmy.DefaultGPOConfig.DefaultPrice,
+		MaxPrice:          hmy.DefaultGPOConfig.MaxPrice,
+		LowUsageThreshold: hmy.DefaultGPOConfig.LowUsageThreshold,
+		BlockGasLimit:     hmy.DefaultGPOConfig.BlockGasLimit,
 	},
 }
 

--- a/cmd/harmony/flags.go
+++ b/cmd/harmony/flags.go
@@ -249,6 +249,16 @@ var (
 		cacheSizeFlag,
 	}
 
+	gpoFlags = []cli.Flag{
+		gpoBlocksFlag,
+		gpoTransactionsFlag,
+		gpoPercentileFlag,
+		gpoDefaultPriceFlag,
+		gpoMaxPriceFlag,
+		gpoLowUsageThresholdFlag,
+		gpoBlockGasLimitFlag,
+	}
+
 	metricsFlags = []cli.Flag{
 		metricsETHFlag,
 		metricsExpensiveETHFlag,
@@ -364,6 +374,7 @@ func getRootFlags() []cli.Flag {
 	flags = append(flags, prometheusFlags...)
 	flags = append(flags, syncFlags...)
 	flags = append(flags, shardDataFlags...)
+	flags = append(flags, gpoFlags...)
 	flags = append(flags, metricsFlags...)
 
 	return flags
@@ -1932,6 +1943,45 @@ var (
 	}
 )
 
+// gas price oracle flags
+var (
+	gpoBlocksFlag = cli.IntFlag{
+		Name:     "gpo.blocks",
+		Usage:    "Number of recent blocks to check for gas prices",
+		DefValue: defaultConfig.GPO.Blocks,
+	}
+	gpoTransactionsFlag = cli.IntFlag{
+		Name:     "gpo.transactions",
+		Usage:    "Number of transactions to sample in a block",
+		DefValue: defaultConfig.GPO.Transactions,
+	}
+	gpoPercentileFlag = cli.IntFlag{
+		Name:     "gpo.percentile",
+		Usage:    "Suggested gas price is the given percentile of a set of recent transaction gas prices",
+		DefValue: defaultConfig.GPO.Percentile,
+	}
+	gpoDefaultPriceFlag = cli.Int64Flag{
+		Name:     "gpo.defaultprice",
+		Usage:    "The gas price to suggest before data is available, and the price to suggest when block utilization is low",
+		DefValue: defaultConfig.GPO.DefaultPrice,
+	}
+	gpoMaxPriceFlag = cli.Int64Flag{
+		Name:     "gpo.maxprice",
+		Usage:    "Maximum gasprice to be recommended by gpo",
+		DefValue: defaultConfig.GPO.MaxPrice,
+	}
+	gpoLowUsageThresholdFlag = cli.IntFlag{
+		Name:     "gpo.low-usage-threshold",
+		Usage:    "The block usage threshold below which the default gas price is suggested (0 to disable)",
+		DefValue: defaultConfig.GPO.LowUsageThreshold,
+	}
+	gpoBlockGasLimitFlag = cli.IntFlag{
+		Name:     "gpo.block-gas-limit",
+		Usage:    "The gas limit, per block. If set to 0, it is pulled from the block header",
+		DefValue: defaultConfig.GPO.BlockGasLimit,
+	}
+)
+
 // metrics flags required for the go-eth library
 // https://github.com/ethereum/go-ethereum/blob/master/metrics/metrics.go#L35-L55
 var (
@@ -1963,5 +2013,29 @@ func applyShardDataFlags(cmd *cobra.Command, cfg *harmonyconfig.HarmonyConfig) {
 	}
 	if cli.IsFlagChanged(cmd, cacheSizeFlag) {
 		cfg.ShardData.CacheSize = cli.GetIntFlagValue(cmd, cacheSizeFlag)
+	}
+}
+
+func applyGPOFlags(cmd *cobra.Command, cfg *harmonyconfig.HarmonyConfig) {
+	if cli.IsFlagChanged(cmd, gpoBlocksFlag) {
+		cfg.GPO.Blocks = cli.GetIntFlagValue(cmd, gpoBlocksFlag)
+	}
+	if cli.IsFlagChanged(cmd, gpoTransactionsFlag) {
+		cfg.GPO.Transactions = cli.GetIntFlagValue(cmd, gpoTransactionsFlag)
+	}
+	if cli.IsFlagChanged(cmd, gpoPercentileFlag) {
+		cfg.GPO.Percentile = cli.GetIntFlagValue(cmd, gpoPercentileFlag)
+	}
+	if cli.IsFlagChanged(cmd, gpoDefaultPriceFlag) {
+		cfg.GPO.DefaultPrice = cli.GetInt64FlagValue(cmd, gpoDefaultPriceFlag)
+	}
+	if cli.IsFlagChanged(cmd, gpoMaxPriceFlag) {
+		cfg.GPO.MaxPrice = cli.GetInt64FlagValue(cmd, gpoMaxPriceFlag)
+	}
+	if cli.IsFlagChanged(cmd, gpoLowUsageThresholdFlag) {
+		cfg.GPO.LowUsageThreshold = cli.GetIntFlagValue(cmd, gpoLowUsageThresholdFlag)
+	}
+	if cli.IsFlagChanged(cmd, gpoBlockGasLimitFlag) {
+		cfg.GPO.BlockGasLimit = cli.GetIntFlagValue(cmd, gpoBlockGasLimitFlag)
 	}
 }

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -249,6 +249,7 @@ func applyRootFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 	applyPrometheusFlags(cmd, config)
 	applySyncFlags(cmd, config)
 	applyShardDataFlags(cmd, config)
+	applyGPOFlags(cmd, config)
 }
 
 func setupNodeLog(config harmonyconfig.HarmonyConfig) {
@@ -262,7 +263,7 @@ func setupNodeLog(config harmonyconfig.HarmonyConfig) {
 		utils.SetLogContext(ip, strconv.Itoa(port))
 	}
 
-	if config.Log.Console != true {
+	if !config.Log.Console {
 		utils.AddLogFile(logPath, config.Log.RotateSize, config.Log.RotateCount, config.Log.RotateMaxAge)
 	}
 }

--- a/hmy/hmy.go
+++ b/hmy/hmy.go
@@ -157,12 +157,8 @@ func New(
 	}
 
 	// Setup gas price oracle
-	gpoParams := GasPriceConfig{
-		Blocks:     20,                // take all eligible txs past 20 blocks and sort them
-		Percentile: 80,                // get the 80th percentile when sorted in an ascending manner
-		Default:    big.NewInt(100e9), // minimum of 100 gwei
-	}
-	gpo := NewOracle(backend, gpoParams)
+	config := nodeAPI.GetConfig().HarmonyConfig.GPO
+	gpo := NewOracle(backend, &config)
 	backend.gpo = gpo
 
 	return backend

--- a/internal/cli/flag.go
+++ b/internal/cli/flag.go
@@ -3,7 +3,9 @@
 
 package cli
 
-import "github.com/spf13/pflag"
+import (
+	"github.com/spf13/pflag"
+)
 
 // Flag is the interface for cli flags.
 // To get the value after cli parsing, use fs.GetString(flag.Name)
@@ -59,6 +61,23 @@ type IntFlag struct {
 // RegisterTo register the int flag to FlagSet
 func (f IntFlag) RegisterTo(fs *pflag.FlagSet) error {
 	fs.IntP(f.Name, f.Shorthand, f.DefValue, f.Usage)
+	return markHiddenOrDeprecated(fs, f.Name, f.Deprecated, f.Hidden)
+}
+
+// Int64Flag is the flag with int64 value, used for gwei configurations
+type Int64Flag struct {
+	Name       string
+	Shorthand  string
+	Usage      string
+	Deprecated string
+	Hidden     bool
+
+	DefValue int64
+}
+
+// RegisterTo register the int flag to FlagSet
+func (f Int64Flag) RegisterTo(fs *pflag.FlagSet) error {
+	fs.Int64P(f.Name, f.Shorthand, f.DefValue, f.Usage)
 	return markHiddenOrDeprecated(fs, f.Name, f.Deprecated, f.Hidden)
 }
 
@@ -121,6 +140,8 @@ func getFlagName(flag Flag) string {
 	case StringSliceFlag:
 		return f.Name
 	case IntSliceFlag:
+		return f.Name
+	case Int64Flag:
 		return f.Name
 	}
 	return ""

--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -70,6 +70,12 @@ func GetIntFlagValue(cmd *cobra.Command, flag IntFlag) int {
 	return getIntFlagValue(cmd.Flags(), flag)
 }
 
+// GetInt64FlagValue get the int value for the given Int64Flag from the local flags of the
+// cobra command.
+func GetInt64FlagValue(cmd *cobra.Command, flag Int64Flag) int64 {
+	return getInt64FlagValue(cmd.Flags(), flag)
+}
+
 // GetIntPersistentFlagValue get the int value for the given IntFlag from the persistent
 // flags of the cobra command.
 func GetIntPersistentFlagValue(cmd *cobra.Command, flag IntFlag) int {
@@ -78,6 +84,15 @@ func GetIntPersistentFlagValue(cmd *cobra.Command, flag IntFlag) int {
 
 func getIntFlagValue(fs *pflag.FlagSet, flag IntFlag) int {
 	val, err := fs.GetInt(flag.Name)
+	if err != nil {
+		handleParseError(err)
+		return 0
+	}
+	return val
+}
+
+func getInt64FlagValue(fs *pflag.FlagSet, flag Int64Flag) int64 {
+	val, err := fs.GetInt64(flag.Name)
 	if err != nil {
 		handleParseError(err)
 		return 0

--- a/internal/configs/harmony/harmony.go
+++ b/internal/configs/harmony/harmony.go
@@ -35,6 +35,7 @@ type HarmonyConfig struct {
 	TiKV       *TiKVConfig       `toml:",omitempty"`
 	DNSSync    DnsSync
 	ShardData  ShardDataConfig
+	GPO        GasPriceOracleConfig
 }
 
 func (hc HarmonyConfig) ToRPCServerConfig() nodeconfig.RPCServerConfig {
@@ -155,6 +156,25 @@ type ShardDataConfig struct {
 	ShardCount      int
 	CacheTime       int
 	CacheSize       int
+}
+
+type GasPriceOracleConfig struct {
+	// the number of blocks to sample
+	Blocks int
+	// the number of transactions to sample, per block
+	Transactions int
+	// the percentile to pick from there
+	Percentile int
+	// the default gas price, if the above data is not available
+	DefaultPrice int64
+	// the maximum suggested gas price
+	MaxPrice int64
+	// when block usage (gas) for last `Blocks` blocks is below `LowUsageThreshold`,
+	// we return the Default price
+	LowUsageThreshold int
+	// hack: our block header reports an 80m gas limit, but it is actually 30M.
+	// if set to non-zero, this is applied UNCHECKED
+	BlockGasLimit int
 }
 
 type ConsensusConfig struct {


### PR DESCRIPTION
This change makes the gas price oracle options available as options in the configuration file / command line. In addition, the gas price oracle's suggestion mechanism has been modified to return the default gas price when block utilization is low. In other words, the oracle can be configured to return the 60th percentile gas price from the last 5 blocks with 3 transactions each, or return the default gas price if those 5 blocks were utilized less than 50% of their capacity

Fixes #4357 and supersedes #4362
