### PR TITLE
update the hardcoded settings in stream sync

### DIFF
--- a/api/service/stagedstreamsync/const.go
+++ b/api/service/stagedstreamsync/const.go
@@ -36,11 +36,14 @@ type (
 		ServerOnly bool
 
 		// parameters
-		Network              nodeconfig.NetworkType
-		Concurrency          int // Number of concurrent sync requests
-		MinStreams           int // Minimum number of streams to do sync
-		InitStreams          int // Number of streams requirement for initial bootstrap
-		MaxAdvertiseWaitTime int // maximum time duration between protocol advertisements
+		Network               nodeconfig.NetworkType
+		Concurrency           int    // Number of concurrent sync requests
+		MinStreams            int    // Minimum number of streams to do sync
+		InitStreams           int    // Number of streams requirement for initial bootstrap
+		MaxAdvertiseWaitTime  int    // maximum time duration between protocol advertisements
+		MaxBlocksPerSyncCycle uint64 // maximum number of blocks per each sync cycle, if set to zero, all blocks will be synced in one full cycle
+		MaxMemSyncCycleSize   uint64 // maximum number of blocks to use in a single transaction for staged sync
+
 		// stream manager config
 		SmSoftLowCap int
 		SmHardLowCap int

--- a/api/service/stagedstreamsync/stage_heads.go
+++ b/api/service/stagedstreamsync/stage_heads.go
@@ -52,7 +52,7 @@ func (heads *StageHeads) Exec(ctx context.Context, firstCycle bool, invalidBlock
 	}
 
 	maxHeight := s.state.status.targetBN
-	maxBlocksPerSyncCycle := uint64(1024) // TODO: should be in config -> s.state.MaxBlocksPerSyncCycle
+	maxBlocksPerSyncCycle := s.state.config.MaxBlocksPerSyncCycle
 	currentHeight := heads.configs.bc.CurrentBlock().NumberU64()
 	s.state.currentCycle.TargetHeight = maxHeight
 	targetHeight := uint64(0)

--- a/api/service/stagedstreamsync/syncing.go
+++ b/api/service/stagedstreamsync/syncing.go
@@ -227,7 +227,7 @@ func (s *StagedStreamSync) doSyncCycle(ctx context.Context, initSync bool) (int,
 
 	s.inserted = 0
 	startHead := s.bc.CurrentBlock().NumberU64()
-	canRunCycleInOneTransaction := false
+	canRunCycleInOneTransaction := s.config.MaxBlocksPerSyncCycle > 0 && s.config.MaxBlocksPerSyncCycle <= s.config.MaxMemSyncCycleSize
 
 	var tx kv.RwTx
 	if canRunCycleInOneTransaction {

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -932,17 +932,19 @@ func setupStagedSyncService(node *node.Node, host p2p.Host, hc harmonyconfig.Har
 	}
 
 	sConfig := stagedstreamsync.Config{
-		ServerOnly:           !hc.Sync.Downloader,
-		Network:              nodeconfig.NetworkType(hc.Network.NetworkType),
-		Concurrency:          hc.Sync.Concurrency,
-		MinStreams:           hc.Sync.MinPeers,
-		InitStreams:          hc.Sync.InitStreams,
-		MaxAdvertiseWaitTime: hc.Sync.MaxAdvertiseWaitTime,
-		SmSoftLowCap:         hc.Sync.DiscSoftLowCap,
-		SmHardLowCap:         hc.Sync.DiscHardLowCap,
-		SmHiCap:              hc.Sync.DiscHighCap,
-		SmDiscBatch:          hc.Sync.DiscBatch,
-		LogProgress:          node.NodeConfig.LogProgress,
+		ServerOnly:            !hc.Sync.Downloader,
+		Network:               nodeconfig.NetworkType(hc.Network.NetworkType),
+		Concurrency:           hc.Sync.Concurrency,
+		MinStreams:            hc.Sync.MinPeers,
+		InitStreams:           hc.Sync.InitStreams,
+		MaxAdvertiseWaitTime:  hc.Sync.MaxAdvertiseWaitTime,
+		MaxBlocksPerSyncCycle: hc.Sync.StagedSyncCfg.MaxBlocksPerSyncCycle,
+		MaxMemSyncCycleSize:   hc.Sync.StagedSyncCfg.MaxMemSyncCycleSize,
+		SmSoftLowCap:          hc.Sync.DiscSoftLowCap,
+		SmHardLowCap:          hc.Sync.DiscHardLowCap,
+		SmHiCap:               hc.Sync.DiscHighCap,
+		SmDiscBatch:           hc.Sync.DiscBatch,
+		LogProgress:           node.NodeConfig.LogProgress,
 	}
 
 	// If we are running side chain, we will need to do some extra works for beacon


### PR DESCRIPTION
## Issue

We used hard-coded values for a few of the sync settings in the present version of staged stream sync so that we could test them in dev-net. The plan was to make them dynamic after all of the testing were completed successfully. This PR updates those options and get the values from config file.