### PR TITLE
Configurable reward frequency. 2x times faster tests. No drawbacks.

### DIFF
--- a/internal/chain/reward.go
+++ b/internal/chain/reward.go
@@ -33,8 +33,6 @@ import (
 const (
 	// AsyncBlockProposalTimeout is the timeout which will abort the async block proposal.
 	AsyncBlockProposalTimeout = 9 * time.Second
-	// RewardFrequency the number of blocks between each aggregated reward distribution
-	RewardFrequency = 64
 )
 
 type slotPayable struct {
@@ -281,7 +279,7 @@ func AccumulateRewardsAndCountSigs(
 	}
 
 	// Only do reward distribution at the 63th block in the modulus.
-	if blockNum%RewardFrequency != RewardFrequency-1 {
+	if blockNum%shard.Schedule.RewardFrequency() != shard.Schedule.RewardFrequency()-1 {
 		return numeric.ZeroDec(), network.EmptyPayout, nil
 	}
 
@@ -322,7 +320,7 @@ func distributeRewardAfterAggregateEpoch(bc engine.ChainReader, state *state.DB,
 	startTime := time.Now()
 	// loop through [0...63] position in the modulus index of the 64 blocks
 	// Note the current block is at position 63 of the modulus.
-	for i := curBlockNum - RewardFrequency + 1; i <= curBlockNum; i++ {
+	for i := curBlockNum - shard.Schedule.RewardFrequency() + 1; i <= curBlockNum; i++ {
 		if i < 0 {
 			continue
 		}

--- a/internal/configs/sharding/fixedschedule.go
+++ b/internal/configs/sharding/fixedschedule.go
@@ -60,3 +60,8 @@ func (s fixedSchedule) IsSkippedEpoch(shardID uint32, epoch *big.Int) bool {
 func NewFixedSchedule(instance Instance) Schedule {
 	return fixedSchedule{instance: instance}
 }
+
+// RewardFrequency returns the frequency of block reward
+func (s fixedSchedule) RewardFrequency() uint64 {
+	return RewardFrequency
+}

--- a/internal/configs/sharding/localnet.go
+++ b/internal/configs/sharding/localnet.go
@@ -31,8 +31,8 @@ const (
 	localnetV1Epoch = 1
 
 	localnetEpochBlock1      = 5
-	localnetBlocksPerEpoch   = 64
-	localnetBlocksPerEpochV2 = 64
+	localnetBlocksPerEpoch   = 16
+	localnetBlocksPerEpochV2 = 16
 
 	localnetVdfDifficulty = 5000 // This takes about 10s to finish the vdf
 )
@@ -155,6 +155,11 @@ func (ls localnetSchedule) GetShardingStructure(numShard, shardID int) []map[str
 // IsSkippedEpoch returns if an epoch was skipped on shard due to staking epoch
 func (ls localnetSchedule) IsSkippedEpoch(shardID uint32, epoch *big.Int) bool {
 	return false
+}
+
+// RewardFrequency returns the frequency of block reward
+func (ls localnetSchedule) RewardFrequency() uint64 {
+	return 16
 }
 
 var (

--- a/internal/configs/sharding/mainnet.go
+++ b/internal/configs/sharding/mainnet.go
@@ -225,6 +225,11 @@ func (ms mainnetSchedule) IsSkippedEpoch(shardID uint32, epoch *big.Int) bool {
 	return false
 }
 
+// RewardFrequency returns the frequency of block reward
+func (ms mainnetSchedule) RewardFrequency() uint64 {
+	return RewardFrequency
+}
+
 var mainnetReshardingEpoch = []*big.Int{big.NewInt(0), big.NewInt(mainnetV0_1Epoch), big.NewInt(mainnetV0_2Epoch), big.NewInt(mainnetV0_3Epoch), big.NewInt(mainnetV0_4Epoch), big.NewInt(mainnetV1Epoch), big.NewInt(mainnetV1_1Epoch), big.NewInt(mainnetV1_2Epoch), big.NewInt(mainnetV1_3Epoch), big.NewInt(mainnetV1_4Epoch), big.NewInt(mainnetV1_5Epoch), big.NewInt(mainnetV2_0Epoch), big.NewInt(mainnetV2_1Epoch), big.NewInt(mainnetV2_2Epoch), params.MainnetChainConfig.TwoSecondsEpoch, params.MainnetChainConfig.SixtyPercentEpoch, params.MainnetChainConfig.HIP6And8Epoch}
 
 var (

--- a/internal/configs/sharding/pangaea.go
+++ b/internal/configs/sharding/pangaea.go
@@ -71,6 +71,11 @@ func (ps pangaeaSchedule) IsSkippedEpoch(shardID uint32, epoch *big.Int) bool {
 	return false
 }
 
+// RewardFrequency returns the frequency of block reward
+func (ps pangaeaSchedule) RewardFrequency() uint64 {
+	return RewardFrequency
+}
+
 var pangaeaReshardingEpoch = []*big.Int{
 	big.NewInt(0),
 	params.PangaeaChainConfig.StakingEpoch,

--- a/internal/configs/sharding/partner.go
+++ b/internal/configs/sharding/partner.go
@@ -88,6 +88,11 @@ func (ps partnerSchedule) IsSkippedEpoch(shardID uint32, epoch *big.Int) bool {
 	return false
 }
 
+// RewardFrequency returns the frequency of block reward
+func (ps partnerSchedule) RewardFrequency() uint64 {
+	return RewardFrequency
+}
+
 var partnerReshardingEpoch = []*big.Int{
 	big.NewInt(0),
 	params.PartnerChainConfig.StakingEpoch,

--- a/internal/configs/sharding/shardingconfig.go
+++ b/internal/configs/sharding/shardingconfig.go
@@ -13,6 +13,11 @@ import (
 	"github.com/harmony-one/harmony/internal/genesis"
 )
 
+const (
+	// RewardFrequency the number of blocks between each aggregated reward distribution
+	RewardFrequency = 64
+)
+
 // Schedule returns the sharding configuration instance for the given
 // epoch.
 type Schedule interface {
@@ -40,6 +45,9 @@ type Schedule interface {
 
 	// IsSkippedEpoch returns if epoch was skipped on shard chain
 	IsSkippedEpoch(uint32, *big.Int) bool
+
+	// RewardFrequency returns the frequency of block reward
+	RewardFrequency() uint64
 }
 
 // Instance is one sharding configuration instance.

--- a/internal/configs/sharding/stress.go
+++ b/internal/configs/sharding/stress.go
@@ -74,6 +74,11 @@ func (ss stressnetSchedule) IsSkippedEpoch(shardID uint32, epoch *big.Int) bool 
 	return false
 }
 
+// RewardFrequency returns the frequency of block reward
+func (ss stressnetSchedule) RewardFrequency() uint64 {
+	return RewardFrequency
+}
+
 var stressnetReshardingEpoch = []*big.Int{
 	big.NewInt(0),
 	params.StressnetChainConfig.StakingEpoch,

--- a/internal/configs/sharding/testnet.go
+++ b/internal/configs/sharding/testnet.go
@@ -125,6 +125,11 @@ func (ts testnetSchedule) IsSkippedEpoch(shardID uint32, epoch *big.Int) bool {
 	return false
 }
 
+// RewardFrequency returns the frequency of block reward
+func (ts testnetSchedule) RewardFrequency() uint64 {
+	return RewardFrequency
+}
+
 var testnetReshardingEpoch = []*big.Int{
 	big.NewInt(0),
 	params.TestnetChainConfig.StakingEpoch,


### PR DESCRIPTION
disabled: make travis_rpc_checker  0.47s user 0.30s system 0% cpu **6:25.26** total
enabled:  make travis_rpc_checker  0.45s user 0.28s system 0% cpu **3:46.12** total


