### PR TITLE
[CI] - point to master, cover fork repos in ci, silence docker output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ install:
   - make go-get
   - go install golang.org/x/tools/cmd/goimports@latest
   - go install github.com/harmony-ek/gencodec@latest
+  - echo "[WARN] - workaround for the GOPATH:"
+  - mv /home/travis/build/harmony-one/harmony $GOPATH/src/github.com/harmony-one/
 script:
   - ${TEST}
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,9 @@ install:
   #   /home/travis/gopath/src/github.com/harmony-one/harmony
   # https://docs.travis-ci.com/user/languages/go/#go-import-path
   - echo $TRAVIS_PULL_REQUEST_BRANCH
-    #TODO: return back to master
-  - TEST_REPO_BRANCH="feature/go1.22"
+  - TEST_REPO_BRANCH="master"
   - git clone https://github.com/harmony-one/mcl.git $GOPATH/src/github.com/harmony-one/mcl
   - git clone https://github.com/harmony-one/bls.git $GOPATH/src/github.com/harmony-one/bls
-    #TODO: return back harmony instead of personal fork
   - git clone --branch $TEST_REPO_BRANCH https://github.com/harmony-one/harmony-test.git $GOPATH/src/github.com/harmony-one/harmony-test
   - (cd $GOPATH/src/github.com/harmony-one/mcl; make -j4)
   - (cd $GOPATH/src/github.com/harmony-one/bls; make BLS_SWAP_G=1 -j4)

--- a/scripts/travis_rosetta_checker.sh
+++ b/scripts/travis_rosetta_checker.sh
@@ -3,8 +3,16 @@ set -e
 
 TEST_REPO_BRANCH=${TEST_REPO_BRANCH:-master}
 # handle for the Travis build run:
+# * uses TRAVIS_PULL_REQUEST_SLUG if PR is done from fork
 # * uses TRAVIS_PULL_REQUEST_BRANCH for RP branch
 # * uses TRAVIS_BRANCH for simple branch builds
+if [[ -z ${TRAVIS_PULL_REQUEST_SLUG} ]]; then
+    MAIN_REPO_ORG='harmony-one'
+else
+    MAIN_REPO_ORG=${TRAVIS_PULL_REQUEST_SLUG%/*}
+    echo "[WARN] - working on the fork - ${MAIN_REPO_ORG}"
+fi
+
 MAIN_REPO_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-${TRAVIS_BRANCH}}
 # handle for the local run, covers:
 # * branch exist on remote - will use it in the tests
@@ -32,6 +40,9 @@ git fetch origin "${TEST_REPO_BRANCH}"
 git checkout "${TEST_REPO_BRANCH}"
 git pull --rebase=true
 cd localnet
-docker build --build-arg MAIN_REPO_BRANCH="${MAIN_REPO_BRANCH}" -t harmonyone/localnet-test .
+# we don't care about build logs - if wonna debug it - go to harmony-test repo
+#  and run local debug
+docker build --build-arg MAIN_REPO_BRANCH="${MAIN_REPO_BRANCH}" \
+    --build-arg MAIN_REPO_ORG="${MAIN_REPO_ORG}" -t harmonyone/localnet-test . > /dev/null 2>&1
 # WARN: this is the place where LOCAL repository is provided to the harmony-tests repo
 docker run -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test -r

--- a/scripts/travis_rosetta_checker.sh
+++ b/scripts/travis_rosetta_checker.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-#TODO: return back to master
-TEST_REPO_BRANCH="feature/go1.22"
 TEST_REPO_BRANCH=${TEST_REPO_BRANCH:-master}
 # handle for the Travis build run:
 # * uses TRAVIS_PULL_REQUEST_BRANCH for RP branch

--- a/scripts/travis_rosetta_checker.sh
+++ b/scripts/travis_rosetta_checker.sh
@@ -40,9 +40,7 @@ git fetch origin "${TEST_REPO_BRANCH}"
 git checkout "${TEST_REPO_BRANCH}"
 git pull --rebase=true
 cd localnet
-# we don't care about build logs - if wonna debug it - go to harmony-test repo
-#  and run local debug
-docker build --build-arg MAIN_REPO_BRANCH="${MAIN_REPO_BRANCH}" \
-    --build-arg MAIN_REPO_ORG="${MAIN_REPO_ORG}" -t harmonyone/localnet-test . > /dev/null 2>&1
+docker build --build-arg MAIN_REPO_BRANCH="${MAIN_REPO_BRANCH}" --progress plain \
+    --build-arg MAIN_REPO_ORG="${MAIN_REPO_ORG}" -t harmonyone/localnet-test .
 # WARN: this is the place where LOCAL repository is provided to the harmony-tests repo
 docker run -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test -r

--- a/scripts/travis_rpc_checker.sh
+++ b/scripts/travis_rpc_checker.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-#TODO: return back to master
-TEST_REPO_BRANCH="feature/go1.22"
 TEST_REPO_BRANCH=${TEST_REPO_BRANCH:-master}
 # handle for the Travis build run:
 # * uses TRAVIS_PULL_REQUEST_BRANCH for RP branch

--- a/scripts/travis_rpc_checker.sh
+++ b/scripts/travis_rpc_checker.sh
@@ -40,9 +40,7 @@ git fetch origin "${TEST_REPO_BRANCH}"
 git checkout "${TEST_REPO_BRANCH}"
 git pull --rebase=true
 cd localnet
-# we don't care about build logs - if wonna debug it - go to harmony-test repo 
-#  and run local debug
-docker build --build-arg MAIN_REPO_BRANCH="${MAIN_REPO_BRANCH}" \
-    --build-arg MAIN_REPO_ORG="${MAIN_REPO_ORG}" -t harmonyone/localnet-test . > /dev/null 2>&1
+docker build --build-arg MAIN_REPO_BRANCH="${MAIN_REPO_BRANCH}" --progress plain \
+    --build-arg MAIN_REPO_ORG="${MAIN_REPO_ORG}" -t harmonyone/localnet-test .
 # WARN: this is the place where LOCAL repository is provided to the harmony-tests repo
 docker run -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test -n


### PR DESCRIPTION
## Issue

This PR includes several changes:
1. Switch to the `master` branch of harmony-test repo
2. CI Support for the forks via  `TRAVIS_PULL_REQUEST_SLUG`.
* Example of faulty run where we skipped CI - https://github.com/harmony-one/harmony/pull/4742
* Example of successful fix - this PR itself, I'm using fork
3. Fix for the docker logs with `--progress plain`, 
* problematic example - https://app.travis-ci.com/github/harmony-one/harmony/jobs/625579512 - it failed due to huge amount of docker debug logs.  
* Example of successful fix - last run for this PR - just layer info and that is it 

## Test

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

5. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

6. **Describe how the plan was tested.**

7. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

8. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

9. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

10. **What should node operators know about this planned change?**

11. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

12. **Does the existing `node.sh` continue to work with this change?**

13. **What should node operators know about this change?**

14. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
