### PR TITLE
Revert "fix: max-rate bellow the era min-rate"

### DIFF
--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -448,14 +448,6 @@ func setElectionEpochAndMinFee(chain engine.ChainReader, header *block.Header, s
 		}
 		isElected[addr] = struct{}{}
 	}
-
-	if config.IsMaxRate(newShardState.Epoch) {
-		for _, addr := range chain.ValidatorCandidates() {
-			if _, err := availability.UpdateMaxCommissionFee(state, addr, minRate); err != nil {
-				return err
-			}
-		}
-	}
 	// due to a bug in the old implementation of the minimum fee,
 	// unelected validators did not have their fee updated even
 	// when the protocol required them to do so. here we fix it,

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -75,7 +75,6 @@ var (
 		ValidatorCodeFixEpoch:                 big.NewInt(1535), // 2023-07-20 05:51:07+00:00
 		HIP30Epoch:                            big.NewInt(1673), // 2023-11-02 17:30:00+00:00
 		BlockGas30MEpoch:                      big.NewInt(1673), // 2023-11-02 17:30:00+00:00
-		MaxRateEpoch:                          EpochTBD,
 	}
 
 	// TestnetChainConfig contains the chain parameters to run a node on the harmony test network.
@@ -119,7 +118,6 @@ var (
 		ValidatorCodeFixEpoch:                 big.NewInt(1296), // 2023-04-28 07:14:20+00:00
 		HIP30Epoch:                            big.NewInt(2176), // 2023-10-12 10:00:00+00:00
 		BlockGas30MEpoch:                      big.NewInt(2176), // 2023-10-12 10:00:00+00:00
-		MaxRateEpoch:                          EpochTBD,
 	}
 	// PangaeaChainConfig contains the chain parameters for the Pangaea network.
 	// All features except for CrossLink are enabled at launch.
@@ -163,7 +161,6 @@ var (
 		ValidatorCodeFixEpoch:                 EpochTBD,
 		HIP30Epoch:                            EpochTBD,
 		BlockGas30MEpoch:                      big.NewInt(0),
-		MaxRateEpoch:                          EpochTBD,
 	}
 
 	// PartnerChainConfig contains the chain parameters for the Partner network.
@@ -208,7 +205,6 @@ var (
 		ValidatorCodeFixEpoch:                 big.NewInt(5),
 		HIP30Epoch:                            big.NewInt(7),
 		BlockGas30MEpoch:                      big.NewInt(7),
-		MaxRateEpoch:                          EpochTBD,
 	}
 
 	// StressnetChainConfig contains the chain parameters for the Stress test network.
@@ -253,7 +249,6 @@ var (
 		ValidatorCodeFixEpoch:                 EpochTBD,
 		HIP30Epoch:                            EpochTBD,
 		BlockGas30MEpoch:                      big.NewInt(0),
-		MaxRateEpoch:                          EpochTBD,
 	}
 
 	// LocalnetChainConfig contains the chain parameters to run for local development.
@@ -295,9 +290,8 @@ var (
 		LeaderRotationExternalValidatorsEpoch: big.NewInt(6),
 		FeeCollectEpoch:                       big.NewInt(2),
 		ValidatorCodeFixEpoch:                 big.NewInt(2),
-		HIP30Epoch:                            big.NewInt(3),
+		HIP30Epoch:                            EpochTBD,
 		BlockGas30MEpoch:                      big.NewInt(0),
-		MaxRateEpoch:                          big.NewInt(4),
 	}
 
 	// AllProtocolChanges ...
@@ -342,8 +336,7 @@ var (
 		big.NewInt(0),                      // FeeCollectEpoch
 		big.NewInt(0),                      // ValidatorCodeFixEpoch
 		big.NewInt(0),                      // BlockGas30M
-		big.NewInt(0),                      // BlockGas30M
-		big.NewInt(0),                      // MaxRateEpoch
+		big.NewInt(0),                      // HIP30Epoch
 	}
 
 	// TestChainConfig ...
@@ -389,7 +382,6 @@ var (
 		big.NewInt(0),        // ValidatorCodeFixEpoch
 		big.NewInt(0),        // HIP30Epoch
 		big.NewInt(0),        // BlockGas30M
-		big.NewInt(0),        // MaxRateEpoch
 	}
 
 	// TestRules ...
