### PR TITLE
Fix kill_node script

### DIFF
--- a/test/kill_node.sh
+++ b/test/kill_node.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
-pkill -9 '^(harmony|soldier|commander|profiler|bootnode)$' | sed 's/^/Killed process: /'
+
+# list of process name to be killed
+targetProcess=( "harmony" "bootnode" "soldier" "commander" "profiler" )
+
+for pname in "${targetProcess[@]}"
+do
+  sudo pkill -9 -e "^(${pname})$"
+done
+
 rm -rf db-127.0.0.1-*


### PR DESCRIPTION
## Issue

The script to kill harmony process doesn't work. This is the error given from Travis logs:
```
pkill: pattern that searches for process name longer than 15 characters will result in zero matches
Try `pkill -f' option to match against the complete command line.
```
The issue is the pattern for **pkill** command can't be longer than 15 characters. This PR uses an array rather than a long pattern to address the issue.