### PR TITLE
Fix fast sync null snapshot and null response issue

### DIFF
--- a/api/service/stagedstreamsync/stage_statesync_full.go
+++ b/api/service/stagedstreamsync/stage_statesync_full.go
@@ -190,7 +190,10 @@ func (sss *StageFullStateSync) runStateWorkerLoop(ctx context.Context, sdm *Full
 		default:
 		}
 		accountTasks, codes, storages, healtask, codetask, nTasks, err := sdm.GetNextBatch()
-		if nTasks == 0 || err != nil {
+		if nTasks == 0 {
+			return
+		}
+		if err != nil {
 			select {
 			case <-ctx.Done():
 				return
@@ -199,7 +202,7 @@ func (sss *StageFullStateSync) runStateWorkerLoop(ctx context.Context, sdm *Full
 			}
 		}
 
-		if len(accountTasks) > 0 {
+		if accountTasks != nil && len(accountTasks) > 0 {
 
 			task := accountTasks[0]
 			origin := task.Next
@@ -222,8 +225,8 @@ func (sss *StageFullStateSync) runStateWorkerLoop(ctx context.Context, sdm *Full
 				utils.Logger().Warn().
 					Str("stream", string(stid)).
 					Msg(WrapStagedSyncMsg("GetAccountRange failed, received empty accounts"))
-				err := errors.New("GetAccountRange received empty slots")
-				sdm.HandleRequestError(accountTasks, codes, storages, healtask, codetask, stid, err)
+				//err := errors.New("GetAccountRange received empty slots")
+				//sdm.HandleRequestError(accountTasks, codes, storages, healtask, codetask, stid, err)
 				return
 			}
 			if err := sdm.HandleAccountRequestResult(task, retAccounts, proof, origin[:], limit[:], loopID, stid); err != nil {
@@ -236,7 +239,7 @@ func (sss *StageFullStateSync) runStateWorkerLoop(ctx context.Context, sdm *Full
 				return
 			}
 
-		} else if len(codes) > 0 {
+		} else if codes != nil && len(codes) > 0 {
 
 			stid, err := sss.downloadByteCodes(ctx, sdm, codes, loopID)
 			if err != nil {
@@ -252,7 +255,7 @@ func (sss *StageFullStateSync) runStateWorkerLoop(ctx context.Context, sdm *Full
 				return
 			}
 
-		} else if len(storages.accounts) > 0 {
+		} else if storages != nil && len(storages.accounts) > 0 {
 
 			root := storages.root
 			roots := storages.roots
@@ -295,7 +298,7 @@ func (sss *StageFullStateSync) runStateWorkerLoop(ctx context.Context, sdm *Full
 
 		} else {
 			// assign trie node Heal Tasks
-			if len(healtask.hashes) > 0 {
+			if healtask != nil && len(healtask.hashes) > 0 {
 				root := healtask.root
 				task := healtask.task
 				hashes := healtask.hashes
@@ -334,7 +337,7 @@ func (sss *StageFullStateSync) runStateWorkerLoop(ctx context.Context, sdm *Full
 				}
 			}
 
-			if len(codetask.hashes) > 0 {
+			if codetask != nil && len(codetask.hashes) > 0 {
 				task := codetask.task
 				hashes := codetask.hashes
 				bytes := codetask.bytes

--- a/api/service/stagedstreamsync/stage_statesync_full.go
+++ b/api/service/stagedstreamsync/stage_statesync_full.go
@@ -191,6 +191,7 @@ func (sss *StageFullStateSync) runStateWorkerLoop(ctx context.Context, sdm *Full
 		}
 		accountTasks, codes, storages, healtask, codetask, nTasks, err := sdm.GetNextBatch()
 		if nTasks == 0 {
+			utils.Logger().Debug().Msg("the state worker loop received no more tasks")
 			return
 		}
 		if err != nil {

--- a/api/service/stagedstreamsync/syncing.go
+++ b/api/service/stagedstreamsync/syncing.go
@@ -465,6 +465,10 @@ func (s *StagedStreamSync) CurrentBlockNumber() uint64 {
 		return s.bc.CurrentBlock().NumberU64()
 	}
 
+	if s.status.pivotBlock != nil && s.bc.CurrentFastBlock().NumberU64() >= s.status.pivotBlock.NumberU64() {
+		return s.bc.CurrentFastBlock().NumberU64()
+	}
+
 	current := uint64(0)
 	switch s.config.SyncMode {
 	case FullSync:

--- a/core/blockchain_impl.go
+++ b/core/blockchain_impl.go
@@ -924,6 +924,9 @@ func (bc *BlockChainImpl) writeHeadBlock(block *types.Block) error {
 	if err := rawdb.WriteHeadHeaderHash(batch, block.Hash()); err != nil {
 		return err
 	}
+	if err := rawdb.WriteHeaderNumber(batch, block.Hash(), block.NumberU64()); err != nil {
+		return err
+	}
 
 	isNewEpoch := block.IsLastBlockInEpoch()
 	if isNewEpoch {

--- a/p2p/stream/protocols/sync/chain.go
+++ b/p2p/stream/protocols/sync/chain.go
@@ -209,7 +209,11 @@ func (ch *chainHelperImpl) getAccountRange(root common.Hash, origin common.Hash,
 	if err != nil {
 		return nil, nil, err
 	}
-	it, err := ch.chain.Snapshots().AccountIterator(root, origin)
+	snapshots := ch.chain.Snapshots()
+	if snapshots == nil {
+		return nil, nil, errors.Errorf("failed to retrieve snapshots")
+	}
+	it, err := snapshots.AccountIterator(root, origin)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -275,6 +279,10 @@ func (ch *chainHelperImpl) getStorageRanges(root common.Hash, accounts []common.
 		proofs [][]byte
 		size   uint64
 	)
+	snapshots := ch.chain.Snapshots()
+	if snapshots == nil {
+		return nil, nil, errors.Errorf("failed to retrieve snapshots")
+	}
 	for _, account := range accounts {
 		// If we've exceeded the requested data limit, abort without opening
 		// a new storage range (that we'd need to prove due to exceeded size)
@@ -284,7 +292,7 @@ func (ch *chainHelperImpl) getStorageRanges(root common.Hash, accounts []common.
 		// The first account might start from a different origin and end sooner
 		// origin==nil or limit ==nil
 		// Retrieve the requested state and bail out if non existent
-		it, err := ch.chain.Snapshots().StorageIterator(root, account, origin)
+		it, err := snapshots.StorageIterator(root, account, origin)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -409,7 +417,11 @@ func (ch *chainHelperImpl) getTrieNodes(root common.Hash, paths []*message.TrieN
 		return nil, nil
 	}
 	// The 'snap' might be nil, in which case we cannot serve storage slots.
-	snap := ch.chain.Snapshots().Snapshot(root)
+	snapshots := ch.chain.Snapshots()
+	if snapshots == nil {
+		return nil, errors.Errorf("failed to retrieve snapshots")
+	}
+	snap := snapshots.Snapshot(root)
 	// Retrieve trie nodes until the packet size limit is reached
 	var (
 		nodes      [][]byte


### PR DESCRIPTION
## Issue
If a snapshot is not available, the client receives null for snapshots and attempts to call methods on a null instance. This pull request addresses the issue of null snapshots and null responses in fast sync by checking and validating values.