### PR TITLE
add linux static quick command to make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,9 @@ linux_static:
 	make -C $(TOP)/bls minimised_static BLS_SWAP_G=1 -j8
 	bash ./scripts/go_executable_build.sh -s
 
+linux_static_quick:
+	bash ./scripts/go_executable_build.sh -s
+
 deb_init:
 	rm -rf $(DEBBUILD)
 	mkdir -p $(DEBBUILD)/$(PKGNAME)-$(VERSION)-$(RELEASE)/{etc/systemd/system,usr/sbin,etc/sysctl.d,etc/harmony}


### PR DESCRIPTION
## Issue

This pull request introduces a new command in the Makefile to create a Linux executable more quickly by only building the main binary without recompiling dependencies. The existing linux_static command remains unchanged and continues to perform a full build, including all dependencies (mcl & bls). The new command is named **linux_static_quick**