### PR TITLE
Skip epochchain errors.

### DIFF
--- a/api/service/legacysync/syncing.go
+++ b/api/service/legacysync/syncing.go
@@ -1158,7 +1158,11 @@ func (ss *StateSync) addConsensusLastMile(bc core.BlockChain, consensus *consens
 			if block == nil {
 				break
 			}
-			if _, err := bc.InsertChain(types.Blocks{block}, true); err != nil {
+			_, err := bc.InsertChain(types.Blocks{block}, true)
+			switch {
+			case errors.Is(err, core.ErrKnownBlock):
+			case errors.Is(err, core.ErrNotLastBlockInEpoch):
+			case err != nil:
 				return errors.Wrap(err, "failed to InsertChain")
 			}
 		}

--- a/api/service/stagedstreamsync/staged_stream_sync.go
+++ b/api/service/stagedstreamsync/staged_stream_sync.go
@@ -637,7 +637,10 @@ func (ss *StagedStreamSync) addConsensusLastMile(bc core.BlockChain, cs *consens
 				break
 			}
 			_, err := bc.InsertChain(types.Blocks{block}, true)
-			if err != nil && !errors.Is(err, core.ErrKnownBlock) {
+			switch {
+			case errors.Is(err, core.ErrKnownBlock):
+			case errors.Is(err, core.ErrNotLastBlockInEpoch):
+			case err != nil:
 				return errors.Wrap(err, "failed to InsertChain")
 			}
 			hashes = append(hashes, block.Header().Hash())

--- a/api/service/stagedsync/stagedsync.go
+++ b/api/service/stagedsync/stagedsync.go
@@ -1221,7 +1221,11 @@ func (ss *StagedSync) addConsensusLastMile(bc core.BlockChain, cs *consensus.Con
 			if block == nil {
 				break
 			}
-			if _, err := bc.InsertChain(types.Blocks{block}, true); err != nil && !errors.Is(err, core.ErrKnownBlock) {
+			_, err := bc.InsertChain(types.Blocks{block}, true)
+			switch {
+			case errors.Is(err, core.ErrKnownBlock):
+			case errors.Is(err, core.ErrNotLastBlockInEpoch):
+			case err != nil:
 				return errors.Wrap(err, "failed to InsertChain")
 			}
 		}

--- a/consensus/downloader.go
+++ b/consensus/downloader.go
@@ -91,7 +91,11 @@ func (consensus *Consensus) AddConsensusLastMile() error {
 			if block == nil {
 				break
 			}
-			if _, err := consensus.Blockchain().InsertChain(types.Blocks{block}, true); err != nil && !errors.Is(err, core.ErrKnownBlock) {
+			_, err := consensus.Blockchain().InsertChain(types.Blocks{block}, true)
+			switch {
+			case errors.Is(err, core.ErrKnownBlock):
+			case errors.Is(err, core.ErrNotLastBlockInEpoch):
+			case err != nil:
 				return errors.Wrap(err, "failed to InsertChain")
 			}
 		}

--- a/core/blockchain_impl.go
+++ b/core/blockchain_impl.go
@@ -90,8 +90,9 @@ var (
 	blockWriteTimer      = metrics.NewRegisteredTimer("chain/write", nil)
 
 	// ErrNoGenesis is the error when there is no genesis.
-	ErrNoGenesis  = errors.New("Genesis not found in chain")
-	ErrEmptyChain = errors.New("empty chain")
+	ErrNoGenesis           = errors.New("Genesis not found in chain")
+	ErrEmptyChain          = errors.New("empty chain")
+	ErrNotLastBlockInEpoch = errors.New("not last block in epoch")
 	// errExceedMaxPendingSlashes ..
 	errExceedMaxPendingSlashes = errors.New("exceeed max pending slashes")
 	errNilEpoch                = errors.New("nil epoch for voting power computation")

--- a/core/epochchain.go
+++ b/core/epochchain.go
@@ -124,7 +124,7 @@ func (bc *EpochChain) InsertChain(blocks types.Blocks, _ bool) (int, error) {
 	}()
 	for i, block := range blocks {
 		if !block.IsLastBlockInEpoch() {
-			return i, errors.New("block is not last block in epoch")
+			return i, ErrNotLastBlockInEpoch
 		}
 		sig, bitmap, err := chain.ParseCommitSigAndBitmap(block.GetCurrentCommitSig())
 		if err != nil {


### PR DESCRIPTION
`LastMileBlockIter` may contain blocks other than last in epoch, but we can just skip this errors. 