### PR TITLE
Block gas 30m.

### DIFF
--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -540,7 +540,7 @@ type ChainConfig struct {
 	// 4. Change the minimum validator commission from 5 to 7% (all nets)
 	HIP30Epoch *big.Int `json:"hip30-epoch,omitempty"`
 
-	BlockGas30M *big.Int `json:"block-gas-30m,omitempty"`
+	BlockGas30MEpoch *big.Int `json:"block-gas-30m-epoch,omitempty"`
 }
 
 // String implements the fmt.Stringer interface.
@@ -777,7 +777,7 @@ func (c *ChainConfig) IsLeaderRotation(epoch *big.Int) bool {
 }
 
 func (c *ChainConfig) IsBlockGas30M(epoch *big.Int) bool {
-	return isForked(c.BlockGas30M, epoch)
+	return isForked(c.BlockGas30MEpoch, epoch)
 }
 
 func (c *ChainConfig) IsLeaderRotationExternalValidatorsAllowed(epoch *big.Int, shardID uint32) bool {

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -329,6 +329,7 @@ var (
 		big.NewInt(1),                      // LeaderRotationExternalBeaconLeaders
 		big.NewInt(0),                      // FeeCollectEpoch
 		big.NewInt(0),                      // ValidatorCodeFixEpoch
+		big.NewInt(0),                      // BlockGas30M
 		big.NewInt(0),                      // HIP30Epoch
 	}
 
@@ -374,6 +375,7 @@ var (
 		big.NewInt(0),        // FeeCollectEpoch
 		big.NewInt(0),        // ValidatorCodeFixEpoch
 		big.NewInt(0),        // HIP30Epoch
+		big.NewInt(0),        // BlockGas30M
 	}
 
 	// TestRules ...
@@ -537,6 +539,8 @@ type ChainConfig struct {
 	// 3. Change from 250 to 200 nodes for remaining shards (mainnet and localnet)
 	// 4. Change the minimum validator commission from 5 to 7% (all nets)
 	HIP30Epoch *big.Int `json:"hip30-epoch,omitempty"`
+
+	BlockGas30M *big.Int `json:"block-gas-30m,omitempty"`
 }
 
 // String implements the fmt.Stringer interface.
@@ -770,6 +774,10 @@ func (c *ChainConfig) IsAllowlistEpoch(epoch *big.Int) bool {
 
 func (c *ChainConfig) IsLeaderRotation(epoch *big.Int) bool {
 	return isForked(c.LeaderRotationExternalNonBeaconLeaders, epoch)
+}
+
+func (c *ChainConfig) IsBlockGas30M(epoch *big.Int) bool {
+	return isForked(c.BlockGas30M, epoch)
 }
 
 func (c *ChainConfig) IsLeaderRotationExternalValidatorsAllowed(epoch *big.Int, shardID uint32) bool {

--- a/node/worker/worker.go
+++ b/node/worker/worker.go
@@ -308,7 +308,7 @@ func (w *Worker) UpdateCurrent() error {
 	header := w.factory.NewHeader(epoch).With().
 		ParentHash(parent.Hash()).
 		Number(num.Add(num, common.Big1)).
-		GasLimit(core.CalcGasLimit(parent, w.gasFloor, w.gasCeil)).
+		GasLimit(core.CalcGasLimit(parent, w.GasFloor(epoch), w.gasCeil)).
 		Time(big.NewInt(timestamp)).
 		ShardID(w.chain.ShardID()).
 		Header()
@@ -601,4 +601,16 @@ func New(
 	worker.makeCurrent(parent, header)
 
 	return worker
+}
+
+func (w *Worker) GasFloor(epoch *big.Int) uint64 {
+	if w.chain.Config().IsBlockGas30M(epoch) {
+		return 30_000_000
+	}
+
+	return w.gasFloor
+}
+
+func (w *Worker) GasCeil() uint64 {
+	return w.gasCeil
 }

--- a/node/worker/worker.go
+++ b/node/worker/worker.go
@@ -70,12 +70,6 @@ func (w *Worker) CommitSortedTransactions(
 	coinbase common.Address,
 ) {
 	for {
-		if w.current.gasPool.Gas() < 50000000 {
-			// Temporary solution to reduce the fullness of the block. Break here when the available gas left hit 50M.
-			// Effectively making the gas limit 30M (since 80M is the default gas limit)
-			utils.Logger().Info().Uint64("have", w.current.gasPool.Gas()).Uint64("want", params.TxGas).Msg("[Temp Gas Limit] Not enough gas for further transactions")
-			break
-		}
 		// If we don't have enough gas for any further transactions then we're done
 		if w.current.gasPool.Gas() < params.TxGas {
 			utils.Logger().Info().Uint64("have", w.current.gasPool.Gas()).Uint64("want", params.TxGas).Msg("Not enough gas for further transactions")


### PR DESCRIPTION
Default value for gas limit is 80m, but this value is for 5 seconds blocks. Harmony validators do not produce blocks more than 30m gas, and we should store this value across the network. Validators still allowed to reduce the value less than 30m, it's not restricted by protocol. 