### PR TITLE
Next validator in view change. 

### DIFF
--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -749,7 +749,7 @@ func (consensus *Consensus) rotateLeader(epoch *big.Int) {
 		next     *bls.PublicKeyWrapper
 	)
 	if bc.Config().IsLeaderRotationExternalValidatorsAllowed(epoch, consensus.ShardID) {
-		wasFound, next = consensus.Decider.NthNext(leader, 1)
+		wasFound, next = consensus.Decider.NthNextValidator(committee.Slots, leader, 1)
 	} else {
 		wasFound, next = consensus.Decider.NthNextHmy(shard.Schedule.InstanceForEpoch(epoch), leader, 1)
 	}

--- a/consensus/quorum/quorom_test.go
+++ b/consensus/quorum/quorom_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/harmony-one/harmony/numeric"
 	"github.com/harmony-one/harmony/shard"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/crypto/bls"
@@ -592,4 +593,34 @@ func TestNthNextHmyExt(test *testing.T) {
 			}
 		}
 	}
+}
+
+func TestCIdentities_NthNextValidatorHmy(t *testing.T) {
+	address := []common.Address{
+		common.HexToAddress("0x1"),
+		common.HexToAddress("0x2"),
+		common.HexToAddress("0x3"),
+	}
+	slots := shard.SlotList{}
+	list := []harmony_bls.PublicKeyWrapper{}
+	for i := 0; i < 3; i++ {
+		for j := 0; j < 3; j++ {
+			blsKey := harmony_bls.RandPrivateKey()
+			wrapper := harmony_bls.PublicKeyWrapper{Object: blsKey.GetPublicKey()}
+			wrapper.Bytes.FromLibBLSPublicKey(wrapper.Object)
+			slots = append(slots, shard.Slot{
+				EcdsaAddress:   address[i%3],
+				BLSPublicKey:   wrapper.Bytes,
+				EffectiveStake: nil,
+			})
+			list = append(list, wrapper)
+		}
+	}
+
+	c := newCIdentities()
+	c.UpdateParticipants(list, []bls.PublicKeyWrapper{})
+	found, key := c.NthNextValidatorHmy(nil, slots, &list[0], 1)
+	require.Equal(t, true, found)
+	// because we skip 3 keys of current validator
+	require.Equal(t, 3, c.IndexOf(key.Bytes))
 }

