### PR TITLE
[fix] - update macos from 12 to 13, sync the CI steps for macos

### DIFF
--- a/.github/workflows/ci-tag.yaml
+++ b/.github/workflows/ci-tag.yaml
@@ -42,7 +42,7 @@ jobs:
     if: needs.check.outputs.tag_annotated == 'true'
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12, [self-hosted, linux, ARM64]]
+        os: [ubuntu-22.04, macos-13, [self-hosted, linux, ARM64]]
 
     steps:
       - name: Import GPG key
@@ -104,11 +104,15 @@ jobs:
         working-directory: harmony
 
       - name: Build harmony binary and packages for MacOS
-        if: matrix.os == 'macos-12'
+        if: matrix.os == 'macos-13'
         run: |
           brew install bash
           sudo rm -f /usr/local/opt/openssl
           sudo ln -sf /usr/local/opt/openssl@1.1 /usr/local/opt/openssl
+          # hack for older chip (macos)
+          sudo mkdir -p /opt/homebrew/opt
+          sudo ln -sf /usr/local/opt/openssl@1.1 /opt/homebrew/opt/openssl@1.1
+          sudo ln -sf /usr/local/opt/gmp /opt/homebrew/opt/gmp
           make
           cd ./bin && mkdir ./lib && mv ./*.dylib ./lib && rm -f ./bootnode
           gpg --detach-sign harmony

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
     if: needs.check.outputs.tag_annotated == 'true'
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12, [self-hosted, linux, ARM64]]
+        os: [ubuntu-22.04, macos-13, [self-hosted, linux, ARM64]]
 
     steps:
       - name: Import GPG key
@@ -102,7 +102,7 @@ jobs:
         working-directory: harmony
 
       - name: Build harmony binary and packages for MacOS
-        if: matrix.os == 'macos-12'
+        if: matrix.os == 'macos-13'
         run: |
           brew install bash
           sudo rm -f /usr/local/opt/openssl


### PR DESCRIPTION
## Issue

We have a deprecation warning for the macos12, so we need to update to the new one.
After lurking the issue I found that the new Intel based Macos 14-15 will be
* only a  large image for the github actions, it  will be 0.12$ per minute instead of 0.08$ - https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners/about-larger-runners#understanding-billing
* and MacOS minutes are * 10 than linux minutes - https://github.com/actions/runner-images/issues/9741#issuecomment-2075259811

So my idea was to just update to the macos13, it is still regular github actions runner.

## Test

1. I've uploaded artifact via Github action job - https://github.com/mur-me/harmony/actions/runs/11688454932/job/32548949803, 
2. Link to download is https://github.com/mur-me/harmony/actions/runs/11688454932/artifacts/2147768551
3. Used MacBook Air Intel with MacOS - 15.0.1
4. Installed harmony and libs on it, used explorer config to start
5. Checked the logs and as you can see harmony started to sync:
```
{"level":"info","epoch":"2938","size":1375,"caller":"/Users/runner/work/harmony/harmony/harmony/core/rawdb/accessors_offchain.go:46","time":"2024-11-06T18:07:38.312901+03:00","message":"wrote sharding state, epoch 2938"}
{"level":"info","caller":"/Users/runner/work/harmony/harmony/harmony/core/epochchain.go:169","time":"2024-11-06T18:07:38.313151+03:00","message":"[EPOCHSYNC] Added block 24051787, epoch 2937, 0xe87972c979e7f42a9943ee9d04dde4522c98a8f87b0f9f982814ff149a7dee9b"}
{"level":"info","epoch":"2939","size":1375,"caller":"/Users/runner/work/harmony/harmony/harmony/core/rawdb/accessors_offchain.go:46","time":"2024-11-06T18:07:38.315394+03:00","message":"wrote sharding state, epoch 2939"}
{"level":"info","caller":"/Users/runner/work/harmony/harmony/harmony/core/epochchain.go:169","time":"2024-11-06T18:07:38.3156+03:00","message":"[EPOCHSYNC] Added block 24059979, epoch 2938, 0xc3fbd5ef6320a9d0989a04da0436da660bfd1c01e834c2a1268eeaedbab5852c"}

Result: we can use macos13 runner until it deprecated and removed by Github 
```

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

3. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

7. **Describe how the plan was tested.**

8. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

9. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

10. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

11. **What should node operators know about this planned change?**

12. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

13. **Does the existing `node.sh` continue to work with this change?**

14. **What should node operators know about this change?**

15. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
