### PR TITLE
build: update base distribution in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: bionic
+dist: jammy
 language: go
 go:
   - 1.19.5


### PR DESCRIPTION
On Docker versions < 20.10.9, `apt update` fails due to the use of syscall `clone3` by `Glibc >= 2.34`. This change upgrades the base distribution used by Travis to `jammy`, which contains Docker engine 20.10.12.

See https://docs.travis-ci.com/user/reference/jammy/#docker and moby/moby#42681 for reference.
