### PR TITLE
feat(CI) - add possibility to point harmony-test repo to non-master branch via CI and locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,10 @@ install:
   #   /home/travis/gopath/src/github.com/harmony-one/harmony
   # https://docs.travis-ci.com/user/languages/go/#go-import-path
   - echo $TRAVIS_PULL_REQUEST_BRANCH
+  - TEST_REPO_BRANCH="master"
   - git clone https://github.com/harmony-one/mcl.git $GOPATH/src/github.com/harmony-one/mcl
   - git clone https://github.com/harmony-one/bls.git $GOPATH/src/github.com/harmony-one/bls
-  - git clone https://github.com/harmony-one/harmony-test.git $GOPATH/src/github.com/harmony-one/harmony-test
+  - git clone --branch $TEST_REPO_BRANCH https://github.com/harmony-one/harmony-test.git $GOPATH/src/github.com/harmony-one/harmony-test
   - (cd $GOPATH/src/github.com/harmony-one/mcl; make -j4)
   - (cd $GOPATH/src/github.com/harmony-one/bls; make BLS_SWAP_G=1 -j4)
 #  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.41.1

--- a/Makefile
+++ b/Makefile
@@ -173,9 +173,13 @@ travis_go_checker:
 	bash ./scripts/travis_go_checker.sh
 
 travis_rpc_checker:
+	# value from command line will override this value, use point test to non-default
+	TEST_REPO_BRANCH='master'
 	bash ./scripts/travis_rpc_checker.sh
 
 travis_rosetta_checker:
+	# value from command line will override this value, use point test to non-default
+	TEST_REPO_BRANCH='master'
 	bash ./scripts/travis_rosetta_checker.sh
 
 debug_external: clean

--- a/scripts/travis_rosetta_checker.sh
+++ b/scripts/travis_rosetta_checker.sh
@@ -1,15 +1,36 @@
 #!/usr/bin/env bash
 set -e
 
