### PR TITLE
update deprecated ioutil

### DIFF
--- a/accounts/abi/bind/auth.go
+++ b/accounts/abi/bind/auth.go
@@ -20,7 +20,6 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"io"
-	"io/ioutil"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -44,7 +43,7 @@ var ErrNotAuthorized = errors.New("not authorized to sign this account")
 // Deprecated: Use NewTransactorWithChainID instead.
 func NewTransactor(keyin io.Reader, passphrase string) (*TransactOpts, error) {
 	log.Warn("WARNING: NewTransactor has been deprecated in favour of NewTransactorWithChainID")
-	json, err := ioutil.ReadAll(keyin)
+	json, err := io.ReadAll(keyin)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +102,7 @@ func NewKeyedTransactor(key *ecdsa.PrivateKey) *TransactOpts {
 // NewTransactorWithChainID is a utility method to easily create a transaction signer from
 // an encrypted json key stream and the associated passphrase.
 func NewTransactorWithChainID(keyin io.Reader, passphrase string, chainID *big.Int) (*TransactOpts, error) {
-	json, err := ioutil.ReadAll(keyin)
+	json, err := io.ReadAll(keyin)
 	if err != nil {
 		return nil, err
 	}

--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -18,7 +18,6 @@ package keystore
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -133,11 +132,11 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 		return
 	}
 
-	// needed so that modTime of `file` is different to its current value after ioutil.WriteFile
+	// needed so that modTime of `file` is different to its current value after io.WriteFile
 	time.Sleep(1000 * time.Millisecond)
 
 	// Now replace file contents with crap
-	if err := ioutil.WriteFile(file, []byte("foo"), 0644); err != nil {
+	if err := os.WriteFile(file, []byte("foo"), 0644); err != nil {
 		t.Fatal(err)
 		return
 	}
@@ -150,9 +149,9 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 
 // forceCopyFile is like cp.CopyFile, but doesn't complain if the destination exists.
 func forceCopyFile(dst, src string) error {
-	data, err := ioutil.ReadFile(src)
+	data, err := os.ReadFile(src)
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(dst, data, 0644)
+	return os.WriteFile(dst, data, 0644)
 }

--- a/accounts/keystore/file_cache.go
+++ b/accounts/keystore/file_cache.go
@@ -17,7 +17,7 @@
 package keystore
 
 import (
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -42,7 +42,7 @@ func (fc *fileCache) scan(keyDir string) (mapset.Set, mapset.Set, mapset.Set, er
 	t0 := time.Now()
 
 	// List all the failes from the keystore folder
-	files, err := ioutil.ReadDir(keyDir)
+	files, err := os.ReadDir(keyDir)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -63,15 +63,19 @@ func (fc *fileCache) scan(keyDir string) (mapset.Set, mapset.Set, mapset.Set, er
 			utils.Logger().Debug().Str("path", path).Msg("Ignoring file on account scan")
 			continue
 		}
-		// Gather the set of all and fresly modified files
+		// Gather the set of all and freshly modified files
 		all.Add(path)
 
-		modified := fi.ModTime()
-		if modified.After(fc.lastMod) {
-			mods.Add(path)
-		}
-		if modified.After(newLastMod) {
-			newLastMod = modified
+		if info, err := fi.Info(); err != nil {
+			continue
+		} else {
+			modified := info.ModTime()
+			if modified.After(fc.lastMod) {
+				mods.Add(path)
+			}
+			if modified.After(newLastMod) {
+				newLastMod = modified
+			}
 		}
 	}
 	t2 := time.Now()
@@ -94,14 +98,18 @@ func (fc *fileCache) scan(keyDir string) (mapset.Set, mapset.Set, mapset.Set, er
 }
 
 // nonKeyFile ignores editor backups, hidden files and folders/symlinks.
-func nonKeyFile(fi os.FileInfo) bool {
+func nonKeyFile(fi fs.DirEntry) bool {
 	// Skip editor backups and UNIX-style hidden files.
 	if strings.HasSuffix(fi.Name(), "~") || strings.HasPrefix(fi.Name(), ".") {
 		return true
 	}
 	// Skip misc special files, directories (yes, symlinks too).
-	if fi.IsDir() || fi.Mode()&os.ModeType != 0 {
+	if info, err := fi.Info(); err != nil {
 		return true
+	} else {
+		if fi.IsDir() || info.Mode()&os.ModeType != 0 {
+			return true
+		}
 	}
 	return false
 }

--- a/accounts/keystore/key.go
+++ b/accounts/keystore/key.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -195,7 +194,7 @@ func writeTemporaryKeyFile(file string, content []byte) (string, error) {
 	}
 	// Atomic write: create a temporary hidden file first
 	// then move it into place. TempFile assigns mode 0600.
-	f, err := ioutil.TempFile(filepath.Dir(file), "."+filepath.Base(file)+".tmp")
+	f, err := os.CreateTemp(filepath.Dir(file), "."+filepath.Base(file)+".tmp")
 	if err != nil {
 		return "", err
 	}

--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -17,7 +17,6 @@
 package keystore
 
 import (
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -213,7 +212,7 @@ func TestSignRace(t *testing.T) {
 }
 
 func tmpKeyStore(t *testing.T, encrypted bool) (string, *KeyStore) {
-	d, err := ioutil.TempDir("", "eth-keystore-test")
+	d, err := os.MkdirTemp("", "eth-keystore-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/accounts/keystore/passphrase.go
+++ b/accounts/keystore/passphrase.go
@@ -34,7 +34,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -82,7 +81,7 @@ type keyStorePassphrase struct {
 
 func (ks keyStorePassphrase) GetKey(addr common.Address, filename, auth string) (*Key, error) {
 	// Load the key from the keystore and decrypt its contents
-	keyjson, err := ioutil.ReadFile(filename)
+	keyjson, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/accounts/keystore/passphrase_test.go
+++ b/accounts/keystore/passphrase_test.go
@@ -17,7 +17,7 @@
 package keystore
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -30,7 +30,7 @@ const (
 
 // Tests that a json key file can be decrypted and encrypted in multiple rounds.
 func TestKeyEncryptDecrypt(t *testing.T) {
-	keyjson, err := ioutil.ReadFile("testdata/very-light-scrypt.json")
+	keyjson, err := os.ReadFile("testdata/very-light-scrypt.json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/accounts/keystore/plain_test.go
+++ b/accounts/keystore/plain_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -32,7 +31,7 @@ import (
 )
 
 func tmpKeyStoreIface(t *testing.T, encrypted bool) (dir string, ks keyStore) {
-	d, err := ioutil.TempDir("", "geth-keystore-test")
+	d, err := os.MkdirTemp("", "geth-keystore-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/harmony/config.go
+++ b/cmd/harmony/config.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -221,7 +220,7 @@ func promptConfigUpdate() bool {
 }
 
 func loadHarmonyConfig(file string) (harmonyconfig.HarmonyConfig, string, error) {
-	b, err := ioutil.ReadFile(file)
+	b, err := os.ReadFile(file)
 	if err != nil {
 		return harmonyconfig.HarmonyConfig{}, "", err
 	}
@@ -234,12 +233,12 @@ func loadHarmonyConfig(file string) (harmonyconfig.HarmonyConfig, string, error)
 }
 
 func updateConfigFile(file string) error {
-	configBytes, err := ioutil.ReadFile(file)
+	configBytes, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}
 	backup := fmt.Sprintf("%s.backup", file)
-	if err := ioutil.WriteFile(backup, configBytes, 0664); err != nil {
+	if err := os.WriteFile(backup, configBytes, 0664); err != nil {
 		return err
 	}
 	fmt.Printf("Original config backed up to %s\n", fmt.Sprintf("%s.backup", file))
@@ -259,5 +258,5 @@ func writeHarmonyConfigToFile(config harmonyconfig.HarmonyConfig, file string) e
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(file, b, 0644)
+	return os.WriteFile(file, b, 0644)
 }

--- a/cmd/harmony/config_test.go
+++ b/cmd/harmony/config_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -120,7 +119,7 @@ Version = "1.0.4"
 	os.RemoveAll(testDir)
 	os.MkdirAll(testDir, 0777)
 	file := filepath.Join(testDir, "test.config")
-	err := ioutil.WriteFile(file, []byte(testConfig), 0644)
+	err := os.WriteFile(file, []byte(testConfig), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/genesis_util.go
+++ b/core/genesis_util.go
@@ -3,8 +3,8 @@ package core
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"sort"
 
 	"github.com/ethereum/go-ethereum/rlp"
@@ -29,7 +29,7 @@ func encodeGenesisConfig(ga []GenesisItem) string {
 }
 
 func parseGenesisConfigFile(fileName string) genesisConfig {
-	input, err := ioutil.ReadFile(fileName)
+	input, err := os.ReadFile(fileName)
 	if err != nil {
 		panic(fmt.Sprintf("cannot open genesisblock config file %v, err %v\n", fileName, err))
 	}

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -19,7 +19,6 @@ package core
 import (
 	"crypto/ecdsa"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
@@ -1354,7 +1353,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 	t.Parallel()
 
 	// Create a temporary file for the journal
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temporary journal: %v", err)
 	}

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -20,8 +20,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -240,7 +240,7 @@ func TestWriteExpectedValues(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		_ = ioutil.WriteFile(fmt.Sprintf("testdata/testcases_%v.json", name), data, 0644)
+		_ = os.WriteFile(fmt.Sprintf("testdata/testcases_%v.json", name), data, 0644)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -250,7 +250,7 @@ func TestWriteExpectedValues(t *testing.T) {
 // TestJsonTestcases runs through all the testcases defined as json-files
 func TestJsonTestcases(t *testing.T) {
 	for name := range twoOpMethods {
-		data, err := ioutil.ReadFile(fmt.Sprintf("testdata/testcases_%v.json", name))
+		data, err := os.ReadFile(fmt.Sprintf("testdata/testcases_%v.json", name))
 		if err != nil {
 			t.Fatal("Failed to read file", err)
 		}

--- a/eth/rpc/gzip.go
+++ b/eth/rpc/gzip.go
@@ -19,7 +19,6 @@ package rpc
 import (
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
@@ -27,7 +26,7 @@ import (
 
 var gzPool = sync.Pool{
 	New: func() interface{} {
-		w := gzip.NewWriter(ioutil.Discard)
+		w := gzip.NewWriter(io.Discard)
 		return w
 	},
 }

--- a/eth/rpc/http.go
+++ b/eth/rpc/http.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net"
 	"net/http"
@@ -172,7 +171,7 @@ func (hc *httpConn) doRequest(ctx context.Context, msg interface{}) (io.ReadClos
 		return nil, err
 	}
 	req := hc.req.WithContext(ctx)
-	req.Body = ioutil.NopCloser(bytes.NewReader(body))
+	req.Body = io.NopCloser(bytes.NewReader(body))
 	req.ContentLength = int64(len(body))
 
 	resp, err := hc.client.Do(req)

--- a/eth/rpc/method_filter.go
+++ b/eth/rpc/method_filter.go
@@ -3,7 +3,6 @@ package rpc
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -32,7 +31,7 @@ Deny = [ ... ]
 func (rmf *RpcMethodFilter) LoadRpcMethodFiltersFromFile(file string) error {
 	// check if file exist
 	if _, err := os.Stat(file); err == nil {
-		b, errRead := ioutil.ReadFile(file)
+		b, errRead := os.ReadFile(file)
 		if errRead != nil {
 			return fmt.Errorf("rpc filter file read error - %s", errRead.Error())
 		}

--- a/eth/rpc/server_test.go
+++ b/eth/rpc/server_test.go
@@ -20,8 +20,8 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -52,7 +52,7 @@ func TestServerRegisterName(t *testing.T) {
 }
 
 func TestServer(t *testing.T) {
-	files, err := ioutil.ReadDir("testdata")
+	files, err := os.ReadDir("testdata")
 	if err != nil {
 		t.Fatal("where'd my testdata go?")
 	}
@@ -70,7 +70,7 @@ func TestServer(t *testing.T) {
 
 func runTestScript(t *testing.T, file string) {
 	server := newTestServer()
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/hmy/tracer.go
+++ b/hmy/tracer.go
@@ -22,7 +22,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"runtime"
@@ -577,7 +576,7 @@ func (hmy *Harmony) standardTraceBlockToFile(ctx context.Context, block *types.B
 			// Generate a unique temporary file to dump it into
 			prefix := fmt.Sprintf("block_%#x-%d-%#x-", block.Hash().Bytes()[:4], i, tx.Hash().Bytes()[:4])
 
-			dump, err = ioutil.TempFile(os.TempDir(), prefix)
+			dump, err = os.CreateTemp(os.TempDir(), prefix)
 			if err != nil {
 				return nil, err
 			}

--- a/hmy/tracers/internal/tracers/assets.go
+++ b/hmy/tracers/internal/tracers/assets.go
@@ -19,7 +19,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -410,7 +409,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = os.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}

--- a/internal/blsgen/kms.go
+++ b/internal/blsgen/kms.go
@@ -3,7 +3,7 @@ package blsgen
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sync"
 	"time"
 
@@ -178,7 +178,7 @@ func newFileACProvider(file string) *fileACProvider {
 }
 
 func (provider *fileACProvider) getAwsConfig() (*AwsConfig, error) {
-	b, err := ioutil.ReadFile(provider.file)
+	b, err := os.ReadFile(provider.file)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/blsgen/kms_test.go
+++ b/internal/blsgen/kms_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -107,7 +106,7 @@ func writeAwsConfigFile(file string, config AwsConfig) error {
 			return err
 		}
 	}
-	return ioutil.WriteFile(file, b, 0700)
+	return os.WriteFile(file, b, 0700)
 }
 
 func TestPromptACProvider_getAwsConfig(t *testing.T) {

--- a/internal/blsgen/lib.go
+++ b/internal/blsgen/lib.go
@@ -7,7 +7,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -50,7 +49,7 @@ func WriteToFile(filename string, data string) error {
 
 // LoadBLSKeyWithPassPhrase loads bls key with passphrase.
 func LoadBLSKeyWithPassPhrase(fileName, passphrase string) (*ffi_bls.SecretKey, error) {
-	encryptedPrivateKeyBytes, err := ioutil.ReadFile(fileName)
+	encryptedPrivateKeyBytes, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, errors.Wrapf(err, "attempted to load from %s", fileName)
 	}
@@ -72,7 +71,7 @@ func LoadBLSKeyWithPassPhrase(fileName, passphrase string) (*ffi_bls.SecretKey, 
 
 // LoadAwsCMKEncryptedBLSKey loads aws encrypted bls key.
 func LoadAwsCMKEncryptedBLSKey(fileName string, kmsClient *kms.KMS) (*ffi_bls.SecretKey, error) {
-	encryptedPrivateKeyBytes, err := ioutil.ReadFile(fileName)
+	encryptedPrivateKeyBytes, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, errors.Wrapf(err, "fail read at: %s", fileName)
 	}

--- a/internal/blsgen/passphrase.go
+++ b/internal/blsgen/passphrase.go
@@ -3,7 +3,7 @@ package blsgen
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"sync"
@@ -177,7 +177,7 @@ func (provider *promptPassProvider) persistPassphrase(keyFile string, passPhrase
 		return err
 	}
 
-	return ioutil.WriteFile(passFile, []byte(passPhrase), defWritePassFileMode)
+	return os.WriteFile(passFile, []byte(passPhrase), defWritePassFileMode)
 }
 
 // staticPassProvider provide the bls passphrase from a static .pass file
@@ -222,7 +222,7 @@ func readPassFromFile(file string) (string, error) {
 	}
 	defer f.Close()
 
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	if err != nil {
 		return "", err
 	}

--- a/internal/blsgen/passphrase_test.go
+++ b/internal/blsgen/passphrase_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -315,7 +314,7 @@ func TestPromptPassProvider_getPassphrase(t *testing.T) {
 				t.Errorf("Test %v: pass file exist %v", i, passFile)
 			}
 		} else {
-			b, err := ioutil.ReadFile(passFile)
+			b, err := os.ReadFile(passFile)
 			if err != nil {
 				t.Error(err)
 				continue

--- a/internal/blsgen/utils_test.go
+++ b/internal/blsgen/utils_test.go
@@ -2,7 +2,6 @@ package blsgen
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -47,7 +46,7 @@ var testKeys = []testKey{
 func writeFile(file string, data string) error {
 	dir := filepath.Dir(file)
 	os.MkdirAll(dir, 0700)
-	return ioutil.WriteFile(file, []byte(data), 0600)
+	return os.WriteFile(file, []byte(data), 0600)
 }
 
 func TestPromptYesNo(t *testing.T) {

--- a/internal/utils/passphrase.go
+++ b/internal/utils/passphrase.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -28,7 +27,7 @@ func AskForPassphrase(prompt string) string {
 
 // readAllAsString reads the entire file contents as a string.
 func readAllAsString(r io.Reader) (data string, err error) {
-	bytes, err := ioutil.ReadAll(r)
+	bytes, err := io.ReadAll(r)
 	return string(bytes), err
 }
 

--- a/internal/utils/testing/tempfile.go
+++ b/internal/utils/testing/tempfile.go
@@ -2,7 +2,6 @@ package testutils
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -13,7 +12,7 @@ import (
 // NewTempFile creates a new, empty temp file for testing.  Errors are fatal.
 func NewTempFile(t *testing.T) *os.File {
 	pattern := strings.ReplaceAll(t.Name(), string(os.PathSeparator), "_")
-	f, err := ioutil.TempFile("", pattern)
+	f, err := os.CreateTemp("", pattern)
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "cannot create temp file"))
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"runtime/pprof"
@@ -1434,7 +1433,7 @@ func (node *Node) syncFromTiKVWriter() {
 				if err != nil {
 					panic(err)
 				}
-				err = ioutil.WriteFile(fmt.Sprintf("/local/%s", time.Now().Format("hmy_0102150405.error.log")), buf.Bytes(), 0644)
+				err = os.WriteFile(fmt.Sprintf("/local/%s", time.Now().Format("hmy_0102150405.error.log")), buf.Bytes(), 0644)
 				if err != nil {
 					panic(err)
 				}

--- a/staking/effective/calculate_test.go
+++ b/staking/effective/calculate_test.go
@@ -3,9 +3,9 @@ package effective
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
+	"os"
 	"sort"
 	"testing"
 
@@ -35,7 +35,7 @@ type slotsData struct {
 }
 
 func init() {
-	input, err := ioutil.ReadFile(eposTestingFile)
+	input, err := os.ReadFile(eposTestingFile)
 	if err != nil {
 		panic(
 			fmt.Sprintf("cannot open genesisblock config file %v, err %v\n",

--- a/webhooks/yaml.go
+++ b/webhooks/yaml.go
@@ -3,8 +3,9 @@ package webhooks
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 
 	"gopkg.in/yaml.v2"
 )
@@ -63,7 +64,7 @@ func DoPost(url string, record interface{}) (*ReportResult, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	result, err := ioutil.ReadAll(resp.Body)
+	result, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +77,7 @@ func DoPost(url string, record interface{}) (*ReportResult, error) {
 
 // NewWebHooksFromPath ..
 func NewWebHooksFromPath(yamlPath string) (*Hooks, error) {
-	rawYAML, err := ioutil.ReadFile(yamlPath)
+	rawYAML, err := os.ReadFile(yamlPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Issue

Based on the GoLang documentation, the use of the ioutil package is deprecated. This PR aims to update the code to utilize the **os** or **io** packages instead.

https://pkg.go.dev/io/ioutil
```
As of Go 1.16, the same functionality is now provided
by package [io](https://pkg.go.dev/io) 
or package [os](https://pkg.go.dev/os), 
and those implementations should be preferred in new code.
```