### PR TITLE
Force verify all sign.

### DIFF
--- a/api/service/legacysync/syncing.go
+++ b/api/service/legacysync/syncing.go
@@ -860,11 +860,12 @@ func (ss *StateSync) getBlockFromLastMileBlocksByParentHash(parentHash common.Ha
 }
 
 // UpdateBlockAndStatus ...
-func (ss *StateSync) UpdateBlockAndStatus(block *types.Block, bc core.BlockChain, verifyAllSig bool) error {
+func (ss *StateSync) UpdateBlockAndStatus(block *types.Block, bc core.BlockChain) error {
 	if block.NumberU64() != bc.CurrentBlock().NumberU64()+1 {
 		utils.Logger().Debug().Uint64("curBlockNum", bc.CurrentBlock().NumberU64()).Uint64("receivedBlockNum", block.NumberU64()).Msg("[SYNC] Inappropriate block number, ignore!")
 		return nil
 	}
+	verifyAllSig := true
 
 	haveCurrentSig := len(block.GetCurrentCommitSig()) != 0
 	// Verify block signatures
@@ -954,8 +955,8 @@ func (ss *StateSync) generateNewState(bc core.BlockChain) error {
 			break
 		}
 		// Enforce sig check for the last block in a batch
-		enforceSigCheck := !commonIter.HasNext()
-		err = ss.UpdateBlockAndStatus(block, bc, enforceSigCheck)
+		_ = !commonIter.HasNext()
+		err = ss.UpdateBlockAndStatus(block, bc)
 		if err != nil {
 			break
 		}
@@ -972,7 +973,7 @@ func (ss *StateSync) generateNewState(bc core.BlockChain) error {
 		if block == nil {
 			break
 		}
-		err = ss.UpdateBlockAndStatus(block, bc, true)
+		err = ss.UpdateBlockAndStatus(block, bc)
 		if err != nil {
 			break
 		}
@@ -993,7 +994,7 @@ func (ss *StateSync) generateNewState(bc core.BlockChain) error {
 		if block == nil {
 			break
 		}
-		err = ss.UpdateBlockAndStatus(block, bc, false)
+		err = ss.UpdateBlockAndStatus(block, bc)
 		if err != nil {
 			break
 		}

--- a/api/service/stagedsync/stage_lastmile.go
+++ b/api/service/stagedsync/stage_lastmile.go
@@ -49,7 +49,7 @@ func (lm *StageLastMile) Exec(firstCycle bool, invalidBlockRevert bool, s *Stage
 		if block == nil {
 			break
 		}
-		err = s.state.UpdateBlockAndStatus(block, bc, true)
+		err = s.state.UpdateBlockAndStatus(block, bc)
 		if err != nil {
 			break
 		}
@@ -70,7 +70,7 @@ func (lm *StageLastMile) Exec(firstCycle bool, invalidBlockRevert bool, s *Stage
 		if block == nil {
 			break
 		}
-		err = s.state.UpdateBlockAndStatus(block, bc, false)
+		err = s.state.UpdateBlockAndStatus(block, bc)
 		if err != nil {
 			break
 		}

--- a/api/service/stagedsync/stagedsync.go
+++ b/api/service/stagedsync/stagedsync.go
@@ -1035,7 +1035,7 @@ func (ss *StagedSync) getBlockFromLastMileBlocksByParentHash(parentHash common.H
 }
 
 // UpdateBlockAndStatus updates block and its status in db
-func (ss *StagedSync) UpdateBlockAndStatus(block *types.Block, bc core.BlockChain, verifyAllSig bool) error {
+func (ss *StagedSync) UpdateBlockAndStatus(block *types.Block, bc core.BlockChain) error {
 	if block.NumberU64() != bc.CurrentBlock().NumberU64()+1 {
 		utils.Logger().Debug().
 			Uint64("curBlockNum", bc.CurrentBlock().NumberU64()).
@@ -1043,6 +1043,7 @@ func (ss *StagedSync) UpdateBlockAndStatus(block *types.Block, bc core.BlockChai
 			Msg("[STAGED_SYNC] Inappropriate block number, ignore!")
 		return nil
 	}
+	verifyAllSig := true
 
 	haveCurrentSig := len(block.GetCurrentCommitSig()) != 0
 	// Verify block signatures

--- a/node/node.go
+++ b/node/node.go
@@ -81,7 +81,7 @@ type syncConfig struct {
 }
 
 type ISync interface {
-	UpdateBlockAndStatus(block *types.Block, bc core.BlockChain, verifyAllSig bool) error
+	UpdateBlockAndStatus(block *types.Block, bc core.BlockChain) error
 	AddLastMileBlock(block *types.Block)
 	GetActivePeerNumber() int
 	CreateSyncConfig(peers []p2p.Peer, shardID uint32, selfPeerID libp2p_peer.ID, waitForEachPeerToConnect bool) error


### PR DESCRIPTION
When we try to insert with `varefyAllSign := false`, we insert bunch of blocks, and later rollback, if smth went wrong. If force `varefyAllSign` being always true, no rollback code is executed. 