### PR TITLE
Hip30 : localnet account migration fix

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
+	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -252,6 +253,12 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 		for key, value := range account.Storage {
 			statedb.SetState(addr, key, value)
 		}
+		//statedb.AddPreimage(crypto.Keccak256Hash((addr[:])), addr.Bytes()[:])
+		rawdb.WritePreimages(
+			statedb.Database().DiskDB(), map[ethCommon.Hash][]byte{
+				crypto.Keccak256Hash((addr.Bytes())): addr.Bytes(),
+			},
+		)
 	}
 	root := statedb.IntermediateRoot(false)
 	shardStateBytes, err := shard.EncodeWrapper(g.ShardState, false)

--- a/core/preimages.go
+++ b/core/preimages.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/ethereum/go-ethereum/crypto"
-
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/harmony-one/harmony/api/service/prometheus"

--- a/internal/configs/sharding/localnet.go
+++ b/internal/configs/sharding/localnet.go
@@ -31,8 +31,8 @@ const (
 	localnetV1Epoch = 1
 
 	localnetEpochBlock1      = 5
-	localnetBlocksPerEpoch   = 8
-	localnetBlocksPerEpochV2 = 8
+	localnetBlocksPerEpoch   = 64
+	localnetBlocksPerEpochV2 = 64
 
 	localnetVdfDifficulty = 5000 // This takes about 10s to finish the vdf
 )

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -157,6 +157,7 @@ func (node *Node) ProposeNewBlock(commitSigs chan []byte) (*types.Block, error) 
 		}
 	}
 
+	// Execute all the time except for last block of epoch for shard 0
 	if !shard.Schedule.IsLastBlock(header.Number().Uint64()) || node.Consensus.ShardID != 0 {
 		// Prepare normal and staking transactions retrieved from transaction pool
 		utils.AnalysisStart("proposeNewBlockChooseFromTxnPool")

--- a/rpc/preimages.go
+++ b/rpc/preimages.go
@@ -2,7 +2,6 @@ package rpc
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/eth/rpc"
@@ -24,8 +23,7 @@ func NewPreimagesAPI(hmy *hmy.Harmony, version string) rpc.API {
 	}
 }
 
-func (s *PreimagesService) Export(_ context.Context, path string) error {
+func (s *PreimagesService) Export(ctx context.Context, path string) error {
 	// these are by default not blocking
 	return core.ExportPreimages(s.hmy.BlockChain, path)
 }
-


### PR DESCRIPTION
This PR fixes a few items :
- Consensus failed when the localnet genesis account didn't have their preimage
- Consensus failed when leader didn't process cross shard receipt account migration for the last block of epoch which was mainly used for shard 0, for non shard 0 it should still proceed. Normal validator were still processing the cross shard receipt hence the discrepancies in block verification
- Consensus failed when we finish the last account migration

During the merge conflict, I also removed the preimage rpc generate method that will not be used since the node is actively adding new preimage as it sees it when inserting a new block.

It also updates a few more items:
- update back in the generateOneMigrationMessage the failure when hitting the `cannot find preimage` error 
- changing back to 64 the number of block per epoch. It has been previously verified that 64 was required to have a stable localnet with external validator

note : we still need to look at the mainnet genesis account deployed in shard 2 and 3 if any to make sure their preimage are present.

test result:
```
date && hmy balances one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur
Tue Sep 19 14:22:30 +07 2023
[
  {
    "shard": 0,
    "amount": 10000000000.000000000000000000
  },
  {
    "shard": 1,
    "amount": 10000000000.000000000000000000
  }
]
$ date && hmy utility metadata | grep current-epoch
Tue Sep 19 14:22:34 +07 2023
    "current-epoch": 0,
$ date && hmy utility metadata | grep current-epoch
Tue Sep 19 14:22:50 +07 2023
    "current-epoch": 1,
$ date && hmy utility metadata | grep current-epoch
Tue Sep 19 14:25:18 +07 2023
    "current-epoch": 2,
$ date && hmy balances one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur
Tue Sep 19 14:25:20 +07 2023
[
  {
    "shard": 0,
    "amount": 20000000000.000000000000000000
  },
  {
    "shard": 1,
    "amount": 0.000000000000000000
  }
]
```