### PR TITLE
Fix: Inconsistent from field Hash Calculation in Different API Versions #2

### DIFF
--- a/rpc/transaction.go
+++ b/rpc/transaction.go
@@ -751,19 +751,11 @@ func (s *PublicTransactionService) GetTransactionReceipt(
 			return nil, err
 		}
 		return NewStructuredResponse(RPCReceipt)
-	case V2:
+	case V2, Eth:
 		if tx == nil {
 			RPCReceipt, err = v2.NewReceipt(stx, blockHash, blockNumber, index, receipt)
 		} else {
 			RPCReceipt, err = v2.NewReceipt(tx, blockHash, blockNumber, index, receipt)
-		}
-		if err != nil {
-			return nil, err
-		}
-		return NewStructuredResponse(RPCReceipt)
-	case Eth:
-		if tx != nil {
-			RPCReceipt, err = eth.NewReceipt(tx.ConvertToEth(), blockHash, blockNumber, index, receipt)
 		}
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Issue

This is a followup to https://github.com/harmony-one/harmony/pull/4581 where the hash calculation resulted in an incorrect from address when querying the eth api. 
This corrects the GetTransactionReceipt path that also incorported tx.ConvertEth() so that receipts will also show the correct from address.
