### PR TITLE
fix consensus catchup issue

### DIFF
--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -352,7 +352,7 @@ func (node *Node) NodeSyncing() {
 		if node.HarmonyConfig.TiKV.Role == tikv.RoleWriter {
 			node.supportSyncing() // the writer needs to be in sync with it's other peers
 		}
-	} else if !node.HarmonyConfig.General.IsOffline && node.HarmonyConfig.DNSSync.Client {
+	} else if !node.HarmonyConfig.General.IsOffline && (node.HarmonyConfig.DNSSync.Client || node.HarmonyConfig.Sync.Downloader) {
 		node.supportSyncing() // for non-writer-reader mode a.k.a tikv nodes
 	}
 }

--- a/node/node_syncing.go
+++ b/node/node_syncing.go
@@ -372,6 +372,11 @@ func (node *Node) supportSyncing() {
 		go node.SendNewBlockToUnsync()
 	}
 
+	// if stream sync client is running, don't create other sync client instances
+	if node.HarmonyConfig.Sync.Downloader {
+		return
+	}
+
 	if !node.NodeConfig.StagedSync && node.stateSync == nil {
 		node.stateSync = node.createStateSync(node.Blockchain())
 		utils.Logger().Debug().Msg("[SYNC] initialized state sync")


### PR DESCRIPTION
## Issue
Current logs show many issues like the one below:
```css
[TryCatchup] Consensus-verified block send to channel failed.
```
The issue is that the current code only joins consensus if the client is enabled, but it doesn't check the stream downloader. Therefore, if the node wants to disable DNS sync and only use the stream, it won't run `supportSyncing`, and as a result, it won't join consensus. This means that the `VerifiedNewBlock` channel will always be full, and new blocks will not be sent to unsynced nodes. Consequently, it will produce the catchup issue. This PR fixes this issue by adding a simple check for the downloader as well.