### PR TITLE
Moved the `UpdateConsensusInformation` method to the test suite

### DIFF
--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -75,14 +75,6 @@ func (consensus *Consensus) signAndMarshalConsensusMessage(message *msg_pb.Messa
 	return marshaledMessage, nil
 }
 
-// UpdatePublicKeys updates the PublicKeys for
-// quorum on current subcommittee, protected by a mutex
-func (consensus *Consensus) UpdatePublicKeys(pubKeys, allowlist []bls_cosi.PublicKeyWrapper) int64 {
-	consensus.mutex.Lock()
-	defer consensus.mutex.Unlock()
-	return consensus.updatePublicKeys(pubKeys, allowlist)
-}
-
 func (consensus *Consensus) updatePublicKeys(pubKeys, allowlist []bls_cosi.PublicKeyWrapper) int64 {
 	consensus.decider.UpdateParticipants(pubKeys, allowlist)
 	consensus.getLogger().Info().Msg("My Committee updated")

--- a/consensus/construct_test.go
+++ b/consensus/construct_test.go
@@ -18,6 +18,14 @@ import (
 	"github.com/pkg/errors"
 )
 
+// UpdatePublicKeys updates the PublicKeys for
+// quorum on current subcommittee, protected by a mutex
+func (consensus *Consensus) UpdatePublicKeys(pubKeys, allowlist []bls.PublicKeyWrapper) int64 {
+	consensus.mutex.Lock()
+	defer consensus.mutex.Unlock()
+	return consensus.updatePublicKeys(pubKeys, allowlist)
+}
+
 func TestConstructAnnounceMessage(test *testing.T) {
 	leader := p2p.Peer{IP: "127.0.0.1", Port: "19999"}
 	priKey, _, _ := utils.GenKeyP2P("127.0.0.1", "9902")


### PR DESCRIPTION
Moved the `UpdateConsensusInformation` method to the test suite, given its primary usage in testing. Notably, `UpdateConsensusInformation` internally invokes `resetState`, which clears blockHash and could potentially trigger a hard fork.