### PR TITLE
Fix typo in README test steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ make debug-kill
 
 To keep things consistent, we have a docker image to run all tests. **These are the same tests ran on the pull request checks**.
 
-Note that all testing docker container binds a couple of ports to the host machine for your convince. The ports are:
+Note that all test Docker containers bind several ports to the host machine for your convenience. The ports are:
 * `9500` - Shard 0 RPC for a validator
 * `9501` - Shard 1 RPC for a validator
 * `9599` - Shard 0 RPC for an explorer


### PR DESCRIPTION
Just noticed a minor typo and unclear sentence while reading through the README file.

## Test
N/A doc only change.

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**
