### PR TITLE
Not Checking Pending Crosslinks for First ten Epoch

### DIFF
--- a/node/harmony/node.go
+++ b/node/harmony/node.go
@@ -1108,8 +1108,9 @@ func New(
 
 	// delete old pending crosslinks
 	ten := big.NewInt(10)
-	if node.Blockchain().ShardID() == shard.BeaconChainShardID && node.Blockchain().CurrentBlock().Epoch().Cmp(ten) > 0 {
-		crossLinkEpochThreshold := new(big.Int).Sub(node.Blockchain().CurrentHeader().Epoch(), ten)
+	epoch := node.Blockchain().CurrentHeader().Epoch()
+	if node.Blockchain().ShardID() == shard.BeaconChainShardID && node.Blockchain().Config().IsCrossLink(epoch) {
+		crossLinkEpochThreshold := new(big.Int).Sub(epoch, ten)
 
 		invalidToDelete := make([]types.CrossLink, 0, 1000)
 		allPending, err := node.Blockchain().ReadPendingCrossLinks()

--- a/node/harmony/node.go
+++ b/node/harmony/node.go
@@ -1107,8 +1107,8 @@ func New(
 	node.serviceManager = service.NewManager()
 
 	// delete old pending crosslinks
-	if node.Blockchain().ShardID() == shard.BeaconChainShardID {
-		ten := big.NewInt(10)
+	ten := big.NewInt(10)
+	if node.Blockchain().ShardID() == shard.BeaconChainShardID && node.Blockchain().CurrentBlock().Epoch().Cmp(ten) > 0 {
 		crossLinkEpochThreshold := new(big.Int).Sub(node.Blockchain().CurrentHeader().Epoch(), ten)
 
 		invalidToDelete := make([]types.CrossLink, 0, 1000)


### PR DESCRIPTION
## Issue
The current code attempts to delete pending crosslinks that are older than 10 epochs. However, if the pending crosslinks were not added to the database within the first 10 epochs, this can lead to an `leveldb: not found`. This PR resolves the issue by adding a condition to skip checking pending crosslinks during the first 10 epochs, ensuring we avoid unnecessary database lookups and potential errors.