### PR TITLE
[HOTFIX] fix leader crosslink issue to not include old cross link in the propo…

### DIFF
--- a/consensus/view_change_construct.go
+++ b/consensus/view_change_construct.go
@@ -464,7 +464,7 @@ func (vc *viewChange) InitPayload(
 	if !inited {
 		viewIDBytes := make([]byte, 8)
 		binary.LittleEndian.PutUint64(viewIDBytes, viewID)
-		vc.getLogger().Info().Uint64("viewID", viewID).Uint64("blockNum", blockNum).Msg("[InitPayload] add my M3 (ViewID) type messaage")
+		vc.getLogger().Info().Uint64("viewID", viewID).Uint64("blockNum", blockNum).Msg("[InitPayload] add my M3 (ViewID) type message")
 		for _, key := range privKeys {
 			if _, ok := vc.viewIDBitmap[viewID]; !ok {
 				viewIDBitmap := bls_cosi.NewMask(members)

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -231,6 +231,9 @@ func (node *Node) ProposeNewBlock(commitSigs chan []byte) (*types.Block, error) 
 		invalidToDelete := []types.CrossLink{}
 		if err == nil {
 			for _, pending := range allPending {
+				if pending.EpochF.Int64() < currentHeader.Epoch().Int64()-3 {
+					continue
+				}
 				// ReadCrossLink beacon chain usage.
 				exist, err := node.Blockchain().ReadCrossLink(pending.ShardID(), pending.BlockNum())
 				if err == nil || exist != nil {


### PR DESCRIPTION
## Issue

The leader is adding pending crosslinks without verifying them. This could break the consensus if other validators don't have the old shard state needed to verify crosslinks. This PR addresses that issue by ignoring very old crosslinks and not adding them to proposing blocks.