### PR TITLE
Enhance Final Commit Function with Improved Error Handling

### DIFF
--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -40,7 +40,7 @@ func (consensus *Consensus) WaitForNewRandomness() {
 	}()
 }
 
-// GetNextRnd returns the oldest available randomness along with the hash of the block there randomness preimage is committed.
+// GetNextRnd returns the oldest available randomness along with the hash of the block where randomness preimage is committed.
 func (consensus *Consensus) GetNextRnd() ([vdFAndProofSize]byte, [32]byte, error) {
 	if len(consensus.pendingRnds) == 0 {
 		return [vdFAndProofSize]byte{}, [32]byte{}, errors.New("No available randomness")


### PR DESCRIPTION
## Imptovements:

This PR enhances the finalCommit function in the consensus module. It improves the logs and adds return statements after error checks to prevent further processing in case of a failure. This change ensures that the function terminates immediately when critical errors occur:


- `Failed WriteCommitSig`: The WriteCommitSig saves the commits signatures signed on a block. This function is responsible for writing the commit signature of a block to the blockchain's database (rawdb). The commit signature is essential for proving that the block has reached consensus and that it has been accepted by the network.

- `Failed commitBlock`: This function adds a new block to the blockchain after consensus is reached. It inserts the block into the chain and performs additional post-consensus processing, such as setting up for the next round of consensus. So the failure could be for two main reason:
  - **If the block cannot be added to the chain (InsertChain fails)**, continuing the rest of the commitBlock logic will cause inconsistencies:
    - Consensus State: The consensus state will be updated to reflect the new block as committed, but the block will not be present in the chain. This could lead to an inconsistent state where the blockchain thinks it has a block, but it actually hasn’t been added.
    - Blockchain Synchronization: Other nodes might assume the block is committed and included in the chain, while locally, it is missing. This inconsistency could lead to synchronization issues, consensus failures, and network instability. 

  - **Invalid Leader or Commit Message:** The function checks if the commit message has a valid sender (HasSingleSender). If this check fails, it indicates an issue with the consensus process, such as a possible malicious or improperly formed message. Proceeding after detecting such an issue could compromise the security and correctness of the blockchain.

Previously, these errors were logged but the function continued to execute, potentially leading to inconsistent states or incorrect behaviors.



