### PR TITLE
Dumpdb fixed memory leak.

### DIFF
--- a/cmd/harmony/dumpdb.go
+++ b/cmd/harmony/dumpdb.go
@@ -156,6 +156,7 @@ func (db *KakashiDB) copyKV(key, value []byte) {
 	db.toDBBatch.Put(key, value)
 	snapdbInfo.DumpedSize += uint64(len(key) + len(value))
 	dumpPrint("copyKV", false)
+	db.flush()
 }
 
 func (db *KakashiDB) flush() {


### PR DESCRIPTION

after
![pprof001](https://github.com/harmony-one/harmony/assets/355847/c02e19a8-f640-4990-9fb9-bf633352f2f8)
