### PR TITLE
fix allowed txs to be able to handle multiple txs for same from address

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -1061,8 +1061,8 @@ func setupBlacklist(hc harmonyconfig.HarmonyConfig) (map[ethCommon.Address]struc
 	return addrMap, nil
 }
 
-func parseAllowedTxs(data []byte) (map[ethCommon.Address]core.AllowedTxData, error) {
-	allowedTxs := make(map[ethCommon.Address]core.AllowedTxData)
+func parseAllowedTxs(data []byte) (map[ethCommon.Address][]core.AllowedTxData, error) {
+	allowedTxs := make(map[ethCommon.Address][]core.AllowedTxData)
 	for _, line := range strings.Split(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if len(line) != 0 { // AllowedTxs file may have trailing empty string line
@@ -1083,16 +1083,16 @@ func parseAllowedTxs(data []byte) (map[ethCommon.Address]core.AllowedTxData, err
 			if err != nil {
 				return nil, err
 			}
-			allowedTxs[from] = core.AllowedTxData{
+			allowedTxs[from] = append(allowedTxs[from], core.AllowedTxData{
 				To:   to,
 				Data: data,
-			}
+			})
 		}
 	}
 	return allowedTxs, nil
 }
 
-func setupAllowedTxs(hc harmonyconfig.HarmonyConfig) (map[ethCommon.Address]core.AllowedTxData, error) {
+func setupAllowedTxs(hc harmonyconfig.HarmonyConfig) (map[ethCommon.Address][]core.AllowedTxData, error) {
 	utils.Logger().Debug().Msgf("Using AllowedTxs file at `%s`", hc.TxPool.AllowedTxsFile)
 	data, err := os.ReadFile(hc.TxPool.AllowedTxsFile)
 	if err != nil {

--- a/cmd/harmony/main_test.go
+++ b/cmd/harmony/main_test.go
@@ -16,22 +16,26 @@ func TestAllowedTxsParse(t *testing.T) {
 		one1s4dvv454dtmkzsulffz3epewsyhrjq9y0g3fqz->0x985458E523dB3d53125813eD68c274899e9DfAb4:0xa9059cbb
 		one1s4dvv454dtmkzsulffz3epewsyhrjq9y0g3fqz->one10fhdp2g9q5azrs2ukk608x6krd4rleg0ueskug:0x
 	`)
-	expected := map[ethCommon.Address]core.AllowedTxData{
-		common.HexToAddress("0x7A6Ed0a905053A21C15cB5b4F39b561B6A3FE50f"): core.AllowedTxData{
-			To:   common.HexToAddress("0x855Ac656956AF761439f4a451c872E812E3900a4"),
-			Data: common.FromHex("0x"),
+	expected := map[ethCommon.Address][]core.AllowedTxData{
+		common.HexToAddress("0x7A6Ed0a905053A21C15cB5b4F39b561B6A3FE50f"): {
+			core.AllowedTxData{
+				To:   common.HexToAddress("0x855Ac656956AF761439f4a451c872E812E3900a4"),
+				Data: common.FromHex("0x"),
+			},
+			core.AllowedTxData{
+				To:   common.HexToAddress("0x985458E523dB3d53125813eD68c274899e9DfAb4"),
+				Data: common.FromHex("0xa9059cbb"),
+			},
 		},
-		common.HexToAddress("0x7A6Ed0a905053A21C15cB5b4F39b561B6A3FE50f"): core.AllowedTxData{
-			To:   common.HexToAddress("0x985458E523dB3d53125813eD68c274899e9DfAb4"),
-			Data: common.FromHex("0xa9059cbb"),
-		},
-		common.HexToAddress("0x855Ac656956AF761439f4a451c872E812E3900a4"): core.AllowedTxData{
-			To:   common.HexToAddress("0x985458E523dB3d53125813eD68c274899e9DfAb4"),
-			Data: common.FromHex("0xa9059cbb"),
-		},
-		common.HexToAddress("0x855Ac656956AF761439f4a451c872E812E3900a4"): core.AllowedTxData{
-			To:   common.HexToAddress("0x7A6Ed0a905053A21C15cB5b4F39b561B6A3FE50f"),
-			Data: common.FromHex("0x"),
+		common.HexToAddress("0x855Ac656956AF761439f4a451c872E812E3900a4"): {
+			core.AllowedTxData{
+				To:   common.HexToAddress("0x985458E523dB3d53125813eD68c274899e9DfAb4"),
+				Data: common.FromHex("0xa9059cbb"),
+			},
+			core.AllowedTxData{
+				To:   common.HexToAddress("0x7A6Ed0a905053A21C15cB5b4F39b561B6A3FE50f"),
+				Data: common.FromHex("0x"),
+			},
 		},
 	}
 	got, err := parseAllowedTxs(testData)
@@ -41,10 +45,12 @@ func TestAllowedTxsParse(t *testing.T) {
 	if len(got) != len(expected) {
 		t.Errorf("lenght of allowed transactions not equal, got: %d expected: %d", len(got), len(expected))
 	}
-	for from, txData := range got {
-		expectedTxData := expected[from]
-		if expectedTxData.To != txData.To || !bytes.Equal(expectedTxData.Data, txData.Data) {
-			t.Errorf("txData not equal: got: %v expected: %v", txData, expectedTxData)
+	for from, txsData := range got {
+		for i, txData := range txsData {
+			expectedTxData := expected[from][i]
+			if expectedTxData.To != txData.To || !bytes.Equal(expectedTxData.Data, txData.Data) {
+				t.Errorf("txData not equal: got: %v expected: %v", txData, expectedTxData)
+			}
 		}
 	}
 }

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -172,8 +172,8 @@ type TxPoolConfig struct {
 
 	AddEvent func(tx types.PoolTransaction, local bool) // Fire add event
 
-	Blacklist  map[common.Address]struct{}      // Set of accounts that cannot be a part of any transaction
-	AllowedTxs map[common.Address]AllowedTxData // Set of allowed transactions can break the blocklist
+	Blacklist  map[common.Address]struct{}        // Set of accounts that cannot be a part of any transaction
+	AllowedTxs map[common.Address][]AllowedTxData // Set of allowed transactions can break the blocklist
 }
 
 // DefaultTxPoolConfig contains the default configurations for the transaction
@@ -193,7 +193,7 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	Lifetime: 30 * time.Minute, // --txpool.lifetime
 
 	Blacklist:  map[common.Address]struct{}{},
-	AllowedTxs: map[common.Address]AllowedTxData{},
+	AllowedTxs: map[common.Address][]AllowedTxData{},
 }
 
 // sanitize checks the provided user configurations and changes anything that's
@@ -753,12 +753,20 @@ func (pool *TxPool) validateTx(tx types.PoolTransaction, local bool) error {
 	}
 
 	// do whitelist check first, if tx not in whitelist, do blacklist check
-	if allowedTx, exists := pool.config.AllowedTxs[from]; exists {
-		if to := tx.To(); to == nil || *to != allowedTx.To || !bytes.Equal(tx.Data(), allowedTx.Data) {
-			toAddr := common.Address{}
-			if to != nil {
-				toAddr = *to
+	if allowedTxs, exists := pool.config.AllowedTxs[from]; exists {
+		txIsAllowed := false
+		to := tx.To()
+		toAddr := common.Address{}
+		if to != nil {
+			toAddr = *to
+			for _, allowedTx := range allowedTxs {
+				if to != nil && *to == allowedTx.To && bytes.Equal(tx.Data(), allowedTx.Data) {
+					txIsAllowed = true
+					break
+				}
 			}
+		}
+		if !txIsAllowed {
 			return errors.WithMessagef(ErrAllowedTxs, "transaction sender: %x, receiver: %x, input: %x", tx.From(), toAddr, tx.Data())
 		}
 	} else {

--- a/node/node.go
+++ b/node/node.go
@@ -1022,7 +1022,7 @@ func New(
 	host p2p.Host,
 	consensusObj *consensus.Consensus,
 	blacklist map[common.Address]struct{},
-	allowedTxs map[common.Address]core.AllowedTxData,
+	allowedTxs map[common.Address][]core.AllowedTxData,
 	localAccounts []common.Address,
 	harmonyconfig *harmonyconfig.HarmonyConfig,
 	registry *registry.Registry,


### PR DESCRIPTION
## Issue

The allowed transactions file could have multiple entries for the same "from" address. The current code only keeps the latest entry and ignores the previous ones. This PR addresses this issue by setting a map of allowed transactions to an array of transaction data, rather than a map of "from" to a single transaction data.