### PR TITLE
Improvements of streamsync to deploy on mainnet

### DIFF
--- a/api/service/stagedstreamsync/const.go
+++ b/api/service/stagedstreamsync/const.go
@@ -23,9 +23,6 @@ const (
 	// no more request will be assigned to workers to wait for InsertChain to finish.
 	SoftQueueCap int = 100
 
-	// DefaultConcurrency is the default settings for concurrency
-	DefaultConcurrency int = 4
-
 	// ShortRangeTimeout is the timeout for each short range sync, which allow short range sync
 	// to restart automatically when stuck in `getBlockHashes`
 	ShortRangeTimeout time.Duration = 1 * time.Minute
@@ -74,10 +71,10 @@ type (
 
 func (c *Config) fixValues() {
 	if c.Concurrency == 0 {
-		c.Concurrency = DefaultConcurrency
+		c.Concurrency = c.MinStreams
 	}
 	if c.Concurrency > c.MinStreams {
-		c.MinStreams = c.Concurrency
+		c.Concurrency = c.MinStreams 
 	}
 	if c.MinStreams > c.InitStreams {
 		c.InitStreams = c.MinStreams

--- a/api/service/stagedstreamsync/const.go
+++ b/api/service/stagedstreamsync/const.go
@@ -74,7 +74,7 @@ func (c *Config) fixValues() {
 		c.Concurrency = c.MinStreams
 	}
 	if c.Concurrency > c.MinStreams {
-		c.Concurrency = c.MinStreams 
+		c.Concurrency = c.MinStreams
 	}
 	if c.MinStreams > c.InitStreams {
 		c.InitStreams = c.MinStreams

--- a/api/service/stagedstreamsync/errors.go
+++ b/api/service/stagedstreamsync/errors.go
@@ -14,7 +14,7 @@ var (
 	ErrUnexpectedNumberOfBlockHashes = WrapStagedSyncError("unexpected number of getBlocksByHashes result")
 	ErrUnexpectedBlockHashes         = WrapStagedSyncError("unexpected get block hashes result delivered")
 	ErrNilBlock                      = WrapStagedSyncError("nil block found")
-	ErrNotEnoughStreams              = WrapStagedSyncError("not enough streams")
+	ErrNotEnoughStreams              = WrapStagedSyncError("number of streams smaller than minimum required")
 	ErrParseCommitSigAndBitmapFail   = WrapStagedSyncError("parse commitSigAndBitmap failed")
 	ErrVerifyHeaderFail              = WrapStagedSyncError("verify header failed")
 	ErrInsertChainFail               = WrapStagedSyncError("insert to chain failed")

--- a/api/service/stagedstreamsync/short_range_helper.go
+++ b/api/service/stagedstreamsync/short_range_helper.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/core/types"
+	"github.com/harmony-one/harmony/internal/utils"
 	syncProto "github.com/harmony-one/harmony/p2p/stream/protocols/sync"
 	sttypes "github.com/harmony-one/harmony/p2p/stream/types"
 	"github.com/pkg/errors"
@@ -132,6 +133,10 @@ func (sh *srHelper) getBlocksByHashes(ctx context.Context, hashes []common.Hash,
 
 func (sh *srHelper) checkPrerequisites() error {
 	if sh.syncProtocol.NumStreams() < sh.config.Concurrency {
+		utils.Logger().Info().
+			Int("available streams", sh.syncProtocol.NumStreams()).
+			Interface("concurrency", sh.config.Concurrency).
+			Msg("not enough streams to do concurrent processes")
 		return ErrNotEnoughStreams
 	}
 	return nil

--- a/api/service/stagedstreamsync/staged_stream_sync.go
+++ b/api/service/stagedstreamsync/staged_stream_sync.go
@@ -337,8 +337,9 @@ func (s *StagedStreamSync) promLabels() prometheus.Labels {
 func (s *StagedStreamSync) checkHaveEnoughStreams() error {
 	numStreams := s.protocol.NumStreams()
 	if numStreams < s.config.MinStreams {
-		return fmt.Errorf("number of streams smaller than minimum: %v < %v",
+		s.logger.Debug().Msgf("number of streams smaller than minimum: %v < %v",
 			numStreams, s.config.MinStreams)
+		return ErrNotEnoughStreams
 	}
 	return nil
 }

--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -232,7 +232,7 @@ var (
 		Downloader:           true,
 		StagedSync:           false,
 		StagedSyncCfg:        defaultStagedSyncConfig,
-		Concurrency:          4,
+		Concurrency:          2,
 		MinPeers:             2,
 		InitStreams:          2,
 		MaxAdvertiseWaitTime: 2, //minutes

--- a/p2p/stream/common/requestmanager/interface_test.go
+++ b/p2p/stream/common/requestmanager/interface_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -118,7 +119,7 @@ func (st *testStream) FailedTimes() int {
 	return 0
 }
 
-func (st *testStream) AddFailedTimes() {
+func (st *testStream) AddFailedTimes(faultRecoveryThreshold time.Duration) {
 	return
 }
 

--- a/p2p/stream/common/streammanager/interface_test.go
+++ b/p2p/stream/common/streammanager/interface_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	sttypes "github.com/harmony-one/harmony/p2p/stream/types"
 	"github.com/libp2p/go-libp2p/core/network"
@@ -74,7 +75,7 @@ func (st *testStream) FailedTimes() int {
 	return 0
 }
 
-func (st *testStream) AddFailedTimes() {
+func (st *testStream) AddFailedTimes(faultRecoveryThreshold time.Duration) {
 	return
 }
 

--- a/p2p/stream/protocols/sync/chain.go
+++ b/p2p/stream/protocols/sync/chain.go
@@ -168,7 +168,7 @@ func (ch *chainHelperImpl) getNodeData(hs []common.Hash) ([][]byte, error) {
 
 // getReceipts assembles the response to a receipt query.
 func (ch *chainHelperImpl) getReceipts(hs []common.Hash) ([]types.Receipts, error) {
-	receipts := make([]types.Receipts, 0, len(hs))
+	receipts := make([]types.Receipts, len(hs))
 	for i, hash := range hs {
 		// Retrieve the requested block's receipts
 		results := ch.chain.GetReceiptsByHash(hash)
@@ -178,7 +178,7 @@ func (ch *chainHelperImpl) getReceipts(hs []common.Hash) ([]types.Receipts, erro
 			}
 			return nil, errors.New("invalid hashes to get receipts")
 		}
-		receipts[i] = append(receipts[i], results...)
+		receipts[i] = results
 	}
 	return receipts, nil
 }

--- a/p2p/stream/protocols/sync/chain.go
+++ b/p2p/stream/protocols/sync/chain.go
@@ -168,8 +168,7 @@ func (ch *chainHelperImpl) getNodeData(hs []common.Hash) ([][]byte, error) {
 
 // getReceipts assembles the response to a receipt query.
 func (ch *chainHelperImpl) getReceipts(hs []common.Hash) ([]types.Receipts, error) {
-	var receipts []types.Receipts
-
+	receipts := make([]types.Receipts, 0, len(hs))
 	for i, hash := range hs {
 		// Retrieve the requested block's receipts
 		results := ch.chain.GetReceiptsByHash(hash)
@@ -177,6 +176,7 @@ func (ch *chainHelperImpl) getReceipts(hs []common.Hash) ([]types.Receipts, erro
 			if header := ch.chain.GetHeaderByHash(hash); header == nil || header.ReceiptHash() != types.EmptyRootHash {
 				continue
 			}
+			return nil, errors.New("invalid hashes to get receipts")
 		}
 		receipts[i] = append(receipts[i], results...)
 	}

--- a/p2p/stream/protocols/sync/chain_test.go
+++ b/p2p/stream/protocols/sync/chain_test.go
@@ -53,7 +53,7 @@ func (tch *testChainHelper) getNodeData(hs []common.Hash) ([][]byte, error) {
 
 func (tch *testChainHelper) getReceipts(hs []common.Hash) ([]types.Receipts, error) {
 	testReceipts := makeTestReceipts(len(hs), 3)
-	receipts := make([]types.Receipts, len(hs)*3)
+	receipts := make([]types.Receipts, len(hs))
 	for i, _ := range hs {
 		receipts[i] = testReceipts
 	}
@@ -197,6 +197,21 @@ func checkBlocksByHashesResult(b []byte, hs []common.Hash) error {
 		if blk.NumberU64() != num {
 			return fmt.Errorf("unexpected number %v != %v", blk.NumberU64(), num)
 		}
+	}
+	return nil
+}
+
+func checkGetReceiptsResult(b []byte, hs []common.Hash) error {
+	var msg = &syncpb.Message{}
+	if err := protobuf.Unmarshal(b, msg); err != nil {
+		return err
+	}
+	bhResp, err := msg.GetReceiptsResponse()
+	if err != nil {
+		return err
+	}
+	if len(hs) != len(bhResp.Receipts) {
+		return errors.New("unexpected size")
 	}
 	return nil
 }

--- a/p2p/stream/protocols/sync/const.go
+++ b/p2p/stream/protocols/sync/const.go
@@ -28,6 +28,10 @@ const (
 	// MaxStreamFailures is the maximum allowed failures before stream gets removed
 	MaxStreamFailures = 3
 
+	// FaultRecoveryThreshold is the minimum duration before it resets the previous failures
+	// So, if stream hasn't had any issue for a certain amount of time since last failure, we can still trust it
+	FaultRecoveryThreshold = 30 * time.Minute
+
 	// minAdvertiseInterval is the minimum advertise interval
 	minAdvertiseInterval = 1 * time.Minute
 

--- a/p2p/stream/protocols/sync/const.go
+++ b/p2p/stream/protocols/sync/const.go
@@ -26,7 +26,7 @@ const (
 	GetReceiptsCap = 10
 
 	// MaxStreamFailures is the maximum allowed failures before stream gets removed
-	MaxStreamFailures = 3
+	MaxStreamFailures = 5
 
 	// FaultRecoveryThreshold is the minimum duration before it resets the previous failures
 	// So, if stream hasn't had any issue for a certain amount of time since last failure, we can still trust it

--- a/p2p/stream/protocols/sync/message/parse.go
+++ b/p2p/stream/protocols/sync/message/parse.go
@@ -79,3 +79,19 @@ func (msg *Message) GetBlocksByHashesResponse() (*GetBlocksByHashesResponse, err
 	}
 	return gbResp, nil
 }
+
+// GetReceiptsResponse parse the message to GetReceiptsResponse
+func (msg *Message) GetReceiptsResponse() (*GetReceiptsResponse, error) {
+	resp := msg.GetResp()
+	if resp == nil {
+		return nil, errors.New("not response message")
+	}
+	if errResp := resp.GetErrorResponse(); errResp != nil {
+		return nil, &ResponseError{errResp.Error}
+	}
+	grResp := resp.GetGetReceiptsResponse()
+	if grResp == nil {
+		return nil, errors.New("not GetGetReceiptsResponse")
+	}
+	return grResp, nil
+}

--- a/p2p/stream/protocols/sync/protocol.go
+++ b/p2p/stream/protocols/sync/protocol.go
@@ -272,13 +272,16 @@ func (p *Protocol) RemoveStream(stID sttypes.StreamID) {
 		st.Close()
 		// stream manager removes this stream from the list and triggers discovery if number of streams are not enough
 		p.sm.RemoveStream(stID) //TODO: double check to see if this part is needed
+		p.logger.Info().
+			Str("stream ID", string(stID)).
+			Msg("stream removed")
 	}
 }
 
 func (p *Protocol) StreamFailed(stID sttypes.StreamID, reason string) {
 	st, exist := p.sm.GetStreamByID(stID)
 	if exist && st != nil {
-		st.AddFailedTimes()
+		st.AddFailedTimes(FaultRecoveryThreshold)
 		p.logger.Info().
 			Str("stream ID", string(st.ID())).
 			Int("num failures", st.FailedTimes()).

--- a/p2p/stream/protocols/sync/stream_test.go
+++ b/p2p/stream/protocols/sync/stream_test.go
@@ -40,6 +40,16 @@ var (
 	}
 	testGetBlocksByHashesRequest    = syncpb.MakeGetBlocksByHashesRequest(testGetBlockByHashes)
 	testGetBlocksByHashesRequestMsg = syncpb.MakeMessageFromRequest(testGetBlocksByHashesRequest)
+
+	testGetReceipts = []common.Hash{
+		numberToHash(1),
+		numberToHash(2),
+		numberToHash(3),
+		numberToHash(4),
+		numberToHash(5),
+	}
+	testGetReceiptsRequest    = syncpb.MakeGetReceiptsRequest(testGetReceipts)
+	testGetReceiptsRequestMsg = syncpb.MakeMessageFromRequest(testGetReceiptsRequest)
 )
 
 func TestSyncStream_HandleGetBlocksByRequest(t *testing.T) {
@@ -122,6 +132,27 @@ func TestSyncStream_HandleGetBlocksByHashes(t *testing.T) {
 	receivedBytes, _ := remoteSt.ReadBytes()
 
 	if err := checkBlocksByHashesResult(receivedBytes, testGetBlockByHashes); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSyncStream_HandleGetReceipts(t *testing.T) {
+	st, remoteSt := makeTestSyncStream()
+
+	go st.run()
+	defer close(st.closeC)
+
+	req := testGetReceiptsRequestMsg
+	b, _ := protobuf.Marshal(req)
+	err := remoteSt.WriteBytes(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	receivedBytes, _ := remoteSt.ReadBytes()
+
+	if err := checkGetReceiptsResult(receivedBytes, testGetBlockByHashes); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/p2p/stream/types/stream.go
+++ b/p2p/stream/types/stream.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"io"
 	"sync"
+	"time"
 
 	libp2p_network "github.com/libp2p/go-libp2p/core/network"
 	"github.com/pkg/errors"
@@ -22,7 +23,7 @@ type Stream interface {
 	Close() error
 	CloseOnExit() error
 	FailedTimes() int
-	AddFailedTimes()
+	AddFailedTimes(faultRecoveryThreshold time.Duration)
 	ResetFailedTimes()
 }
 
@@ -38,7 +39,8 @@ type BaseStream struct {
 	specErr  error
 	specOnce sync.Once
 
-	failedTimes int
+	failedTimes     int
+	lastFailureTime time.Time
 }
 
 // NewBaseStream creates BaseStream as the wrapper of libp2p Stream
@@ -82,7 +84,11 @@ func (st *BaseStream) FailedTimes() int {
 	return st.failedTimes
 }
 
-func (st *BaseStream) AddFailedTimes() {
+func (st *BaseStream) AddFailedTimes(faultRecoveryThreshold time.Duration) {
+	durationSinceLastFailure := time.Now().Sub(st.lastFailureTime)
+	if durationSinceLastFailure >= faultRecoveryThreshold {
+		st.ResetFailedTimes()
+	}
 	st.failedTimes++
 }
 

--- a/p2p/stream/types/stream.go
+++ b/p2p/stream/types/stream.go
@@ -85,11 +85,14 @@ func (st *BaseStream) FailedTimes() int {
 }
 
 func (st *BaseStream) AddFailedTimes(faultRecoveryThreshold time.Duration) {
-	durationSinceLastFailure := time.Now().Sub(st.lastFailureTime)
-	if durationSinceLastFailure >= faultRecoveryThreshold {
-		st.ResetFailedTimes()
+	if st.failedTimes > 0 {
+		durationSinceLastFailure := time.Now().Sub(st.lastFailureTime)
+		if durationSinceLastFailure >= faultRecoveryThreshold {
+			st.ResetFailedTimes()
+		}
 	}
 	st.failedTimes++
+	st.lastFailureTime = time.Now()
 }
 
 func (st *BaseStream) ResetFailedTimes() {


### PR DESCRIPTION
## Issue

The current stream sync codes find the neighboring peers and try to connect to them, completing the discovery through the bootstrap process. Once nodes have connected to the minimum number of peers adjusted in the config file, they consider the bootstrap complete and move on to the next step: syncing with the connected peers.
In the main-net, most validators do not have a full database and only have the latest blocks. If a node wants to ask them for old blocks, they most likely won't have them. In this scenario, new nodes won't be able to use neighbors for sync from scratch and will have to use explorer or archive nodes for syncing, which is more centralized.
After the bootstrap process is completed and the node is connected to its neighbors, during the syncing phase, if the remote peer doesn't have the required blocks, the node removes it from the list. In the mainnet, after a few seconds, the stream list will become empty because most validators don't have the full database. Consequently, the node becomes stuck and cannot proceed with the syncing process.
This PR improves discovery process and tries to let streams be longer in list. Also, it ensures that for each sync cycle it has enough streams available.