### PR TITLE
scripts: restore install_build_tools.sh

### DIFF
--- a/scripts/install_build_tools.sh
+++ b/scripts/install_build_tools.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -eu
+
+unset -v progdir
+case "${0}" in
+/*) progdir="/";;
+*/*) progdir="${0%/*}";;
+*) progdir=".";
+esac
+
+sed -n 's/^	_ "\([^"]*\)"$/\1/p' "${progdir}/../tools/tools.go" | \
+	xargs "${progdir}/goget.sh"

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -11,6 +11,5 @@ package tools
 // scripts/install_build_tools.sh parses these imports to install them.
 import (
 	_ "github.com/golang/mock/mockgen"
-	_ "github.com/golang/protobuf/protoc-gen-go"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 )


### PR DESCRIPTION
With #4427, the protofiles are generated using a Docker image and thus `protoc` related binaries are not required. However, `mockgen` and `golangci-lint` are still being used by our Travis build. This change restores the file that installs them, and removes `protoc` related files from the list of installations.