### PR TITLE
fix validator state when trying to update the max-rate

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -895,7 +895,10 @@ func (db *DB) Finalise(deleteEmptyObjects bool) {
 	// TODO: remove validator cache after commit
 	for addr, wrapper := range db.stateValidators {
 		if err := db.UpdateValidatorWrapper(addr, wrapper); err != nil {
-			utils.Logger().Warn().Err(err).Msg("Unable to update the validator wrapper on the finalize")
+			utils.Logger().Warn().Err(err).
+				Str("name", wrapper.Name).
+				Str("addr", addr.String()).
+				Msg("Unable to update the validator wrapper on the finalize")
 		}
 	}
 	addressesToPrefetch := make([][]byte, 0, len(db.journal.dirties))

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -458,7 +458,7 @@ func setElectionEpochAndMinFee(chain engine.ChainReader, header *block.Header, s
 
 	if config.IsMaxRate(newShardState.Epoch) {
 		for _, addr := range chain.ValidatorCandidates() {
-			if _, err := availability.UpdateMaxCommissionFee(state, addr, minRate); err != nil {
+			if _, err := availability.UpdateMaxCommissionFee(newShardState.Epoch, config, state, addr, minRate); err != nil {
 				return err
 			}
 		}
@@ -489,7 +489,7 @@ func setElectionEpochAndMinFee(chain engine.ChainReader, header *block.Header, s
 	// higher than the the MaxRate by UpdateMinimumCommissionFee above
 	if config.IsMaxRate(newShardState.Epoch) && minRateNotZero {
 		for _, addr := range chain.ValidatorCandidates() {
-			if _, err := availability.UpdateMaxCommissionFee(state, addr, minRate); err != nil {
+			if _, err := availability.UpdateMaxCommissionFee(newShardState.Epoch, config, state, addr, minRate); err != nil {
 				return err
 			}
 		}

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -76,6 +76,7 @@ var (
 		HIP30Epoch:                            big.NewInt(1673), // 2023-11-02 17:30:00+00:00
 		BlockGas30MEpoch:                      big.NewInt(1673), // 2023-11-02 17:30:00+00:00
 		MaxRateEpoch:                          EpochTBD,
+		TopMaxRateEpoch:                       EpochTBD,
 		DevnetExternalEpoch:                   EpochTBD,
 		TestnetExternalEpoch:                  EpochTBD,
 	}
@@ -122,6 +123,7 @@ var (
 		HIP30Epoch:                            big.NewInt(2176), // 2023-10-12 10:00:00+00:00
 		BlockGas30MEpoch:                      big.NewInt(2176), // 2023-10-12 10:00:00+00:00
 		MaxRateEpoch:                          EpochTBD,
+		TopMaxRateEpoch:                       EpochTBD,
 		DevnetExternalEpoch:                   EpochTBD,
 		TestnetExternalEpoch:                  EpochTBD,
 	}
@@ -168,6 +170,7 @@ var (
 		HIP30Epoch:                            EpochTBD,
 		BlockGas30MEpoch:                      big.NewInt(0),
 		MaxRateEpoch:                          EpochTBD,
+		TopMaxRateEpoch:                       EpochTBD,
 		DevnetExternalEpoch:                   EpochTBD,
 		TestnetExternalEpoch:                  EpochTBD,
 	}
@@ -261,6 +264,7 @@ var (
 		ValidatorCodeFixEpoch:                 EpochTBD,
 		HIP30Epoch:                            EpochTBD,
 		BlockGas30MEpoch:                      big.NewInt(0),
+		TopMaxRateEpoch:                       big.NewInt(0),
 		MaxRateEpoch:                          EpochTBD,
 		DevnetExternalEpoch:                   EpochTBD,
 		TestnetExternalEpoch:                  EpochTBD,
@@ -308,6 +312,7 @@ var (
 		HIP30Epoch:                            EpochTBD,
 		BlockGas30MEpoch:                      big.NewInt(0),
 		MaxRateEpoch:                          EpochTBD,
+		TopMaxRateEpoch:                       EpochTBD,
 		DevnetExternalEpoch:                   EpochTBD,
 		TestnetExternalEpoch:                  EpochTBD,
 	}
@@ -358,6 +363,7 @@ var (
 		big.NewInt(0),                      // MaxRateEpoch
 		big.NewInt(0),                      // MaxRateEpoch
 		big.NewInt(0),
+		big.NewInt(0),
 	}
 
 	// TestChainConfig ...
@@ -403,6 +409,7 @@ var (
 		big.NewInt(0),        // ValidatorCodeFixEpoch
 		big.NewInt(0),        // HIP30Epoch
 		big.NewInt(0),        // BlockGas30M
+		big.NewInt(0),        // MaxRateEpoch
 		big.NewInt(0),        // MaxRateEpoch
 		big.NewInt(0),        // MaxRateEpoch
 		big.NewInt(0),
@@ -578,6 +585,9 @@ type ChainConfig struct {
 
 	// MaxRateEpoch will make sure the validator max-rate is at least equal to the minRate + the validator max-rate-increase
 	MaxRateEpoch *big.Int `json:"max-rate-epoch,omitempty"`
+
+	// TopMaxRateEpoch will make sure the validator max-rate is less to 100% for the cases where the minRate + the validator max-rate-increase > 100%
+	TopMaxRateEpoch *big.Int `json:"top-max-rate-epoch,omitempty"`
 }
 
 // String implements the fmt.Stringer interface.
@@ -847,6 +857,10 @@ func (c *ChainConfig) IsTestnetExternalEpoch(epoch *big.Int) bool {
 
 func (c *ChainConfig) IsMaxRate(epoch *big.Int) bool {
 	return isForked(c.MaxRateEpoch, epoch)
+}
+
+func (c *ChainConfig) IsTopMaxRate(epoch *big.Int) bool {
+	return isForked(c.TopMaxRateEpoch, epoch)
 }
 
 // During this epoch, shards 2 and 3 will start sending

--- a/staking/availability/measure.go
+++ b/staking/availability/measure.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/crypto/bls"
+	"github.com/harmony-one/harmony/internal/params"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/numeric"
 	"github.com/harmony-one/harmony/shard"
@@ -269,7 +270,7 @@ func UpdateMinimumCommissionFee(
 }
 
 // UpdateMaxCommissionFee makes sure the max-rate is at least higher than the rate + max-rate-change.
-func UpdateMaxCommissionFee(state *state.DB, addr common.Address, minRate numeric.Dec) (bool, error) {
+func UpdateMaxCommissionFee(epoch *big.Int, config *params.ChainConfig, state *state.DB, addr common.Address, minRate numeric.Dec) (bool, error) {
 	utils.Logger().Info().Msg("begin update max commission fee")
 
 	wrapper, err := state.ValidatorWrapper(addr, true, false)
@@ -278,6 +279,13 @@ func UpdateMaxCommissionFee(state *state.DB, addr common.Address, minRate numeri
 	}
 
 	minMaxRate := minRate.Add(wrapper.MaxChangeRate)
+
+	if config.IsTopMaxRate(epoch) {
+		hundredPercent := numeric.NewDec(1)
+		if minMaxRate.GT(hundredPercent) {
+			minMaxRate = hundredPercent
+		}
+	}
 
 	if wrapper.MaxRate.LT(minMaxRate) {
 		utils.Logger().Info().


### PR DESCRIPTION
During the previous hardfork we mad sure to update the max-rate to be at least the `min-rate` + `max-rate-change` to comply with the the minimum 7% rate imposed in HIP30, for validators running under that threshold. However, with that we introduced a subtle bug under the assumption that `max-rate-change` was a small value but in practice is not, it can go up to a 100% which will sum to a number higher than a 100% when adding the min-rate. 
For a handful of validators that caused the sanity checks fails when persisting the state in the hard-drive. A issue that is hard to catch as it'll only happen once per epoch, this bug explains issues like the buggy validator or the validator with undelegated funds issues.
As this is a change in the way the data is stored in the state this will have to go with a hardfork, I guess we can inlcude it with the leader rotation.