### PR TITLE
feat: Prune stale staking data hard fork + onwards pt. 2

### DIFF
--- a/consensus/engine/consensus_engine.go
+++ b/consensus/engine/consensus_engine.go
@@ -143,5 +143,5 @@ type Engine interface {
 		receipts []*types.Receipt, outcxs []*types.CXReceipt,
 		incxs []*types.CXReceiptsProof, stks staking.StakingTransactions,
 		doubleSigners slash.Records, sigsReady chan bool, viewID func() uint64,
-	) (*types.Block, reward.Reader, error)
+	) (*types.Block, map[common.Address][]common.Address, reward.Reader, error)
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -108,6 +108,7 @@ type BlockChain interface {
 		block *types.Block, receipts []*types.Receipt,
 		cxReceipts []*types.CXReceipt,
 		stakeMsgs []types2.StakeMsg,
+		delegationsToRemove map[common.Address][]common.Address,
 		paid reward.Reader,
 		state *state.DB,
 	) (status WriteStatus, err error)
@@ -299,6 +300,7 @@ type BlockChain interface {
 	UpdateStakingMetaData(
 		batch rawdb.DatabaseWriter, block *types.Block,
 		stakeMsgs []types2.StakeMsg,
+		delegationsToRemove map[common.Address][]common.Address,
 		state *state.DB, epoch, newEpoch *big.Int,
 	) (newValidators []common.Address, err error)
 	// ReadBlockRewardAccumulator must only be called on beaconchain
@@ -339,6 +341,7 @@ type BlockChain interface {
 		receipts []*types.Receipt,
 		cxReceipts []*types.CXReceipt,
 		stakeMsgs []types2.StakeMsg,
+		delegationsToRemove map[common.Address][]common.Address,
 		payout reward.Reader,
 		state *state.DB,
 	) (status WriteStatus, err error)

--- a/core/blockchain_impl.go
+++ b/core/blockchain_impl.go
@@ -539,7 +539,7 @@ func (bc *BlockChainImpl) validateNewBlock(block *types.Block) error {
 	// NOTE Order of mutating state here matters.
 	// Process block using the parent state as reference point.
 	// Do not read cache from processor.
-	receipts, cxReceipts, _, _, usedGas, _, _, err := bc.processor.Process(
+	receipts, cxReceipts, _, _, _, usedGas, _, _, err := bc.processor.Process(
 		block, state, bc.vmConfig, false,
 	)
 	if err != nil {
@@ -1460,6 +1460,7 @@ func (bc *BlockChainImpl) WriteBlockWithState(
 	block *types.Block, receipts []*types.Receipt,
 	cxReceipts []*types.CXReceipt,
 	stakeMsgs []staking.StakeMsg,
+	delegationsToRemove map[common.Address][]common.Address,
 	paid reward.Reader,
 	state *state.DB,
 ) (status WriteStatus, err error) {
@@ -1560,7 +1561,7 @@ func (bc *BlockChainImpl) WriteBlockWithState(
 	// Write offchain data
 	if status, err := bc.CommitOffChainData(
 		batch, block, receipts,
-		cxReceipts, stakeMsgs,
+		cxReceipts, stakeMsgs, delegationsToRemove, 
 		paid, state,
 	); err != nil {
 		return status, err
@@ -1883,7 +1884,7 @@ func (bc *BlockChainImpl) insertChain(chain types.Blocks, verifyHeaders bool) (i
 		}
 		// Process block using the parent state as reference point.
 		substart := time.Now()
-		receipts, cxReceipts, stakeMsgs, logs, usedGas, payout, newState, err := bc.processor.Process(
+		receipts, cxReceipts, stakeMsgs, delegationsToRemove, logs, usedGas, payout, newState, err := bc.processor.Process(
 			block, state, vmConfig, true,
 		)
 		state = newState // update state in case the new state is cached.
@@ -1920,7 +1921,7 @@ func (bc *BlockChainImpl) insertChain(chain types.Blocks, verifyHeaders bool) (i
 		// Write the block to the chain and get the status.
 		substart = time.Now()
 		status, err := bc.WriteBlockWithState(
-			block, receipts, cxReceipts, stakeMsgs, payout, state,
+			block, receipts, cxReceipts, stakeMsgs, delegationsToRemove, payout, state,
 		)
 		if err != nil {
 			return i, events, coalescedLogs, err
@@ -3065,6 +3066,7 @@ func (bc *BlockChainImpl) writeDelegationsByDelegator(
 func (bc *BlockChainImpl) UpdateStakingMetaData(
 	batch rawdb.DatabaseWriter, block *types.Block,
 	stakeMsgs []staking.StakeMsg,
+	delegationsToRemove map[common.Address][]common.Address,
 	state *state.DB, epoch, newEpoch *big.Int,
 ) (newValidators []common.Address, err error) {
 	newValidators, newDelegations, err := bc.prepareStakingMetaData(block, stakeMsgs, state)
@@ -3119,6 +3121,16 @@ func (bc *BlockChainImpl) UpdateStakingMetaData(
 		if err := bc.writeDelegationsByDelegator(batch, addr, delegations); err != nil {
 			return newValidators, err
 		}
+
+
+
+		for delegatorAddress, validatorAddresses := range delegationsToRemove {
+			if err := bc.RemoveDelegationsFromDelegator(batch, delegatorAddress, validatorAddresses); err != nil {
+				return newValidators, err
+			}
+		}
+
+
 	}
 	return newValidators, nil
 }
@@ -3149,7 +3161,7 @@ func (bc *BlockChainImpl) prepareStakingMetaData(
 				return nil, nil, err
 			}
 		} else {
-			panic("Only *staking.Delegate stakeMsgs are supported at the moment")
+			return nil, nil, errors.New("Only *staking.Delegate stakeMsgs are supported at the moment")
 		}
 	}
 	for _, txn := range block.StakingTransactions() {
@@ -3277,7 +3289,7 @@ func (bc *BlockChainImpl) addDelegationIndex(
 		}
 	}
 
-	// Found the delegation from state and add the delegation index
+	// Find the delegation from state and add the delegation index (the position in validator)
 	// Note this should read from the state of current block in concern
 	wrapper, err := state.ValidatorWrapper(validatorAddress, true, false)
 	if err != nil {
@@ -3293,6 +3305,11 @@ func (bc *BlockChainImpl) addDelegationIndex(
 				Index:            uint64(i),
 				BlockNum:         blockNum,
 			})
+
+			// wrapper.Delegations will not have another delegator
+			// with the same address, so we are done
+			break
+
 		}
 	}
 	return delegations, nil

--- a/core/blockchain_stub.go
+++ b/core/blockchain_stub.go
@@ -113,7 +113,7 @@ func (a Stub) WriteBlockWithoutState(block *types.Block, td *big.Int) (err error
 	return errors.Errorf("method WriteBlockWithoutState not implemented for %s", a.Name)
 }
 
-func (a Stub) WriteBlockWithState(block *types.Block, receipts []*types.Receipt, cxReceipts []*types.CXReceipt, stakeMsgs []staking.StakeMsg, paid reward.Reader, state *state.DB) (status WriteStatus, err error) {
+func (a Stub) WriteBlockWithState(block *types.Block, receipts []*types.Receipt, cxReceipts []*types.CXReceipt, stakeMsgs []staking.StakeMsg, delegationsToRemove map[common.Address][]common.Address, paid reward.Reader, state *state.DB) (status WriteStatus, err error) {
 	return 0, errors.Errorf("method WriteBlockWithState not implemented for %s", a.Name)
 }
 
@@ -373,7 +373,7 @@ func (a Stub) ReadDelegationsByDelegatorAt(delegator common.Address, blockNum *b
 	return nil, errors.Errorf("method ReadDelegationsByDelegatorAt not implemented for %s", a.Name)
 }
 
-func (a Stub) UpdateStakingMetaData(batch rawdb.DatabaseWriter, block *types.Block, stakeMsgs []staking.StakeMsg, state *state.DB, epoch, newEpoch *big.Int) (newValidators []common.Address, err error) {
+func (a Stub) UpdateStakingMetaData(batch rawdb.DatabaseWriter, block *types.Block, stakeMsgs []staking.StakeMsg, delegationsToRemove map[common.Address][]common.Address, state *state.DB, epoch, newEpoch *big.Int) (newValidators []common.Address, err error) {
 	return nil, errors.Errorf("method UpdateStakingMetaData not implemented for %s", a.Name)
 }
 
@@ -412,7 +412,7 @@ func (a Stub) IsEnablePruneBeaconChainFeature() bool {
 	return false
 }
 
-func (a Stub) CommitOffChainData(batch rawdb.DatabaseWriter, block *types.Block, receipts []*types.Receipt, cxReceipts []*types.CXReceipt, stakeMsgs []staking.StakeMsg, payout reward.Reader, state *state.DB) (status WriteStatus, err error) {
+func (a Stub) CommitOffChainData(batch rawdb.DatabaseWriter, block *types.Block, receipts []*types.Receipt, cxReceipts []*types.CXReceipt, stakeMsgs []staking.StakeMsg, delegationsToRemove map[common.Address][]common.Address, payout reward.Reader, state *state.DB) (status WriteStatus, err error) {
 	return 0, errors.Errorf("method CommitOffChainData not implemented for %s", a.Name)
 }
 

--- a/core/evm.go
+++ b/core/evm.go
@@ -243,7 +243,7 @@ func DelegateFn(ref *block.Header, chain ChainContext) vm.DelegateFunc {
 func UndelegateFn(ref *block.Header, chain ChainContext) vm.UndelegateFunc {
 	// moved from state_transition.go to here, with some modifications
 	return func(db vm.StateDB, rosettaTracer vm.RosettaTracer, undelegate *stakingTypes.Undelegate) error {
-		wrapper, err := VerifyAndUndelegateFromMsg(db, ref.Epoch(), undelegate)
+		wrapper, err := VerifyAndUndelegateFromMsg(db, ref.Epoch(), chain.Config(), undelegate)
 		if err != nil {
 			return err
 		}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -933,7 +933,7 @@ func (pool *TxPool) validateStakingTx(tx *staking.StakingTransaction) error {
 			return errors.WithMessagef(ErrInvalidSender, "staking transaction sender is %s", b32)
 		}
 
-		_, err = VerifyAndUndelegateFromMsg(pool.currentState, pool.pendingEpoch(), stkMsg)
+		_, err = VerifyAndUndelegateFromMsg(pool.currentState, pool.pendingEpoch(), pool.chainconfig, stkMsg)
 		return err
 	case staking.DirectiveCollectRewards:
 		msg, err := staking.RLPDecodeStakeMsg(tx.Data(), staking.DirectiveCollectRewards)

--- a/core/types.go
+++ b/core/types.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/consensus/reward"
 	"github.com/harmony-one/harmony/core/state"
 	"github.com/harmony-one/harmony/core/types"
@@ -55,6 +56,7 @@ type Validator interface {
 type Processor interface {
 	Process(block *types.Block, statedb *state.DB, cfg vm.Config, readCache bool) (
 		types.Receipts, types.CXReceipts, []stakingTypes.StakeMsg,
+		map[common.Address][]common.Address,
 		[]*types.Log, uint64, reward.Reader, *state.DB, error,
 	)
 	CacheProcessorResult(cacheKey interface{}, result *ProcessorResult)

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -49,6 +49,7 @@ type StateDB interface {
 	UnsetValidatorFlag(common.Address)
 	IsValidator(common.Address) bool
 	GetValidatorFirstElectionEpoch(addr common.Address) *big.Int
+	//AddReward(*staking.ValidatorWrapper, *big.Int, map[common.Address]numeric.Dec, bool) error
 	AddReward(*staking.ValidatorWrapper, *big.Int, map[common.Address]numeric.Dec) error
 
 	AddRefund(uint64)

--- a/hmy/downloader/adapter_test.go
+++ b/hmy/downloader/adapter_test.go
@@ -156,8 +156,8 @@ func (e *dummyEngine) Finalize(
 	receipts []*types.Receipt, outcxs []*types.CXReceipt,
 	incxs []*types.CXReceiptsProof, stks staking.StakingTransactions,
 	doubleSigners slash.Records, sigsReady chan bool, viewID func() uint64,
-) (*types.Block, reward.Reader, error) {
-	return nil, nil, nil
+) (*types.Block, map[common.Address][]common.Address, reward.Reader, error) {
+		return nil, nil, nil, nil
 }
 
 type testInsertHelper struct {

--- a/hmy/tracer.go
+++ b/hmy/tracer.go
@@ -282,7 +282,7 @@ func (hmy *Harmony) TraceChain(ctx context.Context, start, end *types.Block, con
 				traced += uint64(len(txs))
 			}
 			// Generate the next state snapshot fast without tracing
-			_, _, _, _, _, _, _, err := hmy.BlockChain.Processor().Process(block, statedb, vm.Config{}, false)
+			_, _, _, _, _, _, _, _, err := hmy.BlockChain.Processor().Process(block, statedb, vm.Config{}, false)
 			if err != nil {
 				failed = err
 				break
@@ -677,7 +677,7 @@ func (hmy *Harmony) ComputeStateDB(block *types.Block, reexec uint64) (*state.DB
 		if block = hmy.BlockChain.GetBlockByNumber(block.NumberU64() + 1); block == nil {
 			return nil, fmt.Errorf("block #%d not found", block.NumberU64()+1)
 		}
-		_, _, _, _, _, _, _, err := hmy.BlockChain.Processor().Process(block, statedb, vm.Config{}, false)
+		_, _, _, _, _, _, _, _, err := hmy.BlockChain.Processor().Process(block, statedb, vm.Config{}, false)
 		if err != nil {
 			return nil, fmt.Errorf("processing block %d failed: %v", block.NumberU64(), err)
 		}

--- a/node/worker/worker.go
+++ b/node/worker/worker.go
@@ -48,6 +48,7 @@ type environment struct {
 	incxs      []*types.CXReceiptsProof // cross shard receipts and its proof (desitinatin shard)
 	slashes    slash.Records
 	stakeMsgs  []staking.StakeMsg
+	delegationsToRemove map[common.Address][]common.Address
 }
 
 // Worker is the main object which takes care of submitting new work to consensus engine
@@ -344,6 +345,7 @@ func (w *Worker) GetCurrentResult() *core.ProcessorResult {
 		Reward:     w.current.reward,
 		State:      w.current.state,
 		StakeMsgs:  w.current.stakeMsgs,
+		DelegationsToRemove: w.current.delegationsToRemove,
 	}
 }
 
@@ -555,7 +557,7 @@ func (w *Worker) FinalizeNewBlock(
 		}
 	}()
 
-	block, payout, err := w.chain.Engine().Finalize(
+	block, delegationsToRemove, payout, err := w.chain.Engine().Finalize(
 		w.chain,
 		w.beacon,
 		copyHeader, state, w.current.txs, w.current.receipts,
@@ -566,6 +568,7 @@ func (w *Worker) FinalizeNewBlock(
 		return nil, errors.Wrapf(err, "cannot finalize block")
 	}
 	w.current.reward = payout
+	w.current.delegationsToRemove = delegationsToRemove
 	return block, nil
 }
 


### PR DESCRIPTION
Stale staking data is defined as delegations to a validator which have
no rewards, no amount, and no undelegations. This definition, however,
excludes the (inactive) validator's self delegation since it is expected
to be at index 0, and a validator cannot be deleted at the moment. The
process works as below:

At the last block of every epoch including the hard fork epoch,
obtain a list of validators. For each validator, load the
ValidatorWrapper and iterate through Delegations to find stale
delegations. Drop such delegations, and make a map of delegators as
keys with validator addres(es) as the values.
Using the map obtained in (1), clear the delegations by delegator in
offchain data. The map is therefore cached in the ProcessorResult for
ease of access (between state_processor and node_newblock).
Since the objective of this change is to save some space following
the hard fork, do not allow small undelegations. This means that
undelegations must be made in such a manner that the remaining amount
after the undelegation has been made is at least a 100 ONEs, or zero.
Lastly, since the removal results in different lengths between
delegations of validator snapshots and validator wrappers, modify the
algorithm for AddReward to be based on DelegatorAddress rather than
the loop index. See core/state/statedb.go
The impact of this change on block processing speed is small. I ran a
node with this change at epoch 881 on mainnet using the rclone database
and saw that pruneStaleStakingData takes 18ms to complete (if each prune
is not logged individually, it takes 9ms).

The PR has been tested locally for integration testing (the undelegation
bit), and unit tests for pruning stale data, remaining undelegation, and
AddReward have been added. Goimports is included.

This pull requests is a follow up to https://github.com/harmony-one/harmony/pull/4068