### PR TITLE
fix travis checker path issue

### DIFF
--- a/scripts/travis_rosetta_checker.sh
+++ b/scripts/travis_rosetta_checker.sh
@@ -5,9 +5,12 @@ echo $TRAVIS_PULL_REQUEST_BRANCH
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 echo $DIR
 echo $GOPATH
-cd $GOPATH/src/github.com/harmony-one/harmony-test
-git fetch
+cd $GOPATH/src/github.com/harmony-one/harmony
+git fetch --all
 git checkout $TRAVIS_PULL_REQUEST_BRANCH || true
+git pull
+git branch --show-current
+cd $GOPATH/src/github.com/harmony-one/harmony-test
 git pull
 git branch --show-current
 cd localnet

--- a/scripts/travis_rpc_checker.sh
+++ b/scripts/travis_rpc_checker.sh
@@ -5,9 +5,12 @@ echo $TRAVIS_PULL_REQUEST_BRANCH
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 echo $DIR
 echo $GOPATH
-cd $GOPATH/src/github.com/harmony-one/harmony-test
-git fetch
+cd $GOPATH/src/github.com/harmony-one/harmony
+git fetch --all
 git checkout $TRAVIS_PULL_REQUEST_BRANCH || true
+git pull
+git branch --show-current
+cd $GOPATH/src/github.com/harmony-one/harmony-test
 git pull
 git branch --show-current
 cd localnet


### PR DESCRIPTION
## Issue

The **travis_rpc_checker.sh** and **travis_rosetta_checker.sh** are responsible for building the latest Harmony test. However, they utilize incorrect paths for the repositories. The following error is produced in the logs:
```
error: pathspec 'feature/statesync_client' did not match any file(s) known to git
Already up to date.
master
```
So, the **TRAVIS_PULL_REQUEST_BRANCH** is the target branch in harmony repository, while the current script attempts to check out from the harmony-test folder. As a result, the checkout process fails, and it remains on the master branch. Fortunately, this is merely a cosmetic issue and does not impact the actual test.

* Additionally, it is unnecessary to perform a checkout since the current branch has already been checked out by the CI/CD. Hence, the checkout section consists of redundant code. This pull request resolves the path issue and suggests removing these lines altogether.
