### PR TITLE
[ops] Harmony Dockerfile go1.19 upgrade

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,7 +1,7 @@
 ARG GOPATH_DEFAULT=/root/go
 ARG SRC_PATH=src/github.com/harmony-one
 
-FROM golang:1.18-bullseye as builder
+FROM golang:1.19-bullseye as builder
 
 ARG GOPATH_DEFAULT
 ARG SRC_PATH


### PR DESCRIPTION
fix docker image build failing with go1.18 error, see https://github.com/harmony-one/harmony/actions/runs/5422632199/jobs/9872594637

```
docker buildx build --file ./scripts/docker/Dockerfile --tag harmonyone/testtag ./scripts/docker
[+] Building 120.4s (17/17) FINISHED
 => [internal] load build definition from Dockerfile                                                               0.0s
 => => transferring dockerfile: 1.93kB                                                                             0.0s
 => [internal] load .dockerignore                                                                                  0.0s
 => => transferring context: 2B                                                                                    0.0s
 => [internal] load metadata for docker.io/library/alpine:3.16.0                                                   0.0s
 => [internal] load metadata for docker.io/library/golang:1.19-bullseye                                            0.9s
 => [stage-1 1/6] FROM docker.io/library/alpine:3.16.0                                                             0.0s
 => [builder 1/6] FROM docker.io/library/golang:1.19-bullseye@sha256:84c27480a5aac854eb1982f931a48eed1ba0f318673a  7.8s
 => => resolve docker.io/library/golang:1.19-bullseye@sha256:84c27480a5aac854eb1982f931a48eed1ba0f318673a9636e2fd  0.0s
 => => sha256:84c27480a5aac854eb1982f931a48eed1ba0f318673a9636e2fdba2e601955d9 1.86kB / 1.86kB                     0.0s
 => => sha256:d02d3cedc41f021e9fc36a66f0255ea76e9598b059e25329bdd9a0f6cdb4bdad 1.58kB / 1.58kB                     0.0s
 => => sha256:bc1a2021d4d0b360ed1e616858d834c8eadb60489ef2eeb941038fb68c512fcf 6.86kB / 6.86kB                     0.0s
 => => sha256:65b4d59f9abaeb4efe1c66ff2176044e93912966342d76d025b6d1a2a37dde7a 54.59MB / 54.59MB                   0.7s
 => => sha256:93c2d578e4211e82e47e7ada9ed05d1869a2362c6f7509f2ee8d91ccebfb7fbd 55.06MB / 55.06MB                   0.5s
 => => sha256:c87e6f3487e1d7e61ee7a415e0ced4eb6f0b3484eb1e15a4339d110d3cadf899 15.76MB / 15.76MB                   0.2s
 => => sha256:6465554d818c7e767f556e60fe8b297b8fa85216d8c051e3b8b4af47fae05946 86.03MB / 86.03MB                   1.0s
 => => extracting sha256:93c2d578e4211e82e47e7ada9ed05d1869a2362c6f7509f2ee8d91ccebfb7fbd                          1.0s
 => => sha256:f65b961d7cc1fd34a3f5051833591de7278b405cee418cc98431cb7369134594 149.10MB / 149.10MB                 2.2s
 => => sha256:88699c251d75e81f31b6a27cec073d19f1fb11ff020fa129df8d92b290bf7525 156B / 156B                         1.1s
 => => extracting sha256:c87e6f3487e1d7e61ee7a415e0ced4eb6f0b3484eb1e15a4339d110d3cadf899                          0.2s
 => => extracting sha256:65b4d59f9abaeb4efe1c66ff2176044e93912966342d76d025b6d1a2a37dde7a                          1.1s
 => => extracting sha256:6465554d818c7e767f556e60fe8b297b8fa85216d8c051e3b8b4af47fae05946                          1.3s
 => => extracting sha256:f65b961d7cc1fd34a3f5051833591de7278b405cee418cc98431cb7369134594                          2.8s
 => => extracting sha256:88699c251d75e81f31b6a27cec073d19f1fb11ff020fa129df8d92b290bf7525                          0.0s
 => CACHED [stage-1 2/6] RUN apk add --no-cache bash bind-tools tini curl sed     && rm -rf /var/cache/apk/*       0.0s
 => CACHED [stage-1 3/6] RUN echo "[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash/bashrc          0.0s
 => CACHED [stage-1 4/6] WORKDIR /harmony                                                                          0.0s
 => [builder 2/6] RUN apt-get update && apt-get install -y libgmp-dev libssl-dev curl git  psmisc dnsutils jq ma  12.8s
 => [builder 3/6] WORKDIR /root/go/src/github.com/harmony-one                                                      0.0s
 => [builder 4/6] RUN git clone https://github.com/harmony-one/harmony.git harmony   && git clone https://github.  6.3s
 => [builder 5/6] WORKDIR /root/go/src/github.com/harmony-one/harmony                                              0.0s
 => [builder 6/6] RUN make linux_static                                                                           91.0s
 => [stage-1 5/6] COPY --from=builder /root/go/src/github.com/harmony-one/harmony/bin/harmony /usr/local/bin/      0.4s
 => [stage-1 6/6] RUN chmod +x  /usr/local/bin/harmony      && mkdir -p /data     && chown -R 1000:1000 /harmony   0.8s
 => exporting to image                                                                                             0.3s
 => => exporting layers                                                                                            0.3s
 => => writing image sha256:e6ddd9d8d5e7c592b0f20ad0bf39971008fc53c24b1532053a068203c53f1e3a                       0.0s
 => => naming to docker.io/harmonyone/testtag                                                           0.0s
 ```