### PR TITLE
set default snapshotlimit to 0

### DIFF
--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -278,7 +278,7 @@ var defaultCacheConfig = harmonyconfig.CacheConfig{
 	TrieNodeLimit:   256,
 	TriesInMemory:   128,
 	TrieTimeLimit:   2 * time.Minute,
-	SnapshotLimit:   256,
+	SnapshotLimit:   0,
 	SnapshotWait:    true,
 	Preimages:       true,
 	SnapshotNoBuild: false,


### PR DESCRIPTION
this is to avoid unnecessary creation of the snapshot which is currently still experimental