### PR TITLE
fix concurrent map read and write issue for stakedVoteWeight

### DIFF
--- a/consensus/quorum/one-node-staked-vote.go
+++ b/consensus/quorum/one-node-staked-vote.go
@@ -189,20 +189,6 @@ func (v *stakedVoteWeight) IsQuorumAchievedByMask(mask *bls_cosi.Mask) bool {
 	return (*currentTotalPower).GT(threshold)
 }
 
-func (v *stakedVoteWeight) currentTotalPower(p Phase) (*numeric.Dec, error) {
-	switch p {
-	case Prepare:
-		return &v.VoteTally().Prepare.tally, nil
-	case Commit:
-		return &v.VoteTally().Commit.tally, nil
-	case ViewChange:
-		return &v.VoteTally().ViewChange.tally, nil
-	default:
-		// Should not happen
-		return nil, errors.New("wrong phase is provided")
-	}
-}
-
 // ComputeTotalPowerByMask computes the total power indicated by bitmap mask
 func (v *stakedVoteWeight) computeTotalPowerByMask(mask *bls_cosi.Mask) *numeric.Dec {
 	currentTotal := numeric.ZeroDec()


### PR DESCRIPTION
## Issue
The **stakedVoteWeight** structure doesn't support concurrent read and write. This could break the main process if an RPC triggers any write or read from that. This PR addresses this issue by adding a mutex to it and make it thread-safe.
