### PR TITLE
feat(Makefile) - cover verbose mode for the local debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,8 @@ debug:
 	# uncomment the following lines to enable debug logging for libp2p, it produces a lot of logs, so disabled by default
 	#export GOLOG_LOG_LEVEL=debug
 	#export GOLOG_OUTPUT=stdout
+	# uncomment the following line to enable max logging
+	# export VERBOSE=true
 	bash ./test/debug.sh
 
 debug-kill:
@@ -82,6 +84,8 @@ debug-ext:
 	# update localnet block per epoch to ensure a stable localnet
 	sed -i 's/localnetBlocksPerEpoch\s*=\s*[0-9]*/localnetBlocksPerEpoch = 64/' internal/configs/sharding/localnet.go
 	sed -i 's/localnetBlocksPerEpochV2\s*=\s*[0-9]*/localnetBlocksPerEpochV2 = 64/' internal/configs/sharding/localnet.go
+	# uncomment the following line to enable max logging
+	# export VERBOSE=true
 	bash ./test/debug-external.sh &
 	echo sleep 10s before creating the external validator
 	sleep 10

--- a/test/debug-external.sh
+++ b/test/debug-external.sh
@@ -5,4 +5,9 @@ rm -rf tmp_log* 2> /dev/null
 rm *.rlp 2> /dev/null
 rm -rf .dht* 2> /dev/null
 scripts/go_executable_build.sh -S || exit 1  # dynamic builds are faster for debug iteration...
-./test/deploy.sh -B -D 600000 ./test/configs/local-resharding-with-external.txt
+if [ "${VERBOSE}" = "true" ]; then
+    echo "[WARN] - running with verbose logs"
+    ./test/deploy.sh -v -B -D 600000 ./test/configs/local-resharding-with-external.txt
+else
+    ./test/deploy.sh -B -D 600000 ./test/configs/local-resharding-with-external.txt
+fi

--- a/test/debug.sh
+++ b/test/debug.sh
@@ -5,4 +5,9 @@ rm -rf tmp_log* 2> /dev/null
 rm *.rlp 2> /dev/null
 rm -rf .dht* 2> /dev/null
 scripts/go_executable_build.sh -S || exit 1  # dynamic builds are faster for debug iteration...
-./test/deploy.sh -B -D 600000 ./test/configs/local-resharding.txt
+if [ "${VERBOSE}" = "true" ]; then
+    echo "[WARN] - running with verbose logs"
+    ./test/deploy.sh -v -B -D 600000 ./test/configs/local-resharding.txt
+else
+    ./test/deploy.sh -B -D 600000 ./test/configs/local-resharding.txt
+fi


### PR DESCRIPTION
## Issue

Our devs need a convenient way to run `debug` and `debug-ext` in the verbose mode, so I've created this PR to handle this.
VERBOSE variable can be enabled by:
1. uncomment in the Makefile
2. `export VERBOSE=true` in the current bash session
3. as a variable before the make run like `VERBOSE=true make debug` 

* Additionally, I've added explicit log saying that you are in verbose mode

## Test

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

5. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

6. **Describe how the plan was tested.**

7. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

8. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

9. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

10. **What should node operators know about this planned change?**

11. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

12. **Does the existing `node.sh` continue to work with this change?**

13. **What should node operators know about this change?**

14. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
