### PR TITLE
Fix syntax issue in stream sync

### DIFF
--- a/api/service/stagedstreamsync/staged_stream_sync.go
+++ b/api/service/stagedstreamsync/staged_stream_sync.go
@@ -248,6 +248,9 @@ func (s *StagedStreamSync) cleanUp(ctx context.Context, fromStage int, db kv.RwD
 			continue
 		}
 		if err := s.pruneStage(ctx, firstCycle, s.pruningOrder[i], db, tx); err != nil {
+			utils.Logger().Error().Err(err).
+				Interface("stage id", s.pruningOrder[i].ID).
+				Msgf(WrapStagedSyncMsg("stage cleanup failed"))
 			panic(err)
 		}
 	}

--- a/api/service/stagedstreamsync/state_sync_full.go
+++ b/api/service/stagedstreamsync/state_sync_full.go
@@ -789,7 +789,7 @@ func (s *FullStateDownloadManager) cleanAccountTasks() {
 		return
 	}
 	// Sync wasn't finished previously, check for any task that can be finalized
-	for taskID, _ := range s.tasks.accountTasks {
+	for taskID := range s.tasks.accountTasks {
 		if s.tasks.accountTasks[taskID].done {
 			s.tasks.deleteAccountTask(taskID)
 		}
@@ -2333,7 +2333,7 @@ func (s *FullStateDownloadManager) onHealByteCodes(task *healTask,
 		Msg("Delivering set of healing bytecodes")
 
 	s.lock.Lock()
-	s.lock.Unlock()
+	defer s.lock.Unlock()
 
 	// Response is valid, but check if peer is signalling that it does not have
 	// the requested data. For bytecode range queries that means the peer is not


### PR DESCRIPTION
## Issue

This PR addresses a syntax issue (missed defer) with using lock in stream sync. 