### PR TITLE
reset devnet and set 30M epoch for all network except mainnet/testnet

### DIFF
--- a/internal/configs/sharding/partner.go
+++ b/internal/configs/sharding/partner.go
@@ -14,8 +14,6 @@ import (
 // configuration schedule.
 var PartnerSchedule partnerSchedule
 
-var feeCollectEpochV1 = big.NewInt(574)
-
 var feeCollectorsDevnet = []FeeCollectors{
 	FeeCollectors{
 		mustAddress("0xb728AEaBF60fD01816ee9e756c18bc01dC91ba5D"): numeric.OneDec(),

--- a/internal/configs/sharding/partner.go
+++ b/internal/configs/sharding/partner.go
@@ -44,10 +44,6 @@ func (ps partnerSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	switch {
 	case params.PartnerChainConfig.IsHIP30(epoch):
 		return partnerV4
-	case params.PartnerChainConfig.IsFeeCollectEpoch(epoch):
-		return partnerV3
-	case epoch.Cmp(feeCollectEpochV1) >= 0:
-		return partnerV2
 	case epoch.Cmp(params.PartnerChainConfig.StakingEpoch) >= 0:
 		return partnerV1
 	default: // genesis

--- a/internal/configs/sharding/partner.go
+++ b/internal/configs/sharding/partner.go
@@ -41,7 +41,7 @@ const (
 func (ps partnerSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	switch {
 	case params.PartnerChainConfig.IsHIP30(epoch):
-		return partnerV4
+		return partnerV2
 	case epoch.Cmp(params.PartnerChainConfig.StakingEpoch) >= 0:
 		return partnerV1
 	default: // genesis
@@ -104,20 +104,6 @@ var partnerV1 = MustNewInstance(
 	partnerReshardingEpoch, PartnerSchedule.BlocksPerEpoch(),
 )
 var partnerV2 = MustNewInstance(
-	2, 5, 4, 0,
-	numeric.MustNewDecFromStr("0.9"), genesis.TNHarmonyAccounts,
-	genesis.TNFoundationalAccounts, emptyAllowlist,
-	feeCollectorsDevnet[0], numeric.ZeroDec(), ethCommon.Address{},
-	partnerReshardingEpoch, PartnerSchedule.BlocksPerEpoch(),
-)
-var partnerV3 = MustNewInstance(
-	2, 5, 4, 0,
-	numeric.MustNewDecFromStr("0.9"), genesis.TNHarmonyAccounts,
-	genesis.TNFoundationalAccounts, emptyAllowlist,
-	feeCollectorsDevnet[1], numeric.ZeroDec(), ethCommon.Address{},
-	partnerReshardingEpoch, PartnerSchedule.BlocksPerEpoch(),
-)
-var partnerV4 = MustNewInstance(
 	2, 5, 4, 0,
 	numeric.MustNewDecFromStr("0.9"), genesis.TNHarmonyAccounts,
 	genesis.TNFoundationalAccounts, emptyAllowlist,

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -74,6 +74,7 @@ var (
 		FeeCollectEpoch:                        big.NewInt(1535), // 2023-07-20 05:51:07+00:00
 		ValidatorCodeFixEpoch:                  big.NewInt(1535), // 2023-07-20 05:51:07+00:00
 		HIP30Epoch:                             EpochTBD,
+		BlockGas30MEpoch:                       EpochTBD,
 	}
 
 	// TestnetChainConfig contains the chain parameters to run a node on the harmony test network.
@@ -116,6 +117,7 @@ var (
 		FeeCollectEpoch:                        big.NewInt(1296), // 2023-04-28 07:14:20+00:00
 		ValidatorCodeFixEpoch:                  big.NewInt(1296), // 2023-04-28 07:14:20+00:00
 		HIP30Epoch:                             EpochTBD,
+		BlockGas30MEpoch:                       EpochTBD,
 	}
 	// PangaeaChainConfig contains the chain parameters for the Pangaea network.
 	// All features except for CrossLink are enabled at launch.
@@ -158,6 +160,7 @@ var (
 		FeeCollectEpoch:                        EpochTBD,
 		ValidatorCodeFixEpoch:                  EpochTBD,
 		HIP30Epoch:                             EpochTBD,
+		BlockGas30MEpoch:                       big.NewInt(0),
 	}
 
 	// PartnerChainConfig contains the chain parameters for the Partner network.
@@ -175,7 +178,7 @@ var (
 		QuickUnlockEpoch:                       big.NewInt(0),
 		FiveSecondsEpoch:                       big.NewInt(0),
 		TwoSecondsEpoch:                        big.NewInt(0),
-		SixtyPercentEpoch:                      big.NewInt(4),
+		SixtyPercentEpoch:                      EpochTBD,
 		RedelegationEpoch:                      big.NewInt(0),
 		NoEarlyUnlockEpoch:                     big.NewInt(0),
 		VRFEpoch:                               big.NewInt(0),
@@ -198,9 +201,10 @@ var (
 		AllowlistEpoch:                         EpochTBD,
 		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
 		LeaderRotationExternalBeaconLeaders:    EpochTBD,
-		FeeCollectEpoch:                        big.NewInt(848), // 2023-04-28 04:33:33+00:00
-		ValidatorCodeFixEpoch:                  big.NewInt(848),
-		HIP30Epoch:                             EpochTBD,
+		FeeCollectEpoch:                        big.NewInt(5),
+		ValidatorCodeFixEpoch:                  big.NewInt(5),
+		HIP30Epoch:                             big.NewInt(8),
+		BlockGas30MEpoch:                       big.NewInt(0),
 	}
 
 	// StressnetChainConfig contains the chain parameters for the Stress test network.
@@ -244,6 +248,7 @@ var (
 		LeaderRotationExternalBeaconLeaders:    EpochTBD,
 		ValidatorCodeFixEpoch:                  EpochTBD,
 		HIP30Epoch:                             EpochTBD,
+		BlockGas30MEpoch:                       big.NewInt(0),
 	}
 
 	// LocalnetChainConfig contains the chain parameters to run for local development.
@@ -286,6 +291,7 @@ var (
 		FeeCollectEpoch:                        big.NewInt(2),
 		ValidatorCodeFixEpoch:                  big.NewInt(2),
 		HIP30Epoch:                             EpochTBD,
+		BlockGas30MEpoch:                       big.NewInt(0),
 	}
 
 	// AllProtocolChanges ...

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -194,17 +194,17 @@ var (
 		ReceiptLogEpoch:                        big.NewInt(0),
 		SHA3Epoch:                              big.NewInt(0),
 		HIP6And8Epoch:                          big.NewInt(0),
-		StakingPrecompileEpoch:                 big.NewInt(2),
-		ChainIdFixEpoch:                        big.NewInt(0),
+		StakingPrecompileEpoch:                 big.NewInt(5),
+		ChainIdFixEpoch:                        big.NewInt(5),
 		SlotsLimitedEpoch:                      EpochTBD, // epoch to enable HIP-16
-		CrossShardXferPrecompileEpoch:          big.NewInt(1),
+		CrossShardXferPrecompileEpoch:          big.NewInt(5),
 		AllowlistEpoch:                         EpochTBD,
 		LeaderRotationExternalNonBeaconLeaders: EpochTBD,
 		LeaderRotationExternalBeaconLeaders:    EpochTBD,
 		FeeCollectEpoch:                        big.NewInt(5),
 		ValidatorCodeFixEpoch:                  big.NewInt(5),
-		HIP30Epoch:                             big.NewInt(8),
-		BlockGas30MEpoch:                       big.NewInt(0),
+		HIP30Epoch:                             big.NewInt(7),
+		BlockGas30MEpoch:                       big.NewInt(7),
 	}
 
 	// StressnetChainConfig contains the chain parameters for the Stress test network.


### PR DESCRIPTION
This PR is preparing for the devnet reset by :
- updating the different epoch feature activation
- updating the devnet instance configuration

and also update the epoch activation for 30M block gas for all network except mainnet and testnet