### PR TITLE
Invalid dht prevents to start localnet.

### DIFF
--- a/scripts/go_executable_build.sh
+++ b/scripts/go_executable_build.sh
@@ -26,6 +26,8 @@ fi
 DEBUG=false
 STATIC=true
 
+rm -rf .dht-127.0.0.1*
+
 unset -v progdir
 case "${0}" in
 */*) progdir="${0%/*}";;


### PR DESCRIPTION
Based on https://github.com/harmony-one/harmony/issues/4471

In my case, there was a Docker container that got terminated and failed to save the DHT (Distributed Hash Table) data correctly. This directory with the corrupted DHT data was then copied into a Docker image. As a result, the new image failed to start properly at a later time.