### PR TITLE
fix allowed txs to be able to handle multiple txs for same from address

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -1064,8 +1064,8 @@ func setupBlacklist(hc harmonyconfig.HarmonyConfig) (map[ethCommon.Address]struc
 	return addrMap, nil
 }
 
-func parseAllowedTxs(data []byte) (map[ethCommon.Address]core.AllowedTxData, error) {
-	allowedTxs := make(map[ethCommon.Address]core.AllowedTxData)
+func parseAllowedTxs(data []byte) (map[ethCommon.Address][]core.AllowedTxData, error) {
+	allowedTxs := make(map[ethCommon.Address][]core.AllowedTxData)
 	for _, line := range strings.Split(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if len(line) != 0 { // AllowedTxs file may have trailing empty string line
@@ -1086,16 +1086,16 @@ func parseAllowedTxs(data []byte) (map[ethCommon.Address]core.AllowedTxData, err
 			if err != nil {
 				return nil, err
 			}
-			allowedTxs[from] = core.AllowedTxData{
+			allowedTxs[from] = append(allowedTxs[from], core.AllowedTxData{
 				To:   to,
 				Data: data,
-			}
+			})
 		}
 	}
 	return allowedTxs, nil
 }
 
-func setupAllowedTxs(hc harmonyconfig.HarmonyConfig) (map[ethCommon.Address]core.AllowedTxData, error) {
+func setupAllowedTxs(hc harmonyconfig.HarmonyConfig) (map[ethCommon.Address][]core.AllowedTxData, error) {
 	utils.Logger().Debug().Msgf("Using AllowedTxs file at `%s`", hc.TxPool.AllowedTxsFile)
 	data, err := os.ReadFile(hc.TxPool.AllowedTxsFile)
 	if err != nil {

--- a/cmd/harmony/main_test.go
+++ b/cmd/harmony/main_test.go
@@ -16,22 +16,26 @@ func TestAllowedTxsParse(t *testing.T) {
 		one1s4dvv454dtmkzsulffz3epewsyhrjq9y0g3fqz->0x985458E523dB3d53125813eD68c274899e9DfAb4:0xa9059cbb
 		one1s4dvv454dtmkzsulffz3epewsyhrjq9y0g3fqz->one10fhdp2g9q5azrs2ukk608x6krd4rleg0ueskug:0x
 	`)
-	expected := map[ethCommon.Address]core.AllowedTxData{
-		common.HexToAddress("0x7A6Ed0a905053A21C15cB5b4F39b561B6A3FE50f"): core.AllowedTxData{
-			To:   common.HexToAddress("0x855Ac656956AF761439f4a451c872E812E3900a4"),
-			Data: common.FromHex("0x"),
+	expected := map[ethCommon.Address][]core.AllowedTxData{
+		common.HexToAddress("0x7A6Ed0a905053A21C15cB5b4F39b561B6A3FE50f"): {
+			core.AllowedTxData{
+				To:   common.HexToAddress("0x855Ac656956AF761439f4a451c872E812E3900a4"),
+				Data: common.FromHex("0x"),
+			},
+			core.AllowedTxData{
+				To:   common.HexToAddress("0x985458E523dB3d53125813eD68c274899e9DfAb4"),
+				Data: common.FromHex("0xa9059cbb"),
+			},
 		},
-		common.HexToAddress("0x7A6Ed0a905053A21C15cB5b4F39b561B6A3FE50f"): core.AllowedTxData{
-			To:   common.HexToAddress("0x985458E523dB3d53125813eD68c274899e9DfAb4"),
-			Data: common.FromHex("0xa9059cbb"),
-		},
-		common.HexToAddress("0x855Ac656956AF761439f4a451c872E812E3900a4"): core.AllowedTxData{
-			To:   common.HexToAddress("0x985458E523dB3d53125813eD68c274899e9DfAb4"),
-			Data: common.FromHex("0xa9059cbb"),
-		},
-		common.HexToAddress("0x855Ac656956AF761439f4a451c872E812E3900a4"): core.AllowedTxData{
-			To:   common.HexToAddress("0x7A6Ed0a905053A21C15cB5b4F39b561B6A3FE50f"),
-			Data: common.FromHex("0x"),
+		common.HexToAddress("0x855Ac656956AF761439f4a451c872E812E3900a4"): {
+			core.AllowedTxData{
+				To:   common.HexToAddress("0x985458E523dB3d53125813eD68c274899e9DfAb4"),
+				Data: common.FromHex("0xa9059cbb"),
+			},
+			core.AllowedTxData{
+				To:   common.HexToAddress("0x7A6Ed0a905053A21C15cB5b4F39b561B6A3FE50f"),
+				Data: common.FromHex("0x"),
+			},
 		},
 	}
 	got, err := parseAllowedTxs(testData)
@@ -41,10 +45,12 @@ func TestAllowedTxsParse(t *testing.T) {
 	if len(got) != len(expected) {
 		t.Errorf("lenght of allowed transactions not equal, got: %d expected: %d", len(got), len(expected))
 	}
-	for from, txData := range got {
-		expectedTxData := expected[from]
-		if expectedTxData.To != txData.To || !bytes.Equal(expectedTxData.Data, txData.Data) {
-			t.Errorf("txData not equal: got: %v expected: %v", txData, expectedTxData)
+	for from, txsData := range got {
+		for i, txData := range txsData {
+			expectedTxData := expected[from][i]
+			if expectedTxData.To != txData.To || !bytes.Equal(expectedTxData.Data, txData.Data) {
+				t.Errorf("txData not equal: got: %v expected: %v", txData, expectedTxData)
+			}
 		}
 	}
 }

--- a/node/node.go
+++ b/node/node.go
@@ -1027,7 +1027,7 @@ func New(
 	host p2p.Host,
 	consensusObj *consensus.Consensus,
 	blacklist map[common.Address]struct{},
-	allowedTxs map[common.Address]core.AllowedTxData,
+	allowedTxs map[common.Address][]core.AllowedTxData,
 	localAccounts []common.Address,
 	harmonyconfig *harmonyconfig.HarmonyConfig,
 	registry *registry.Registry,


### PR DESCRIPTION
## Issue
The allowed transactions file could have multiple entries for the same "from" address. The current code only keeps the latest entry and ignores the previous ones. This PR addresses this issue by setting a map of allowed transactions to an array of transaction data, rather than a map of "from" to a single transaction data.