### PR TITLE
[ci] upgrade github actions and merge artifacts

### DIFF
--- a/.github/workflows/build-docker-proto-image.yaml
+++ b/.github/workflows/build-docker-proto-image.yaml
@@ -9,14 +9,14 @@ jobs:
 
     steps:
       - name: Checkout harmony core code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: harmony
           ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
         uses: docker/login-action@v2
@@ -25,7 +25,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: ./harmony/api/service/legacysync/downloader
           file: ./harmony/api/service/legacysync/downloader/Proto.Dockerfile

--- a/.github/workflows/ci-tag.yaml
+++ b/.github/workflows/ci-tag.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout harmony core code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: harmony
           ref: ${{ github.event.inputs.tag }}
@@ -29,9 +29,9 @@ jobs:
           VERSION=$(git tag -l --sort=-v:refname | head -n 1)
           if git rev-parse $VERSION^{tag} -- &>/dev/null
           then
-            echo "::set-output name=tag_annotated::true"
+            echo "tag_annotated=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=tag_annotated::false"
+            echo "tag_annotated=false" >> $GITHUB_OUTPUT
           fi
         working-directory: harmony
 
@@ -47,32 +47,32 @@ jobs:
     steps:
       - name: Import GPG key
         if: join(matrix.os, '-') != 'self-hosted-linux-ARM64'
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASS }}
 
       - name: Checkout dependence repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: harmony-one/mcl
           path: mcl
 
       - name: Checkout dependence repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: harmony-one/bls
           path: bls
 
       - name: Checkout harmony core code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: harmony
           ref: ${{ github.event.inputs.tag }}
           fetch-depth: 0
 
       - name: Set up Go go.mod
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'harmony/go.mod'
 
@@ -117,21 +117,30 @@ jobs:
         working-directory: harmony
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: harmony
+          name: harmony-${{ matrix.os }}
           path: harmony/bin/*
           retention-days: 1
 
+  merge_artifacts:
+    runs-on: ubuntu-22.04
+    needs: build
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: harmony
+
   docker-build:
     name: Build and push harmony docker image
-    needs: [check, build]
+    needs: [check, build, merge_artifacts]
     runs-on: ubuntu-22.04
     if: needs.check.outputs.tag_annotated == 'true'
 
     steps:
       - name: Checkout harmony core code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: harmony
           ref: ${{ github.event.inputs.tag }}
@@ -146,7 +155,7 @@ jobs:
         working-directory: harmony
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: harmony
 
@@ -156,16 +165,16 @@ jobs:
         working-directory: harmony
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: ./harmony/scripts/docker
           file: ./harmony/scripts/docker/Dockerfile
@@ -178,19 +187,19 @@ jobs:
 
   release-page:
     name: Sign binary and create and publish release page
-    needs: [check, build]
+    needs: [check, build, merge_artifacts]
     runs-on: ubuntu-22.04
     if: needs.check.outputs.tag_annotated == 'true'
 
     steps:
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASS }}
 
       - name: Checkout harmony core code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: harmony
           ref: ${{ github.event.inputs.tag }}
@@ -207,7 +216,7 @@ jobs:
         working-directory: harmony
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: harmony
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout harmony core code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: harmony
           ref: ${{ github.ref }}
@@ -27,9 +27,9 @@ jobs:
           VERSION=$(git tag -l --sort=-v:refname | head -n 1)
           if git rev-parse $VERSION^{tag} -- &>/dev/null
           then
-            echo "::set-output name=tag_annotated::true"
+            echo "tag_annotated=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=tag_annotated::false"
+            echo "tag_annotated=false" >> $GITHUB_OUTPUT
           fi
         working-directory: harmony
 
@@ -45,32 +45,32 @@ jobs:
     steps:
       - name: Import GPG key
         if: join(matrix.os, '-') != 'self-hosted-linux-ARM64'
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASS }}
 
       - name: Checkout dependence repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: harmony-one/mcl
           path: mcl
 
       - name: Checkout dependence repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: harmony-one/bls
           path: bls
 
       - name: Checkout harmony core code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: harmony
           ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Set up Go with go.mod
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'harmony/go.mod'
 
@@ -119,21 +119,30 @@ jobs:
         working-directory: harmony
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: harmony
+          name: harmony-${{ matrix.os }}
           path: harmony/bin/*
           retention-days: 1
 
+  merge_artifacts:
+    runs-on: ubuntu-22.04
+    needs: build
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: harmony
+
   docker-build:
     name: Build and push harmony docker image
-    needs: [check, build]
+    needs: [check, build, merge_artifacts]
     runs-on: ubuntu-22.04
     if: needs.check.outputs.tag_annotated == 'true'
 
     steps:
       - name: Checkout harmony core code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: harmony
           ref: ${{ github.ref }}
@@ -148,7 +157,7 @@ jobs:
         working-directory: harmony
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: harmony
 
@@ -158,16 +167,16 @@ jobs:
         working-directory: harmony
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: ./harmony/scripts/docker
           file: ./harmony/scripts/docker/Dockerfile
@@ -180,19 +189,19 @@ jobs:
 
   release-page:
     name: Sign binary and create and publish release page
-    needs: [check, build]
+    needs: [check, build, merge_artifacts]
     runs-on: ubuntu-22.04
     if: needs.check.outputs.tag_annotated == 'true'
 
     steps:
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASS }}
 
       - name: Checkout harmony core code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: harmony
           ref: ${{ github.ref }}
@@ -209,7 +218,7 @@ jobs:
         working-directory: harmony
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: harmony
 


### PR DESCRIPTION
Testing logs for ci.yaml can be seen here : https://github.com/sophoah/harmony/actions/runs/11362513771/job/31604875903

the error at the end is the docker image push which would work if the github action was running on the harmony github organization

upload-artifact:v4 doesn't accept an artefact with the same name, they all have to be unique and be merged at the end. More detail here https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#merging-multiple-artifacts