### PR TITLE
Fixed data race.

### DIFF
--- a/core/blockchain_impl.go
+++ b/core/blockchain_impl.go
@@ -490,6 +490,9 @@ func (bc *BlockChainImpl) ValidateNewBlock(block *types.Block, beaconChain Block
 	if block.NumberU64() <= bc.CurrentBlock().NumberU64() {
 		return errors.Errorf("block with the same block number is already committed: %d", block.NumberU64())
 	}
+
+	bc.chainmu.Lock()
+	defer bc.chainmu.Unlock()
 	if err := bc.validator.ValidateHeader(block, true); err != nil {
 		utils.Logger().Error().
 			Str("blockHash", block.Hash().Hex()).


### PR DESCRIPTION
```
WARNING: DATA RACE
Read at 0x00c00c09bd58 by goroutine 1458:
  github.com/harmony-one/harmony/core/state.(*DB).clearJournalAndRefund()
      /Users/frozen/go/src/github.com/harmony-one/harmony/core/state/statedb.go:1033 +0x860
  github.com/harmony-one/harmony/core/state.(*DB).Finalise()
      /Users/frozen/go/src/github.com/harmony-one/harmony/core/state/statedb.go:946 +0x74c
  github.com/harmony-one/harmony/core/state.(*DB).IntermediateRoot()
      /Users/frozen/go/src/github.com/harmony-one/harmony/core/state/statedb.go:954 +0x48
  github.com/harmony-one/harmony/core.(*BlockValidator).ValidateState()
      /Users/frozen/go/src/github.com/harmony-one/harmony/core/block_validator.go:114 +0x488
  github.com/harmony-one/harmony/core.(*BlockChainImpl).insertChain()
      /Users/frozen/go/src/github.com/harmony-one/harmony/core/blockchain_impl.go:1874 +0x1088
  github.com/harmony-one/harmony/core.(*BlockChainImpl).InsertChain()
      /Users/frozen/go/src/github.com/harmony-one/harmony/core/blockchain_impl.go:1675 +0x2b8
  github.com/harmony-one/harmony/api/service/stagedstreamsync.verifyAndInsertBlock()
      /Users/frozen/go/src/github.com/harmony-one/harmony/api/service/stagedstreamsync/sig_verify.go:67 +0xb4
  github.com/harmony-one/harmony/api/service/stagedstreamsync.verifyAndInsertBlocks()
      /Users/frozen/go/src/github.com/harmony-one/harmony/api/service/stagedstreamsync/sig_verify.go:25 +0xb0
  github.com/harmony-one/harmony/api/service/stagedstreamsync.(*StageShortRange).doShortRangeSync()
      /Users/frozen/go/src/github.com/harmony-one/harmony/api/service/stagedstreamsync/stage_short_range.go:141 +0x9c4
  github.com/harmony-one/harmony/api/service/stagedstreamsync.(*StageShortRange).Exec()
      /Users/frozen/go/src/github.com/harmony-one/harmony/api/service/stagedstreamsync/stage_short_range.go:53 +0xdc
  github.com/harmony-one/harmony/api/service/stagedstreamsync.(*StagedStreamSync).runStage()
      /Users/frozen/go/src/github.com/harmony-one/harmony/api/service/stagedstreamsync/staged_stream_sync.go:552 +0x114
  github.com/harmony-one/harmony/api/service/stagedstreamsync.(*StagedStreamSync).Run()
      /Users/frozen/go/src/github.com/harmony-one/harmony/api/service/stagedstreamsync/staged_stream_sync.go:414 +0x468
  github.com/harmony-one/harmony/api/service/stagedstreamsync.(*StagedStreamSync).doSyncCycle()
      /Users/frozen/go/src/github.com/harmony-one/harmony/api/service/stagedstreamsync/syncing.go:423 +0xc0
  github.com/harmony-one/harmony/api/service/stagedstreamsync.(*StagedStreamSync).doSync()
      /Users/frozen/go/src/github.com/harmony-one/harmony/api/service/stagedstreamsync/syncing.go:343 +0x488
  github.com/harmony-one/harmony/api/service/stagedstreamsync.(*Downloader).loop()
      /Users/frozen/go/src/github.com/harmony-one/harmony/api/service/stagedstreamsync/downloader.go:224 +0x24c
  github.com/harmony-one/harmony/api/service/stagedstreamsync.(*Downloader).Start.func1()
      /Users/frozen/go/src/github.com/harmony-one/harmony/api/service/stagedstreamsync/downloader.go:99 +0x34

Previous write at 0x00c00c09bd58 by goroutine 1452:
  github.com/harmony-one/harmony/core/state.(*DB).clearJournalAndRefund()
      /Users/frozen/go/src/github.com/harmony-one/harmony/core/state/statedb.go:1033 +0x868
  github.com/harmony-one/harmony/core/state.(*DB).Finalise()
      /Users/frozen/go/src/github.com/harmony-one/harmony/core/state/statedb.go:946 +0x74c
  github.com/harmony-one/harmony/core/state.(*DB).IntermediateRoot()
      /Users/frozen/go/src/github.com/harmony-one/harmony/core/state/statedb.go:954 +0x48
  github.com/harmony-one/harmony/core.(*BlockValidator).ValidateState()
      /Users/frozen/go/src/github.com/harmony-one/harmony/core/block_validator.go:114 +0x488
  github.com/harmony-one/harmony/core.(*BlockChainImpl).validateNewBlock()
      /Users/frozen/go/src/github.com/harmony-one/harmony/core/blockchain_impl.go:555 +0x258
  github.com/harmony-one/harmony/core.(*BlockChainImpl).ValidateNewBlock()
      /Users/frozen/go/src/github.com/harmony-one/harmony/core/blockchain_impl.go:522 +0x630
  github.com/harmony-one/harmony/consensus.(*Consensus).BlockVerifier()
      /Users/frozen/go/src/github.com/harmony-one/harmony/consensus/consensus_service.go:670 +0x8c
  github.com/harmony-one/harmony/consensus.(*Consensus).BlockVerifier-fm()
      <autogenerated>:1 +0x3c
  github.com/harmony-one/harmony/consensus.(*LastMileBlockIter).Next()
      /Users/frozen/go/src/github.com/harmony-one/harmony/consensus/consensus_v2.go:495 +0x1a0
  github.com/harmony-one/harmony/consensus.(*Consensus).AddConsensusLastMile.func1()
      /Users/frozen/go/src/github.com/harmony-one/harmony/consensus/downloader.go:90 +0x30
  github.com/harmony-one/harmony/consensus.(*Consensus).getLastMileBlockIter()
      /Users/frozen/go/src/github.com/harmony-one/harmony/consensus/consensus_v2.go:477 +0x1ec
  github.com/harmony-one/harmony/consensus.(*Consensus).GetLastMileBlockIter()
      /Users/frozen/go/src/github.com/harmony-one/harmony/consensus/consensus_v2.go:468 +0x9c
  github.com/harmony-one/harmony/consensus.(*Consensus).AddConsensusLastMile()
      /Users/frozen/go/src/github.com/harmony-one/harmony/consensus/downloader.go:88 +0x78
  github.com/harmony-one/harmony/consensus.(*Consensus).BlocksSynchronized()
      /Users/frozen/go/src/github.com/harmony-one/harmony/consensus/consensus.go:195 +0x2c
  github.com/harmony-one/harmony/consensus.(*downloadHelper).downloadFinishedLoop()
      /Users/frozen/go/src/github.com/harmony-one/harmony/consensus/downloader.go:77 +0x34
  github.com/harmony-one/harmony/consensus.newDownloadHelper.func2()
      /Users/frozen/go/src/github.com/harmony-one/harmony/consensus/downloader.go:52 +0x40
      
```