### PR TITLE
zero snapshot limit config

### DIFF
--- a/cmd/harmony/default.go
+++ b/cmd/harmony/default.go
@@ -284,7 +284,7 @@ var defaultCacheConfig = harmonyconfig.CacheConfig{
 	TrieNodeLimit:   256,
 	TriesInMemory:   128,
 	TrieTimeLimit:   2 * time.Minute,
-	SnapshotLimit:   256,
+	SnapshotLimit:   0,
 	SnapshotWait:    true,
 	Preimages:       true,
 	SnapshotNoBuild: false,


### PR DESCRIPTION
This PR configure default snapshot limit to 0 to avoid enabling the feature that is still currently being tested