### PR TITLE
feat(Makefile) - add switch for the legacy sync, make stream sync default option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,8 @@ debug:
 	# uncomment the following lines to enable debug logging for libp2p, it produces a lot of logs, so disabled by default
 	#export GOLOG_LOG_LEVEL=debug
 	#export GOLOG_OUTPUT=stdout
-	# uncomment the following line to enable max logging
-	# export VERBOSE=true
+	# add VERBOSE=true before bash or run `export VERBOSE=true` on the shell level for have max logging
+	# add LEGACY_SYNC=true before bash  or run `export LEGACY_SYNC=true` on the shell level to switch to the legacy sync
 	bash ./test/debug.sh
 
 debug-kill:
@@ -87,8 +87,8 @@ debug-ext:
 	# update localnet block per epoch to ensure a stable localnet
 	sed -i 's/localnetBlocksPerEpoch\s*=\s*[0-9]*/localnetBlocksPerEpoch = 64/' internal/configs/sharding/localnet.go
 	sed -i 's/localnetBlocksPerEpochV2\s*=\s*[0-9]*/localnetBlocksPerEpochV2 = 64/' internal/configs/sharding/localnet.go
-	# uncomment the following line to enable max logging
-	# export VERBOSE=true
+	# add VERBOSE=true before bash or run `export VERBOSE=true` on the shell level for have max logging
+	# add LEGACY_SYNC=true before bash  or run `export LEGACY_SYNC=true` on the shell level to switch to the legacy sync
 	bash ./test/debug-external.sh &
 	echo sleep 10s before creating the external validator
 	sleep 10

--- a/test/debug-external.sh
+++ b/test/debug-external.sh
@@ -5,9 +5,16 @@ rm -rf tmp_log* 2> /dev/null
 rm *.rlp 2> /dev/null
 rm -rf .dht* 2> /dev/null
 scripts/go_executable_build.sh -S || exit 1  # dynamic builds are faster for debug iteration...
+LEGACY_SYNC=${LEGACY_SYNC:-"false"}
+if [ "${LEGACY_SYNC}" == "true" ]; then
+    echo "[WARN] - using legacy sync"
+    SYNC_OPT=(-L "true")
+else
+    SYNC_OPT=(-L "false")
+fi
 if [ "${VERBOSE}" = "true" ]; then
     echo "[WARN] - running with verbose logs"
-    ./test/deploy.sh -v -B -D 600000 ./test/configs/local-resharding-with-external.txt
+    ./test/deploy.sh -v -B -D 600000 "${SYNC_OPT[@]}" ./test/configs/local-resharding-with-external.txt
 else
-    ./test/deploy.sh -B -D 600000 ./test/configs/local-resharding-with-external.txt
+    ./test/deploy.sh -B -D 600000 "${SYNC_OPT[@]}" ./test/configs/local-resharding-with-external.txt
 fi

--- a/test/debug.sh
+++ b/test/debug.sh
@@ -5,9 +5,16 @@ rm -rf tmp_log* 2> /dev/null
 rm *.rlp 2> /dev/null
 rm -rf .dht* 2> /dev/null
 scripts/go_executable_build.sh -S || exit 1  # dynamic builds are faster for debug iteration...
+LEGACY_SYNC=${LEGACY_SYNC:-"false"}
+if [ "${LEGACY_SYNC}" == "true" ]; then
+    echo "[WARN] - using legacy sync"
+    SYNC_OPT=(-L "true")
+else
+    SYNC_OPT=(-L "false")
+fi
 if [ "${VERBOSE}" = "true" ]; then
     echo "[WARN] - running with verbose logs"
-    ./test/deploy.sh -v -B -D 600000 ./test/configs/local-resharding.txt
+    ./test/deploy.sh -v -B -D 600000 "${SYNC_OPT[@]}" ./test/configs/local-resharding.txt
 else
-    ./test/deploy.sh -B -D 600000 ./test/configs/local-resharding.txt
+    ./test/deploy.sh -B -D 600000 "${SYNC_OPT[@]}" ./test/configs/local-resharding.txt
 fi

