### PR TITLE
fix duplicate function def

### DIFF
--- a/p2p/stream/protocols/sync/chain_test.go
+++ b/p2p/stream/protocols/sync/chain_test.go
@@ -215,18 +215,3 @@ func checkBlocksByHashesResult(b []byte, hs []common.Hash) error {
 	}
 	return nil
 }
-
-func checkGetReceiptsResult(b []byte, hs []common.Hash) error {
-	var msg = &syncpb.Message{}
-	if err := protobuf.Unmarshal(b, msg); err != nil {
-		return err
-	}
-	bhResp, err := msg.GetReceiptsResponse()
-	if err != nil {
-		return err
-	}
-	if len(hs) != len(bhResp.Receipts) {
-		return errors.New("unexpected size")
-	}
-	return nil
-}


### PR DESCRIPTION
## Issue

function **checkGetReceiptsResult** is defined two times in same package. This issue could be because of merge conflicts resolution. This PR fixes that. 