### PR TITLE
fix decryptRaw issue for nil/empty data

### DIFF
--- a/internal/blsgen/lib.go
+++ b/internal/blsgen/lib.go
@@ -6,6 +6,7 @@ import (
 	"crypto/md5"
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -136,6 +137,9 @@ func decrypt(encrypted []byte, passphrase string) (decrypted []byte, err error) 
 }
 
 func decryptRaw(data []byte, passphrase string) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("unable to decrypt raw data with the provided passphrase; the data is empty")
+	}
 	var err error
 	key := []byte(createHash(passphrase))
 	block, err := aes.NewCipher(key)
@@ -147,6 +151,9 @@ func decryptRaw(data []byte, passphrase string) ([]byte, error) {
 		return nil, err
 	}
 	nonceSize := gcm.NonceSize()
+	if len(data) < nonceSize {
+		return nil, fmt.Errorf("failed to decrypt raw data with the provided passphrase; the data size is invalid")
+	}
 	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
 	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
 	return plaintext, err


### PR DESCRIPTION
## Issue

This pull request addresses an issue that leads to a panic error in one of the nodes, originating from the `loadBasicKeyWithProvider` function. The problem arises when this function employs the `getPassphrase` method to read the passphrase from a key file. In certain instances, the `getPassphrase` method returns a nil or empty value. Consequently, when the subsequent function, `LoadBLSKeyWithPassPhrase`, is called, it attempts to decrypt a null value, leading to an error.

Based on a analysis of the code, it has been confirmed that this issue arises due to the `getPassphrase` function returning empty or nil values. This pull request introduces a modification to add a length check for the data obtained from `getPassphrase`. By verifying the data's length, we can ensure that it is non-empty before proceeding to decrypt it.