### PR TITLE
Add Logging to ReadySignal Method for New Block Proposals

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -162,7 +162,11 @@ func (consensus *Consensus) ChainReader() engine.ChainReader {
 	return consensus.Blockchain()
 }
 
-func (consensus *Consensus) ReadySignal(p Proposal) {
+func (consensus *Consensus) ReadySignal(p Proposal, signalSource string, signalReason string) {
+	utils.Logger().Info().
+		Str("signalSource", signalSource).
+		Str("signalReason", signalReason).
+		Msg("ReadySignal is called to propose new block")
 	consensus.readySignal <- p
 }
 

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -498,7 +498,7 @@ func (consensus *Consensus) updateConsensusInformation() Mode {
 					consensus.GetLogger().Info().
 						Str("myKey", myPubKeys.SerializeToHexStr()).
 						Msg("[UpdateConsensusInformation] I am the New Leader")
-					consensus.ReadySignal(NewProposal(SyncProposal))
+					consensus.ReadySignal(NewProposal(SyncProposal), "updateConsensusInformation", "leader changed and I am the new leader")
 				}()
 			}
 			return Normal

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -278,7 +278,7 @@ func (consensus *Consensus) finalCommit(isLeader bool) {
 			// No pipelining
 			go func() {
 				consensus.getLogger().Info().Msg("[finalCommit] sending block proposal signal")
-				consensus.ReadySignal(NewProposal(SyncProposal))
+				consensus.ReadySignal(NewProposal(SyncProposal), "finalCommit", "I am leader and it's the last block in epoch")
 			}()
 		} else {
 			// pipelining
@@ -354,7 +354,7 @@ func (consensus *Consensus) StartChannel() {
 		consensus.start = true
 		consensus.getLogger().Info().Time("time", time.Now()).Msg("[ConsensusMainLoop] Send ReadySignal")
 		consensus.mutex.Unlock()
-		consensus.ReadySignal(NewProposal(SyncProposal))
+		consensus.ReadySignal(NewProposal(SyncProposal), "StartChannel", "consensus channel is started")
 		return
 	}
 	consensus.mutex.Unlock()
@@ -606,7 +606,7 @@ func (consensus *Consensus) preCommitAndPropose(blk *types.Block) error {
 		// Send signal to Node to propose the new block for consensus
 		consensus.getLogger().Info().Msg("[preCommitAndPropose] sending block proposal signal")
 		consensus.mutex.Unlock()
-		consensus.ReadySignal(NewProposal(AsyncProposal))
+		consensus.ReadySignal(NewProposal(AsyncProposal), "preCommitAndPropose", "proposing new block which will wait on the full commit signatures to finish")
 	}()
 
 	return nil
@@ -842,7 +842,7 @@ func (consensus *Consensus) setupForNewConsensus(blk *types.Block, committedMsg 
 				blockPeriod := consensus.BlockPeriod
 				go func() {
 					<-time.After(blockPeriod)
-					consensus.ReadySignal(NewProposal(SyncProposal))
+					consensus.ReadySignal(NewProposal(SyncProposal), "setupForNewConsensus", "I am the new leader")
 				}()
 			}
 		}

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -435,7 +435,7 @@ func (consensus *Consensus) onViewChange(recvMsg *FBFTMessage) {
 				consensus.getLogger().Error().Err(err).Msg("[onViewChange] startNewView failed")
 				return
 			}
-			go consensus.ReadySignal(NewProposal(SyncProposal))
+			go consensus.ReadySignal(NewProposal(SyncProposal), "onViewChange", "quorum is achieved by mask and is view change mode and M1 payload is empty")
 			return
 		}
 


### PR DESCRIPTION
## Description

This PR enhances the ReadySignal method by adding a log entry each time it is called, which occurs whenever a new block proposal is produced. The added log provides visibility into the source and reason behind each ReadySignal invocation, aiding in tracking block proposal events during consensus.