### PR TITLE
statedb: return correct validator code size

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -561,7 +561,7 @@ func (s *Object) CodeSize(db Database) int {
 	if s.validatorWrapper || err != nil {
 		vcSize, errVCSize := db.ValidatorCodeSize(s.addrHash, common.BytesToHash(s.CodeHash()))
 		if errVCSize == nil && vcSize > 0 {
-			return size
+			return vcSize
 		}
 		if s.validatorWrapper {
 			s.setError(fmt.Errorf("can't load validator code size %x for account address hash %x : %v", s.CodeHash(), s.addrHash, err))


### PR DESCRIPTION
The function `state_object.CodeSize` erroneously returns the validator code size to be 0. This functionality is only used by the EVM, where the size is overridden by the after the `ValidatorCodeFixEpoch` hard fork to be 0 anyway.

However, for nodes currently syncing blocks before the hard fork was effective, this causes an error. A transaction which attempts to mint an NFT to a validator address prior to the hard fork would have failed, because `onERC1155Received` is not implemented by a validator's code. With the erroneous line, the transaction goes through - causing a node with the unpatched binary to reject the block.