### PR TITLE
Optimize Syncing-Consensus Communication to Prevent Unnecessary Consensus Resets

### DIFF
--- a/api/service/stagedstreamsync/syncing.go
+++ b/api/service/stagedstreamsync/syncing.go
@@ -345,6 +345,8 @@ func (s *StagedStreamSync) doSync(downloaderContext context.Context, initSync bo
 			s.logger.Info().Uint64("current number", curBN).Uint64("target number", estimatedHeight).
 				Msg(WrapStagedSyncMsg("early return of long range sync (chain is already ahead of target height)"))
 			return estimatedHeight, 0, nil
+		} else if curBN < estimatedHeight && s.consensus != nil {
+			s.consensus.BlocksNotSynchronized("StagedStreamSync.doSync")
 		}
 	}
 

--- a/api/service/stagedstreamsync/syncing.go
+++ b/api/service/stagedstreamsync/syncing.go
@@ -421,7 +421,7 @@ func (s *StagedStreamSync) doSync(downloaderContext context.Context, initSync bo
 		}
 		s.purgeLastMileBlocksFromCache()
 
-		if totalInserted > 0 {
+		if totalInserted > 0 && !s.isEpochChain {
 			s.consensus.BlocksSynchronized()
 		}
 	}

--- a/api/service/stagedstreamsync/syncing.go
+++ b/api/service/stagedstreamsync/syncing.go
@@ -419,7 +419,9 @@ func (s *StagedStreamSync) doSync(downloaderContext context.Context, initSync bo
 		}
 		s.purgeLastMileBlocksFromCache()
 
-		s.consensus.BlocksSynchronized()
+		if totalInserted > 0 {
+			s.consensus.BlocksSynchronized()
+		}
 	}
 
 	return estimatedHeight, totalInserted, nil

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -236,7 +236,7 @@ func (consensus *Consensus) finalCommit(isLeader bool) {
 		}
 		encodedBlock, err := rlp.EncodeToBytes(blockWithSig)
 		if err != nil {
-			consensus.getLogger().Debug().Msg("[finalCommit] Failed encoding block for epoch end")
+			consensus.getLogger().Error().Msg("[finalCommit] Failed encoding block for epoch end")
 			return
 		}
 		err = consensus.host.SendMessageToGroups(

--- a/node/harmony/node_syncing.go
+++ b/node/harmony/node_syncing.go
@@ -322,8 +322,11 @@ func (node *Node) doSync(syncInstance ISync, syncingPeerProvider SyncingPeerProv
 			consensus.BlocksNotSynchronized("node.doSync")
 		}
 		isBeacon := bc.ShardID() == shard.BeaconChainShardID
+		heightBeforeSync := bc.CurrentBlock().NumberU64()
 		syncInstance.SyncLoop(bc, isBeacon, consensus, legacysync.LoopMinTime)
-		if willJoinConsensus {
+		heightAfterSync := bc.CurrentBlock().NumberU64()
+		addedBlocks := heightAfterSync - heightBeforeSync
+		if willJoinConsensus && addedBlocks > 0 {
 			node.IsSynchronized.Set()
 			consensus.BlocksSynchronized()
 		}


### PR DESCRIPTION
## Issue
This PR resolves a communication issue between the consensus and syncing modules by refining the conditions for triggering `BlocksSynchronized`. Now, `BlocksSynchronized` is only triggered if new blocks are added to the chain during the syncing process loop. This change prevents unnecessary consensus reset states, ensuring that resets are triggered only when genuinely needed, thereby improving the stability and efficiency of the synchronization process.