### PR TITLE
[fix] - Makefile - change sed expression to be cross platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,11 +82,17 @@ debug:
 
 debug-kill:
 	bash ./test/kill_node.sh
+	# restore the config after external run
+	git restore internal/configs/sharding/localnet.go
 
 debug-ext:
-	# update localnet block per epoch to ensure a stable localnet
-	sed -i 's/localnetBlocksPerEpoch\s*=\s*[0-9]*/localnetBlocksPerEpoch = 64/' internal/configs/sharding/localnet.go
-	sed -i 's/localnetBlocksPerEpochV2\s*=\s*[0-9]*/localnetBlocksPerEpochV2 = 64/' internal/configs/sharding/localnet.go
+	# update localnet block per epoch to ensure a stable localnet,
+	# -i.bak and rm bac are used for the Macos/Linux sed compitability
+	sed -i.bak 's#localnetBlocksPerEpoch[[:space:]]*=[[:space:]]*[0-9]*#localnetBlocksPerEpoch = 64#' \
+		internal/configs/sharding/localnet.go
+	sed -i.bak 's#localnetBlocksPerEpochV2[[:space:]]*=[[:space:]]*[0-9]*#localnetBlocksPerEpochV2 = 64#' \
+		internal/configs/sharding/localnet.go
+	rm internal/configs/sharding/localnet.go.bak
 	# add VERBOSE=true before bash or run `export VERBOSE=true` on the shell level for have max logging
 	# add LEGACY_SYNC=true before bash  or run `export LEGACY_SYNC=true` on the shell level to switch to the legacy sync
 	bash ./test/debug-external.sh &


### PR DESCRIPTION
## Issue

Makefile - change sed expression to be cross platform, because Macos has sed openbsd version and linux has GNU one, add git restore for the localnet configs on the explicit debug-kill

## Tested on the Linux and Mac

`$ make debug-ext` and `grep localnetBlocks internal/configs/sharding/localnet.go` 
```
	localnetBlocksPerEpoch = 64
	localnetBlocksPerEpochV2 = 64
```

`$ make debug-kill` and `grep localnetBlocks internal/configs/sharding/localnet.go` 
```
        localnetBlocksPerEpoch   = 16
        localnetBlocksPerEpochV2 = 16
```


Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
