### PR TITLE
fix getTransactionReceipt response

### DIFF
--- a/rpc/blockchain.go
+++ b/rpc/blockchain.go
@@ -461,10 +461,10 @@ func (s *PublicBlockchainService) GetBlockReceipts(
 		case V1:
 			r, err = v1.NewReceipt(tx, blockHash, block.NumberU64(), index, rmap[tx.Hash()])
 		case V2:
-			r, err = v2.NewReceipt(tx, blockHash, block.NumberU64(), index, rmap[tx.Hash()], false)
+			r, err = v2.NewReceipt(tx, blockHash, block.NumberU64(), index, rmap[tx.Hash()])
 		case Eth:
 			if tx, ok := tx.(*types.Transaction); ok {
-				r, err = v2.NewReceipt(tx, blockHash, block.NumberU64(), index, rmap[tx.Hash()], true)
+				r, err = v2.NewReceipt(tx, blockHash, block.NumberU64(), index, rmap[tx.Hash()])
 			}
 		default:
 			return nil, ErrUnknownRPCVersion

--- a/rpc/transaction.go
+++ b/rpc/transaction.go
@@ -751,11 +751,19 @@ func (s *PublicTransactionService) GetTransactionReceipt(
 			return nil, err
 		}
 		return NewStructuredResponse(RPCReceipt)
-	case V2, Eth:
+	case V2:
 		if tx == nil {
-			RPCReceipt, err = v2.NewReceipt(stx, blockHash, blockNumber, index, receipt, false)
+			RPCReceipt, err = v2.NewReceipt(stx, blockHash, blockNumber, index, receipt)
 		} else {
-			RPCReceipt, err = v2.NewReceipt(tx, blockHash, blockNumber, index, receipt, s.version == Eth)
+			RPCReceipt, err = v2.NewReceipt(tx, blockHash, blockNumber, index, receipt)
+		}
+		if err != nil {
+			return nil, err
+		}
+		return NewStructuredResponse(RPCReceipt)
+	case Eth:
+		if tx != nil {
+			RPCReceipt, err = eth.NewReceiptFromTransaction(tx, blockHash, blockNumber, index, receipt)
 		}
 		if err != nil {
 			return nil, err

--- a/rpc/v2/types.go
+++ b/rpc/v2/types.go
@@ -334,11 +334,11 @@ func NewTransaction(
 
 // NewReceipt returns a transaction OR staking transaction that will serialize to the RPC representation
 func NewReceipt(
-	tx interface{}, blockHash common.Hash, blockNumber, blockIndex uint64, receipt *types.Receipt, eth bool,
+	tx interface{}, blockHash common.Hash, blockNumber, blockIndex uint64, receipt *types.Receipt,
 ) (interface{}, error) {
 	plainTx, ok := tx.(*types.Transaction)
 	if ok {
-		return NewTxReceipt(plainTx, blockHash, blockNumber, blockIndex, receipt, eth)
+		return NewTxReceipt(plainTx, blockHash, blockNumber, blockIndex, receipt)
 	}
 	stakingTx, ok := tx.(*staking.StakingTransaction)
 	if ok {
@@ -349,7 +349,7 @@ func NewReceipt(
 
 // NewTxReceipt returns a plain transaction receipt that will serialize to the RPC representation
 func NewTxReceipt(
-	tx *types.Transaction, blockHash common.Hash, blockNumber, blockIndex uint64, receipt *types.Receipt, eth bool,
+	tx *types.Transaction, blockHash common.Hash, blockNumber, blockIndex uint64, receipt *types.Receipt,
 ) (*TxReceipt, error) {
 	// Set correct to & from address
 	senderAddr, err := tx.SenderAddress()
@@ -362,19 +362,13 @@ func NewTxReceipt(
 		sender = senderAddr.String()
 		receiver = ""
 	} else {
-		// Handle response type for regular transaction
-		if eth {
-			sender = senderAddr.String()
-			receiver = tx.To().String()
-		} else {
-			sender, err = internal_common.AddressToBech32(senderAddr)
-			if err != nil {
-				return nil, err
-			}
-			receiver, err = internal_common.AddressToBech32(*tx.To())
-			if err != nil {
-				return nil, err
-			}
+		sender, err = internal_common.AddressToBech32(senderAddr)
+		if err != nil {
+			return nil, err
+		}
+		receiver, err = internal_common.AddressToBech32(*tx.To())
+		if err != nil {
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
Fixed an issue in the v2 package where certain integer fields in the transaction receipt were not correctly serialized in hexadecimal format such as (gas, blocknumber, etc). This PR introduces a new Receipt method for transactions within the `eth` package, ensuring all integer fields are properly converted to hexadecimal representation.