### PR TITLE
[github action] build and push harmony proto docker image

### DIFF
--- a/.github/workflows/build-docker-proto-image.yaml
+++ b/.github/workflows/build-docker-proto-image.yaml
@@ -1,0 +1,35 @@
+name: Build and Push harmony proto Docker Image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout harmony core code
+        uses: actions/checkout@v3
+        with:
+          path: harmony
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: ./harmony/api/service/legacysync/downloader
+          file: ./harmony/api/service/legacysync/downloader/Proto.Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            harmonyone/harmony-proto:latest


### PR DESCRIPTION
## Issue

The harmony proto-image is on an individual developer docker account today. This PR create a new github action allowing harmony developer to build and push an updated version of the harmony proto docker image hosted on the harmonyone docker account https://hub.docker.com/u/harmonyone

## Test

### Unit Test Coverage

NA

### Test/Run Logs

https://github.com/sophoah/harmony/actions/runs/5343077100

## Operational Checklist

NA

## TODO
