### PR TITLE
Early return from `finalCommit` to prevent processing with empty hash.

### DIFF
--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -140,6 +140,10 @@ func (consensus *Consensus) HandleMessageUpdate(ctx context.Context, peer libp2p
 
 func (consensus *Consensus) finalCommit(isLeader bool) {
 	numCommits := consensus.decider.SignersCount(quorum.Commit)
+	if consensus.blockHash == [32]byte{} {
+		consensus.getLogger().Warn().Msg("[finalCommit] Block hash is empty")
+		return
+	}
 
 	consensus.getLogger().Info().
 		Int64("NumCommits", numCommits).


### PR DESCRIPTION
`StagedStreamSync::doSync` calls `finishSyncing` which internally calls `reset` on consensus. `finalCommit`runs in goroutine, so it receives empty hash after `reset`. 