### PR TITLE
activate devnet external hardfork

### DIFF
--- a/internal/configs/sharding/partner.go
+++ b/internal/configs/sharding/partner.go
@@ -114,7 +114,7 @@ var partnerV2 = MustNewInstance(
 	PartnerSchedule.BlocksPerEpoch(),
 )
 var partnerV3 = MustNewInstance(
-	2, 20, 1, 0,
+	2, 20, 0, 0,
 	numeric.MustNewDecFromStr("0.0"), genesis.TNHarmonyAccounts,
 	genesis.TNFoundationalAccounts, emptyAllowlist,
 	feeCollectorsDevnet[1], numeric.MustNewDecFromStr("0.25"),

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -212,7 +212,7 @@ var (
 		HIP30Epoch:                            big.NewInt(7),
 		BlockGas30MEpoch:                      big.NewInt(7),
 		MaxRateEpoch:                          EpochTBD,
-		DevnetExternalEpoch:                   EpochTBD,
+		DevnetExternalEpoch:                   big.NewInt(135),
 	}
 
 	// StressnetChainConfig contains the chain parameters for the Stress test network.


### PR DESCRIPTION
## Issue

This is to activate the devnet external hardfork which will make devnet run on external only
