### PR TITLE
Skip check when the 100% check is achieved.

### DIFF
--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -178,7 +178,10 @@ func (consensus *Consensus) finalCommit() {
 		return
 	}
 	consensus.getLogger().Info().Hex("new", commitSigAndBitmap).Msg("[finalCommit] Overriding commit signatures!!")
-	consensus.Blockchain().WriteCommitSig(block.NumberU64(), commitSigAndBitmap)
+
+	if err := consensus.Blockchain().WriteCommitSig(block.NumberU64(), commitSigAndBitmap); err != nil {
+		consensus.getLogger().Warn().Err(err).Msg("[finalCommit] failed writting commit sig")
+	}
 
 	// Send committed message before block insertion.
 	// if leader successfully finalizes the block, send committed message to validators

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -285,14 +285,6 @@ func (consensus *Consensus) onCommit(recvMsg *FBFTMessage) {
 	//// Read - Start
 	viewID := consensus.getCurBlockViewID()
 
-	//if consensus.decider.IsAllSigsCollected() {
-	//	logger.Info().Msg("[OnCommit] 100% Enough commits received")
-	//	consensus.finalCommit()
-	//
-	//	consensus.msgSender.StopRetry(msg_pb.MessageType_PREPARED)
-	//	return
-	//}
-
 	quorumIsMet := consensus.decider.IsQuorumAchieved(quorum.Commit)
 	//// Read - End
 


### PR DESCRIPTION
We are currently experiencing an issue in our devnet, leading to frequent view changes and extending block finality time from 1 second to 10 seconds. This problem became apparent after transitioning the network to operate exclusively on external nodes. These nodes are located in the same datacenter and region, eliminating geographical constraints. As a result, we achieve nearly 100% voting rate for almost every block.

This issue has not occurred in our testnet or mainnet, where nodes are globally distributed, making it rare to reach a 100% voting rate.

Through research conducted by Soph, we identified a specific logic block in the code that bypasses the precommit and propose phases. After reviewing the code, i believe this block is unnecessary. Our primary concern is achieving a 2/3 vote rate. The conditions `consensus.decider.IsAllSigsCollected()` and `consensus.decider.IsQuorumAchieved(quorum.Commit)` in the codebase use the same structure to determine if the Commit phase has received sufficient votes. You can see this in the code at [line 296](https://github.com/harmony-one/harmony/blob/8dff66146a7a858e654e10c84baff8ef25d8e703/consensus/leader.go#L296), [IsQuorumAchieved](https://github.com/harmony-one/harmony/blob/8dff66146a7a858e654e10c84baff8ef25d8e703/consensus/quorum/one-node-staked-vote.go#L140-L141), and [IsAllSigsCollected](https://github.com/harmony-one/harmony/blob/8dff66146a7a858e654e10c84baff8ef25d8e703/consensus/quorum/one-node-staked-vote.go#L189). Meaning that even if we reach a 100% we will run the same logic as for when we have [2/3 or more](https://github.com/harmony-one/harmony/blob/8dff66146a7a858e654e10c84baff8ef25d8e703/consensus/quorum/one-node-staked-vote.go#L118-L125) the lines of code being run at the commented code are also run at the main block rendering this block of code redundant.

EDIT: I've also added the `consensus.decider.IsAllSigsCollected()` in case we go from 0 to a 100% signatures in one go, so we run the same logic.