-echo $TRAVIS_PULL_REQUEST_BRANCH
+TEST_REPO_BRANCH=${TEST_REPO_BRANCH:-master}
+# handle for the Travis build run:
+# * uses TRAVIS_PULL_REQUEST_BRANCH for RP branch
+# * uses TRAVIS_BRANCH for simple branch builds
+MAIN_REPO_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-${TRAVIS_BRANCH}}
+# handle for the local run, covers:
+# * branch exist on remote - will use it in the tests
+# * branch exists locally - will use dev as base branch in test
+if [[ -z "$MAIN_REPO_BRANCH" ]]; then
+    MAIN_REPO_BRANCH=${MAIN_REPO_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
+    git ls-remote --exit-code --heads origin "${MAIN_REPO_BRANCH}" >/dev/null 2>&1 || EXIT_CODE=$?
+    if [[ $EXIT_CODE == '0' ]]; then
+        echo "[INFO] - Git branch '$MAIN_REPO_BRANCH' exists in the remote repository"
+    elif [[ $EXIT_CODE == '2' ]]; then
+        echo "[WARN] - Git branch '$MAIN_REPO_BRANCH' does not exist in the remote repository, using" \
+            "'dev' branch as a workaround for a local-only branch"
+        MAIN_REPO_BRANCH='dev'
+    fi
+fi
+
+echo "[harmony-test repo] - working on '${TEST_REPO_BRANCH}' branch"
+echo "[harmony repo] - working on '${MAIN_REPO_BRANCH}' branch"
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-echo $DIR
-echo $GOPATH
-cd $GOPATH/src/github.com/harmony-one/harmony-test
-git fetch
-git pull
-git checkout $TRAVIS_PULL_REQUEST_BRANCH || true
-git branch --show-current
+echo "Working dir is ${DIR}"
+echo "GOPATH is ${GOPATH}"
+cd "${GOPATH}/src/github.com/harmony-one/harmony-test"
+# cover possible force pushes to remote branches - just rebase local on top of origin
+git checkout "${TEST_REPO_BRANCH}"
+git pull --rebase=true
 cd localnet
-docker build -t harmonyone/localnet-test .
+docker build --build-arg MAIN_REPO_BRANCH="${MAIN_REPO_BRANCH}" -t harmonyone/localnet-test .
+# WARN: this is the place where LOCAL repository is provided to the harmony-tests repo
 docker run -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test -r

--- a/scripts/travis_rpc_checker.sh
+++ b/scripts/travis_rpc_checker.sh
@@ -1,15 +1,36 @@
 #!/usr/bin/env bash
 set -e
 
-echo $TRAVIS_PULL_REQUEST_BRANCH
+TEST_REPO_BRANCH=${TEST_REPO_BRANCH:-master}
+# handle for the Travis build run:
+# * uses TRAVIS_PULL_REQUEST_BRANCH for RP branch
+# * uses TRAVIS_BRANCH for simple branch builds
+MAIN_REPO_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-${TRAVIS_BRANCH}}
+# handle for the local run, covers:
+# * branch exist on remote - will use it in the tests
+# * branch exists locally - will use dev as base branch in test
+if [[ -z "$MAIN_REPO_BRANCH" ]]; then
+    MAIN_REPO_BRANCH=${MAIN_REPO_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
+    git ls-remote --exit-code --heads origin "${MAIN_REPO_BRANCH}" >/dev/null 2>&1 || EXIT_CODE=$?
+    if [[ $EXIT_CODE == '0' ]]; then
+        echo "[INFO] - Git branch '$MAIN_REPO_BRANCH' exists in the remote repository"
+    elif [[ $EXIT_CODE == '2' ]]; then
+        echo "[WARN] - Git branch '$MAIN_REPO_BRANCH' does not exist in the remote repository, using" \
+            "'dev' branch as a workaround for a local-only branch"
+        MAIN_REPO_BRANCH='dev'
+    fi
+fi
+
+echo "[harmony-test repo] - working on '${TEST_REPO_BRANCH}' branch"
+echo "[harmony repo] - working on '${MAIN_REPO_BRANCH}' branch"
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-echo $DIR
-echo $GOPATH
-cd $GOPATH/src/github.com/harmony-one/harmony-test
-git fetch
-git checkout $TRAVIS_PULL_REQUEST_BRANCH || true
-git pull
-git branch --show-current
+echo "Working dir is ${DIR}"
+echo "GOPATH is ${GOPATH}"
+cd "${GOPATH}/src/github.com/harmony-one/harmony-test"
+# cover possible force pushes to remote branches - just rebase local on top of origin
+git checkout "${TEST_REPO_BRANCH}"
+git pull --rebase=true
 cd localnet
-docker build -t harmonyone/localnet-test .
+docker build --build-arg MAIN_REPO_BRANCH="${MAIN_REPO_BRANCH}" -t harmonyone/localnet-test .
+# WARN: this is the place where LOCAL repository is provided to the harmony-tests repo
 docker run -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test -n


### PR DESCRIPTION
**TL;DR**: this PR give us an easier way to point to any harmony-test repo branch, details below.

**What was done:**
* add possibility to point harmony-test repo to non-master branch via CI, for this I've added this logic - https://github.com/harmony-one/harmony/blob/8b1cda41fa8f17a27d966f615fb9894cf12ee1bf/scripts/travis_rosetta_checker.sh#L5-L8, if it is PR - use special PR env, if it is regular branch - use branch env. 
  * Q: why not to check it vice-versa like `MAIN_REPO_BRANCH=${TRAVIS_BRANCH:-${TRAVIS_PULL_REQUEST_BRANCH}}`?
  * A: Because TRAVIS_BRANCH becomes the branch name in which you want to merge, `dev` in my case
* add MAIN_REPO_BRANCH to point exactly the same repo version in the test run instead of hardcoded main branch
* cover local runs of travis_rosetta_checker.sh and travis_rpc_checker.sh, it will support the same logic as in CI, if your branch in already on remote, else use dev branch for harmony-test repo

===

* Example run in the CI - https://github.com/harmony-one/harmony/pull/4730/checks?check_run_id=28572079834
* example local run for the `travis_rpc_checker.sh`, you can see the main branch name used by `harmony-test` repo in the last log line:
```
user@laptop:~/go/src/github.com/harmony-one/harmony$ ./scripts/travis_rpc_checker.sh 
[harmony-test repo] - working on 'master' branch
[harmony repo] - working on 'feat/TRAVIS_CI_add_possibility_to_point_to_non_master_branch' branch
...
=> [ 8/23] RUN git clone --branch feat/TRAVIS_CI_add_possibility_to_point_to_non_master_branch https://github.com/harmony-one/harmony.git > /dev/null 2>1
```
* the same logic applies for the local rossetta tests:
```
user@laptop:~/go/src/github.com/harmony-one/harmony$ ./scripts/travis_rosetta_checker.sh 
[harmony-test repo] - working on 'master' branch
[harmony repo] - working on 'feat/TRAVIS_CI_add_possibility_to_point_to_non_master_branch' branch
...
 => [ 8/23] RUN git clone --branch feat/TRAVIS_CI_add_possibility_to_point_to_non_master_branch https://github.com/harmony-one/harmony.git > /dev/null 2>1
```
* example of fresh local-only branch run, you can see this WARN about local only:
```
user@laptop:~/go/src/github.com/harmony-one/harmony$ ./scripts/travis_rosetta_checker.sh 
[WARN] - Git branch 'test_demo' does not exist in the remote repository, using 'dev' branch as a workaround for a local-only branch
[harmony-test repo] - working on 'master' branch
[harmony repo] - working on 'dev' branch
=> [ 8/23] RUN git clone --branch dev https://github.com/harmony-one/harmony.git > /dev/null 2>1
```

## Issue

<!-- link to the issue number or description of the issue -->

## Test

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
