### PR TITLE
improve logs to reduce OUT of SYNC lines

### DIFF
--- a/api/service/legacysync/epoch_syncing.go
+++ b/api/service/legacysync/epoch_syncing.go
@@ -101,13 +101,25 @@ func syncLoop(bc core.BlockChain, syncConfig *SyncConfig) (timeout int) {
 		return 10
 	}
 
+	utils.Logger().Info().
+		Bool("isBeacon", isBeacon).
+		Uint32("ShardID", bc.ShardID()).
+		Uint64("otherEpoch", shard.Schedule.CalcEpochNumber(maxHeight).Uint64()).
+		Uint64("currentEpoch", bc.CurrentBlock().Epoch().Uint64()).
+		Int("peers count", syncConfig.PeersCount()).
+		Msg("[EPOCHSYNC] Node is OUT OF SYNC, it's trying to get fully synchronized")
+
 	for {
 		curEpoch := bc.CurrentBlock().Epoch().Uint64()
 		otherEpoch := shard.Schedule.CalcEpochNumber(maxHeight).Uint64()
 		if otherEpoch == curEpoch+1 {
 			utils.Logger().Info().
-				Msgf("[EPOCHSYNC] Node is now IN SYNC! (isBeacon: %t, ShardID: %d, otherEpoch: %d, currentEpoch: %d, peersCount: %d)",
-					isBeacon, bc.ShardID(), otherEpoch, curEpoch, syncConfig.PeersCount())
+				Bool("isBeacon", isBeacon).
+				Uint32("ShardID", bc.ShardID()).
+				Uint64("otherEpoch", otherEpoch).
+				Uint64("currentEpoch", curEpoch).
+				Int("peers count", syncConfig.PeersCount()).
+				Msg("[EPOCHSYNC] Node is now IN SYNC!")
 			return 60
 		}
 		if otherEpoch < curEpoch {
@@ -116,10 +128,6 @@ func syncLoop(bc core.BlockChain, syncConfig *SyncConfig) (timeout int) {
 			}
 			return 2
 		}
-
-		utils.Logger().Info().
-			Msgf("[EPOCHSYNC] Node is OUT OF SYNC (isBeacon: %t, ShardID: %d, otherEpoch: %d, currentEpoch: %d, peers count %d)",
-				isBeacon, bc.ShardID(), otherEpoch, curEpoch, syncConfig.PeersCount())
 
 		var heights []uint64
 		loopEpoch := curEpoch + 1
@@ -142,8 +150,12 @@ func syncLoop(bc core.BlockChain, syncConfig *SyncConfig) (timeout int) {
 				return 10
 			}
 			utils.Logger().Error().Err(err).
-				Msgf("[EPOCHSYNC] ProcessStateSync failed (isBeacon: %t, ShardID: %d, otherEpoch: %d, currentEpoch: %d)",
-					isBeacon, bc.ShardID(), otherEpoch, curEpoch)
+				Bool("isBeacon", isBeacon).
+				Uint32("ShardID", bc.ShardID()).
+				Uint64("otherEpoch", otherEpoch).
+				Uint64("currentEpoch", curEpoch).
+				Int("peers count", syncConfig.PeersCount()).
+				Msg("[EPOCHSYNC] ProcessStateSync failed")
 			return 2
 		}
 	}

--- a/api/service/legacysync/syncing.go
+++ b/api/service/legacysync/syncing.go
@@ -1093,29 +1093,35 @@ func (ss *StateSync) SyncLoop(bc core.BlockChain, isBeacon bool, consensus *cons
 		ss.RegisterNodeInfo()
 	}
 
