### PR TITLE
Remove Unnecessary Error Message for Force Deleting of Non-Existent Directories

### DIFF
--- a/test/debug-external.sh
+++ b/test/debug-external.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 ./test/kill_node.sh
-rm -rf tmp_log*
-rm *.rlp
-rm -rf .dht*
+rm -rf tmp_log* 2> /dev/null
+rm *.rlp 2> /dev/null
+rm -rf .dht* 2> /dev/null
 scripts/go_executable_build.sh -S || exit 1  # dynamic builds are faster for debug iteration...
 ./test/deploy.sh -B -D 600000 ./test/configs/local-resharding-with-external.txt

--- a/test/debug.sh
+++ b/test/debug.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 ./test/kill_node.sh
-rm -rf tmp_log*
-rm *.rlp
-rm -rf .dht*
+rm -rf tmp_log* 2> /dev/null
+rm *.rlp 2> /dev/null
+rm -rf .dht* 2> /dev/null
 scripts/go_executable_build.sh -S || exit 1  # dynamic builds are faster for debug iteration...
 ./test/deploy.sh -B -D 600000 ./test/configs/local-resharding.txt


### PR DESCRIPTION
## Issue
This PR updates the debug scripts to remove unnecessary error messages when attempting to delete non-existent directories and files. An example of unnecessary error messages is like this:
```
cannot remove '*.rlp': No such file or directory
```
The changes improves the script's cleanliness by preventing unwanted error output during forced deletions. 