@@ -555,9 +547,6 @@ type ChainConfig struct {
 	HIP30Epoch *big.Int `json:"hip30-epoch,omitempty"`
 
 	BlockGas30MEpoch *big.Int `json:"block-gas-30m-epoch,omitempty"`
-
-	// MaxRateEpoch will make sure the validator max-rate is at least equal to the minRate + the validator max-rate-increase
-	MaxRateEpoch *big.Int `json:"max-rate-epoch,omitempty"`
 }
 
 // String implements the fmt.Stringer interface.
@@ -812,10 +801,6 @@ func (c *ChainConfig) IsValidatorCodeFix(epoch *big.Int) bool {
 
 func (c *ChainConfig) IsHIP30(epoch *big.Int) bool {
 	return isForked(c.HIP30Epoch, epoch)
-}
-
-func (c *ChainConfig) IsMaxRate(epoch *big.Int) bool {
-	return isForked(c.MaxRateEpoch, epoch)
 }
 
 // During this epoch, shards 2 and 3 will start sending

--- a/staking/availability/measure.go
+++ b/staking/availability/measure.go
@@ -267,27 +267,3 @@ func UpdateMinimumCommissionFee(
 	}
 	return false, nil
 }
-
-// UpdateMaxCommissionFee makes sure the max-rate is at least higher than the rate + max-rate-change.
-func UpdateMaxCommissionFee(state *state.DB, addr common.Address, minRate numeric.Dec) (bool, error) {
-	utils.Logger().Info().Msg("begin update max commission fee")
-
-	wrapper, err := state.ValidatorWrapper(addr, true, false)
-	if err != nil {
-		return false, err
-	}
-
-	minMaxRate := minRate.Add(wrapper.MaxChangeRate)
-
-	if wrapper.MaxRate.LT(minMaxRate) {
-		utils.Logger().Info().
-			Str("addr", addr.Hex()).
-			Str("old max-rate", wrapper.MaxRate.String()).
-			Str("new max-rate", minMaxRate.String()).
-			Msg("updating max commission rate")
-		wrapper.MaxRate.SetBytes(minMaxRate.Bytes())
-		return true, nil
-	}
-
-	return false, nil
-}

--- a/test/build-localnet-validator.sh
+++ b/test/build-localnet-validator.sh
@@ -32,7 +32,7 @@ hmy --node="http://localhost:9500" staking create-validator \
     --bls-pubkeys 4f41a37a3a8d0695dd6edcc58142c6b7d98e74da5c90e79b587b3b960b6a4f5e048e6d8b8a000d77a478d44cd640270c,7dcc035a943e29e17959dabe636efad7303d2c6f273ace457ba9dcc2fd19d3f37e70ba1cd8d082cf8ff7be2f861db48c \
     --name "s0-localnet-validator1" --identity "validator1" --details "validator1" \
     --security-contact "localnet" --website "localnet.one" \
-    --max-change-rate 0.01 --max-rate 0.01 --rate 0.01 \
+    --max-change-rate 0.1 --max-rate 0.1 --rate 0.1 \
     --max-total-delegation 100000000 --min-self-delegation 10000 --bls-pubkeys-dir .hmy/extbls/
 	
 hmy --node="http://localhost:9500" staking create-validator \
@@ -40,7 +40,7 @@ hmy --node="http://localhost:9500" staking create-validator \
     --bls-pubkeys b0917378b179a519a5055259c4f8980cce37d58af300b00dd98b07076d3d9a3b16c4a55f84522f553872225a7b1efc0c \
     --name "s0-localnet-validator2" --identity "validator2" --details "validator2" \
     --security-contact "localnet" --website "localnet.one" \
-    --max-change-rate 0.1 --max-rate 0.1 --rate 0.05 \
+    --max-change-rate 0.1 --max-rate 0.1 --rate 0.1 \
     --max-total-delegation 100000000 --min-self-delegation 10000 --bls-pubkeys-dir .hmy/extbls/
 	
 hmy --node="http://localhost:9500" staking create-validator \


### PR DESCRIPTION
Reverts harmony-one/harmony#4552

<img width="941" alt="image" src="https://github.com/harmony-one/harmony/assets/355847/7f237854-a222-4023-97bf-b3fb9006b015">

Branch did not pass tests successfully