### PR TITLE
Fix Sync Response Handling and Context Usage in doGetBlocksByHashesRequest

### DIFF
--- a/api/service/legacysync/helpers.go
+++ b/api/service/legacysync/helpers.go
@@ -33,18 +33,21 @@ func getMaxPeerHeight(syncConfig *SyncConfig) (uint64, error) {
 				syncConfig.RemovePeer(peerConfig, fmt.Sprintf("failed getMaxPeerHeight for shard %d with message: %s", syncConfig.ShardID(), err.Error()))
 				return
 			}
-			utils.Logger().Info().Str("peerIP", peerConfig.peer.IP).Uint64("blockHeight", response.BlockHeight).
-				Msg("[SYNC] getMaxPeerHeight")
 
-			lock.Lock()
 			if response != nil {
+				lock.Lock()
+				utils.Logger().Info().
+					Str("peerIP", peerConfig.peer.IP).
+					Uint64("blockHeight", response.BlockHeight).
+					Msg("[SYNC] getMaxPeerHeight")
 				if response.BlockHeight < math.MaxUint32 { // That's enough for decades.
 					if maxHeight == uint64(math.MaxUint64) || maxHeight < response.BlockHeight {
 						maxHeight = response.BlockHeight
 					}
 				}
+				lock.Unlock()
 			}
-			lock.Unlock()
+
 		}()
 		return
 	})

--- a/api/service/legacysync/syncing.go
+++ b/api/service/legacysync/syncing.go
@@ -883,7 +883,7 @@ func (ss *StateSync) UpdateBlockAndStatus(block *types.Block, bc core.BlockChain
 			if err := bc.Engine().VerifyHeaderSignature(bc, block.Header(), sig, bitmap); err != nil {
 				return errors.Wrapf(err, "verify header signature %v", block.Hash().String())
 			}
-			utils.Logger().Debug().Int64("elapsed time", time.Now().Sub(startTime).Milliseconds()).Msg("[Sync] VerifyHeaderSignature")
+			utils.Logger().Debug().Int64("elapsed time", time.Since(startTime).Milliseconds()).Msg("[Sync] VerifyHeaderSignature")
 		}
 		err := bc.Engine().VerifyHeader(bc, block.Header(), verifySeal)
 		if err == engine.ErrUnknownAncestor {

--- a/hmy/downloader/shortrange.go
+++ b/hmy/downloader/shortrange.go
@@ -312,7 +312,7 @@ func (sh *srHelper) doGetBlocksByNumbersRequest(bns []uint64) ([]*types.Block, s
 }
 
 func (sh *srHelper) doGetBlocksByHashesRequest(ctx context.Context, hashes []common.Hash, wl []sttypes.StreamID) ([]*types.Block, sttypes.StreamID, error) {
-	ctx, cancel := context.WithTimeout(sh.ctx, 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	blocks, stid, err := sh.syncProtocol.GetBlocksByHashes(ctx, hashes,


### PR DESCRIPTION
## Issue

This pull request addresses two minor issues in the synchronization process:

- Added a check to ensure that the response is not nil before using its value.

- Updated the doGetBlocksByHashesRequest function to correctly utilize the ctx parameter. Previously, the context was not being used, which could lead to improper request handling and potential resource leaks.