+	utils.Logger().Info().
+		Bool("isBeacon", isBeacon).
+		Uint32("ShardID", bc.ShardID()).
+		Uint64("currentHeight", bc.CurrentBlock().NumberU64()).
+		Int("peers count", ss.syncConfig.PeersCount()).
+		Msg("[SYNC] Node is OUT OF SYNC, it's trying to get fully synchronized")
+
 	for {
 		start := time.Now()
 		currentHeight := bc.CurrentBlock().NumberU64()
 		otherHeight, errMaxHeight := getMaxPeerHeight(ss.syncConfig)
 		if errMaxHeight != nil {
-			utils.Logger().Error().
+			utils.Logger().Error().Err(errMaxHeight).
 				Bool("isBeacon", isBeacon).
 				Uint32("ShardID", bc.ShardID()).
 				Uint64("currentHeight", currentHeight).
 				Int("peers count", ss.syncConfig.PeersCount()).
-				Msgf("[SYNC] get max height failed")
+				Msg("[SYNC] get max height failed")
 			break
 		}
 		if currentHeight >= otherHeight {
 			utils.Logger().Info().
-				Msgf("[SYNC] Node is now IN SYNC! (isBeacon: %t, ShardID: %d, otherHeight: %d, currentHeight: %d)",
-					isBeacon, bc.ShardID(), otherHeight, currentHeight)
+				Bool("isBeacon", isBeacon).
+				Uint32("ShardID", bc.ShardID()).
+				Uint64("currentHeight", bc.CurrentBlock().NumberU64()).
+				Int("peers count", ss.syncConfig.PeersCount()).
+				Msg("[SYNC] Node is now IN SYNC!")
 			break
 		}
-		utils.Logger().Info().
-			Msgf("[SYNC] Node is OUT OF SYNC (isBeacon: %t, ShardID: %d, otherHeight: %d, currentHeight: %d)",
-				isBeacon, bc.ShardID(), otherHeight, currentHeight)
-
 		startHash := bc.CurrentBlock().Hash()
 		size := uint32(otherHeight - currentHeight)
 		if size > SyncLoopBatchSize {
@@ -1127,8 +1133,11 @@ func (ss *StateSync) SyncLoop(bc core.BlockChain, isBeacon bool, consensus *cons
 				continue
 			}
 			utils.Logger().Error().Err(err).
-				Msgf("[SYNC] ProcessStateSync failed (isBeacon: %t, ShardID: %d, otherHeight: %d, currentHeight: %d)",
-					isBeacon, bc.ShardID(), otherHeight, currentHeight)
+				Bool("isBeacon", isBeacon).
+				Uint32("ShardID", bc.ShardID()).
+				Uint64("currentHeight", bc.CurrentBlock().NumberU64()).
+				Int("peers count", ss.syncConfig.PeersCount()).
+				Msg("[SYNC] ProcessStateSync failed")
 			ss.purgeOldBlocksFromCache()
 			break
 		}
@@ -1332,6 +1341,8 @@ func (ss *StateSync) isSynchronized(doubleCheck bool) SyncCheckResult {
 		utils.Logger().Info().
 			Uint64("OtherHeight", otherHeight1).
 			Uint64("lastHeight", lastHeight).
+			Uint64("heightDiff", heightDiff).
+			Bool("wasOutOfSync", wasOutOfSync).
 			Msg("[SYNC] Checking sync status")
 		return SyncCheckResult{
 			IsSynchronized: !wasOutOfSync,
@@ -1354,7 +1365,8 @@ func (ss *StateSync) isSynchronized(doubleCheck bool) SyncCheckResult {
 		Uint64("OtherHeight2", otherHeight2).
 		Uint64("lastHeight", lastHeight).
 		Uint64("currentHeight", currentHeight).
-		Msg("[SYNC] Checking sync status")
+		Bool("isOutOfSync", isOutOfSync).
+		Msg("[SYNC] Double checking sync status")
 	// Only confirm out of sync when the node has lower height and didn't move in heights for 2 consecutive checks
 	heightDiff := otherHeight2 - lastHeight
 	if otherHeight2 < lastHeight {

--- a/api/service/stagedsync/stagedsync.go
+++ b/api/service/stagedsync/stagedsync.go
@@ -1306,6 +1306,8 @@ func (ss *StagedSync) isSynchronized(doubleCheck bool) SyncCheckResult {
 		utils.Logger().Info().
 			Uint64("OtherHeight", otherHeight1).
 			Uint64("lastHeight", lastHeight).
+			Uint64("heightDiff", heightDiff).
+			Bool("wasOutOfSync", wasOutOfSync).
 			Msg("[STAGED_SYNC] Checking sync status")
 		return SyncCheckResult{
 			IsSynchronized: !wasOutOfSync,
@@ -1328,7 +1330,8 @@ func (ss *StagedSync) isSynchronized(doubleCheck bool) SyncCheckResult {
 		Uint64("OtherHeight2", otherHeight2).
 		Uint64("lastHeight", lastHeight).
 		Uint64("currentHeight", currentHeight).
-		Msg("[STAGED_SYNC] Checking sync status")
+		Bool("isOutOfSync", isOutOfSync).
+		Msg("[STAGED_SYNC] Double checking sync status")
 	// Only confirm out of sync when the node has lower height and didn't move in heights for 2 consecutive checks
 	heightDiff := otherHeight2 - lastHeight
 	if otherHeight2 < lastHeight {


### PR DESCRIPTION
## Issue
The unsynchronized node continues to log "OUT OF SYNC" while it is syncing. This PR addresses this issue and enhances the logging mechanism to reduce the occurrence of "OUT OF SYNC" lines.
