### PR TITLE
Update testnet internal vote power back to 90%

### DIFF
--- a/internal/configs/sharding/testnet.go
+++ b/internal/configs/sharding/testnet.go
@@ -42,6 +42,8 @@ const (
 
 func (ts testnetSchedule) InstanceForEpoch(epoch *big.Int) Instance {
 	switch {
+	case epoch.Cmp(big.NewInt(3388)) >= 0: // one time fix for devnet shard 1 down, estimated 30 May 7:50AM UTC
+		return testnetV6_1
 	case params.TestnetChainConfig.IsTestnetExternalEpoch(epoch):
 		return testnetV6
 	case params.TestnetChainConfig.IsHIP30(epoch):
@@ -174,6 +176,14 @@ var (
 	testnetV6 = MustNewInstance(
 		2, 30, 0, 0,
 		numeric.MustNewDecFromStr("0.0"), genesis.TNHarmonyAccountsV1,
+		genesis.TNFoundationalAccounts, emptyAllowlist,
+		feeCollectorsTestnet, numeric.MustNewDecFromStr("0.25"),
+		hip30CollectionAddressTestnet, testnetReshardingEpoch,
+		TestnetSchedule.BlocksPerEpoch(),
+	)
+	testnetV6_1 = MustNewInstance(
+		2, 30, 0, 0,
+		numeric.MustNewDecFromStr("0.9"), genesis.TNHarmonyAccountsV1,
 		genesis.TNFoundationalAccounts, emptyAllowlist,
 		feeCollectorsTestnet, numeric.MustNewDecFromStr("0.25"),
 		hip30CollectionAddressTestnet, testnetReshardingEpoch,


### PR DESCRIPTION
Shard 1 was down due to no available committee in the current epoch. The issue happened due to two things :
- crosslink wasn't working and leading to shard 1 signature information not updated on shard 0 which has an effect to kick out all the external validator
- not enough voting power for internal node

this PR is to restore internal node VP to revive shard 1 consensus. 

shard 1 last block will have to be reverted so the latest committee containing internal VP with 90% can be re-added to the shard 1 last block of epoch.