### PR TITLE
Make peer connected/disconnected log debug

### DIFF
--- a/p2p/host.go
+++ b/p2p/host.go
@@ -536,7 +536,7 @@ func (host *HostV2) ListenClose(net libp2p_network.Network, addr ma.Multiaddr) {
 
 // called when a connection opened
 func (host *HostV2) Connected(net libp2p_network.Network, conn libp2p_network.Conn) {
-	host.logger.Info().Interface("node", conn.RemotePeer()).Msg("peer connected")
+	host.logger.Debug().Interface("node", conn.RemotePeer()).Msg("peer connected")
 
 	for _, function := range host.onConnections.GetAll() {
 		if err := function(net, conn); err != nil {
@@ -547,7 +547,7 @@ func (host *HostV2) Connected(net libp2p_network.Network, conn libp2p_network.Co
 
 // called when a connection closed
 func (host *HostV2) Disconnected(net libp2p_network.Network, conn libp2p_network.Conn) {
-	host.logger.Info().Interface("node", conn.RemotePeer()).Msg("peer disconnected")
+	host.logger.Debug().Interface("node", conn.RemotePeer()).Msg("peer disconnected")
 
 	for _, function := range host.onDisconnects.GetAll() {
 		if err := function(conn); err != nil {


### PR DESCRIPTION
While debugging these logs usually flood the logfiles making it a bit harder to look at, I think their level should be increased to debug.