### PR TITLE
prepare devnet reset

### DIFF
--- a/internal/configs/sharding/partner.go
+++ b/internal/configs/sharding/partner.go
@@ -106,7 +106,7 @@ var partnerV1 = MustNewInstance(
 	partnerReshardingEpoch, PartnerSchedule.BlocksPerEpoch(),
 )
 var partnerV2 = MustNewInstance(
-	2, 5, 4, 0,
+	2, 20, 4, 0,
 	numeric.MustNewDecFromStr("0.9"), genesis.TNHarmonyAccounts,
 	genesis.TNFoundationalAccounts, emptyAllowlist,
 	feeCollectorsDevnet[1], numeric.MustNewDecFromStr("0.25"),
@@ -114,8 +114,8 @@ var partnerV2 = MustNewInstance(
 	PartnerSchedule.BlocksPerEpoch(),
 )
 var partnerV3 = MustNewInstance(
-	2, 5, 1, 0,
-	numeric.MustNewDecFromStr("0.1"), genesis.TNHarmonyAccounts,
+	2, 20, 1, 0,
+	numeric.MustNewDecFromStr("0.0"), genesis.TNHarmonyAccounts,
 	genesis.TNFoundationalAccounts, emptyAllowlist,
 	feeCollectorsDevnet[1], numeric.MustNewDecFromStr("0.25"),
 	hip30CollectionAddressTestnet, partnerReshardingEpoch,

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -205,8 +205,8 @@ var (
 		SlotsLimitedEpoch:                     EpochTBD, // epoch to enable HIP-16
 		CrossShardXferPrecompileEpoch:         big.NewInt(5),
 		AllowlistEpoch:                        EpochTBD,
-		LeaderRotationInternalValidatorsEpoch: big.NewInt(4),
-		LeaderRotationExternalValidatorsEpoch: big.NewInt(4),
+		LeaderRotationInternalValidatorsEpoch: big.NewInt(12),
+		LeaderRotationExternalValidatorsEpoch: big.NewInt(12),
 		FeeCollectEpoch:                       big.NewInt(5),
 		ValidatorCodeFixEpoch:                 big.NewInt(5),
 		HIP30Epoch:                            big.NewInt(7),


### PR DESCRIPTION
Preparing devnet reset
- Increasing the max number of slots so we allow for more external validators
- Reducing the partnerv3 to 0% internal (This is epoch is not set yet, this is so we keep inline with the current config partnerv2)
- Pushing the leader rotation epoch starts to post-hip30 and stackign epoch leaving enough room so we can setup the external validators