### PR TITLE
fix crosslink processing, add logs for crosslinks

### DIFF
--- a/consensus/view_change_construct.go
+++ b/consensus/view_change_construct.go
@@ -464,7 +464,7 @@ func (vc *viewChange) InitPayload(
 	if !inited {
 		viewIDBytes := make([]byte, 8)
 		binary.LittleEndian.PutUint64(viewIDBytes, viewID)
-		vc.getLogger().Info().Uint64("viewID", viewID).Uint64("blockNum", blockNum).Msg("[InitPayload] add my M3 (ViewID) type messaage")
+		vc.getLogger().Info().Uint64("viewID", viewID).Uint64("blockNum", blockNum).Msg("[InitPayload] add my M3 (ViewID) type message")
 		for _, key := range privKeys {
 			if _, ok := vc.viewIDBitmap[viewID]; !ok {
 				viewIDBitmap := bls_cosi.NewMask(members)

--- a/node/node.go
+++ b/node/node.go
@@ -1183,6 +1183,24 @@ func New(
 
 	node.serviceManager = service.NewManager()
 
+	// log all pending crosslinks
+	allPending, err := node.Blockchain().ReadPendingCrossLinks()
+	if err == nil {
+		for _, pending := range allPending {
+			utils.Logger().Info().
+				Uint32("shard", pending.ShardID()).
+				Int64("epoch", pending.Epoch().Int64()).
+				Uint64("blockNum", pending.BlockNum()).
+				Int64("viewID", pending.ViewID().Int64()).
+				Interface("hash", pending.Hash()).
+				Msg("[PendingCrossLinksOnInit] pending cross links")
+		}
+	} else {
+		utils.Logger().Error().
+			Err(err).
+			Msg("read pending cross links failed")
+	}
+
 	return &node
 }
 

--- a/node/node_newblock.go
+++ b/node/node_newblock.go
@@ -231,6 +231,9 @@ func (node *Node) ProposeNewBlock(commitSigs chan []byte) (*types.Block, error) 
 		invalidToDelete := []types.CrossLink{}
 		if err == nil {
 			for _, pending := range allPending {
+				if pending.EpochF.Int64() < currentHeader.Epoch().Int64()-3 {
+					continue
+				}
 				// ReadCrossLink beacon chain usage.
 				exist, err := node.Blockchain().ReadCrossLink(pending.ShardID(), pending.BlockNum())
 				if err == nil || exist != nil {


### PR DESCRIPTION
## Issue
The leader is adding pending crosslinks without verifying them. This could break the consensus if other validators don't have the old shard state needed to verify crosslinks. This PR addresses that issue by ignoring very old crosslinks and not adding them to proposing blocks. crosslinks are today used only to calculate the reward to be distributed every 64 blocks, hence discarding those old pending crosslinks should be safe and shouldn't affect the protocol.