### PR TITLE
fix: max-rate bellow the era min-rate

### DIFF
--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -466,6 +466,14 @@ func setElectionEpochAndMinFee(chain engine.ChainReader, header *block.Header, s
 			}
 		}
 	}
+
+	if config.IsMaxRate(newShardState.Epoch) {
+		for _, addr := range chain.ValidatorCandidates() {
+			if _, err := availability.UpdateMaxCommissionFee(state, addr, minRate); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -75,6 +75,7 @@ var (
 		ValidatorCodeFixEpoch:                 big.NewInt(1535), // 2023-07-20 05:51:07+00:00
 		HIP30Epoch:                            big.NewInt(1673), // 2023-11-02 17:30:00+00:00
 		BlockGas30MEpoch:                      big.NewInt(1673), // 2023-11-02 17:30:00+00:00
+		MaxRateEpoch:                          EpochTBD,
 	}
 
 	// TestnetChainConfig contains the chain parameters to run a node on the harmony test network.
@@ -118,6 +119,7 @@ var (
 		ValidatorCodeFixEpoch:                 big.NewInt(1296), // 2023-04-28 07:14:20+00:00
 		HIP30Epoch:                            big.NewInt(2176), // 2023-10-12 10:00:00+00:00
 		BlockGas30MEpoch:                      big.NewInt(2176), // 2023-10-12 10:00:00+00:00
+		MaxRateEpoch:                          EpochTBD,
 	}
 	// PangaeaChainConfig contains the chain parameters for the Pangaea network.
 	// All features except for CrossLink are enabled at launch.
@@ -161,6 +163,7 @@ var (
 		ValidatorCodeFixEpoch:                 EpochTBD,
 		HIP30Epoch:                            EpochTBD,
 		BlockGas30MEpoch:                      big.NewInt(0),
+		MaxRateEpoch:                          EpochTBD,
 	}
 
 	// PartnerChainConfig contains the chain parameters for the Partner network.
@@ -205,6 +208,7 @@ var (
 		ValidatorCodeFixEpoch:                 big.NewInt(5),
 		HIP30Epoch:                            big.NewInt(7),
 		BlockGas30MEpoch:                      big.NewInt(7),
+		MaxRateEpoch:                          EpochTBD,
 	}
 
 	// StressnetChainConfig contains the chain parameters for the Stress test network.
@@ -249,6 +253,7 @@ var (
 		ValidatorCodeFixEpoch:                 EpochTBD,
 		HIP30Epoch:                            EpochTBD,
 		BlockGas30MEpoch:                      big.NewInt(0),
+		MaxRateEpoch:                          EpochTBD,
 	}
 
 	// LocalnetChainConfig contains the chain parameters to run for local development.
@@ -292,6 +297,7 @@ var (
 		ValidatorCodeFixEpoch:                 big.NewInt(2),
 		HIP30Epoch:                            EpochTBD,
 		BlockGas30MEpoch:                      big.NewInt(0),
+		MaxRateEpoch:                          EpochTBD,
 	}
 
 	// AllProtocolChanges ...
@@ -335,6 +341,7 @@ var (
 		big.NewInt(1),                      // LeaderRotationExternalBeaconLeaders
 		big.NewInt(0),                      // FeeCollectEpoch
 		big.NewInt(0),                      // ValidatorCodeFixEpoch
+		big.NewInt(0),                      // BlockGas30M
 		big.NewInt(0),                      // BlockGas30M
 		big.NewInt(0),                      // HIP30Epoch
 	}
@@ -380,6 +387,7 @@ var (
 		big.NewInt(1),        // LeaderRotationExternalBeaconLeaders
 		big.NewInt(0),        // FeeCollectEpoch
 		big.NewInt(0),        // ValidatorCodeFixEpoch
+		big.NewInt(0),        // HIP30Epoch
 		big.NewInt(0),        // HIP30Epoch
 		big.NewInt(0),        // BlockGas30M
 	}
@@ -547,6 +555,9 @@ type ChainConfig struct {
 	HIP30Epoch *big.Int `json:"hip30-epoch,omitempty"`
 
 	BlockGas30MEpoch *big.Int `json:"block-gas-30m-epoch,omitempty"`
+
+	// MaxRateEpoch will make sure the validator max-rate is at least equal to the minRate + the validator max-rate-increase
+	MaxRateEpoch *big.Int `json:"max-rate-epoch,omitempty"`
 }
 
 // String implements the fmt.Stringer interface.
@@ -801,6 +812,10 @@ func (c *ChainConfig) IsValidatorCodeFix(epoch *big.Int) bool {
 
 func (c *ChainConfig) IsHIP30(epoch *big.Int) bool {
 	return isForked(c.HIP30Epoch, epoch)
+}
+
+func (c *ChainConfig) IsMaxRate(epoch *big.Int) bool {
+	return isForked(c.MaxRateEpoch, epoch)
 }
 
 // During this epoch, shards 2 and 3 will start sending

--- a/staking/availability/measure.go
+++ b/staking/availability/measure.go
@@ -267,3 +267,27 @@ func UpdateMinimumCommissionFee(
 	}
 	return false, nil
 }
+
+// UpdateMaxCommissionFee makes sure the max-rate is at least higher than the rate + max-rate-change.
+func UpdateMaxCommissionFee(state *state.DB, addr common.Address, minRate numeric.Dec) (bool, error) {
+	utils.Logger().Info().Msg("begin update max commission fee")
+
+	wrapper, err := state.ValidatorWrapper(addr, true, false)
+	if err != nil {
+		return false, err
+	}
+
+	minMaxRate := minRate.Add(wrapper.MaxChangeRate)
+
+	if wrapper.MaxRate.LT(minMaxRate) {
+		utils.Logger().Info().
+			Str("addr", addr.Hex()).
+			Str("old max-rate", wrapper.MaxRate.String()).
+			Str("new max-rate", minMaxRate.String()).
+			Msg("updating max commission rate")
+		wrapper.MaxRate.SetBytes(minMaxRate.Bytes())
+		return true, nil
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
### Issue 
Following the discovery in [issue #4549](https://github.com/harmony-one/harmony/issues/4549) on the Harmony repository, there is an operational inconsistency that occurs before a block is finalized. During the process where the validator data stored in memory, are written to disk as defined in [statedb.go lines 896-898](https://github.com/harmony-one/harmony/blob/258d5de4661d5b4b5ca911640400c47753c8159d/core/state/statedb.go#L896-L898), a sanity check is performed. This check executes a series of rules to ensure the integrity of the data before it's committed to disk. One particular rule, which can be found in [validator.go lines 315-320](https://github.com/harmony-one/harmony/blob/258d5de4661d5b4b5ca911640400c47753c8159d/staking/types/validator.go#L315-L320), verifies that the rate is not exceeding the maximum allowed rate. If the rate is greater than the maximum, the write operation fails.

This issue became prominent after the HIP30 hard fork, which increased the minimum rate to 7%. Subsequently, validators with a 5% maximum rate were unable to adjust their fees accordingly due to the aforementioned validation rule.

In this PR, we address the issue by adjusting the max-rate to be at least equal to the sum of the minRate and the max-increase-rate. This change requires a hard fork, as it necessitates consensus across the majority of the nodes to ensure that all participants agree on the same value.