### PR TITLE
Improve Crosslink Retrieve from RawDB

### DIFF
--- a/consensus/consensus_block_proposing.go
+++ b/consensus/consensus_block_proposing.go
@@ -154,6 +154,12 @@ func (consensus *Consensus) ProposeNewBlock(commitSigs chan []byte) (*types.Bloc
 		invalidToDelete := []types.CrossLink{}
 		if err == nil {
 			for _, pending := range allPending {
+				if !consensus.Blockchain().Config().IsCrossLink(pending.Epoch()) {
+					invalidToDelete = append(invalidToDelete, pending)
+					utils.Logger().Debug().
+						AnErr("[ProposeNewBlock] pending crosslink that's before crosslink epoch", err)
+					continue
+				}
 				// ReadCrossLink beacon chain usage.
 				exist, err := consensus.Blockchain().ReadCrossLink(pending.ShardID(), pending.BlockNum())
 				if err == nil || exist != nil {
@@ -170,14 +176,11 @@ func (consensus *Consensus) ProposeNewBlock(commitSigs chan []byte) (*types.Bloc
 				}
 				// if pending crosslink is older than the last crosslink, delete it and continue
 				if err == nil && exist == nil && last != nil && last.BlockNum() >= pending.BlockNum() {
+					// Crosslink is already verified before it's accepted to pending,
+					// no need to verify again in proposal.
 					invalidToDelete = append(invalidToDelete, pending)
-				}
-
-				// Crosslink is already verified before it's accepted to pending,
-				// no need to verify again in proposal.
-				if !consensus.Blockchain().Config().IsCrossLink(pending.Epoch()) {
 					utils.Logger().Debug().
-						AnErr("[ProposeNewBlock] pending crosslink that's before crosslink epoch", err)
+						AnErr("[ProposeNewBlock] pending crosslink is older than last shard crosslink", err)
 					continue
 				}
 

--- a/core/offchain.go
+++ b/core/offchain.go
@@ -163,6 +163,11 @@ func (bc *BlockChainImpl) CommitOffChainData(
 					Uint64("blockNum", crossLink.BlockNum()).
 					Uint32("shardID", crossLink.ShardID()).
 					Msg("[insertChain/crosslinks] Cross Link Added to Beaconchain")
+			} else {
+				utils.Logger().Debug().Err(err).
+					Uint64("blockNum", crossLink.BlockNum()).
+					Uint32("shardID", crossLink.ShardID()).
+					Msg("[insertChain/crosslinks] Cross Link failed to Add to Beaconchain")
 			}
 
 			cl0, _ := bc.ReadShardLastCrossLink(crossLink.ShardID())

--- a/hmy/blockchain.go
+++ b/hmy/blockchain.go
@@ -196,6 +196,8 @@ func (hmy *Harmony) GetLastCrossLinks() ([]*types.CrossLink, error) {
 		link, err := hmy.BlockChain.ReadShardLastCrossLink(i)
 		if err != nil {
 			return nil, err
+		} else if link == nil { // if it's before epoch crosslink HF, it returns nil
+			continue
 		}
 		crossLinks = append(crossLinks, link)
 	}


### PR DESCRIPTION
## Issue

This PR introduces a check for the Crosslink Epoch before attempting to retrieve crosslinks from the database. By validating the epoch first, it prevents errors related to the retrieval of non-existent crosslinks.