### PR TITLE
HIP30 - aggregate the recovery multisig reward

### DIFF
--- a/internal/chain/reward.go
+++ b/internal/chain/reward.go
@@ -412,7 +412,8 @@ func distributeRewardAfterAggregateEpoch(bc engine.ChainReader, state *state.DB,
 	utils.Logger().Debug().Int64("elapsed time", time.Now().Sub(startTimeLocal).Milliseconds()).Msg("After Chain Reward (AddReward)")
 	utils.Logger().Debug().Int64("elapsed time", time.Now().Sub(startTime).Milliseconds()).Msg("After Chain Reward")
 
-	return remainingReward, network.NewStakingEraRewardForRound(
+	// remainingReward needs to be multipled with the number of crosslinks across all shards
+	return remainingReward.MulInt(big.NewInt(int64(len(allCrossLinks)))), network.NewStakingEraRewardForRound(
 		newRewards, payouts,
 	), nil
 }


### PR DESCRIPTION
## Issue

As part of HIP30, 25% of the total reward is supposed to be credited to the recovery multisig account.

## Test

### Unit Test Coverage
NA
### Test/Run Logs

localnet test - every 64 blocks, with 2 shards and with 14 ONEs per block, we receive 448 ONE (14 * 0.25 * 2 * 64) into the recovery multisig account 
```bash
$ curl --location $URL --header 'Content-Type: application/json' --data '{"jsonrpc": "2.0", "id": 1, "method": "hmyv2_getBalanceByBlockNumber", "params": ["'$ADD'",192]}'
{"jsonrpc":"2.0","id":1,"result":448000000000000000000}
$ curl --location $URL --header 'Content-Type: application/json' --data '{"jsonrpc": "2.0", "id": 1, "method": "hmyv2_getBalanceByBlockNumber", "params": ["'$ADD'",256]}'
{"jsonrpc":"2.0","id":1,"result":896000000000000000000}
```
