### PR TITLE
Switch Localnet Muxer to Yamux

### DIFF
--- a/test/deploy.sh
+++ b/test/deploy.sh
@@ -72,7 +72,7 @@ function launch_localnet() {
     verbosity=3
   fi
 
-  base_args=(--log_folder "${log_folder}" --min_peers "${MIN}" --bootnodes "${BN_MA}" \
+  base_args=(--log_folder "${log_folder}" --min_peers "${MIN}" --bootnodes "${BN_MA}" --p2p.muxer "yamux" \
     "--network=$NETWORK" --blspass file:"${ROOT}/.hmy/blspass.txt" \
     "--verbosity=${verbosity}" "--p2p.security.max-conn-per-ip=100")
   if [ "${LEGACY_SYNC}" == "true" ]; then


### PR DESCRIPTION
## Issue
This PR addresses stream stability issues caused by the mplex muxer. Specifically, mplex has been identified as the source of instability, leading to streams being closed or restarted unexpectedly.
To resolve this, the PR removes the use of the mplex muxer for localnet and configures localnet to exclusively use the Yamux muxer. This change aims to enhance stability and fixes the stream handling within the localnet environment.
**This PR addresses the issue mentioned in #4749**