### PR TITLE
Ignore known blocks for processsing state sync in legacy sync

### DIFF
--- a/api/service/legacysync/epoch_syncing.go
+++ b/api/service/legacysync/epoch_syncing.go
@@ -138,6 +138,9 @@ func syncLoop(bc core.BlockChain, syncConfig *SyncConfig) (timeout int) {
 
 		err := ProcessStateSync(syncConfig, heights, bc)
 		if err != nil {
+			if errors.Is(err, core.ErrKnownBlock) {
+				return 10
+			}
 			utils.Logger().Error().Err(err).
 				Msgf("[EPOCHSYNC] ProcessStateSync failed (isBeacon: %t, ShardID: %d, otherEpoch: %d, currentEpoch: %d)",
 					isBeacon, bc.ShardID(), otherEpoch, curEpoch)

--- a/api/service/legacysync/syncing.go
+++ b/api/service/legacysync/syncing.go
@@ -1121,6 +1121,9 @@ func (ss *StateSync) SyncLoop(bc core.BlockChain, isBeacon bool, consensus *cons
 		}
 		err := ss.ProcessStateSync(startHash[:], size, bc)
 		if err != nil {
+			if errors.Is(err, core.ErrKnownBlock) {
+				continue
+			}
 			utils.Logger().Error().Err(err).
 				Msgf("[SYNC] ProcessStateSync failed (isBeacon: %t, ShardID: %d, otherHeight: %d, currentHeight: %d)",
 					isBeacon, bc.ShardID(), otherHeight, currentHeight)


### PR DESCRIPTION
## Issue

There is an issue could make node stuck and node can't sync due to that. the error is `block already exists: block already known`. This PR address this issue by ignoring it.
