### PR TITLE
Improve Consensus logic for Multi-BLS Validators with quorum

### DIFF
--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -148,7 +148,6 @@ func (consensus *Consensus) onPrepare(recvMsg *FBFTMessage) {
 		consensus.getLogger().Debug().
 			Interface("validatorPubKeys", recvMsg.SenderPubkeys).
 			Msg("[OnPrepare] Received Additional Prepare Message")
-		return
 	}
 	//// Read - End
 

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -219,12 +219,17 @@ func (consensus *Consensus) onCommit(recvMsg *FBFTMessage) {
 
 	// check if it is first received commit
 	// it may multi bls key validators can achieve quorum on first commit
-	var myPubkeys []bls.SerializedPublicKey
-	for _, key := range consensus.priKey {
-		myPubkeys = append(myPubkeys, key.Pub.Bytes)
+	isFirstReceivedSignature := false
+	lenPrvKeys := len(consensus.priKey)
+	hasMultiBlsKey := lenPrvKeys > 0
+	if hasMultiBlsKey {
+		var myPubkeys []bls.SerializedPublicKey
+		for _, key := range consensus.priKey {
+			myPubkeys = append(myPubkeys, key.Pub.Bytes)
+		}
+		mySignsCount := consensus.decider.GetBallotsCount(quorum.Commit, myPubkeys)
+		isFirstReceivedSignature = signerCount == mySignsCount
 	}
-	mySignsCount := consensus.decider.GetBallotsCount(quorum.Commit, myPubkeys)
-	isFirstReceivedSignature := signerCount == mySignsCount
 
 	//// Read - End
 
@@ -299,7 +304,8 @@ func (consensus *Consensus) onCommit(recvMsg *FBFTMessage) {
 
 	quorumIsMet := consensus.decider.IsQuorumAchieved(quorum.Commit)
 	//// Read - End
-	quorumAchievedByFirstCommit := isFirstReceivedSignature && quorumWasMet
+
+	quorumAchievedByFirstCommit := hasMultiBlsKey && isFirstReceivedSignature && quorumWasMet
 	quorumAchievedByThisCommit := !quorumWasMet && quorumIsMet
 
 	if quorumAchievedByFirstCommit || quorumAchievedByThisCommit {

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -220,9 +220,8 @@ func (consensus *Consensus) onCommit(recvMsg *FBFTMessage) {
 	// check if it is first received commit
 	// it may multi bls key validators can achieve quorum on first commit
 	isFirstReceivedSignature := false
-	lenPrvKeys := len(consensus.priKey)
-	hasMultiBlsKey := lenPrvKeys > 0
-	if hasMultiBlsKey {
+	hasMultiBlsKeys := len(consensus.priKey) > 0
+	if hasMultiBlsKeys {
 		var myPubkeys []bls.SerializedPublicKey
 		for _, key := range consensus.priKey {
 			myPubkeys = append(myPubkeys, key.Pub.Bytes)
@@ -305,7 +304,7 @@ func (consensus *Consensus) onCommit(recvMsg *FBFTMessage) {
 	quorumIsMet := consensus.decider.IsQuorumAchieved(quorum.Commit)
 	//// Read - End
 
-	quorumAchievedByFirstCommit := hasMultiBlsKey && isFirstReceivedSignature && quorumWasMet
+	quorumAchievedByFirstCommit := hasMultiBlsKeys && isFirstReceivedSignature && quorumWasMet
 	quorumAchievedByThisCommit := !quorumWasMet && quorumIsMet
 
 	if quorumAchievedByFirstCommit || quorumAchievedByThisCommit {

--- a/consensus/quorum/thread_safe_decider.go
+++ b/consensus/quorum/thread_safe_decider.go
@@ -104,6 +104,12 @@ func (a threadSafeDeciderImpl) ReadBallot(p Phase, pubkey bls.SerializedPublicKe
 	return a.decider.ReadBallot(p, pubkey)
 }
 
+func (a threadSafeDeciderImpl) GetBallotsCount(p Phase, pubkeys []bls.SerializedPublicKey) int64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.decider.GetBallotsCount(p, pubkeys)
+}
+
 func (a threadSafeDeciderImpl) TwoThirdsSignersCount() int64 {
 	a.mu.Lock()
 	defer a.mu.Unlock()


### PR DESCRIPTION
## Issue

This PR improves the consensus logic to handle cases where validators with multiple BLS keys achieve quorum on their initial signatures or commits. Currently, such scenarios can block phase transitions because the condition `if !quorumWasMet && quorumIsMet` doesn't account for quorum being achieved immediately.

To fix this, a new function, `checkFirstReceivedSignature`, is introduced. It checks whether quorum is reached on the first batch of signatures or commits. The PR also updates the logic for `Prepare` and `Commit` phases to properly handle these edge cases. The PR helps to better handling of multi-BLS key validators while maintaining compatibility with single-key setups.
