### PR TITLE
use new(big.Int) so we don't modify the epoch value

### DIFF
--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -806,7 +806,7 @@ func (c *ChainConfig) IsHIP30(epoch *big.Int) bool {
 // During this epoch, shards 2 and 3 will start sending
 // their balances over to shard 0 or 1.
 func (c *ChainConfig) IsOneEpochBeforeHIP30(epoch *big.Int) bool {
-	return epoch.Sub(c.HIP30Epoch, epoch).Cmp(common.Big1) == 0
+	return new(big.Int).Sub(c.HIP30Epoch, epoch).Cmp(common.Big1) == 0
 }
 
 // UpdateEthChainIDByShard update the ethChainID based on shard ID.


### PR DESCRIPTION
## Issue

I think if we use the epoch variable as it's a pointer we would modify the original value, and since we just want to run a comparison I think it's safer to store the resulting Subtraction on a brand new variable by using `new(big.Int)`
