### PR TITLE
Fix for last mile block

### DIFF
--- a/api/service/stagedstreamsync/syncing.go
+++ b/api/service/stagedstreamsync/syncing.go
@@ -285,7 +285,7 @@ func (s *StagedStreamSync) doSync(downloaderContext context.Context, initSync bo
 	}
 
 	// add consensus last mile blocks
-	if s.consensus != nil {
+	if s.consensus != nil && s.consensus.ShardID == 0 {
 		if hashes, err := s.addConsensusLastMile(s.Blockchain(), s.consensus); err != nil {
 			utils.Logger().Error().Err(err).
 				Msg("[STAGED_STREAM_SYNC] Add consensus last mile failed")


### PR DESCRIPTION
`addConsensusLastMile` should be used only on `0` shard