--- a/test/deploy.sh
+++ b/test/deploy.sh
@@ -63,8 +63,8 @@ function launch_bootnode() {
 function launch_localnet() {
   launch_bootnode
 
-  unset -v base_args
-  declare -a base_args args
+  unset -v base_args sync_options
+  declare -a base_args args sync_options
 
   if ${VERBOSE}; then
     verbosity=5
@@ -72,14 +72,22 @@ function launch_localnet() {
     verbosity=3
   fi
 
-  base_args=(--log_folder "${log_folder}" --min_peers "${MIN}" --bootnodes "${BN_MA}" "--network_type=$NETWORK" --blspass file:"${ROOT}/.hmy/blspass.txt" "--dns=false" "--verbosity=${verbosity}" "--p2p.security.max-conn-per-ip=100")
+  base_args=(--log_folder "${log_folder}" --min_peers "${MIN}" --bootnodes "${BN_MA}" \
+    "--network=$NETWORK" --blspass file:"${ROOT}/.hmy/blspass.txt" \
+    "--verbosity=${verbosity}" "--p2p.security.max-conn-per-ip=100")
+  if [ "${LEGACY_SYNC}" == "true" ]; then
+    sync_options=("--dns=true" "--sync=false" "--dns.client=true" "--sync.downloader=false" "--sync.stagedsync=false")
+  else
+    sync_options=("--dns=false" "--sync=true" "--dns.client=false" "--sync.downloader=true" "--sync.stagedsync=true")
+  fi
+
+  base_args+=("${sync_options[@]}")
   sleep 2
 
   # Start nodes
   i=-1
   while IFS='' read -r line || [[ -n "$line" ]]; do
     i=$((i + 1))
-
     # Read config for i-th node form config file
     IFS=' ' read -r ip port mode bls_key shard node_config <<<"${line}"
     args=("${base_args[@]}" --ip "${ip}" --port "${port}" --key "/tmp/${ip}-${port}.key" --db_dir "${ROOT}/db-${ip}-${port}" "--broadcast_invalid_tx=false")
@@ -90,7 +98,6 @@ function launch_localnet() {
     if [[ $EXPOSEAPIS == "true" ]]; then
       args=("${args[@]}" "--http.ip=0.0.0.0" "--ws.ip=0.0.0.0")
     fi
-
     # Setup BLS key for i-th localnet node
     if [[ ! -e "$bls_key" ]]; then
       args=("${args[@]}" --blskey_file "BLSKEY")
@@ -152,6 +159,7 @@ USAGE: $ME [OPTIONS] config_file_name [extra args to node]
    -B             don't build the binary
    -v             verbosity in log (default: $VERBOSE)
    -e             expose WS & HTTP ip (default: $EXPOSEAPIS)
+   -L             start localnet in Legace sync mode(default: $LEGACY_SYNC)
 
 This script will build all the binaries and start harmony and based on the configuration file.
 
@@ -170,8 +178,9 @@ NETWORK=localnet
 VERBOSE=false
 NOBUILD=false
 EXPOSEAPIS=false
+LEGACY_SYNC=false
 
-while getopts "hD:m:s:nBN:ve" option; do
+while getopts "hD:m:s:nBN:veL:" option; do
   case ${option} in
   h) usage ;;
   D) DURATION=$OPTARG ;;
@@ -182,6 +191,7 @@ while getopts "hD:m:s:nBN:ve" option; do
   N) NETWORK=$OPTARG ;;
   v) VERBOSE=true ;;
   e) EXPOSEAPIS=true ;;
+  L) LEGACY_SYNC=$OPTARG ;;
   *) usage ;;
   esac
 done
@@ -198,4 +208,3 @@ setup
 launch_localnet
 sleep "${DURATION}"
 cleanup || true
-


### PR DESCRIPTION
What was done:
* add stream sync as a default option for the `make debug` and `make debug-ext`
* add legacy sync as implicit option to put as variable/export for  `make debug` and `make debug-ext`
* to cover both scenarios above add -L option to the deploy script, which has default value `false` and will use stream sync
* implicitly show the sync options in the deploy.sh:
```
  if [ "${LEGACY_SYNC}" == "true" ]; then
    sync_options=("--dns=true" "--sync=false" "--dns.client=true" "--sync.downloader=false" "--sync.stagedsync=false")
  else
    sync_options=("--dns=false" "--sync=true" "--dns.client=false" "--sync.downloader=true" "--sync.stagedsync=true")
  fi
``` 
* shortly - main idea was to add new option and provide it through wrappers like (Makefile->debug.sh->deploy.sh) and make **the stream sync a default value everywhere**, because our tests for rossetta and RPC are using `deploy.sh` directly.

## Test
Local test:
* `$ LEGACY_SYNC=true make debug`:
  * In the command line log - [WARN] - using legacy sync
  * In the node logs
```
{
  "level": "info",
  "port": "9114",
  "ip": "127.0.0.1",
  "len": 5,
  "shardID": 0,
  "caller": "/home/uladzislau/go/src/github.com/harmony-one/harmony/api/service/legacysync/helpers.go:127",
  "time": "2024-09-24T13:35:48.975398778+03:00",
  "message": "[SYNC] Finished making connection to peers"
}
```

* `$ make debug`:
  * In the node logs:
```
{
  "level": "info",
  "port": "9016",
  "ip": "127.0.0.1",
  "Protocol": "harmony/sync/localnet/0/1.0.0/1",
  "stream": "QmZwB8U1Gq-24-225",
  "caller": "/home/uladzislau/go/src/github.com/harmony-one/harmony/p2p/stream/protocols/sync/protocol.go:175",
  "time": "2024-09-24T13:39:07.006340859+03:00",
  "message": "handle new sync stream"
}
```

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
