### PR TITLE
Fixed bug with storing already cancelled context.

### DIFF
--- a/api/service/stagedstreamsync/short_range_helper.go
+++ b/api/service/stagedstreamsync/short_range_helper.go
@@ -59,8 +59,7 @@ func (sh *srHelper) getBlocksChain(ctx context.Context, bns []uint64) ([]*types.
 }
 
 func (sh *srHelper) getBlocksByHashes(ctx context.Context, hashes []common.Hash, whitelist []sttypes.StreamID) ([]*types.Block, []sttypes.StreamID, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+
 	m := newGetBlocksByHashManager(hashes, whitelist)
 
 	var (
@@ -78,7 +77,8 @@ func (sh *srHelper) getBlocksByHashes(ctx context.Context, hashes []common.Hash,
 	for i := 0; i != concurrency; i++ {
 		go func(index int) {
 			defer wg.Done()
-			defer cancel() // it's ok to cancel context more than once
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
 
 			for {
 				if m.isDone() {

--- a/api/service/stagedstreamsync/short_range_helper.go
+++ b/api/service/stagedstreamsync/short_range_helper.go
@@ -148,7 +148,7 @@ func (sh *srHelper) prepareBlockHashNumbers(curNumber uint64) []uint64 {
 }
 
 func (sh *srHelper) doGetBlockHashesRequest(ctx context.Context, bns []uint64) ([]common.Hash, sttypes.StreamID, error) {
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	hashes, stid, err := sh.syncProtocol.GetBlockHashes(ctx, bns)

--- a/api/service/stagedstreamsync/short_range_helper.go
+++ b/api/service/stagedstreamsync/short_range_helper.go
@@ -15,13 +15,11 @@ import (
 
 type srHelper struct {
 	syncProtocol syncProtocol
-
-	ctx    context.Context
-	config Config
-	logger zerolog.Logger
+	config       Config
+	logger       zerolog.Logger
 }
 
-func (sh *srHelper) getHashChain(bns []uint64) ([]common.Hash, []sttypes.StreamID, error) {
+func (sh *srHelper) getHashChain(ctx context.Context, bns []uint64) ([]common.Hash, []sttypes.StreamID, error) {
 	results := newBlockHashResults(bns)
 
 	var wg sync.WaitGroup
@@ -31,7 +29,7 @@ func (sh *srHelper) getHashChain(bns []uint64) ([]common.Hash, []sttypes.StreamI
 		go func(index int) {
 			defer wg.Done()
 
-			hashes, stid, err := sh.doGetBlockHashesRequest(bns)
+			hashes, stid, err := sh.doGetBlockHashesRequest(ctx, bns)
 			if err != nil {
 				sh.logger.Warn().Err(err).Str("StreamID", string(stid)).
 					Msg(WrapStagedSyncMsg("doGetBlockHashes return error"))
@@ -43,10 +41,10 @@ func (sh *srHelper) getHashChain(bns []uint64) ([]common.Hash, []sttypes.StreamI
 	wg.Wait()
 
 	select {
-	case <-sh.ctx.Done():
-		sh.logger.Info().Err(sh.ctx.Err()).Int("num blocks", results.numBlocksWithResults()).
+	case <-ctx.Done():
+		sh.logger.Info().Err(ctx.Err()).Int("num blocks", results.numBlocksWithResults()).
 			Msg(WrapStagedSyncMsg("short range sync get hashes timed out"))
-		return nil, nil, sh.ctx.Err()
+		return nil, nil, ctx.Err()
 	default:
 	}
 
@@ -56,12 +54,12 @@ func (sh *srHelper) getHashChain(bns []uint64) ([]common.Hash, []sttypes.StreamI
 	return hashChain, wl, nil
 }
 
-func (sh *srHelper) getBlocksChain(bns []uint64) ([]*types.Block, sttypes.StreamID, error) {
-	return sh.doGetBlocksByNumbersRequest(bns)
+func (sh *srHelper) getBlocksChain(ctx context.Context, bns []uint64) ([]*types.Block, sttypes.StreamID, error) {
+	return sh.doGetBlocksByNumbersRequest(ctx, bns)
 }
 
-func (sh *srHelper) getBlocksByHashes(hashes []common.Hash, whitelist []sttypes.StreamID) ([]*types.Block, []sttypes.StreamID, error) {
-	ctx, cancel := context.WithCancel(sh.ctx)
+func (sh *srHelper) getBlocksByHashes(ctx context.Context, hashes []common.Hash, whitelist []sttypes.StreamID) ([]*types.Block, []sttypes.StreamID, error) {
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	m := newGetBlocksByHashManager(hashes, whitelist)
 
@@ -121,11 +119,11 @@ func (sh *srHelper) getBlocksByHashes(hashes []common.Hash, whitelist []sttypes.
 		return nil, nil, gErr
 	}
 	select {
-	case <-sh.ctx.Done():
+	case <-ctx.Done():
 		res, _, _ := m.getResults()
-		sh.logger.Info().Err(sh.ctx.Err()).Int("num blocks", len(res)).
+		sh.logger.Info().Err(ctx.Err()).Int("num blocks", len(res)).
 			Msg(WrapStagedSyncMsg("short range sync get blocks timed out"))
-		return nil, nil, sh.ctx.Err()
+		return nil, nil, ctx.Err()
 	default:
 	}
 
@@ -149,8 +147,8 @@ func (sh *srHelper) prepareBlockHashNumbers(curNumber uint64) []uint64 {
 	return res
 }
 
-func (sh *srHelper) doGetBlockHashesRequest(bns []uint64) ([]common.Hash, sttypes.StreamID, error) {
-	ctx, cancel := context.WithTimeout(sh.ctx, 1*time.Second)
+func (sh *srHelper) doGetBlockHashesRequest(ctx context.Context, bns []uint64) ([]common.Hash, sttypes.StreamID, error) {
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 
 	hashes, stid, err := sh.syncProtocol.GetBlockHashes(ctx, bns)
@@ -171,8 +169,8 @@ func (sh *srHelper) doGetBlockHashesRequest(bns []uint64) ([]common.Hash, sttype
 	return hashes, stid, nil
 }
 
-func (sh *srHelper) doGetBlocksByNumbersRequest(bns []uint64) ([]*types.Block, sttypes.StreamID, error) {
-	ctx, cancel := context.WithTimeout(sh.ctx, 10*time.Second)
+func (sh *srHelper) doGetBlocksByNumbersRequest(ctx context.Context, bns []uint64) ([]*types.Block, sttypes.StreamID, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	blocks, stid, err := sh.syncProtocol.GetBlocksByNumber(ctx, bns)
@@ -186,7 +184,7 @@ func (sh *srHelper) doGetBlocksByNumbersRequest(bns []uint64) ([]*types.Block, s
 }
 
 func (sh *srHelper) doGetBlocksByHashesRequest(ctx context.Context, hashes []common.Hash, wl []sttypes.StreamID) ([]*types.Block, sttypes.StreamID, error) {
-	ctx, cancel := context.WithTimeout(sh.ctx, 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	blocks, stid, err := sh.syncProtocol.GetBlocksByHashes(ctx, hashes,

--- a/api/service/stagedstreamsync/stage.go
+++ b/api/service/stagedstreamsync/stage.go
@@ -16,21 +16,18 @@ type StageHandler interface {
 	// * invalidBlockRevert - whether the execution is to solve the invalid block
 	// * s - is the current state of the stage and contains stage data.
 	// * reverter - if the stage needs to cause reverting, `reverter` methods can be used.
-	Exec(firstCycle bool, invalidBlockRevert bool, s *StageState, reverter Reverter, tx kv.RwTx) error
+	Exec(ctx context.Context, firstCycle bool, invalidBlockRevert bool, s *StageState, reverter Reverter, tx kv.RwTx) error
 
 	// Revert is the reverting logic of the stage.
 	// * firstCycle - is it the first cycle of syncing.
 	// * u - contains information about the revert itself.
 	// * s - represents the state of this stage at the beginning of revert.
-	Revert(firstCycle bool, u *RevertState, s *StageState, tx kv.RwTx) error
+	Revert(ctx context.Context, firstCycle bool, u *RevertState, s *StageState, tx kv.RwTx) error
 
 	// CleanUp is the execution function for the stage to prune old data.
 	// * firstCycle - is it the first cycle of syncing.
 	// * p - is the current state of the stage and contains stage data.
-	CleanUp(firstCycle bool, p *CleanUpState, tx kv.RwTx) error
-
-	// SetStageContext updates the context for stage
-	SetStageContext(ctx context.Context)
+	CleanUp(ctx context.Context, firstCycle bool, p *CleanUpState, tx kv.RwTx) error
 }
 
 // Stage is a single sync stage in staged sync.

--- a/api/service/stagedstreamsync/stage_bodies.go
+++ b/api/service/stagedstreamsync/stage_bodies.go
@@ -218,7 +218,7 @@ func (b *StageBodies) redownloadBadBlock(ctx context.Context, s *StageState) err
 			continue
 		}
 		s.state.gbm.SetDownloadDetails(batch, 0, stid)
-		if errU := b.configs.blockDBs[0].Update(context.Background(), func(tx kv.RwTx) error {
+		if errU := b.configs.blockDBs[0].Update(ctx, func(tx kv.RwTx) error {
 			if err = b.saveBlocks(ctx, tx, batch, blockBytes, sigBytes, 0, stid); err != nil {
 				return errors.Errorf("[STAGED_STREAM_SYNC] saving re-downloaded bad block to db failed.")
 			}

--- a/api/service/stagedstreamsync/stage_bodies.go
+++ b/api/service/stagedstreamsync/stage_bodies.go
@@ -17,8 +17,8 @@ import (
 type StageBodies struct {
 	configs StageBodiesCfg
 }
+
 type StageBodiesCfg struct {
-	ctx         context.Context
 	bc          core.BlockChain
 	db          kv.RwDB
 	blockDBs    []kv.RwDB
@@ -34,9 +34,8 @@ func NewStageBodies(cfg StageBodiesCfg) *StageBodies {
 	}
 }
 
-func NewStageBodiesCfg(ctx context.Context, bc core.BlockChain, db kv.RwDB, blockDBs []kv.RwDB, concurrency int, protocol syncProtocol, isBeacon bool, logProgress bool) StageBodiesCfg {
+func NewStageBodiesCfg(bc core.BlockChain, db kv.RwDB, blockDBs []kv.RwDB, concurrency int, protocol syncProtocol, isBeacon bool, logProgress bool) StageBodiesCfg {
 	return StageBodiesCfg{
-		ctx:         ctx,
 		bc:          bc,
 		db:          db,
 		blockDBs:    blockDBs,
@@ -47,17 +46,13 @@ func NewStageBodiesCfg(ctx context.Context, bc core.BlockChain, db kv.RwDB, bloc
 	}
 }
 
-func (b *StageBodies) SetStageContext(ctx context.Context) {
-	b.configs.ctx = ctx
-}
-
 // Exec progresses Bodies stage in the forward direction
-func (b *StageBodies) Exec(firstCycle bool, invalidBlockRevert bool, s *StageState, reverter Reverter, tx kv.RwTx) (err error) {
+func (b *StageBodies) Exec(ctx context.Context, firstCycle bool, invalidBlockRevert bool, s *StageState, reverter Reverter, tx kv.RwTx) (err error) {
 
 	useInternalTx := tx == nil
 
 	if invalidBlockRevert {
-		return b.redownloadBadBlock(s)
+		return b.redownloadBadBlock(ctx, s)
 	}
 
 	// for short range sync, skip this stage
@@ -72,10 +67,8 @@ func (b *StageBodies) Exec(firstCycle bool, invalidBlockRevert bool, s *StageSta
 	}
 	currProgress := uint64(0)
 	targetHeight := s.state.currentCycle.TargetHeight
-	// isBeacon := s.state.isBeacon
-	// isLastCycle := targetHeight >= maxHeight
 
-	if errV := CreateView(b.configs.ctx, b.configs.db, tx, func(etx kv.Tx) error {
+	if errV := CreateView(ctx, b.configs.db, tx, func(etx kv.Tx) error {
 		if currProgress, err = s.CurrentStageProgress(etx); err != nil {
 			return err
 		}
@@ -85,7 +78,7 @@ func (b *StageBodies) Exec(firstCycle bool, invalidBlockRevert bool, s *StageSta
 	}
 
 	if currProgress == 0 {
-		if err := b.cleanAllBlockDBs(); err != nil {
+		if err := b.cleanAllBlockDBs(ctx); err != nil {
 			return err
 		}
 		currProgress = currentHead
@@ -104,7 +97,7 @@ func (b *StageBodies) Exec(firstCycle bool, invalidBlockRevert bool, s *StageSta
 
 	if useInternalTx {
 		var err error
-		tx, err = b.configs.db.BeginRw(context.Background())
+		tx, err = b.configs.db.BeginRw(ctx)
 		if err != nil {
 			return err
 		}
@@ -119,7 +112,7 @@ func (b *StageBodies) Exec(firstCycle bool, invalidBlockRevert bool, s *StageSta
 
 	for i := 0; i != s.state.config.Concurrency; i++ {
 		wg.Add(1)
-		go b.runBlockWorkerLoop(s.state.gbm, &wg, i, startTime)
+		go b.runBlockWorkerLoop(ctx, s.state.gbm, &wg, i, startTime)
 	}
 
 	wg.Wait()
@@ -134,7 +127,7 @@ func (b *StageBodies) Exec(firstCycle bool, invalidBlockRevert bool, s *StageSta
 }
 
 // runBlockWorkerLoop creates a work loop for download blocks
-func (b *StageBodies) runBlockWorkerLoop(gbm *blockDownloadManager, wg *sync.WaitGroup, loopID int, startTime time.Time) {
+func (b *StageBodies) runBlockWorkerLoop(ctx context.Context, gbm *blockDownloadManager, wg *sync.WaitGroup, loopID int, startTime time.Time) {
 
 	currentBlock := int(b.configs.bc.CurrentBlock().NumberU64())
 
@@ -142,21 +135,21 @@ func (b *StageBodies) runBlockWorkerLoop(gbm *blockDownloadManager, wg *sync.Wai
 
 	for {
 		select {
-		case <-b.configs.ctx.Done():
+		case <-ctx.Done():
 			return
 		default:
 		}
 		batch := gbm.GetNextBatch()
 		if len(batch) == 0 {
 			select {
-			case <-b.configs.ctx.Done():
+			case <-ctx.Done():
 				return
 			case <-time.After(100 * time.Millisecond):
 				return
 			}
 		}
 
-		blockBytes, sigBytes, stid, err := b.downloadRawBlocks(batch)
+		blockBytes, sigBytes, stid, err := b.downloadRawBlocks(ctx, batch)
 		if err != nil {
 			if !errors.Is(err, context.Canceled) {
 				b.configs.protocol.StreamFailed(stid, "downloadRawBlocks failed")
@@ -176,7 +169,7 @@ func (b *StageBodies) runBlockWorkerLoop(gbm *blockDownloadManager, wg *sync.Wai
 			err := errors.New("downloadRawBlocks received empty blockBytes")
 			gbm.HandleRequestError(batch, err, stid)
 		} else {
-			if err = b.saveBlocks(gbm.tx, batch, blockBytes, sigBytes, loopID, stid); err != nil {
+			if err = b.saveBlocks(ctx, gbm.tx, batch, blockBytes, sigBytes, loopID, stid); err != nil {
 				panic(ErrSaveBlocksToDbFailed)
 			}
 			gbm.HandleRequestResult(batch, blockBytes, sigBytes, loopID, stid)
@@ -197,7 +190,7 @@ func (b *StageBodies) runBlockWorkerLoop(gbm *blockDownloadManager, wg *sync.Wai
 }
 
 // redownloadBadBlock tries to redownload the bad block from other streams
-func (b *StageBodies) redownloadBadBlock(s *StageState) error {
+func (b *StageBodies) redownloadBadBlock(ctx context.Context, s *StageState) error {
 
 	batch := make([]uint64, 1)
 	batch = append(batch, s.state.invalidBlock.Number)
@@ -206,7 +199,7 @@ func (b *StageBodies) redownloadBadBlock(s *StageState) error {
 		if b.configs.protocol.NumStreams() == 0 {
 			return errors.Errorf("re-download bad block from all streams failed")
 		}
-		blockBytes, sigBytes, stid, err := b.downloadRawBlocks(batch)
+		blockBytes, sigBytes, stid, err := b.downloadRawBlocks(ctx, batch)
 		if err != nil {
 			if !errors.Is(err, context.Canceled) {
 				b.configs.protocol.StreamFailed(stid, "tried to re-download bad block from this stream, but downloadRawBlocks failed")
@@ -226,7 +219,7 @@ func (b *StageBodies) redownloadBadBlock(s *StageState) error {
 		}
 		s.state.gbm.SetDownloadDetails(batch, 0, stid)
 		if errU := b.configs.blockDBs[0].Update(context.Background(), func(tx kv.RwTx) error {
-			if err = b.saveBlocks(tx, batch, blockBytes, sigBytes, 0, stid); err != nil {
+			if err = b.saveBlocks(ctx, tx, batch, blockBytes, sigBytes, 0, stid); err != nil {
 				return errors.Errorf("[STAGED_STREAM_SYNC] saving re-downloaded bad block to db failed.")
 			}
 			return nil
@@ -238,8 +231,8 @@ func (b *StageBodies) redownloadBadBlock(s *StageState) error {
 	return nil
 }
 
-func (b *StageBodies) downloadBlocks(bns []uint64) ([]*types.Block, sttypes.StreamID, error) {
-	ctx, cancel := context.WithTimeout(b.configs.ctx, 10*time.Second)
+func (b *StageBodies) downloadBlocks(ctx context.Context, bns []uint64) ([]*types.Block, sttypes.StreamID, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	blocks, stid, err := b.configs.protocol.GetBlocksByNumber(ctx, bns)
@@ -252,8 +245,8 @@ func (b *StageBodies) downloadBlocks(bns []uint64) ([]*types.Block, sttypes.Stre
 	return blocks, stid, nil
 }
 
-func (b *StageBodies) downloadRawBlocks(bns []uint64) ([][]byte, [][]byte, sttypes.StreamID, error) {
-	ctx, cancel := context.WithTimeout(b.configs.ctx, 10*time.Second)
+func (b *StageBodies) downloadRawBlocks(ctx context.Context, bns []uint64) ([][]byte, [][]byte, sttypes.StreamID, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	return b.configs.protocol.GetRawBlocksByNumber(ctx, bns)
@@ -272,9 +265,9 @@ func validateGetBlocksResult(requested []uint64, result []*types.Block) error {
 }
 
 // saveBlocks saves the blocks into db
-func (b *StageBodies) saveBlocks(tx kv.RwTx, bns []uint64, blockBytes [][]byte, sigBytes [][]byte, loopID int, stid sttypes.StreamID) error {
+func (b *StageBodies) saveBlocks(ctx context.Context, tx kv.RwTx, bns []uint64, blockBytes [][]byte, sigBytes [][]byte, loopID int, stid sttypes.StreamID) error {
 
-	tx, err := b.configs.blockDBs[loopID].BeginRw(context.Background())
+	tx, err := b.configs.blockDBs[loopID].BeginRw(ctx)
 	if err != nil {
 		return err
 	}
@@ -313,11 +306,11 @@ func (b *StageBodies) saveBlocks(tx kv.RwTx, bns []uint64, blockBytes [][]byte, 
 	return nil
 }
 
-func (b *StageBodies) saveProgress(s *StageState, progress uint64, tx kv.RwTx) (err error) {
+func (b *StageBodies) saveProgress(ctx context.Context, s *StageState, progress uint64, tx kv.RwTx) (err error) {
 	useInternalTx := tx == nil
 	if useInternalTx {
 		var err error
-		tx, err = b.configs.db.BeginRw(context.Background())
+		tx, err = b.configs.db.BeginRw(ctx)
 		if err != nil {
 			return err
 		}
@@ -340,9 +333,8 @@ func (b *StageBodies) saveProgress(s *StageState, progress uint64, tx kv.RwTx) (
 	return nil
 }
 
-func (b *StageBodies) cleanBlocksDB(loopID int) (err error) {
-
-	tx, errb := b.configs.blockDBs[loopID].BeginRw(b.configs.ctx)
+func (b *StageBodies) cleanBlocksDB(ctx context.Context, loopID int) (err error) {
+	tx, errb := b.configs.blockDBs[loopID].BeginRw(ctx)
 	if errb != nil {
 		return errb
 	}
@@ -370,26 +362,26 @@ func (b *StageBodies) cleanBlocksDB(loopID int) (err error) {
 	return nil
 }
 
-func (b *StageBodies) cleanAllBlockDBs() (err error) {
+func (b *StageBodies) cleanAllBlockDBs(ctx context.Context) (err error) {
 	//clean all blocks DBs
 	for i := 0; i < b.configs.concurrency; i++ {
-		if err := b.cleanBlocksDB(i); err != nil {
+		if err := b.cleanBlocksDB(ctx, i); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (b *StageBodies) Revert(firstCycle bool, u *RevertState, s *StageState, tx kv.RwTx) (err error) {
+func (b *StageBodies) Revert(ctx context.Context, firstCycle bool, u *RevertState, s *StageState, tx kv.RwTx) (err error) {
 
 	//clean all blocks DBs
-	if err := b.cleanAllBlockDBs(); err != nil {
+	if err := b.cleanAllBlockDBs(ctx); err != nil {
 		return err
 	}
 
 	useInternalTx := tx == nil
 	if useInternalTx {
-		tx, err = b.configs.db.BeginRw(b.configs.ctx)
+		tx, err = b.configs.db.BeginRw(ctx)
 		if err != nil {
 			return err
 		}
@@ -416,10 +408,9 @@ func (b *StageBodies) Revert(firstCycle bool, u *RevertState, s *StageState, tx 
 	return nil
 }
 
-func (b *StageBodies) CleanUp(firstCycle bool, p *CleanUpState, tx kv.RwTx) (err error) {
-
+func (b *StageBodies) CleanUp(ctx context.Context, firstCycle bool, p *CleanUpState, tx kv.RwTx) (err error) {
 	//clean all blocks DBs
-	if err := b.cleanAllBlockDBs(); err != nil {
+	if err := b.cleanAllBlockDBs(ctx); err != nil {
 		return err
 	}
 

--- a/api/service/stagedstreamsync/stage_epoch.go
+++ b/api/service/stagedstreamsync/stage_epoch.go
@@ -77,13 +77,12 @@ func (sr *StageEpoch) doShortRangeSyncForEpochSync(ctx context.Context, s *Stage
 
 	numShortRangeCounterVec.With(s.state.promLabels()).Inc()
 
-	srCtx, cancel := context.WithTimeout(ctx, ShortRangeTimeout)
+	ctx, cancel := context.WithTimeout(ctx, ShortRangeTimeout)
 	defer cancel()
 
 	//TODO: merge srHelper with StageEpochConfig
 	sh := &srHelper{
 		syncProtocol: s.state.protocol,
-		ctx:          srCtx,
 		config:       s.state.config,
 		logger:       utils.Logger().With().Str("mode", "epoch chain short range").Logger(),
 	}
@@ -110,7 +109,7 @@ func (sr *StageEpoch) doShortRangeSyncForEpochSync(ctx context.Context, s *Stage
 	}
 
 	////////////////////////////////////////////////////////
-	hashChain, whitelist, err := sh.getHashChain(bns)
+	hashChain, whitelist, err := sh.getHashChain(ctx, bns)
 	if err != nil {
 		return 0, errors.Wrap(err, "getHashChain")
 	}
@@ -118,7 +117,7 @@ func (sr *StageEpoch) doShortRangeSyncForEpochSync(ctx context.Context, s *Stage
 		// short circuit for no sync is needed
 		return 0, nil
 	}
-	blocks, streamID, err := sh.getBlocksByHashes(hashChain, whitelist)
+	blocks, streamID, err := sh.getBlocksByHashes(ctx, hashChain, whitelist)
 	if err != nil {
 		utils.Logger().Warn().Err(err).Msg("epoch sync getBlocksByHashes failed")
 		if !errors.Is(err, context.Canceled) {

--- a/api/service/stagedstreamsync/stage_epoch.go
+++ b/api/service/stagedstreamsync/stage_epoch.go
@@ -15,9 +15,8 @@ type StageEpoch struct {
 }
 
 type StageEpochCfg struct {
-	ctx context.Context
-	bc  core.BlockChain
-	db  kv.RwDB
+	bc core.BlockChain
+	db kv.RwDB
 }
 
 func NewStageEpoch(cfg StageEpochCfg) *StageEpoch {
@@ -26,19 +25,14 @@ func NewStageEpoch(cfg StageEpochCfg) *StageEpoch {
 	}
 }
 
-func NewStageEpochCfg(ctx context.Context, bc core.BlockChain, db kv.RwDB) StageEpochCfg {
+func NewStageEpochCfg(bc core.BlockChain, db kv.RwDB) StageEpochCfg {
 	return StageEpochCfg{
-		ctx: ctx,
-		bc:  bc,
-		db:  db,
+		bc: bc,
+		db: db,
 	}
 }
 
-func (sr *StageEpoch) SetStageContext(ctx context.Context) {
-	sr.configs.ctx = ctx
-}
-
-func (sr *StageEpoch) Exec(firstCycle bool, invalidBlockRevert bool, s *StageState, reverter Reverter, tx kv.RwTx) error {
+func (sr *StageEpoch) Exec(ctx context.Context, firstCycle bool, invalidBlockRevert bool, s *StageState, reverter Reverter, tx kv.RwTx) error {
 
 	// no need to update epoch chain if we are redoing the stages because of bad block
 	if invalidBlockRevert {
@@ -54,7 +48,7 @@ func (sr *StageEpoch) Exec(firstCycle bool, invalidBlockRevert bool, s *StageSta
 	}
 
 	// doShortRangeSyncForEpochSync
-	n, err := sr.doShortRangeSyncForEpochSync(s)
+	n, err := sr.doShortRangeSyncForEpochSync(ctx, s)
 	s.state.inserted = n
 	if err != nil {
 		return err
@@ -63,7 +57,7 @@ func (sr *StageEpoch) Exec(firstCycle bool, invalidBlockRevert bool, s *StageSta
 	useInternalTx := tx == nil
 	if useInternalTx {
 		var err error
-		tx, err = sr.configs.db.BeginRw(sr.configs.ctx)
+		tx, err = sr.configs.db.BeginRw(ctx)
 		if err != nil {
 			return err
 		}
@@ -79,11 +73,11 @@ func (sr *StageEpoch) Exec(firstCycle bool, invalidBlockRevert bool, s *StageSta
 	return nil
 }
 
-func (sr *StageEpoch) doShortRangeSyncForEpochSync(s *StageState) (int, error) {
+func (sr *StageEpoch) doShortRangeSyncForEpochSync(ctx context.Context, s *StageState) (int, error) {
 
 	numShortRangeCounterVec.With(s.state.promLabels()).Inc()
 
-	srCtx, cancel := context.WithTimeout(s.state.ctx, ShortRangeTimeout)
+	srCtx, cancel := context.WithTimeout(ctx, ShortRangeTimeout)
 	defer cancel()
 
 	//TODO: merge srHelper with StageEpochConfig
@@ -157,10 +151,10 @@ func (sr *StageEpoch) doShortRangeSyncForEpochSync(s *StageState) (int, error) {
 	return n, nil
 }
 
-func (sr *StageEpoch) Revert(firstCycle bool, u *RevertState, s *StageState, tx kv.RwTx) (err error) {
+func (sr *StageEpoch) Revert(ctx context.Context, firstCycle bool, u *RevertState, s *StageState, tx kv.RwTx) (err error) {
 	useInternalTx := tx == nil
 	if useInternalTx {
-		tx, err = sr.configs.db.BeginRw(context.Background())
+		tx, err = sr.configs.db.BeginRw(ctx)
 		if err != nil {
 			return err
 		}
@@ -179,10 +173,10 @@ func (sr *StageEpoch) Revert(firstCycle bool, u *RevertState, s *StageState, tx 
 	return nil
 }
 
-func (sr *StageEpoch) CleanUp(firstCycle bool, p *CleanUpState, tx kv.RwTx) (err error) {
+func (sr *StageEpoch) CleanUp(ctx context.Context, firstCycle bool, p *CleanUpState, tx kv.RwTx) (err error) {
 	useInternalTx := tx == nil
 	if useInternalTx {
-		tx, err = sr.configs.db.BeginRw(context.Background())
+		tx, err = sr.configs.db.BeginRw(ctx)
 		if err != nil {
 			return err
 		}

--- a/api/service/stagedstreamsync/stage_finish.go
+++ b/api/service/stagedstreamsync/stage_finish.go
@@ -30,7 +30,7 @@ func (finish *StageFinish) Exec(ctx context.Context, firstCycle bool, invalidBlo
 	useInternalTx := tx == nil
 	if useInternalTx {
 		var err error
-		tx, err = finish.configs.db.BeginRw(context.Background())
+		tx, err = finish.configs.db.BeginRw(ctx)
 		if err != nil {
 			return err
 		}

--- a/api/service/stagedstreamsync/stage_finish.go
+++ b/api/service/stagedstreamsync/stage_finish.go
@@ -11,8 +11,7 @@ type StageFinish struct {
 }
 
 type StageFinishCfg struct {
-	ctx context.Context
-	db  kv.RwDB
+	db kv.RwDB
 }
 
 func NewStageFinish(cfg StageFinishCfg) *StageFinish {
@@ -21,18 +20,13 @@ func NewStageFinish(cfg StageFinishCfg) *StageFinish {
 	}
 }
 
-func NewStageFinishCfg(ctx context.Context, db kv.RwDB) StageFinishCfg {
+func NewStageFinishCfg(db kv.RwDB) StageFinishCfg {
 	return StageFinishCfg{
-		ctx: ctx,
-		db:  db,
+		db: db,
 	}
 }
 
-func (finish *StageFinish) SetStageContext(ctx context.Context) {
-	finish.configs.ctx = ctx
-}
-
-func (finish *StageFinish) Exec(firstCycle bool, invalidBlockRevert bool, s *StageState, reverter Reverter, tx kv.RwTx) error {
+func (finish *StageFinish) Exec(ctx context.Context, firstCycle bool, invalidBlockRevert bool, s *StageState, reverter Reverter, tx kv.RwTx) error {
 	useInternalTx := tx == nil
 	if useInternalTx {
 		var err error
@@ -54,11 +48,11 @@ func (finish *StageFinish) Exec(firstCycle bool, invalidBlockRevert bool, s *Sta
 	return nil
 }
 
-func (bh *StageFinish) clearBucket(tx kv.RwTx, isBeacon bool) error {
+func (finish *StageFinish) clearBucket(ctx context.Context, tx kv.RwTx, isBeacon bool) error {
 	useInternalTx := tx == nil
 	if useInternalTx {
 		var err error
-		tx, err = bh.configs.db.BeginRw(context.Background())
+		tx, err = finish.configs.db.BeginRw(ctx)
 		if err != nil {
 			return err
 		}
@@ -73,10 +67,10 @@ func (bh *StageFinish) clearBucket(tx kv.RwTx, isBeacon bool) error {
 	return nil
 }
 
-func (finish *StageFinish) Revert(firstCycle bool, u *RevertState, s *StageState, tx kv.RwTx) (err error) {
+func (finish *StageFinish) Revert(ctx context.Context, firstCycle bool, u *RevertState, s *StageState, tx kv.RwTx) (err error) {
 	useInternalTx := tx == nil
 	if useInternalTx {
-		tx, err = finish.configs.db.BeginRw(finish.configs.ctx)
+		tx, err = finish.configs.db.BeginRw(ctx)
 		if err != nil {
 			return err
 		}
@@ -95,10 +89,10 @@ func (finish *StageFinish) Revert(firstCycle bool, u *RevertState, s *StageState
 	return nil
 }
 
-func (finish *StageFinish) CleanUp(firstCycle bool, p *CleanUpState, tx kv.RwTx) (err error) {
+func (finish *StageFinish) CleanUp(ctx context.Context, firstCycle bool, p *CleanUpState, tx kv.RwTx) (err error) {
 	useInternalTx := tx == nil
 	if useInternalTx {
-		tx, err = finish.configs.db.BeginRw(finish.configs.ctx)
+		tx, err = finish.configs.db.BeginRw(ctx)
 		if err != nil {
 			return err
 		}

--- a/api/service/stagedstreamsync/staged_stream_sync.go
+++ b/api/service/stagedstreamsync/staged_stream_sync.go
@@ -54,7 +54,6 @@ func (ib *InvalidBlock) addBadStream(bsID sttypes.StreamID) {
 }
 
 type StagedStreamSync struct {
-	ctx          context.Context
 	bc           core.BlockChain
 	isBeacon     bool
 	isExplorer   bool
@@ -101,7 +100,6 @@ type SyncCycle struct {
 }
 
 func (s *StagedStreamSync) Len() int                    { return len(s.stages) }
-func (s *StagedStreamSync) Context() context.Context    { return s.ctx }
 func (s *StagedStreamSync) Blockchain() core.BlockChain { return s.bc }
 func (s *StagedStreamSync) DB() kv.RwDB                 { return s.db }
 func (s *StagedStreamSync) IsBeacon() bool              { return s.isBeacon }
@@ -232,7 +230,7 @@ func (s *StagedStreamSync) StageState(stage SyncStageID, tx kv.Tx, db kv.RwDB) (
 }
 
 // cleanUp cleans up the stage by calling pruneStage
-func (s *StagedStreamSync) cleanUp(fromStage int, db kv.RwDB, tx kv.RwTx, firstCycle bool) error {
+func (s *StagedStreamSync) cleanUp(ctx context.Context, fromStage int, db kv.RwDB, tx kv.RwTx, firstCycle bool) error {
 	found := false
 	for i := 0; i < len(s.pruningOrder); i++ {
 		if s.pruningOrder[i].ID == s.stages[fromStage].ID {
@@ -241,7 +239,7 @@ func (s *StagedStreamSync) cleanUp(fromStage int, db kv.RwDB, tx kv.RwTx, firstC
 		if !found || s.pruningOrder[i] == nil || s.pruningOrder[i].Disabled {
 			continue
 		}
-		if err := s.pruneStage(firstCycle, s.pruningOrder[i], db, tx); err != nil {
+		if err := s.pruneStage(ctx, firstCycle, s.pruningOrder[i], db, tx); err != nil {
 			panic(err)
 		}
 	}
@@ -249,7 +247,7 @@ func (s *StagedStreamSync) cleanUp(fromStage int, db kv.RwDB, tx kv.RwTx, firstC
 }
 
 // New creates a new StagedStreamSync instance
-func New(ctx context.Context,
+func New(
 	bc core.BlockChain,
 	db kv.RwDB,
 	stagesList []*Stage,
@@ -288,7 +286,6 @@ func New(ctx context.Context,
 	status := newStatus()
 
 	return &StagedStreamSync{
-		ctx:          ctx,
 		bc:           bc,
 		isBeacon:     isBeacon,
 		db:           db,
@@ -309,8 +306,8 @@ func New(ctx context.Context,
 }
 
 // doGetCurrentNumberRequest returns estimated current block number and corresponding stream
-func (s *StagedStreamSync) doGetCurrentNumberRequest() (uint64, sttypes.StreamID, error) {
-	ctx, cancel := context.WithTimeout(s.ctx, 10*time.Second)
+func (s *StagedStreamSync) doGetCurrentNumberRequest(ctx context.Context) (uint64, sttypes.StreamID, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	bn, stid, err := s.protocol.GetCurrentBlockNumber(ctx, syncproto.WithHighPriority())
@@ -336,16 +333,8 @@ func (s *StagedStreamSync) checkHaveEnoughStreams() error {
 	return nil
 }
 
-// SetNewContext sets a new context for all stages
-func (s *StagedStreamSync) SetNewContext(ctx context.Context) error {
-	for _, s := range s.stages {
-		s.Handler.SetStageContext(ctx)
-	}
-	return nil
-}
-
 // Run runs a full cycle of stages
-func (s *StagedStreamSync) Run(db kv.RwDB, tx kv.RwTx, firstCycle bool) error {
+func (s *StagedStreamSync) Run(ctx context.Context, db kv.RwDB, tx kv.RwTx, firstCycle bool) error {
 	s.prevRevertPoint = nil
 	s.timings = s.timings[:0]
 
@@ -358,7 +347,7 @@ func (s *StagedStreamSync) Run(db kv.RwDB, tx kv.RwTx, firstCycle bool) error {
 					if s.revertOrder[j] == nil || s.revertOrder[j].Disabled {
 						continue
 					}
-					if err := s.revertStage(firstCycle, s.revertOrder[j], db, tx); err != nil {
+					if err := s.revertStage(ctx, firstCycle, s.revertOrder[j], db, tx); err != nil {
 						utils.Logger().Error().
 							Err(err).
 							Interface("stage id", s.revertOrder[j].ID).
@@ -383,7 +372,7 @@ func (s *StagedStreamSync) Run(db kv.RwDB, tx kv.RwTx, firstCycle bool) error {
 			continue
 		}
 
-		if err := s.runStage(stage, db, tx, firstCycle, s.invalidBlock.Active); err != nil {
+		if err := s.runStage(ctx, stage, db, tx, firstCycle, s.invalidBlock.Active); err != nil {
 			utils.Logger().Error().
 				Err(err).
 				Interface("stage id", stage.ID).
@@ -393,7 +382,7 @@ func (s *StagedStreamSync) Run(db kv.RwDB, tx kv.RwTx, firstCycle bool) error {
 		s.NextStage()
 	}
 
-	if err := s.cleanUp(0, db, tx, firstCycle); err != nil {
+	if err := s.cleanUp(ctx, 0, db, tx, firstCycle); err != nil {
 		utils.Logger().Error().
 			Err(err).
 			Msgf(WrapStagedSyncMsg("stages cleanup failed"))
@@ -414,7 +403,7 @@ func CreateView(ctx context.Context, db kv.RwDB, tx kv.Tx, f func(tx kv.Tx) erro
 	if tx != nil {
 		return f(tx)
 	}
-	return db.View(context.Background(), func(etx kv.Tx) error {
+	return db.View(ctx, func(etx kv.Tx) error {
 		return f(etx)
 	})
 }
@@ -466,14 +455,14 @@ func printLogs(tx kv.RwTx, timings []Timing) error {
 }
 
 // runStage executes stage
-func (s *StagedStreamSync) runStage(stage *Stage, db kv.RwDB, tx kv.RwTx, firstCycle bool, invalidBlockRevert bool) (err error) {
+func (s *StagedStreamSync) runStage(ctx context.Context, stage *Stage, db kv.RwDB, tx kv.RwTx, firstCycle bool, invalidBlockRevert bool) (err error) {
 	start := time.Now()
 	stageState, err := s.StageState(stage.ID, tx, db)
 	if err != nil {
 		return err
 	}
 
-	if err = stage.Handler.Exec(firstCycle, invalidBlockRevert, stageState, s, tx); err != nil {
+	if err = stage.Handler.Exec(ctx, firstCycle, invalidBlockRevert, stageState, s, tx); err != nil {
 		utils.Logger().Error().
 			Err(err).
 			Interface("stage id", stage.ID).
@@ -493,7 +482,7 @@ func (s *StagedStreamSync) runStage(stage *Stage, db kv.RwDB, tx kv.RwTx, firstC
 }
 
 // revertStage reverts stage
-func (s *StagedStreamSync) revertStage(firstCycle bool, stage *Stage, db kv.RwDB, tx kv.RwTx) error {
+func (s *StagedStreamSync) revertStage(ctx context.Context, firstCycle bool, stage *Stage, db kv.RwDB, tx kv.RwTx) error {
 	start := time.Now()
 	stageState, err := s.StageState(stage.ID, tx, db)
 	if err != nil {
@@ -510,7 +499,7 @@ func (s *StagedStreamSync) revertStage(firstCycle bool, stage *Stage, db kv.RwDB
 		return err
 	}
 
-	err = stage.Handler.Revert(firstCycle, revert, stageState, tx)
+	err = stage.Handler.Revert(ctx, firstCycle, revert, stageState, tx)
 	if err != nil {
 		return fmt.Errorf("[%s] %w", s.LogPrefix(), err)
 	}
@@ -526,7 +515,7 @@ func (s *StagedStreamSync) revertStage(firstCycle bool, stage *Stage, db kv.RwDB
 }
 
 // pruneStage cleans up the stage and logs the timing
-func (s *StagedStreamSync) pruneStage(firstCycle bool, stage *Stage, db kv.RwDB, tx kv.RwTx) error {
+func (s *StagedStreamSync) pruneStage(ctx context.Context, firstCycle bool, stage *Stage, db kv.RwDB, tx kv.RwTx) error {
 	start := time.Now()
 
 	stageState, err := s.StageState(stage.ID, tx, db)
@@ -542,7 +531,7 @@ func (s *StagedStreamSync) pruneStage(firstCycle bool, stage *Stage, db kv.RwDB,
 		return err
 	}
 
-	err = stage.Handler.CleanUp(firstCycle, prune, tx)
+	err = stage.Handler.CleanUp(ctx, firstCycle, prune, tx)
 	if err != nil {
 		return fmt.Errorf("[%s] %w", s.LogPrefix(), err)
 	}

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -682,7 +682,7 @@ func VerifyNewBlock(hooks *webhooks.Hooks, blockChain core.BlockChain, beaconCha
 				Int("numTx", len(newBlock.Transactions())).
 				Int("numStakingTx", len(newBlock.StakingTransactions())).
 				Err(err).
-				Msg("[VerifyNewBlock] Cannot Verify New Block!!!")
+				Msgf("[VerifyNewBlock] Cannot Verify New Block!!!, blockHeight %d, myHeight %d", newBlock.NumberU64(), blockChain.CurrentHeader().NumberU64())
 			return errors.Errorf(
 				"[VerifyNewBlock] Cannot Verify New Block!!! block-hash %s txn-count %d",
 				newBlock.Hash().Hex(),


### PR DESCRIPTION
Firstly, according to this article https://go.dev/blog/context-and-structs
**Contexts should not be stored inside a struct type, but instead passed to each function that needs it.**

Secondly, there is a bug with storing context at https://github.com/harmony-one/harmony/blob/main/api/service/stagedstreamsync/syncing.go#L190

```
		ctx, cancel := context.WithCancel(downloaderContext)
		s.ctx = ctx
		s.SetNewContext(ctx)
```
not sure how exaclty it happenss, but this fix solved issue. 

When something happens, such as a network error, the already canceled context keeps getting passed repeatedly, thereby preventing subsequent synchronization.