### PR TITLE
fix: make BUILD_BRANCH as a dynamic argument for the Dockerfile inste…

### DIFF
--- a/.github/workflows/ci-tag.yaml
+++ b/.github/workflows/ci-tag.yaml
@@ -1,10 +1,10 @@
 name: Manual release harmony (need tag)
 
-on: 
+on:
   workflow_dispatch:
     inputs:
-      tag: 
-        decription: 'tag value to create the release'
+      tag:
+        description: 'tag value to create the release'
         required: true
 
 jobs:
@@ -154,7 +154,7 @@ jobs:
         run: |
           mv $GITHUB_WORKSPACE/harmony-amd64 ./scripts/docker/harmony
         working-directory: harmony
-  
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -170,6 +170,8 @@ jobs:
           context: ./harmony/scripts/docker
           file: ./harmony/scripts/docker/Dockerfile
           push: true
+          build-args: |
+            BUILD_BRANCH=${{ github.ref_name }}
           tags: |
             harmonyone/harmony:${{ github.event.inputs.tag }}
             harmonyone/harmony:${{ env.build_version }}-${{ env.build_release }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,7 +156,7 @@ jobs:
         run: |
           mv $GITHUB_WORKSPACE/harmony-amd64 ./scripts/docker/harmony
         working-directory: harmony
-  
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -171,6 +171,8 @@ jobs:
         with:
           context: ./harmony/scripts/docker
           file: ./harmony/scripts/docker/Dockerfile
+          build-args: |
+            BUILD_BRANCH=${{ github.ref_name }}
           push: true
           tags: |
             harmonyone/harmony:latest

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,14 +1,17 @@
 ARG GOPATH_DEFAULT=/root/go
 ARG SRC_PATH=src/github.com/harmony-one
+ARG BUILD_BRANCH=main
 
 FROM golang:1.19-bullseye as builder
 
 ARG GOPATH_DEFAULT
 ARG SRC_PATH
+ARG BUILD_BRANCH
 
 ENV GOPATH=${GOPATH_DEFAULT}
 ENV GO111MODULE=on
 ENV HMY_PATH=${GOPATH}/${SRC_PATH}
+ENV BRANCH=${BUILD_BRANCH}
 
 ENV PACKAGES libgmp-dev libssl-dev curl git \
 	psmisc dnsutils jq make gcc g++ bash tig tree
@@ -18,7 +21,7 @@ RUN apt-get update && apt-get install -y $PACKAGES --no-install-recommends
 
 WORKDIR ${HMY_PATH}
 
-RUN git clone https://github.com/harmony-one/harmony.git harmony \
+RUN git clone --branch ${BRANCH} https://github.com/harmony-one/harmony.git harmony \
   && git clone https://github.com/harmony-one/bls.git bls \
   && git clone https://github.com/harmony-one/mcl.git mcl \
   && git clone https://github.com/harmony-one/go-sdk.git go-sdk
@@ -39,6 +42,7 @@ ARG HARMONY_USER_GID=1000
 ENV HARMONY_HOME=/harmony
 ENV HOME=${HARMONY_HOME}
 
+# hadolint ignore=DL3018
 RUN apk add --no-cache bash bind-tools tini curl sed \
     && rm -rf /var/cache/apk/* \
     && addgroup -g ${HARMONY_USER_GID} ${HARMONY_USER} \


### PR DESCRIPTION
## Issue

Previously, when we run `main_hotfix` CI build to create an image. 
One of our users noticed that image still has previous version inside.

After quick investigation, I found the root cause: 
https://github.com/harmony-one/harmony/blob/b3aebb62d29379c4bcb32438051ef40870184b24/scripts/docker/Dockerfile#L21-L24

We have hard-coded `main` branch inside the Dockerfile.

What I've done to fix this:
1. Added new argument `BUILD_BRANCH`  with default `main`
2. Added this new argument both to ci-tag.yaml and ci.yaml 
3. Used `github.ref_name` from [Github actions default-environment-variables list](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables) which will give the short ref name of the branch or tag that triggered the workflow run and propagated as BUILD_BRANCH to the docker file.
Details below:

```mermaid
flowchart TD
     id0(Triggered_build) --> id1(github.ref_name populated in Github action)  --> id2(BUILD_BRANCH provided as build-arg to the docker build) --> id3(default ARG is rewritten) --> id4(image build for the custom branch)
```

## Test
I've tested locally the default and custom build argument propagation:
Default:
```bash
user@laptop:~/go/src/github.com/harmony-one/harmony/scripts/docker$ docker buildx build .
...
 => [builder 4/6] RUN git clone --branch main https://github.com/harmony-one/harmony.git harmony
```

```bash
user@laptop:~/go/src/github.com/harmony-one/harmony/scripts/docker$ docker buildx build --build-arg BUILD_BRANCH=dev 
...
 => [builder 4/6] RUN git clone --branch dev https://github.com/harmony-one/harmony.git harmony
```
### End to end testing on my fork
Idea was to remove everything in CI around the changed github action and test the integration of `ARG BUILD_BRANCH` and `github.ref_name` - and value was passed though to the docker itself == test passed :heavy_check_mark:  :

https://github.com/mur-me/harmony/actions/runs/10092656255/job/27906739083#step:5:458

### Unit Test Coverage


### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

5. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

6. **Describe how the plan was tested.**

7. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

8. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

9. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

10. **What should node operators know about this planned change?**

11. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

12. **Does the existing `node.sh` continue to work with this change?**

13. **What should node operators know about this change?**

14. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
