### PR TITLE
Prevents BlocksSynchronized being called before finalCommit

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -142,6 +142,10 @@ type Consensus struct {
 	// value receives from
 	lastKnownSignPower int64
 	lastKnowViewChange int64
+
+	transitions struct {
+		finalCommit bool
+	}
 }
 
 // Blockchain returns the blockchain.
@@ -203,7 +207,9 @@ func (consensus *Consensus) BlocksSynchronized(reason string) {
 	}
 	consensus.mutex.Lock()
 	defer consensus.mutex.Unlock()
-	consensus.syncReadyChan(reason)
+	if !consensus.transitions.finalCommit {
+		consensus.syncReadyChan(reason)
+	}
 }
 
 // BlocksNotSynchronized lets the main loop know that block is not synchronized

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/harmony-one/harmony/staking/slash"
 	"github.com/harmony-one/harmony/test/helpers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConsensusInitialization(t *testing.T) {
@@ -87,4 +88,16 @@ func GenerateConsensusForTesting() (p2p.Host, multibls.PrivateKeys, *Consensus, 
 	}
 
 	return host, multiBLSPrivateKey, consensus, decider, nil
+}
+
+func TestFinalCommitDisablesTransition(t *testing.T) {
+	_, _, consensus, _, err := GenerateConsensusForTesting()
+	require.NoError(t, err)
+
+	require.False(t, consensus.transitions.finalCommit)
+
+	// this method should set consensus.transitions.finalCommit to false even it panics.
+	consensus.finalCommit(0, 1, false)
+
+	require.False(t, consensus.transitions.finalCommit)
 }

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -138,7 +138,21 @@ func (consensus *Consensus) HandleMessageUpdate(ctx context.Context, peer libp2p
 	return nil
 }
 
-func (consensus *Consensus) finalCommit(isLeader bool) {
+func (consensus *Consensus) finalCommit(waitTime time.Duration, viewID uint64, isLeader bool) {
+	consensus.getLogger().Info().Str("waitTime", waitTime.String()).
+		Msg("[OnCommit] Starting Grace Period")
+	time.Sleep(waitTime)
+	utils.Logger().Info().Msg("[OnCommit] Commit Grace Period Ended")
+
+	consensus.mutex.Lock()
+	defer consensus.mutex.Unlock()
+	consensus.transitions.finalCommit = false
+	if viewID == consensus.getCurBlockViewID() {
+		consensus._finalCommit(isLeader)
+	}
+}
+
+func (consensus *Consensus) _finalCommit(isLeader bool) {
 	numCommits := consensus.decider.SignersCount(quorum.Commit)
 
 	consensus.getLogger().Info().

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -298,7 +298,7 @@ func (consensus *Consensus) onCommit(recvMsg *FBFTMessage) {
 			// only do early commit if it's not epoch block to avoid problems
 			consensus.preCommitAndPropose(blockObj)
 		}
-
+		consensus.transitions.finalCommit = true
 		go func(viewID uint64, isLeader bool) {
 			waitTime := 1000 * time.Millisecond
 			maxWaitTime := time.Until(consensus.NextBlockDue) - 200*time.Millisecond
@@ -312,6 +312,7 @@ func (consensus *Consensus) onCommit(recvMsg *FBFTMessage) {
 
 			consensus.mutex.Lock()
 			defer consensus.mutex.Unlock()
+			consensus.transitions.finalCommit = false
 			if viewID == consensus.getCurBlockViewID() {
 				consensus.finalCommit(isLeader)
 			}


### PR DESCRIPTION
Before onCommit and finalCommit exists time gap, but no more BlocksSynchronized can erase state before finalCommit.