### PR TITLE
Refactor NTP, support multiple NTP servers

### DIFF
--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -142,7 +142,7 @@ var defaultConfig = harmonyconfig.HarmonyConfig{
 }
 
 var defaultSysConfig = harmonyconfig.SysConfig{
-	NtpServer: "1.pool.ntp.org",
+	NtpServer: "1.pool.ntp.org,0.beevik-ntp.pool.ntp.org",
 }
 
 var defaultDevnetConfig = harmonyconfig.DevnetConfig{

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -343,14 +343,14 @@ func setupNodeAndRun(hc harmonyconfig.HarmonyConfig) {
 	nodeconfig.GetDefaultConfig().StagedSync = nodeConfig.StagedSync
 
 	// Check NTP configuration
-	accurate, err := ntp.CheckLocalTimeAccurate(nodeConfig.NtpServer)
-	if !accurate {
-		if os.IsTimeout(err) {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			fmt.Fprintf(os.Stderr, "NTP query timed out. Continuing.\n")
+	clockAccuracyResp, err := ntp.CheckLocalTimeAccurate(nodeConfig.NtpServer)
+	if !clockAccuracyResp.IsAccurate() {
+		if clockAccuracyResp.AllNtpServersTimedOut() {
+			fmt.Fprintf(os.Stderr, "Error: querying NTP servers timed out, Continuing.\n")
+		} else if clockAccuracyResp.NtpFailed() {
+			fmt.Fprintf(os.Stderr, "Error: NTP servers are not properly configured, %v\n", err)
 		} else {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			fmt.Fprintf(os.Stderr, "Error: local timeclock is not accurate. Please config NTP properly.\n")
+			fmt.Fprintf(os.Stderr, "Error: local time clock is not accurate, %v\n", clockAccuracyResp.Error())
 		}
 	}
 	if err != nil {

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -350,7 +350,7 @@ func setupNodeAndRun(hc harmonyconfig.HarmonyConfig) {
 		} else if clockAccuracyResp.NtpFailed() {
 			fmt.Fprintf(os.Stderr, "Error: NTP servers are not properly configured, %v\n", err)
 		} else {
-			fmt.Fprintf(os.Stderr, "Error: local time clock is not accurate, %v\n", clockAccuracyResp.Error())
+			fmt.Fprintf(os.Stderr, "Error: local time clock is not accurate, %s\n", clockAccuracyResp.Message())
 		}
 	}
 	if err != nil {

--- a/common/ntp/ntp.go
+++ b/common/ntp/ntp.go
@@ -1,6 +1,9 @@
 package ntp
 
 import (
+	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	beevik_ntp "github.com/beevik/ntp"
@@ -14,26 +17,86 @@ const (
 )
 
 var (
-	errDriftTooMuch = errors.New("local time drift off ntp server more than 30 seconds")
-	errDriftInRange = errors.New("local time drift off ntp server more than 10 seconds")
+	errDriftTooMuch          = errors.New("local time drift off ntp server more than 30 seconds")
+	errDriftInRange          = errors.New("local time drift off ntp server more than 10 seconds")
+	errAllNtpServersTimedOut = errors.New("querying all NTP servers timed out")
+	errNtpServersFailed      = errors.New("querying all NTP servers failed")
 )
 
+type ClockStatus int
+
+const (
+	ClockIsAccurate ClockStatus = iota
+	ClockIsNotAccurate
+	ClockInWarningRange
+	AllNtpServersTimedOut
+	NtpServersFailed
+)
+
+func (s ClockStatus) Error() error {
+	return [...]error{nil, errDriftTooMuch, errDriftInRange, errAllNtpServersTimedOut, errNtpServersFailed}[s]
+}
+
+func (s ClockStatus) IsAccurate() bool {
+	return s == ClockIsAccurate || s == ClockInWarningRange
+}
+
+func (s ClockStatus) IsInWarningRange() bool {
+	return s == ClockInWarningRange
+}
+
+func (s ClockStatus) AllNtpServersTimedOut() bool {
+	return s == AllNtpServersTimedOut
+}
+
+func (s ClockStatus) NtpFailed() bool {
+	return s == ClockInWarningRange
+}
+
 // CheckLocalTimeAccurate returns whether the local clock accurate or not
-func CheckLocalTimeAccurate(ntpServer string) (bool, error) {
-	options := beevik_ntp.QueryOptions{Timeout: 10 * time.Second}
-	response, err := beevik_ntp.QueryWithOptions(ntpServer, options)
-	// failed to query ntp time
-	if err != nil {
-		return false, err
+func CheckLocalTimeAccurate(ntpServers string) (ClockStatus, error) {
+	options := beevik_ntp.QueryOptions{Timeout: 30 * time.Second}
+	servers := strings.Split(ntpServers, ",")
+	// store error messages for each failed NTP server
+	// It doesn't print out any error if querying one of the servers is successful
+	var errorMessages []string
+	allServersTimedOut := true
+
+	for _, ntpServer := range servers {
+		response, err := beevik_ntp.QueryWithOptions(strings.TrimSpace(ntpServer), options)
+		if err != nil {
+			if os.IsTimeout(err) {
+				errorMessages = append(errorMessages, fmt.Sprintf("Error querying NTP server %s: timed out", ntpServer))
+			} else {
+				allServersTimedOut = false
+				errorMessages = append(errorMessages, fmt.Sprintf("Error querying NTP server %s: %v", ntpServer, err))
+				errorMessages = append(errorMessages, fmt.Sprintf("querying NTP server %v failed. Please config NTP properly", ntpServer))
+			}
+			continue
+		}
+		// drift too much
+		if response.ClockOffset > toleranceRangeError {
+			return ClockIsNotAccurate, nil
+		}
+		// drift in warning range
+		if response.ClockOffset > toleranceRangeWarning {
+			return ClockInWarningRange, nil
+		}
+		return ClockIsAccurate, nil
 	}
-	// drift too much
-	if response.ClockOffset > toleranceRangeError {
-		return false, errDriftTooMuch
+
+	// If all servers timed out, it can be a network issue
+	// in this case we can continue and it doesn't return error
+	if allServersTimedOut {
+		return AllNtpServersTimedOut, nil
 	}
-	if response.ClockOffset > toleranceRangeWarning {
-		return true, errDriftInRange
+
+	// If all servers failed, return a combined error message
+	if len(errorMessages) > 0 {
+		return NtpServersFailed, fmt.Errorf("querying NTP servers:\n%s", strings.Join(errorMessages, "\n"))
 	}
-	return true, nil
+
+	return NtpServersFailed, fmt.Errorf("unknown failure")
 }
 
 // CurrentTime return the current time calibrated using ntp server

--- a/common/ntp/ntp.go
+++ b/common/ntp/ntp.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	beevik_ntp "github.com/beevik/ntp"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -17,10 +16,11 @@ const (
 )
 
 var (
-	errDriftTooMuch          = errors.New("local time drift off ntp server more than 30 seconds")
-	errDriftInRange          = errors.New("local time drift off ntp server more than 10 seconds")
-	errAllNtpServersTimedOut = errors.New("querying all NTP servers timed out")
-	errNtpServersFailed      = errors.New("querying all NTP servers failed")
+	msgClockIsAccurate       = "local time is accurate"
+	msgDriftTooMuch          = "local time drift off ntp server more than 30 seconds"
+	msgDriftInRange          = "local time drift off ntp server more than 10 seconds"
+	msgAllNtpServersTimedOut = "querying all NTP servers timed out"
+	msgNtpServersFailed      = "querying all NTP servers failed"
 )
 
 type ClockStatus int
@@ -33,8 +33,8 @@ const (
 	NtpServersFailed
 )
 
-func (s ClockStatus) Error() error {
-	return [...]error{nil, errDriftTooMuch, errDriftInRange, errAllNtpServersTimedOut, errNtpServersFailed}[s]
+func (s ClockStatus) Message() string {
+	return [...]string{msgClockIsAccurate, msgDriftTooMuch, msgDriftInRange, msgAllNtpServersTimedOut, msgNtpServersFailed}[s]
 }
 
 func (s ClockStatus) IsAccurate() bool {

--- a/common/ntp/ntp_test.go
+++ b/common/ntp/ntp_test.go
@@ -2,27 +2,52 @@ package ntp
 
 import (
 	"fmt"
-	"os"
 	"testing"
 )
 
 func TestCheckLocalTimeAccurate(t *testing.T) {
-	accurate, err := CheckLocalTimeAccurate("wrong.ip")
-	if accurate {
-		t.Fatalf("query ntp pool should failed: %v\n", err)
+	response, err := CheckLocalTimeAccurate("wrong.ip")
+	if response.IsAccurate() {
+		if err != nil {
+			t.Fatalf("query ntp pool should failed: %v\n", err)
+		}
+		t.Fatalf("query ntp pool should failed: %v\n", response.Error())
+	}
+	if err == nil {
+		t.Fatalf("query invalid ntp pool should return error\n")
 	}
 
-	accurate, err = CheckLocalTimeAccurate("0.pool.ntp.org")
-	if !accurate {
-		if os.IsTimeout(err) {
-			t.Skip(err)
+	response, err = CheckLocalTimeAccurate("0.pool.ntp.org")
+	if !response.IsAccurate() || err != nil {
+		if response.AllNtpServersTimedOut() {
+			t.Skip(response.Error())
 		}
-		t.Fatal(err)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Fatal(response.Error())
+	}
+
+	// test multiple ntp servers, the second one is a valid server
+	response, err = CheckLocalTimeAccurate("wrong.ip,0.pool.ntp.org")
+	if !response.IsAccurate() || err != nil {
+		if response.AllNtpServersTimedOut() {
+			t.Skip(response.Error())
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Fatal(response.Error())
+	}
+
+	// test multiple ntp servers, both invalid server
+	response, err = CheckLocalTimeAccurate("1.wrong.ip,2.wrong.ip")
+	if response.IsAccurate() || err == nil {
+		t.Fatal("invalid servers can't respond or validate time")
 	}
 }
 
 func TestCurrentTime(t *testing.T) {
 	tt := CurrentTime("1.pool.ntp.org")
 	fmt.Printf("Current Time: %v\n", tt)
-	return
 }

--- a/common/ntp/ntp_test.go
+++ b/common/ntp/ntp_test.go
@@ -11,7 +11,7 @@ func TestCheckLocalTimeAccurate(t *testing.T) {
 		if err != nil {
 			t.Fatalf("query ntp pool should failed: %v\n", err)
 		}
-		t.Fatalf("query ntp pool should failed: %v\n", response.Error())
+		t.Fatalf("query ntp pool should failed: %s\n", response.Message())
 	}
 	if err == nil {
 		t.Fatalf("query invalid ntp pool should return error\n")
@@ -20,24 +20,24 @@ func TestCheckLocalTimeAccurate(t *testing.T) {
 	response, err = CheckLocalTimeAccurate("0.pool.ntp.org")
 	if !response.IsAccurate() || err != nil {
 		if response.AllNtpServersTimedOut() {
-			t.Skip(response.Error())
+			t.Skip(response.Message())
 		}
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("query valid ntp pool shouldn't return error: %v\n", err)
 		}
-		t.Fatal(response.Error())
+		t.Fatalf("local clock is not accurate: %v\n", response.Message())
 	}
 
 	// test multiple ntp servers, the second one is a valid server
 	response, err = CheckLocalTimeAccurate("wrong.ip,0.pool.ntp.org")
 	if !response.IsAccurate() || err != nil {
 		if response.AllNtpServersTimedOut() {
-			t.Skip(response.Error())
+			t.Skip(response.Message())
 		}
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("query multiple ntp pools shouldn't return error: %v\n", err)
 		}
-		t.Fatal(response.Error())
+		t.Fatalf("local clock is not accurate: %v\n", response.Message())
 	}
 
 	// test multiple ntp servers, both invalid server


### PR DESCRIPTION
## Issue
This PR refactors the NTP functionality to support querying multiple NTP servers and addresses the NTP timeout issue commonly encountered in localnet. The PR also includes minor adjustments to error handling and logging for better troubleshooting and debugging.

#### Key Changes:
- **Multiple NTP Servers Support:** 
  - The NTP functionality now accepts a comma-separated list of NTP servers. It adds `0.beevik-ntp.pool.ntp.org` to ntp servers as well.
  - It iterates through the provided servers, using the first successful response to determine time accuracy. If all servers fail, detailed error messages are returned.
  
- **Timeout Issue Fix:**
  - Fixed the issue where NTP queries would frequently time out in localnet.
  - Increased the NTP query timeout from 10 seconds to 30 seconds to provide more resilience in network conditions.