### PR TITLE
Removed unused functions and improved locks usage.

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -47,11 +47,6 @@ type Options struct {
 type BlockChain interface {
 	// ValidateNewBlock validates new block.
 	ValidateNewBlock(block *types.Block, beaconChain BlockChain) error
-	// SetHead rewinds the local chain to a new head. In the case of headers, everything
-	// above the new head will be deleted and the new one set. In the case of blocks
-	// though, the head may be further rewound if block bodies are missing (non-archive
-	// nodes after a fast sync).
-	SetHead(head uint64) error
 	// ShardID returns the shard Id of the blockchain.
 	ShardID() uint32
 	// CurrentBlock retrieves the current head block of the canonical chain. The
@@ -105,18 +100,6 @@ type BlockChain interface {
 	// Rollback is designed to remove a chain of links from the database that aren't
 	// certain enough to be valid.
 	Rollback(chain []common.Hash) error
-	// WriteBlockWithoutState writes only the block and its metadata to the database,
-	// but does not write any state. This is used to construct competing side forks
-	// up to the point where they exceed the canonical total difficulty.
-	WriteBlockWithoutState(block *types.Block, td *big.Int) (err error)
-	// WriteBlockWithState writes the block and all associated state to the database.
-	WriteBlockWithState(
-		block *types.Block, receipts []*types.Receipt,
-		cxReceipts []*types.CXReceipt,
-		stakeMsgs []types2.StakeMsg,
-		paid reward.Reader,
-		state *state.DB,
-	) (status WriteStatus, err error)
 	// GetMaxGarbageCollectedBlockNumber ..
 	GetMaxGarbageCollectedBlockNumber() int64
 	// InsertChain attempts to insert the given batch of blocks in to the canonical
@@ -167,8 +150,6 @@ type BlockChain interface {
 	WriteShardStateBytes(db rawdb.DatabaseWriter,
 		epoch *big.Int, shardState []byte,
 	) (*shard.State, error)
-	// WriteHeadBlock writes head block.
-	WriteHeadBlock(block *types.Block) error
 	// ReadCommitSig retrieves the commit signature on a block.
 	ReadCommitSig(blockNum uint64) ([]byte, error)
 	// WriteCommitSig saves the commits signatures signed on a block.
@@ -179,20 +160,8 @@ type BlockChain interface {
 	GetVrfByNumber(number uint64) []byte
 	// ChainDb returns the database.
 	ChainDb() ethdb.Database
-	// GetEpochBlockNumber returns the first block number of the given epoch.
-	GetEpochBlockNumber(epoch *big.Int) (*big.Int, error)
-	// StoreEpochBlockNumber stores the given epoch-first block number.
-	StoreEpochBlockNumber(
-		epoch *big.Int, blockNum *big.Int,
-	) error
 	// ReadEpochVrfBlockNums retrieves block numbers with valid VRF for the specified epoch.
 	ReadEpochVrfBlockNums(epoch *big.Int) ([]uint64, error)
-	// WriteEpochVrfBlockNums saves block numbers with valid VRF for the specified epoch.
-	WriteEpochVrfBlockNums(epoch *big.Int, vrfNumbers []uint64) error
-	// ReadEpochVdfBlockNum retrieves block number with valid VDF for the specified epoch.
-	ReadEpochVdfBlockNum(epoch *big.Int) (*big.Int, error)
-	// WriteEpochVdfBlockNum saves block number with valid VDF for the specified epoch.
-	WriteEpochVdfBlockNum(epoch *big.Int, blockNum *big.Int) error
 	// WriteCrossLinks saves the hashes of crosslinks by shardID and blockNum combination key.
 	WriteCrossLinks(batch rawdb.DatabaseWriter, cls []types.CrossLink) error
 	// DeleteCrossLinks removes the hashes of crosslinks by shardID and blockNum combination key.


### PR DESCRIPTION
Replaced `procmu`and `mu` locks with `chainmu`. 
I checked all places where this locks used, `mu` is used mostly in dead code. Replaced `Rollback` lock from `mu` to `chainmu`, same as `InsertChain` uses. 

PR takes code parts from https://github.com/harmony-one/harmony/pull/4568, so after merge both can be closed. 