### PR TITLE
Empty signing power workaround

### DIFF
--- a/consensus/post_processing.go
+++ b/consensus/post_processing.go
@@ -85,7 +85,7 @@ func (consensus *Consensus) PostConsensusProcessing(newBlock *types.Block) error
 					return nil
 				}
 				computed := availability.ComputeCurrentSigning(
-					snapshot.Validator, wrapper,
+					snapshot.Validator, wrapper, consensus.Blockchain().Config().IsHIP32(newBlock.Epoch()),
 				)
 				lastBlockOfEpoch := shard.Schedule.EpochLastBlock(consensus.Beaconchain().CurrentBlock().Header().Epoch().Uint64())
 

--- a/hmy/staking.go
+++ b/hmy/staking.go
@@ -353,7 +353,7 @@ func (hmy *Harmony) GetValidatorInformation(
 	}
 
 	computed := availability.ComputeCurrentSigning(
-		snapshot.Validator, wrapper,
+		snapshot.Validator, wrapper, bc.Config().IsHIP32(now),
 	)
 
 	lastBlockOfEpoch := shard.Schedule.EpochLastBlock(hmy.BeaconChain.CurrentBlock().Header().Epoch().Uint64())
@@ -479,7 +479,7 @@ func (hmy *Harmony) GetMedianRawStakeSnapshot() (
 			// Compute for next epoch
 			epoch := big.NewInt(0).Add(hmy.CurrentBlock().Epoch(), big.NewInt(1))
 			instance := shard.Schedule.InstanceForEpoch(epoch)
-			return committee.NewEPoSRound(epoch, hmy.BlockChain, hmy.BlockChain.Config().IsEPoSBound35(epoch), instance.SlotsLimit(), int(instance.NumShards()))
+			return committee.NewEPoSRound(epoch, hmy.BlockChain, instance.SlotsLimit(), int(instance.NumShards()))
 		},
 	)
 	if err != nil {
@@ -634,7 +634,7 @@ func (hmy *Harmony) GetTotalStakingSnapshot() *big.Int {
 		snapshot, _ := hmy.BlockChain.ReadValidatorSnapshot(candidates[i])
 		validator, _ := hmy.BlockChain.ReadValidatorInformation(candidates[i])
 		if !committee.IsEligibleForEPoSAuction(
-			snapshot, validator,
+			snapshot, validator, hmy.BlockChain.Config(),
 		) {
 			continue
 		}

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -414,6 +414,7 @@ var (
 		big.NewInt(0),        // MaxRateEpoch
 		big.NewInt(0),        // MaxRateEpoch
 		big.NewInt(0),
+		big.NewInt(0),
 	}
 
 	// TestRules ...
@@ -589,6 +590,10 @@ type ChainConfig struct {
 
 	// TopMaxRateEpoch will make sure the validator max-rate is less to 100% for the cases where the minRate + the validator max-rate-increase > 100%
 	TopMaxRateEpoch *big.Int `json:"top-max-rate-epoch,omitempty"`
+
+	// vote power feature  https://github.com/harmony-one/harmony/pull/4683
+	// if crosslink are not sent for an entire epoch signed and toSign will be 0 and 0. when that happen, next epoch there will no shard 1 validator elected in the committee.
+	HIP32Epoch *big.Int `json:"hip32-epoch,omitempty"`
 }
 
 // String implements the fmt.Stringer interface.
@@ -842,6 +847,10 @@ func (c *ChainConfig) IsFeeCollectEpoch(epoch *big.Int) bool {
 
 func (c *ChainConfig) IsValidatorCodeFix(epoch *big.Int) bool {
 	return isForked(c.ValidatorCodeFixEpoch, epoch)
+}
+
+func (c *ChainConfig) IsHIP32(epoch *big.Int) bool {
+	return isForked(c.HIP32Epoch, epoch)
 }
 
 func (c *ChainConfig) IsHIP30(epoch *big.Int) bool {

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -365,6 +365,7 @@ var (
 		big.NewInt(0),                      // MaxRateEpoch
 		big.NewInt(0),
 		big.NewInt(0),
+		big.NewInt(0),
 	}
 
 	// TestChainConfig ...

--- a/staking/availability/interface.go
+++ b/staking/availability/interface.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/harmony-one/harmony/internal/params"
 	staking "github.com/harmony-one/harmony/staking/types"
 )
 
@@ -12,6 +13,7 @@ type Reader interface {
 	ReadValidatorSnapshot(
 		addr common.Address,
 	) (*staking.ValidatorSnapshot, error)
+	Config() *params.ChainConfig
 }
 
 // RoundHeader is the interface of block.Header for calculating the BallotResult.

--- a/staking/availability/measure.go
+++ b/staking/availability/measure.go
@@ -138,9 +138,7 @@ func IncrementValidatorSigningCounts(
 }
 
 // ComputeCurrentSigning returns (signed, toSign, quotient, error)
-func ComputeCurrentSigning(
-	snapshot, wrapper *staking.ValidatorWrapper,
-) *staking.Computed {
+func ComputeCurrentSigning(snapshot, wrapper *staking.ValidatorWrapper, isHip32 bool) *staking.Computed {
 	statsNow, snapSigned, snapToSign :=
 		wrapper.Counters,
 		snapshot.Counters.NumBlocksSigned,
@@ -155,7 +153,9 @@ func ComputeCurrentSigning(
 	)
 
 	if toSign.Cmp(common.Big0) == 0 {
-		computed.IsBelowThreshold = false
+		if isHip32 {
+			computed.IsBelowThreshold = false
+		}
 		return computed
 	}
 
@@ -206,7 +206,7 @@ func ComputeAndMutateEPOSStatus(
 		return err
 	}
 
-	computed := ComputeCurrentSigning(snapshot.Validator, wrapper)
+	computed := ComputeCurrentSigning(snapshot.Validator, wrapper, bc.Config().IsHIP32(snapshot.Epoch))
 
 	utils.Logger().
 		Info().Msg("check if signing percent is meeting required threshold")

--- a/staking/availability/measure.go
+++ b/staking/availability/measure.go
@@ -155,6 +155,7 @@ func ComputeCurrentSigning(
 	)
 
 	if toSign.Cmp(common.Big0) == 0 {
+		computed.IsBelowThreshold = false
 		return computed
 	}
 

--- a/staking/availability/measure_test.go
+++ b/staking/availability/measure_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/harmony-one/harmony/crypto/bls"
+	"github.com/harmony-one/harmony/internal/params"
 	"github.com/harmony-one/harmony/numeric"
 	"github.com/harmony-one/harmony/shard"
 	"github.com/harmony-one/harmony/staking/effective"
@@ -188,7 +189,7 @@ func TestComputeCurrentSigning(t *testing.T) {
 		snapWrapper := makeTestWrapper(common.Address{}, test.snapSigned, test.snapToSign)
 		curWrapper := makeTestWrapper(common.Address{}, test.curSigned, test.curToSign)
 
-		computed := ComputeCurrentSigning(&snapWrapper, &curWrapper)
+		computed := ComputeCurrentSigning(&snapWrapper, &curWrapper, false)
 
 		if computed.Signed.Cmp(new(big.Int).SetInt64(test.diffSigned)) != 0 {
 			t.Errorf("test %v: computed signed not expected: %v / %v",
@@ -204,7 +205,48 @@ func TestComputeCurrentSigning(t *testing.T) {
 				i, computed.Percentage, expPct)
 		}
 		if computed.IsBelowThreshold != test.isBelowThreshold {
-			t.Errorf("test %v: computed is below threshold not expected: %v / %v",
+			t.Errorf("test %v: computed is below threshold `%v` expected: `%v`",
+				i, computed.IsBelowThreshold, test.isBelowThreshold)
+		}
+	}
+}
+
+func TestComputeCurrentSigningHIP32(t *testing.T) {
+	tests := []struct {
+		snapSigned, curSigned, diffSigned int64
+		snapToSign, curToSign, diffToSign int64
+		pctNum, pctDiv                    int64
+		isBelowThreshold                  bool
+	}{
+		{0, 0, 0, 0, 0, 0, 0, 1, false},
+		{0, 1, 1, 0, 1, 1, 1, 1, false},
+		{0, 2, 2, 0, 3, 3, 2, 3, true},
+		{0, 1, 1, 0, 3, 3, 1, 3, true},
+		{100, 225, 125, 200, 350, 150, 5, 6, false},
+		{100, 200, 100, 200, 350, 150, 2, 3, true},
+		{100, 200, 100, 200, 400, 200, 1, 2, true},
+	}
+	for i, test := range tests {
+		snapWrapper := makeTestWrapper(common.Address{}, test.snapSigned, test.snapToSign)
+		curWrapper := makeTestWrapper(common.Address{}, test.curSigned, test.curToSign)
+
+		computed := ComputeCurrentSigning(&snapWrapper, &curWrapper, true)
+
+		if computed.Signed.Cmp(new(big.Int).SetInt64(test.diffSigned)) != 0 {
+			t.Errorf("test %v: computed signed not expected: %v / %v",
+				i, computed.Signed, test.diffSigned)
+		}
+		if computed.ToSign.Cmp(new(big.Int).SetInt64(test.diffToSign)) != 0 {
+			t.Errorf("test %v: computed to sign not expected: %v / %v",
+				i, computed.ToSign, test.diffToSign)
+		}
+		expPct := numeric.NewDec(test.pctNum).Quo(numeric.NewDec(test.pctDiv))
+		if !computed.Percentage.Equal(expPct) {
+			t.Errorf("test %v: computed percentage not expected: %v / %v",
+				i, computed.Percentage, expPct)
+		}
+		if computed.IsBelowThreshold != test.isBelowThreshold {
+			t.Errorf("test %v: computed is below threshold `%v`, expected: `%v`",
 				i, computed.IsBelowThreshold, test.isBelowThreshold)
 		}
 	}
@@ -628,16 +670,22 @@ func (state testStateDB) GetCode(addr common.Address, isValidatorCode bool) []by
 }
 
 // testReader is the fake Reader for testing
-type testReader map[common.Address]staking.ValidatorWrapper
+type testReader struct {
+	m      map[common.Address]staking.ValidatorWrapper
+	config *params.ChainConfig
+}
 
 // newTestReader creates an empty test reader
 func newTestReader() testReader {
-	reader := make(testReader)
-	return reader
+	m := make(map[common.Address]staking.ValidatorWrapper)
+	return testReader{
+		m:      m,
+		config: &params.ChainConfig{},
+	}
 }
 
 func (reader testReader) ReadValidatorSnapshot(addr common.Address) (*staking.ValidatorSnapshot, error) {
-	wrapper, ok := reader[addr]
+	wrapper, ok := reader.m[addr]
 	if !ok {
 		return nil, errors.New("not a valid validator address")
 	}
@@ -646,8 +694,12 @@ func (reader testReader) ReadValidatorSnapshot(addr common.Address) (*staking.Va
 	}, nil
 }
 
+func (reader testReader) Config() *params.ChainConfig {
+	return reader.config
+}
+
 func (reader testReader) updateValidatorWrapper(addr common.Address, val *staking.ValidatorWrapper) {
-	reader[addr] = *val
+	reader.m[addr] = *val
 }
 
 func makeTestShardState(numShards, numSlots int) *shard.State {

--- a/staking/availability/measure_test.go
+++ b/staking/availability/measure_test.go
@@ -776,6 +776,7 @@ func indexesToBitMap(idxs []int, n int) ([]byte, error) {
 	return res, nil
 }
 
+// makeTestWrapper makes test wrapper
 func makeTestWrapper(addr common.Address, numSigned, numToSign int64) staking.ValidatorWrapper {
 	var val staking.ValidatorWrapper
 	val.Address = addr


### PR DESCRIPTION
https://github.com/harmony-one/harmony/pull/4663/files#diff-9cfef24a4e8a4cf4ef84b772edcde2d1c3993f8373a9b9a376377c1385802f29R156

if crosslink are not sent for an entire epoch signed and toSign will be 0 and 0.
when that happen, next epoch there will no shard 1 validator elected in the committee.