### PR TITLE
[build] upgrade docker in travis using addons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,24 @@ env:
   - TEST="bash ./scripts/travis_rpc_checker.sh"
   - TEST="bash ./scripts/travis_rosetta_checker.sh"
 
-before_install:
-  # upgrade docker to the latest supported by the OS loaded in the travis image
-  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  - sudo add-apt-repository --yes "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  - sudo apt-get update
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
-  - sudo systemctl restart docker
-  - id
-  - ls -l /var/run/
-  - docker ps
-  - docker info
+addons:
+  apt:
+    sources:
+      - sourceline: deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable
+    packages:
+    - docker-ce
+
+# before_install:
+#   # upgrade docker to the latest supported by the OS loaded in the travis image
+#   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+#   - sudo add-apt-repository --yes "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+#   - sudo apt-get update
+#   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+#   - sudo systemctl restart docker
+#   - id
+#   - ls -l /var/run/
+#   - docker ps
+#   - docker info
 
 install:
   # default working directory with source code is automatically set to

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ addons:
 #   - docker info
 
 install:
+  - docker ps
+  - docker info
+  - sudo systemctl restart docker
   # default working directory with source code is automatically set to
   #   /home/travis/gopath/src/github.com/harmony-one/harmony
   # https://docs.travis-ci.com/user/languages/go/#go-import-path

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   - TEST="bash ./scripts/travis_rpc_checker.sh"
   - TEST="bash ./scripts/travis_rosetta_checker.sh"
 
+# upgrade docker to latest stable version
 addons:
   apt:
     sources:
@@ -20,25 +21,7 @@ addons:
     packages:
     - docker.io
 
-# before_install:
-#   # upgrade docker to the latest supported by the OS loaded in the travis image
-#   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-#   - sudo add-apt-repository --yes "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-#   - sudo apt-get update
-#   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
-#   - sudo systemctl restart docker
-#   - id
-#   - ls -l /var/run/
-#   - docker ps
-#   - docker info
-
 install:
-  - sudo systemctl --type=service
-  - docker --version
-  - which docker
-#  - sudo systemctl restart docker
-  - sudo docker ps
-  - sudo docker info 
   # default working directory with source code is automatically set to
   #   /home/travis/gopath/src/github.com/harmony-one/harmony
   # https://docs.travis-ci.com/user/languages/go/#go-import-path

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
     sources:
       - sourceline: deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable
     packages:
-    - docker-ce
+    - docker.io
 
 # before_install:
 #   # upgrade docker to the latest supported by the OS loaded in the travis image
@@ -36,7 +36,7 @@ install:
   - sudo systemctl --type=service
   - docker --version
   - which docker
-  - sudo systemctl restart docker
+#  - sudo systemctl restart docker
   - sudo docker ps
   - sudo docker info 
   # default working directory with source code is automatically set to

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ addons:
 #   - docker info
 
 install:
-  - docker ps
-  - docker info
   - sudo systemctl restart docker
+  - docker ps
+  - docker info 
   # default working directory with source code is automatically set to
   #   /home/travis/gopath/src/github.com/harmony-one/harmony
   # https://docs.travis-ci.com/user/languages/go/#go-import-path

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,17 @@ env:
   - TEST="bash ./scripts/travis_rpc_checker.sh"
   - TEST="bash ./scripts/travis_rosetta_checker.sh"
 
-addons:
-  apt:
-    packages:
-      - docker-ce
+before_install:
+  # upgrade docker to the latest supported by the OS loaded in the travis image
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository --yes "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  - sudo systemctl restart docker
+  - id
+  - ls -l /var/run/
+  - docker ps
+  - docker info
 
 install:
   # default working directory with source code is automatically set to

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,12 @@ addons:
 #   - docker info
 
 install:
+  - sudo systemctl --type=service
+  - docker --version
+  - which docker
   - sudo systemctl restart docker
-  - docker ps
-  - docker info 
+  - sudo docker ps
+  - sudo docker info 
   # default working directory with source code is automatically set to
   #   /home/travis/gopath/src/github.com/harmony-one/harmony
   # https://docs.travis-ci.com/user/languages/go/#go-import-path

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,10 @@ env:
   - TEST="bash ./scripts/travis_rpc_checker.sh"
   - TEST="bash ./scripts/travis_rosetta_checker.sh"
 
-before_install:
-  # upgrade docker to the latest supported by the OS loaded in the travis image
-  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  - sudo add-apt-repository --yes "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  - sudo apt-get update
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+addons:
+  apt:
+    packages:
+      - docker-ce
 
 install:
   # default working directory with source code is automatically set to


### PR DESCRIPTION
after the docker installation using before_installation we have this message
```
docker.service is a disabled or a static unit, not starting it.
```

following https://travis-ci.community/t/docker-updating-to-newer-version/10229 we are converting the docker upgrade to use `addons`

and upgrading docker.io instead of docker-ce. docker.io was the package installed in the base image