### PR TITLE
fix boot node invalid address issue

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -160,7 +160,7 @@ func main() {
 	}
 
 	fmt.Printf("bootnode BN_MA=%s",
-		fmt.Sprintf("/ip4/%s/tcp/%s/p2p/%s", *ip, *port, host.GetID().Pretty()),
+		fmt.Sprintf("/ip4/%s/tcp/%s/p2p/%s\n", *ip, *port, host.GetID().Pretty()),
 	)
 
 	host.Start()


### PR DESCRIPTION
## Issue

The following part of code from `cmd/bootnode/main.go`:
```go
	fmt.Printf("bootnode BN_MA=%s",
		fmt.Sprintf("/ip4/%s/tcp/%s/p2p/%s", *ip, *port, host.GetID().Pretty()),
	)
```
prints the bootnode address in the format `BN_MA=<address>`. If any output is printed after this line, it will be appended to the same line. 

In the `deploy.sh` script, the bootnode address is extracted using the `launch_bootnode` function:
```shell
function launch_bootnode() {
  echo "launching boot node ..."
  ${DRYRUN} ${ROOT}/bin/bootnode -port 19876 -max_conn_per_ip 100 -force_public true >"${log_folder}"/bootnode.log 2>&1 | tee -a "${LOG_FILE}" &
  sleep 1
  BN_MA=$(grep "BN_MA" "${log_folder}"/bootnode.log | awk -F\= ' { print $2 } ')
  echo "bootnode launched. $BN_MA"
}
```
This function maps the terminal log to a log file and assumes that the line containing `BN_MA` in the log file contains only the bootnode address.

So, If additional output is appended to the same line as the `BN_MA` address, the script's extraction method may fail, leading to incorrect parsing of the bootnode address. This can cause to boot failure and other issues in subsequent steps that rely on the correct bootnode address.

This PR addresses this issue. It prints the address on a new line and no further output is appended to it.