--- a/consensus/quorum/quorom_test.go
+++ b/consensus/quorum/quorom_test.go
@@ -619,7 +619,7 @@ func TestCIdentities_NthNextValidatorHmy(t *testing.T) {
 
 	c := newCIdentities()
 	c.UpdateParticipants(list, []bls.PublicKeyWrapper{})
-	found, key := c.NthNextValidatorHmy(nil, slots, &list[0], 1)
+	found, key := c.NthNextValidator(slots, &list[0], 1)
 	require.Equal(t, true, found)
 	// because we skip 3 keys of current validator
 	require.Equal(t, 3, c.IndexOf(key.Bytes))

--- a/consensus/quorum/quorum.go
+++ b/consensus/quorum/quorum.go
@@ -222,6 +222,13 @@ func (s *cIdentities) NthNext(pubKey *bls.PublicKeyWrapper, next int) (bool, *bl
 func (s *cIdentities) NthNextValidator(slotList shard.SlotList, pubKey *bls.PublicKeyWrapper, next int) (bool, *bls.PublicKeyWrapper) {
 	found := false
 
+	if len(s.publicKeys) == 0 {
+		return false, pubKey
+	}
+	if next < 0 {
+		return false, pubKey
+	}
+
 	publicToAddress := make(map[bls.SerializedPublicKey]common.Address)
 	for _, slot := range slotList {
 		publicToAddress[slot.BLSPublicKey] = slot.EcdsaAddress

--- a/consensus/quorum/quorum.go
+++ b/consensus/quorum/quorum.go
@@ -75,7 +75,8 @@ type ParticipantTracker interface {
 	Participants() multibls.PublicKeys
 	IndexOf(bls.SerializedPublicKey) int
 	ParticipantsCount() int64
-	NthNext(*bls.PublicKeyWrapper, int) (bool, *bls.PublicKeyWrapper)
+	// NthNextValidator returns key for next validator. It assumes external validators and leader rotation.
+	NthNextValidator(slotList shard.SlotList, pubKey *bls.PublicKeyWrapper, next int) (bool, *bls.PublicKeyWrapper)
 	NthNextHmy(shardingconfig.Instance, *bls.PublicKeyWrapper, int) (bool, *bls.PublicKeyWrapper)
 	NthNextHmyExt(shardingconfig.Instance, *bls.PublicKeyWrapper, int) (bool, *bls.PublicKeyWrapper)
 	FirstParticipant(shardingconfig.Instance) *bls.PublicKeyWrapper
@@ -217,8 +218,8 @@ func (s *cIdentities) NthNext(pubKey *bls.PublicKeyWrapper, next int) (bool, *bl
 	return found, &s.publicKeys[idx]
 }
 
-// NthNextValidatorHmy return the Nth next pubkey nodes, but from another validator.
-func (s *cIdentities) NthNextValidatorHmy(instance shardingconfig.Instance, slotList shard.SlotList, pubKey *bls.PublicKeyWrapper, next int) (bool, *bls.PublicKeyWrapper) {
+// NthNextValidator return the Nth next pubkey nodes, but from another validator.
+func (s *cIdentities) NthNextValidator(slotList shard.SlotList, pubKey *bls.PublicKeyWrapper, next int) (bool, *bls.PublicKeyWrapper) {
 	found := false
 
 	publicToAddress := make(map[bls.SerializedPublicKey]common.Address)

--- a/consensus/quorum/quorum.go
+++ b/consensus/quorum/quorum.go
@@ -438,7 +438,7 @@ func (s *cIdentities) ReadAllBallots(p Phase) []*votepower.Ballot {
 	return ballots
 }
 
-func newBallotsBackedSignatureReader() *cIdentities {
+func newCIdentities() *cIdentities {
 	return &cIdentities{
 		publicKeys:  []bls.PublicKeyWrapper{},
 		keyIndexMap: map[bls.SerializedPublicKey]int{},
@@ -446,6 +446,10 @@ func newBallotsBackedSignatureReader() *cIdentities {
 		commit:      votepower.NewRound(),
 		viewChange:  votepower.NewRound(),
 	}
+}
+
+func newBallotsBackedSignatureReader() *cIdentities {
+	return newCIdentities()
 }
 
 // NewDecider ..

--- a/consensus/view_change_test.go
+++ b/consensus/view_change_test.go
@@ -87,7 +87,7 @@ func TestGetNextLeaderKeyShouldFailForStandardGeneratedConsensus(t *testing.T) {
 
 	// The below results in: "panic: runtime error: integer divide by zero"
 	// This happens because there's no check for if there are any participants or not in https://github.com/harmony-one/harmony/blob/main/consensus/quorum/quorum.go#L188-L197
-	assert.Panics(t, func() { consensus.getNextLeaderKey(uint64(1)) })
+	assert.Panics(t, func() { consensus.getNextLeaderKey(uint64(1), nil) })
 }
 
 func TestGetNextLeaderKeyShouldSucceed(t *testing.T) {
@@ -115,7 +115,7 @@ func TestGetNextLeaderKeyShouldSucceed(t *testing.T) {
 	assert.Equal(t, keyCount, consensus.Decider.ParticipantsCount())
 
 	consensus.LeaderPubKey = &wrappedBLSKeys[0]
-	nextKey := consensus.getNextLeaderKey(uint64(1))
+	nextKey := consensus.getNextLeaderKey(uint64(1), nil)
 
 	assert.Equal(t, nextKey, &wrappedBLSKeys[1])
 }


### PR DESCRIPTION
Multiple consecutive keys within a list of validators can be assigned to a single validator. In the worst-case scenario, these consecutive keys could be grouped together. If this validator becomes unavailable, the system experiences prolonged downtime as each key associated with the validator is sequentially checked. The current approach involves iterating through the list of keys, and if the next key belongs to the same validator, it is skipped to optimize the process.

In the default implementation, keys are retrieved one by one from a list, and in the current implementation, each key is checked sequentially. If the next key in line belongs to the same validator as the previous one, it is skipped during the validation process.


go test -cover github.com/harmony-one/harmony/consensus/quorum
ok      github.com/harmony-one/harmony/consensus/quorum 1.813s  coverage: 52.9% of statements

