### PR TITLE
Fix: Inconsistent `from` field Hash Calculation in Different API Versions

### DIFF
--- a/rpc/eth/types.go
+++ b/rpc/eth/types.go
@@ -110,6 +110,37 @@ func NewTransaction(
 	}
 	return result, nil
 }
+func NewTransactionFromTransaction(
+	tx *types.Transaction, blockHash common.Hash,
+	blockNumber uint64, timestamp uint64, index uint64,
+) (*Transaction, error) {
+	from, err := tx.SenderAddress()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get sender address: %w", err)
+	}
+	v, r, s := tx.RawSignatureValues()
+
+	result := &Transaction{
+		From:      from,
+		Gas:       hexutil.Uint64(tx.GasLimit()),
+		GasPrice:  (*hexutil.Big)(tx.GasPrice()),
+		Hash:      tx.Hash(),
+		Input:     hexutil.Bytes(tx.Data()),
+		Nonce:     hexutil.Uint64(tx.Nonce()),
+		To:        tx.To(),
+		Value:     (*hexutil.Big)(tx.Value()),
+		Timestamp: hexutil.Uint64(timestamp),
+		V:         (*hexutil.Big)(v),
+		R:         (*hexutil.Big)(r),
+		S:         (*hexutil.Big)(s),
+	}
+	if blockHash != (common.Hash{}) {
+		result.BlockHash = &blockHash
+		result.BlockNumber = (*hexutil.Big)(new(big.Int).SetUint64(blockNumber))
+		result.TransactionIndex = (*hexutil.Uint64)(&index)
+	}
+	return result, nil
+}
 
 // NewReceipt returns the RPC data for a new receipt
 func NewReceipt(tx *types.EthTransaction, blockHash common.Hash, blockNumber, blockIndex uint64, receipt *types.Receipt) (map[string]interface{}, error) {

--- a/rpc/transaction.go
+++ b/rpc/transaction.go
@@ -236,7 +236,7 @@ func (s *PublicTransactionService) newRPCTransaction(tx *types.Transaction, bloc
 		}
 		return NewStructuredResponse(tx)
 	case Eth:
-		tx, err := eth.NewTransaction(tx.ConvertToEth(), blockHash, blockNumber, timestamp, index)
+		tx, err := eth.NewTransactionFromTransaction(tx, blockHash, blockNumber, timestamp, index)
 		if err != nil {
 			DoMetricRPCQueryInfo(GetTransactionByHash, FailedNumber)
 			return nil, err


### PR DESCRIPTION
## Issue
[Original issue
](https://github.com/harmony-one/harmony/issues/4232)
The issue concerns differing `from` hash values when the same method is executed on different API versions. Initial assumptions about a varying chain ID were dismissed after tests showed consistency in the chain ID across versions.

Further analysis revealed that the transaction hash is generated on the fly, involving the entire transaction body ([source](https://github.com/harmony-one/harmony/blob/7be2b0260bdfb6e98397f923ad441b65b79367ca/core/types/transaction_signing.go#L185-L195)). The `from` hash is calculated using the transaction body ([source](https://github.com/harmony-one/harmony/blob/7be2b0260bdfb6e98397f923ad441b65b79367ca/core/types/transaction_signing.go#L153)). Ethereum-based and Harmony-based transactions differ in `ShardID` and `ToShardID`, which are lost during conversion to an Ethereum transaction ([conversion source](https://github.com/harmony-one/harmony/blob/7be2b0260bdfb6e98397f923ad441b65b79367ca/core/types/transaction.go#L442-L443)).

This issue surfaces when the API fetches a Harmony-based transaction and, if the Ethereum API version is called, converts it to an Ethereum transaction ([RPC method source](https://github.com/harmony-one/harmony/blob/7be2b0260bdfb6e98397f923ad441b65b79367ca/rpc/transaction.go#L238-L239)). The loss of `ShardID` and `ToShardID` in this process results in different `from` hash values, due to the alteration of the transaction body hash.

### Fix

The proposed solution is to implement a transaction decoder that avoids converting to an Ethereum transaction and maintains the original transaction type. This decoder will not transform addresses into the one format, aligning with the required api version. This approach ensures the integrity of the transaction body, including ShardID and ToShardID, thus maintaining consistent from hash calculations across different API versions.

Tests result: you can see how the eth_ based call is computed to the correct hash

```json
URL=http://localhost:9500
txhash=0x620f9db212e658707496a5fe53261643fda29e1c09123745a25cdd4c268e4dd7
ubuntu@mhe-test:~$ curl --location --request POST $URL --header 'Content-Type: application/json' --data-raw '{"jsonrpc": "2.0","id": 1,"method": "eth_getTransactionByHash","params": ["'${txhash}'"]}'
{"jsonrpc":"2.0","id":1,"result":{"blockHash":"0xbf78ec06f3f9b44c661f188daf6374f3ee9039e810107399d39eed3282983d7e","blockNumber":"0x2f61327","from":"0x15a128e599b74842bccba860311efa92991bffb5","gas":"0x5208","gasPrice":"0x174876e800","hash":"0x620f9db212e658707496a5fe53261643fda29e1c09123745a25cdd4c268e4dd7","input":"0x","nonce":"0x22","r":"0xf96de131edbaa6782d2807c0d11a247ec8842f52ed89735e7e78b695f3190f8","s":"0x2bf019da84cb092f707ca4e8db91a287c1912ee6274c1994138545b74426834","timestamp":"0x65530b10","to":"0x15a128e599b74842bccba860311efa92991bffb5","transactionIndex":"0x0","v":"0x26","value":"0x16345785d8a0000"}}
ubuntu@mhe-test:~$ curl --location --request POST $URL --header 'Content-Type: application/json' --data-raw '{"jsonrpc": "2.0","id": 1,"method": "hmy_getTransactionByHash","params": ["'${txhash}'"]}'
{"jsonrpc":"2.0","id":1,"result":{"blockHash":"0xbf78ec06f3f9b44c661f188daf6374f3ee9039e810107399d39eed3282983d7e","blockNumber":"0x2f61327","ethHash":"0x268c9bee58a323856fd78d9cff84bfa120c6ed8e42dc8b0f08e893a59b7c9d6b","from":"one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur","gas":"0x5208","gasPrice":"0x174876e800","hash":"0x620f9db212e658707496a5fe53261643fda29e1c09123745a25cdd4c268e4dd7","input":"0x","nonce":"0x22","r":"0xf96de131edbaa6782d2807c0d11a247ec8842f52ed89735e7e78b695f3190f8","s":"0x2bf019da84cb092f707ca4e8db91a287c1912ee6274c1994138545b74426834","shardID":0,"timestamp":"0x65530b10","to":"one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur","toShardID":1,"transactionIndex":"0x0","v":"0x26","value":"0x16345785d8a0000"}}
```