### PR TITLE
Fix Check for Existence of `allowedtxs.txt` File Before Applying Logic

### DIFF
--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -1112,9 +1112,11 @@ func setupAllowedTxs(hc harmonyconfig.HarmonyConfig) (map[ethCommon.Address][]co
 		return parseAllowedTxs(data)
 	} else if errors.Is(err, os.ErrNotExist) {
 		// file path does not exist
+		utils.Logger().Debug().Str("AllowedTxsFile", hc.TxPool.AllowedTxsFile).Msgf("AllowedTxs file doesn't exist")
 		return make(map[ethCommon.Address][]core.AllowedTxData), nil
 	} else {
 		// some other errors happened
+		utils.Logger().Error().Err(err).Msg("setup allowedTxs failed")
 		return nil, err
 	}
 }

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -1101,12 +1101,22 @@ func parseAllowedTxs(data []byte) (map[ethCommon.Address][]core.AllowedTxData, e
 }
 
 func setupAllowedTxs(hc harmonyconfig.HarmonyConfig) (map[ethCommon.Address][]core.AllowedTxData, error) {
-	utils.Logger().Debug().Msgf("Using AllowedTxs file at `%s`", hc.TxPool.AllowedTxsFile)
-	data, err := os.ReadFile(hc.TxPool.AllowedTxsFile)
-	if err != nil {
+	// check if the file exists
+	if _, err := os.Stat(hc.TxPool.AllowedTxsFile); err == nil {
+		// read the file and parse allowed transactions
+		utils.Logger().Debug().Msgf("Using AllowedTxs file at `%s`", hc.TxPool.AllowedTxsFile)
+		data, err := os.ReadFile(hc.TxPool.AllowedTxsFile)
+		if err != nil {
+			return nil, err
+		}
+		return parseAllowedTxs(data)
+	} else if errors.Is(err, os.ErrNotExist) {
+		// file path does not exist
+		return make(map[ethCommon.Address][]core.AllowedTxData), nil
+	} else {
+		// some other errors happened
 		return nil, err
 	}
-	return parseAllowedTxs(data)
 }
 
 func setupLocalAccounts(hc harmonyconfig.HarmonyConfig, blacklist map[ethCommon.Address]struct{}) ([]ethCommon.Address, error) {

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -1112,7 +1112,9 @@ func setupAllowedTxs(hc harmonyconfig.HarmonyConfig) (map[ethCommon.Address][]co
 		return parseAllowedTxs(data)
 	} else if errors.Is(err, os.ErrNotExist) {
 		// file path does not exist
-		utils.Logger().Debug().Str("AllowedTxsFile", hc.TxPool.AllowedTxsFile).Msgf("AllowedTxs file doesn't exist")
+		utils.Logger().Debug().
+			Str("AllowedTxsFile", hc.TxPool.AllowedTxsFile).
+			Msg("AllowedTxs file doesn't exist")
 		return make(map[ethCommon.Address][]core.AllowedTxData), nil
 	} else {
 		// some other errors happened


### PR DESCRIPTION
## Issue

This PR resolves the issue where an error occurs if the `allowedtxs.txt` file is not present in the `.hmy` directory. Previously, the absence of this file would result in an error:
```
AllowedTxs setup error: open ./.hmy/allowedtxs.txt: no such file or directory
```
The fix involves adding a check to verify the existence of the `allowedtxs.txt` file before proceeding with the setup logic.