### PR TITLE
feat(localnet) - add localnet log aggregation tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ profiles/*.pb.gz
 # cache db
 cache/
 cache_*_db
+
+# log aggregation logs folder variable file, no sense to track it
+test/logs_aggregator/.env

--- a/Makefile
+++ b/Makefile
@@ -216,3 +216,11 @@ build_localnet_validator:
 
 protofiles:
 	bash ./scripts/gogenerate.sh
+
+# start a log aggregation toolset(Promtail->Loki->Grafana)
+# needs docker and docker-compose
+debug-start-log-aggregator:
+	bash ./test/logs_aggregator/start_log_aggregator.sh
+
+debug-stop-log-aggregator:
+	bash ./test/logs_aggregator/stop_log_aggregator.sh

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ help:
 	@echo "travis_rosetta_checker - run the Travis Rosetta checker script, defaulting the test branch to 'master' unless overridden by TEST_REPO_BRANCH"
 	@echo "debug_external - cleans up environment, rebuilds the binary, and deploys with external nodes"
 	@echo "build_localnet_validator - imports validator keys, funds validator accounts, waits for the epoch, and creates external validators on a local network"
+	@echo "debug-start-log - start a docker compose Promtail->Loki->Grafana stack against localnet logs, needs docker compose and started localnet"
+	@echo "debug-stop-log - stops a docker compose Promtail->Loki->Grafana stack"
+	@echo "debug-restart-log - restart a docker compose Promtail->Loki->Grafana stack"
 
 libs:
 	make -C $(TOP)/mcl -j8
@@ -217,10 +220,10 @@ build_localnet_validator:
 protofiles:
 	bash ./scripts/gogenerate.sh
 
-# start a log aggregation toolset(Promtail->Loki->Grafana)
-# needs docker and docker-compose
-debug-start-log-aggregator:
+debug-start-log:
 	bash ./test/logs_aggregator/start_log_aggregator.sh
 
-debug-stop-log-aggregator:
+debug-stop-log:
 	bash ./test/logs_aggregator/stop_log_aggregator.sh
+
+debug-restart-log: debug-stop-log debug-start-log

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -34,7 +34,7 @@ If you need to open another shell, just do:
 docker exec -it harmonyone/harmony /bin/bash
 ```
 
-We also provide a `docker-compose` file for local testing
+We also provide a `docker compose` file for local testing
 
 To use the container in kubernetes, you can use a configmap or secret to mount the `harmony.conf` into the container
 ```bash

--- a/test/logs_aggregator/docker-compose.yml
+++ b/test/logs_aggregator/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  loki:
+    image: grafana/loki:latest
+    ports:
+      - 3100:3100
+    volumes:
+      - ./loki-config.yml:/etc/loki/loki-config.yaml
+  promtail:
+    image: grafana/promtail:latest
+    volumes:
+      - ./promtail-config.yml:/etc/promtail/promtail-config.yaml
+      - ${CURRENT_SESSION_LOGS}:/var/log/
+  grafana:
+    image: grafana/grafana
+    ports:
+      - 3000:3000
+    volumes:
+      - ./loki-datasource.yaml:/etc/grafana/provisioning/datasources/loki-datasource.yaml

--- a/test/logs_aggregator/docker-compose.yml
+++ b/test/logs_aggregator/docker-compose.yml
@@ -1,17 +1,24 @@
 services:
   loki:
+    container_name: loki
     image: grafana/loki:latest
     ports:
       - 3100:3100
     volumes:
       - ./loki-config.yml:/etc/loki/loki-config.yaml
   promtail:
+    container_name: promtail
     image: grafana/promtail:latest
     volumes:
       - ./promtail-config.yml:/etc/promtail/promtail-config.yaml
       - ${CURRENT_SESSION_LOGS}:/var/log/
   grafana:
+    container_name: grafana
     image: grafana/grafana
+    # DANGER: USE THIS TWO OPTIONS ONLY AGAINST LOCAL deploy
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
     ports:
       - 3000:3000
     volumes:

--- a/test/logs_aggregator/loki-config.yml
+++ b/test/logs_aggregator/loki-config.yml
@@ -1,0 +1,34 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 10096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v12
+      index:
+        prefix: index_
+        period: 24h

--- a/test/logs_aggregator/loki-datasource.yaml
+++ b/test/logs_aggregator/loki-datasource.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    jsonData:
+      maxLines: 1000

--- a/test/logs_aggregator/promtail-config.yml
+++ b/test/logs_aggregator/promtail-config.yml
@@ -1,0 +1,18 @@
+server:
+  http_listen_port: 10080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+- job_name: system
+  static_configs:
+  - targets:
+      - "localhost"
+    labels:
+      job: varlogs
+      __path__: /var/log/*.log

--- a/test/logs_aggregator/start_log_aggregator.sh
+++ b/test/logs_aggregator/start_log_aggregator.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+echo "working in ${DIR}"
+cd $DIR && pwd
+logs="$(ls -1 '../../tmp_log/')"
+path="$(readlink -f '../../tmp_log/')"
+echo "Current localnet logs are placed into '${path}/${logs}'"
+echo "CURRENT_SESSION_LOGS='${path}/${logs}'" > .env
+echo "CURRENT_SESSION_LOGS='${path}/${logs}'"
+echo "starting docker compose lor log aggregation"
+docker-compose up --detach
+sleep 5
+echo "Opening Grafana"
+python3 -m webbrowser "http://localhost:3000/explore"

--- a/test/logs_aggregator/start_log_aggregator.sh
+++ b/test/logs_aggregator/start_log_aggregator.sh
@@ -11,7 +11,7 @@ echo "Current localnet logs are placed into '${path}/${logs}'"
 echo "CURRENT_SESSION_LOGS='${path}/${logs}'" > .env
 echo "CURRENT_SESSION_LOGS='${path}/${logs}'"
 echo "starting docker compose lor log aggregation"
-docker-compose up --detach
+docker compose up --detach
 sleep 5
 echo "Opening Grafana"
 python3 -m webbrowser "http://localhost:3000/explore"

--- a/test/logs_aggregator/stop_log_aggregator.sh
+++ b/test/logs_aggregator/stop_log_aggregator.sh
@@ -6,6 +6,6 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 echo "working in ${DIR}"
 cd $DIR && pwd
 echo "[INFO] - stopping log aggregation"
-docker-compose rm --force --stop --volumes
+docker compose rm --force --stop --volumes
 echo "[INFO] - cleanup .env"
 echo > .env

--- a/test/logs_aggregator/stop_log_aggregator.sh
+++ b/test/logs_aggregator/stop_log_aggregator.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+echo "working in ${DIR}"
+cd $DIR && pwd
+echo "[INFO] - stopping log aggregation"
+docker-compose rm --force --stop --volumes
+echo "[INFO] - cleanup .env"
+echo > .env


### PR DESCRIPTION
## Issue

I've covered localnet deployment with the same tool set as higher networks - Promtail-Loki-Grafana.

![image](https://github.com/user-attachments/assets/e2d0eadb-d2d5-4cca-95d4-2a456fafd0c7)

What was done: 
* 3 Makefile commands to start and stop log aggregation - `debug-start-log` and `debug-stop-log`, `debug-restart-log`
* these 2 new Makefile are just are wrappers between our localnet logs location, promtail-grafana-loki configs and the docker-compose file
* WARNING - grafana runs in the anon access, just in case - **DON'T RUN IT AGAINST PRODUCTION**

Details:
*  test/logs_aggregator/start_log_aggregator.sh
  * go to `test/logs_aggregator/` folder
  * find the current localnet logs folder
  * put it inside `.env` file in `test/logs_aggregator/.env`
  * this `test/logs_aggregator/.env` is a source of variables for docker-compose
  * start docker-compose detached
  * open the Grafana in browser
* test/logs_aggregator/stop_log_aggregator.sh
  * just cleanup the `test/logs_aggregator/.env`
  * stop and remove docker compose

## Test

Local run:
* make debug-start-log 
```
bash ./test/logs_aggregator/start_log_aggregator.sh
working in /home/uladzislau/go/src/github.com/harmony-one/harmony/test/logs_aggregator
/home/uladzislau/go/src/github.com/harmony-one/harmony/test/logs_aggregator
Current localnet logs are placed into '/home/uladzislau/go/src/github.com/harmony-one/harmony/tmp_log/log-20240916-175304'
CURRENT_SESSION_LOGS='/home/uladzislau/go/src/github.com/harmony-one/harmony/tmp_log/log-20240916-175304'
starting docker compose lor log aggregation
[+] Running 3/3
 ✔ Container logs_aggregator-promtail-1  Started                                                                                              1.2s 
 ✔ Container logs_aggregator-loki-1      Started                                                                                              1.2s 
 ✔ Container logs_aggregator-grafana-1   Started                                                                                              1.3s 
Opening Grafana
```

* make debug-stop-log
``` bash ./test/logs_aggregator/stop_log_aggregator.sh
working in /home/uladzislau/go/src/github.com/harmony-one/harmony/test/logs_aggregator
/home/uladzislau/go/src/github.com/harmony-one/harmony/test/logs_aggregator
[INFO] - stopping log aggregation
[+] Stopping 3/3
 ✔ Container logs_aggregator-loki-1      Stopped                                                                                              2.6s 
 ✔ Container logs_aggregator-promtail-1  Stopped                                                                                              0.6s 
 ✔ Container logs_aggregator-grafana-1   Stopped                                                                                              0.6s 
Going to remove logs_aggregator-promtail-1, logs_aggregator-grafana-1, logs_aggregator-loki-1
[+] Removing 3/0
 ✔ Container logs_aggregator-promtail-1  Removed                                                                                              0.0s 
 ✔ Container logs_aggregator-grafana-1   Removed                                                                                              0.0s 
 ✔ Container logs_aggregator-loki-1      Removed                                                                                              0.0s 
[INFO] - cleanup .env
```
* make debug-stop-log-aggregator against already stopped/not-started localnet it will be failure
* make debug-start-log-aggregator against not-started localnet it will be failure

* make debug-restart-log:
```
bash ./test/logs_aggregator/stop_log_aggregator.sh
working in /home/uladzislau/go/src/github.com/harmony-one/harmony/test/logs_aggregator
/home/uladzislau/go/src/github.com/harmony-one/harmony/test/logs_aggregator
[INFO] - stopping log aggregation
[+] Stopping 3/3
 ✔ Container localnet-promtail  Stopped                                                                                                       0.6s 
 ✔ Container localnet-grafana   Stopped                                                                                                       0.6s 
 ✔ Container localnet-loki      Stopped                                                                                                       1.8s 
Going to remove localnet-grafana, localnet-promtail, localnet-loki
[+] Removing 3/0
 ✔ Container localnet-loki      Removed                                                                                                       0.1s 
 ✔ Container localnet-grafana   Removed                                                                                                       0.1s 
 ✔ Container localnet-promtail  Removed                                                                                                       0.1s 
[INFO] - cleanup .env
bash ./test/logs_aggregator/start_log_aggregator.sh
working in /home/uladzislau/go/src/github.com/harmony-one/harmony/test/logs_aggregator
/home/uladzislau/go/src/github.com/harmony-one/harmony/test/logs_aggregator
Current localnet logs are placed into '/home/uladzislau/go/src/github.com/harmony-one/harmony/tmp_log/log-20240920-122014'
CURRENT_SESSION_LOGS='/home/uladzislau/go/src/github.com/harmony-one/harmony/tmp_log/log-20240920-122014'
starting docker compose lor log aggregation
[+] Running 3/3
 ✔ Container localnet-loki      Started                                                                                                       0.6s 
 ✔ Container localnet-grafana   Started                                                                                                       0.7s 
 ✔ Container localnet-promtail  Started                                                                                                       0.5s 
Opening Grafana
```

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
