### PR TITLE
Improve Consensus Block Proposal, Fix Multi-BLS Key Leader Triggering Multiple Block Proposals by Introducing Proposal Queue

### DIFF
--- a/api/service/blockproposal/service.go
+++ b/api/service/blockproposal/service.go
@@ -30,7 +30,7 @@ func (s *Service) Start() error {
 }
 
 func (s *Service) run() {
-	s.c.WaitForConsensusReadyV2(s.stopChan, s.stoppedChan)
+	s.c.StartCheckingForNewProposals(s.stopChan, s.stoppedChan)
 }
 
 // Stop stops block proposal service.

--- a/common/types/safe_map.go
+++ b/common/types/safe_map.go
@@ -1,4 +1,4 @@
-package sttypes
+package types
 
 import (
 	"sync"

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -143,16 +143,16 @@ func (consensus *Consensus) ChainReader() engine.ChainReader {
 	return consensus.Blockchain()
 }
 
-func (consensus *Consensus) AddProposal(t ProposalType, source string, reason string) error {
+func (consensus *Consensus) AddProposal(leaderPubKey *bls_cosi.PublicKeyWrapper, t ProposalType, source string, reason string) error {
 	bn := consensus.Blockchain().CurrentBlock().NumberU64()
 	v := consensus.GetViewChangingID()
-	p := NewProposal(t, v, bn, source, reason)
+	p := NewProposal(leaderPubKey ,t, v, bn, source, reason)
 	consensus.proposalManager.AddProposal(p)
 	return nil
 }
 
 func (consensus *Consensus) ReadySignal(t ProposalType, signalSource string, signalReason string) {
-	if err := consensus.AddProposal(t, signalSource, signalReason); err != nil {
+	if err := consensus.AddProposal(consensus.getLeaderPubKey(), t, signalSource, signalReason); err != nil {
 		utils.Logger().Debug().Err(err).
 			Str("signalSource", signalSource).
 			Str("signalReason", signalReason).

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -498,7 +498,7 @@ func (consensus *Consensus) updateConsensusInformation(reason string) Mode {
 					consensus.GetLogger().Info().
 						Str("myKey", myPubKeys.SerializeToHexStr()).
 						Msg("[UpdateConsensusInformation] I am the New Leader")
-					consensus.ReadySignal(NewProposal(SyncProposal), "updateConsensusInformation", "leader changed and I am the new leader")
+					consensus.ReadySignal(SyncProposal, "updateConsensusInformation", "leader changed and I am the new leader")
 				}()
 			}
 			return Normal

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -547,6 +547,10 @@ func (consensus *Consensus) preCommitAndPropose(blk *types.Block) error {
 		return errors.New("block to pre-commit is nil")
 	}
 
+	if !consensus.proposalManager.IsReady() {
+		return nil
+	}
+
 	leaderPriKey, err := consensus.getConsensusLeaderPrivateKey()
 	if err != nil {
 		consensus.getLogger().Error().Err(err).Msg("[preCommitAndPropose] leader not found")

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -278,7 +278,7 @@ func (consensus *Consensus) finalCommit(isLeader bool) {
 			// No pipelining
 			go func() {
 				consensus.getLogger().Info().Msg("[finalCommit] sending block proposal signal")
-				consensus.ReadySignal(NewProposal(SyncProposal), "finalCommit", "I am leader and it's the last block in epoch")
+				consensus.ReadySignal(SyncProposal, "finalCommit", "I am leader and it's the last block in epoch")
 			}()
 		} else {
 			// pipelining
@@ -354,7 +354,7 @@ func (consensus *Consensus) StartChannel() {
 		consensus.start = true
 		consensus.getLogger().Info().Time("time", time.Now()).Msg("[ConsensusMainLoop] Send ReadySignal")
 		consensus.mutex.Unlock()
-		consensus.ReadySignal(NewProposal(SyncProposal), "StartChannel", "consensus channel is started")
+		consensus.ReadySignal(SyncProposal, "StartChannel", "consensus channel is started")
 		return
 	}
 	consensus.mutex.Unlock()
@@ -606,7 +606,7 @@ func (consensus *Consensus) preCommitAndPropose(blk *types.Block) error {
 		// Send signal to Node to propose the new block for consensus
 		consensus.getLogger().Info().Msg("[preCommitAndPropose] sending block proposal signal")
 		consensus.mutex.Unlock()
-		consensus.ReadySignal(NewProposal(AsyncProposal), "preCommitAndPropose", "proposing new block which will wait on the full commit signatures to finish")
+		consensus.ReadySignal(AsyncProposal, "preCommitAndPropose", "proposing new block which will wait on the full commit signatures to finish")
 	}()
 
 	return nil
@@ -848,7 +848,7 @@ func (consensus *Consensus) setupForNewConsensus(blk *types.Block, committedMsg 
 				blockPeriod := consensus.BlockPeriod
 				go func() {
 					<-time.After(blockPeriod)
-					consensus.ReadySignal(NewProposal(SyncProposal), "setupForNewConsensus", "I am the new leader")
+					consensus.ReadySignal(SyncProposal, "setupForNewConsensus", "I am the new leader")
 				}()
 			}
 		}

--- a/consensus/proposal.go
+++ b/consensus/proposal.go
@@ -1,0 +1,134 @@
+package consensus
+
+import (
+	"sync"
+	"time"
+
+	"github.com/harmony-one/harmony/internal/utils"
+)
+
+// ProposalType is to indicate the type of signal for new block proposal
+type ProposalType byte
+
+// Constant of the type of new block proposal
+const (
+	SyncProposal ProposalType = iota
+	AsyncProposal
+)
+
+func (pt ProposalType) String() string {
+	if pt == SyncProposal {
+		return "SyncProposal"
+	}
+	return "AsyncProposal"
+}
+
+// Proposal represents a new block proposal with associated metadata
+type Proposal struct {
+	Type      ProposalType
+	Caller    string
+	Height    uint64
+	ViewID    uint64
+	Source    string
+	Reason    string
+	CreatedAt time.Time
+	lock      *sync.RWMutex
+}
+
+// NewProposal creates a new proposal
+func NewProposal(t ProposalType, viewID uint64, height uint64, source string, reason string) *Proposal {
+	return &Proposal{
+		Type:      t,
+		Caller:    utils.GetCallStackInfo(2),
+		ViewID:    0,
+		Height:    0,
+		Source:    source,
+		Reason:    reason,
+		CreatedAt: time.Now(),
+		lock:      &sync.RWMutex{},
+	}
+}
+
+// Clone returns a copy of proposal
+func (p *Proposal) Clone() *Proposal {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return &Proposal{
+		Type:      p.Type,
+		Caller:    p.Caller,
+		ViewID:    p.ViewID,
+		Height:    p.Height,
+		CreatedAt: p.CreatedAt,
+		lock:      &sync.RWMutex{},
+	}
+}
+
+// GetType retrieves the Proposal type
+func (p *Proposal) GetType() ProposalType {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return p.Type
+}
+
+// SetType updates the Proposal type
+func (p *Proposal) SetType(t ProposalType) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.Type = t
+}
+
+// GetCaller retrieves the Proposal caller
+func (p *Proposal) GetCaller() string {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return p.Caller
+}
+
+// SetCaller updates the Proposal caller
+func (p *Proposal) SetCaller(caller string) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.Caller = caller
+}
+
+// GetHeight retrieves the Proposal height
+func (p *Proposal) GetHeight() uint64 {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return p.Height
+}
+
+// SetHeight updates the Proposal height
+func (p *Proposal) SetHeight(height uint64) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.Height = height
+}
+
+// GetViewID retrieves the Proposal view ID
+func (p *Proposal) GetViewID() uint64 {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return p.ViewID
+}
+
+// SetViewID updates the Proposal view ID
+func (p *Proposal) SetViewID(viewID uint64) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.ViewID = viewID
+}
+
+// GetCreatedAt retrieves the Proposal creation time
+func (p *Proposal) GetCreatedAt() time.Time {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return p.CreatedAt
+}
+
+// SetCreatedAt updates the Proposal creation time
+func (p *Proposal) SetCreatedAt(createdAt time.Time) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.CreatedAt = createdAt
+}

--- a/consensus/proposal.go
+++ b/consensus/proposal.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	bls_cosi "github.com/harmony-one/harmony/crypto/bls"
 	"github.com/harmony-one/harmony/internal/utils"
 )
 
@@ -25,27 +26,29 @@ func (pt ProposalType) String() string {
 
 // Proposal represents a new block proposal with associated metadata
 type Proposal struct {
-	Type      ProposalType
-	Caller    string
-	Height    uint64
-	ViewID    uint64
-	Source    string
-	Reason    string
-	CreatedAt time.Time
-	lock      *sync.RWMutex
+	leaderPubKey *bls_cosi.PublicKeyWrapper
+	Type         ProposalType
+	Caller       string
+	Height       uint64
+	ViewID       uint64
+	Source       string
+	Reason       string
+	CreatedAt    time.Time
+	lock         *sync.RWMutex
 }
 
 // NewProposal creates a new proposal
-func NewProposal(t ProposalType, viewID uint64, height uint64, source string, reason string) *Proposal {
+func NewProposal(leaderPubKey *bls_cosi.PublicKeyWrapper, t ProposalType, viewID uint64, height uint64, source string, reason string) *Proposal {
 	return &Proposal{
-		Type:      t,
-		Caller:    utils.GetCallStackInfo(2),
-		ViewID:    0,
-		Height:    0,
-		Source:    source,
-		Reason:    reason,
-		CreatedAt: time.Now(),
-		lock:      &sync.RWMutex{},
+		leaderPubKey: leaderPubKey,
+		Type:         t,
+		Caller:       utils.GetCallStackInfo(2),
+		ViewID:       0,
+		Height:       0,
+		Source:       source,
+		Reason:       reason,
+		CreatedAt:    time.Now(),
+		lock:         &sync.RWMutex{},
 	}
 }
 
@@ -58,6 +61,8 @@ func (p *Proposal) Clone() *Proposal {
 		Caller:    p.Caller,
 		ViewID:    p.ViewID,
 		Height:    p.Height,
+		Source:    p.Source,
+		Reason:    p.Reason,
 		CreatedAt: p.CreatedAt,
 		lock:      &sync.RWMutex{},
 	}

--- a/consensus/proposal_manager.go
+++ b/consensus/proposal_manager.go
@@ -1,0 +1,175 @@
+package consensus
+
+import (
+	"sync"
+
+	types "github.com/harmony-one/harmony/common/types"
+)
+
+type ProposalCreationStatus int
+
+const (
+	// Ready indicates the consensus is prepared to create a new proposal.
+	// No ongoing proposal or dependencies are blocking the proposal process.
+	Ready ProposalCreationStatus = iota
+
+	// WaitingForCommitSigs signifies the consensus is currently waiting for commit signatures
+	// from the previous block or process. This state can persist for an extended duration,
+	// typically up to 8 seconds, depending on proposal type and processing time.
+	WaitingForCommitSigs
+
+	// CreatingNewProposal indicates the consensus is already engaged in creating a new proposal.
+	// During this state, no additional proposals can be initiated until the current one completes.
+	CreatingNewPropsal
+)
+
+func (pt ProposalCreationStatus) String() string {
+	switch pt {
+	case Ready:
+		return "Ready"
+	case WaitingForCommitSigs:
+		return "WaitingForCommitSigs"
+	case CreatingNewPropsal:
+		return "CreatingNewProposal"
+	default:
+		return "Unknown"
+	}
+}
+
+type ProposalManager struct {
+	history    *types.SafeMap[ProposalType, *Proposal]
+	lastHeight uint64
+	status     ProposalCreationStatus
+	lock       *sync.RWMutex
+}
+
+// NewProposalManager initializes a new ProposalManager.
+func NewProposalManager() *ProposalManager {
+	return &ProposalManager{
+		history:    types.NewSafeMap[ProposalType, *Proposal](),
+		lastHeight: 0,
+		status:     Ready,
+		lock:       &sync.RWMutex{},
+	}
+}
+
+// SetLastHeight updates the last processed proposal height.
+func (pm *ProposalManager) SetLastHeight(h uint64) {
+	pm.lock.Lock()
+	defer pm.lock.Unlock()
+	if h > pm.lastHeight {
+		pm.lastHeight = h
+	}
+}
+
+// GetLastHeight retrieves the last processed proposal height.
+func (pm *ProposalManager) GetLastHeight() uint64 {
+	pm.lock.RLock()
+	defer pm.lock.RUnlock()
+	return pm.lastHeight
+}
+
+// SetStatus sets new proposal creation status.
+func (pm *ProposalManager) SetStatus(newStatus ProposalCreationStatus) {
+	pm.lock.Lock()
+	defer pm.lock.Unlock()
+	pm.status = newStatus
+}
+
+// StartWaitingForCommitSigs sets isWaitingForCommitSigs.
+func (pm *ProposalManager) SetToWaitingForCommitSigsMode() {
+	pm.lock.Lock()
+	defer pm.lock.Unlock()
+	pm.status = WaitingForCommitSigs
+}
+
+// IsWaitingForCommitSigs returns true if current proposal is waiting for commit sigs.
+func (pm *ProposalManager) IsWaitingForCommitSigs() bool {
+	pm.lock.RLock()
+	defer pm.lock.RUnlock()
+	return pm.status == WaitingForCommitSigs
+}
+
+// StartWaitingForCommitSigs sets isWaitingForCommitSigs.
+func (pm *ProposalManager) SetToCreatingNewProposalMode() {
+	pm.lock.Lock()
+	defer pm.lock.Unlock()
+	pm.status = CreatingNewPropsal
+}
+
+// IsCreatingNewProposal returns true if consensus is busy with proposal creation.
+func (pm *ProposalManager) IsCreatingNewProposal() bool {
+	pm.lock.RLock()
+	defer pm.lock.RUnlock()
+	return pm.status == CreatingNewPropsal
+}
+
+// Done sets status to ready.
+func (pm *ProposalManager) Done() {
+	pm.lock.Lock()
+	defer pm.lock.Unlock()
+	pm.status = Ready
+}
+
+// IsWaitingForCommitSigs returns true if current proposal is waiting for commit sigs.
+func (pm *ProposalManager) IsReady() bool {
+	pm.lock.RLock()
+	defer pm.lock.RUnlock()
+	return pm.status == Ready
+}
+
+// AddProposal adds a new proposal if valid or updates an existing one if better.
+func (pm *ProposalManager) AddProposal(p *Proposal) bool {
+	pm.lock.Lock()
+	defer pm.lock.Unlock()
+	existingProposal, exists := pm.history.Get(p.Type)
+	if exists {
+		if p.Height > existingProposal.Height || (p.Height == existingProposal.Height && p.ViewID > existingProposal.ViewID) {
+			pm.history.Set(p.Type, p)
+			return true
+		}
+		return false
+	}
+	pm.history.Set(p.Type, p)
+	return true
+}
+
+// GetNextProposal retrieves and removes the next proposal based on priority.
+func (pm *ProposalManager) GetNextProposal() (*Proposal, error) {
+	pm.lock.Lock()
+	defer pm.lock.Unlock()
+
+	syncProposal, syncExist := pm.history.Get(SyncProposal)
+	asyncProposal, asyncExist := pm.history.Get(AsyncProposal)
+
+	var nextProposal *Proposal
+	if syncExist {
+		nextProposal = syncProposal.Clone()
+		pm.history.Delete(SyncProposal)
+	} else if asyncExist {
+		nextProposal = asyncProposal.Clone()
+		pm.history.Delete(AsyncProposal)
+	}
+
+	if nextProposal == nil {
+		// no proposals available
+		return nil, nil
+	}
+
+	pm.lastHeight = nextProposal.Height
+	return nextProposal, nil
+}
+
+// ClearHistory clears all proposals from the history.
+func (pm *ProposalManager) ClearHistory() {
+	pm.lock.Lock()
+	defer pm.lock.Unlock()
+	pm.history.Clear()
+}
+
+// Length returns the number of proposals in the history.
+func (pm *ProposalManager) Length() int {
+	pm.lock.RLock()
+	defer pm.lock.RUnlock()
+	return pm.history.Length()
+}

--- a/consensus/proposer.go
+++ b/consensus/proposer.go
@@ -16,9 +16,9 @@ func NewProposer(consensus *Consensus) *Proposer {
 	return &Proposer{consensus}
 }
 
-// WaitForConsensusReadyV2 listen for the readiness signal from consensus and generate new block for consensus.
+// StartCheckingForNewProposals checks the proposal queue and generate new block for consensus.
 // only leader will receive the ready signal
-func (p *Proposer) WaitForConsensusReadyV2(stopChan chan struct{}, stoppedChan chan struct{}) {
+func (p *Proposer) StartCheckingForNewProposals(stopChan chan struct{}, stoppedChan chan struct{}) {
 	consensus := p.consensus
 	go func() {
 		// Setup stoppedChan
@@ -39,65 +39,116 @@ func (p *Proposer) WaitForConsensusReadyV2(stopChan chan struct{}, stoppedChan c
 				utils.Logger().Warn().
 					Msg("Consensus new block proposal: STOPPED!")
 				return
-			case proposal := <-consensus.GetReadySignal():
-				for retryCount := 0; retryCount < 3 && consensus.IsLeader(); retryCount++ {
-					time.Sleep(SleepPeriod)
-					utils.Logger().Info().
-						Uint64("blockNum", consensus.Blockchain().CurrentBlock().NumberU64()+1).
-						Bool("asyncProposal", proposal.Type == AsyncProposal).
-						Str("called", proposal.Caller).
-						Msg("PROPOSING NEW BLOCK ------------------------------------------------")
+			//case proposal := <-consensus.GetReadySignal():
 
-					// Prepare last commit signatures
-					newCommitSigsChan := make(chan []byte)
-
-					go func() {
-						waitTime := 0 * time.Second
-						if proposal.Type == AsyncProposal {
-							waitTime = worker.CommitSigReceiverTimeout
-						}
-						select {
-						case <-time.After(waitTime):
-							if waitTime == 0 {
-								utils.Logger().Info().Msg("[ProposeNewBlock] Sync block proposal, reading commit sigs directly from DB")
-							} else {
-								utils.Logger().Info().Msg("[ProposeNewBlock] Timeout waiting for commit sigs, reading directly from DB")
-							}
-							sigs, err := consensus.BlockCommitSigs(consensus.Blockchain().CurrentBlock().NumberU64())
-
-							if err != nil {
-								utils.Logger().Error().Err(err).Msg("[ProposeNewBlock] Cannot get commit signatures from last block")
-							} else {
-								newCommitSigsChan <- sigs
-							}
-						case commitSigs := <-consensus.GetCommitSigChannel():
-							utils.Logger().Info().Msg("[ProposeNewBlock] received commit sigs asynchronously")
-							if len(commitSigs) > bls.BLSSignatureSizeInBytes {
-								newCommitSigsChan <- commitSigs
-							}
-						}
-					}()
-					newBlock, err := consensus.ProposeNewBlock(newCommitSigsChan)
-					if err == nil {
-						utils.Logger().Info().
-							Uint64("blockNum", newBlock.NumberU64()).
-							Uint64("epoch", newBlock.Epoch().Uint64()).
-							Uint64("viewID", newBlock.Header().ViewID().Uint64()).
-							Int("numTxs", newBlock.Transactions().Len()).
-							Int("numStakingTxs", newBlock.StakingTransactions().Len()).
-							Int("crossShardReceipts", newBlock.IncomingReceipts().Len()).
-							Msgf("=========Successfully Proposed New Block, shard: %d epoch: %d number: %d ==========", newBlock.ShardID(), newBlock.Epoch().Uint64(), newBlock.NumberU64())
-
-						// Send the new block to Consensus so it can be confirmed.
-						consensus.BlockChannel(newBlock)
-						break
-					} else {
-						utils.Logger().Err(err).Int("retryCount", retryCount).
-							Msg("!!!!!!!!!Failed Proposing New Block!!!!!!!!!")
-						continue
-					}
+			case <-time.NewTicker(100 * time.Millisecond).C:
+				if !consensus.proposalManager.IsReady() {
+					continue
 				}
+				numProposalsInQueue := consensus.proposalManager.Length()
+				if numProposalsInQueue == 0 {
+					continue
+				}
+				// Send signal every 100ms
+				proposal, errNewProposal := consensus.proposalManager.GetNextProposal()
+				if errNewProposal != nil {
+					utils.Logger().Debug().Err(errNewProposal).Msg("[ProposeNewBlock] Cannot get next proposal")
+				}
+				if proposal == nil {
+					continue
+				}
+				if err := p.CreateProposal(proposal); err != nil {
+					utils.Logger().Warn().Err(err).
+						Str("Caller", proposal.Caller).
+						Uint64("Height", proposal.Height).
+						Uint64("ViewID", proposal.ViewID).
+						Msg("[ProposeNewBlock] proposal creation failed")
+				}
+				if !consensus.proposalManager.IsWaitingForCommitSigs() {
+					consensus.proposalManager.Done()
+				}
+
 			}
 		}
 	}()
+}
+
+func (p *Proposer) CreateProposal(proposal *Proposal) error {
+
+	consensus := p.consensus
+	if consensus == nil {
+		utils.Logger().Warn().Msg("[CreateProposal] trying to create a new block proposal while consensus is not initialized yet")
+		return nil
+	}
+
+	// set proposal manager status status
+	consensus.proposalManager.SetToCreatingNewProposalMode()
+
+	for retryCount := 0; retryCount < 3 && consensus.IsLeader(); retryCount++ {
+		time.Sleep(SleepPeriod)
+		utils.Logger().Info().
+			Uint64("blockNum", consensus.Blockchain().CurrentBlock().NumberU64()+1).
+			Bool("asyncProposal", proposal.Type == AsyncProposal).
+			Str("called", proposal.Caller).
+			Msg("PROPOSING NEW BLOCK ------------------------------------------------")
+
+		// Prepare last commit signatures
+		newCommitSigsChan := make(chan []byte)
+
+		go func() {
+			waitTime := 0 * time.Second
+			if proposal.Type == AsyncProposal {
+				waitTime = worker.CommitSigReceiverTimeout
+			}
+			if waitTime > 0 {
+				consensus.proposalManager.SetToWaitingForCommitSigsMode()
+			}
+			select {
+			case <-time.After(waitTime):
+				if waitTime == 0 {
+					utils.Logger().Info().Msg("[ProposeNewBlock] Sync block proposal, reading commit sigs directly from DB")
+				} else {
+					utils.Logger().Info().Msg("[ProposeNewBlock] Timeout waiting for commit sigs, reading directly from DB")
+				}
+				sigs, err := consensus.BlockCommitSigs(consensus.Blockchain().CurrentBlock().NumberU64())
+
+				if err != nil {
+					utils.Logger().Error().Err(err).Msg("[ProposeNewBlock] Cannot get commit signatures from last block")
+				} else {
+					newCommitSigsChan <- sigs
+				}
+				if waitTime > 0 {
+					consensus.proposalManager.Done()
+				}
+			case commitSigs := <-consensus.GetCommitSigChannel():
+				utils.Logger().Info().Msg("[ProposeNewBlock] received commit sigs asynchronously")
+				if len(commitSigs) > bls.BLSSignatureSizeInBytes {
+					newCommitSigsChan <- commitSigs
+					if waitTime > 0 {
+						consensus.proposalManager.Done()
+					}
+				}
+			}
+		}()
+		newBlock, err := consensus.ProposeNewBlock(newCommitSigsChan)
+		if err == nil {
+			utils.Logger().Info().
+				Uint64("blockNum", newBlock.NumberU64()).
+				Uint64("epoch", newBlock.Epoch().Uint64()).
+				Uint64("viewID", newBlock.Header().ViewID().Uint64()).
+				Int("numTxs", newBlock.Transactions().Len()).
+				Int("numStakingTxs", newBlock.StakingTransactions().Len()).
+				Int("crossShardReceipts", newBlock.IncomingReceipts().Len()).
+				Msgf("=========Successfully Proposed New Block, shard: %d epoch: %d number: %d ==========", newBlock.ShardID(), newBlock.Epoch().Uint64(), newBlock.NumberU64())
+
+			// Send the new block to Consensus so it can be confirmed.
+			consensus.BlockChannel(newBlock)
+			break
+		} else {
+			utils.Logger().Err(err).Int("retryCount", retryCount).
+				Msg("!!!!!!!!!Failed Proposing New Block!!!!!!!!!")
+			continue
+		}
+	}
+	return nil
 }

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -440,7 +440,7 @@ func (consensus *Consensus) onViewChange(recvMsg *FBFTMessage) {
 				consensus.getLogger().Error().Err(err).Msg("[onViewChange] startNewView failed")
 				return
 			}
-			go consensus.ReadySignal(NewProposal(SyncProposal), "onViewChange", "quorum is achieved by mask and is view change mode and M1 payload is empty")
+			go consensus.ReadySignal(SyncProposal, "onViewChange", "quorum is achieved by mask and is view change mode and M1 payload is empty")
 			return
 		}
 

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -312,8 +312,8 @@ var (
 		SlotsLimitedEpoch:                     EpochTBD, // epoch to enable HIP-16
 		CrossShardXferPrecompileEpoch:         big.NewInt(1),
 		AllowlistEpoch:                        EpochTBD,
-		LeaderRotationInternalValidatorsEpoch: big.NewInt(5),
-		LeaderRotationExternalValidatorsEpoch: big.NewInt(6),
+		LeaderRotationInternalValidatorsEpoch: big.NewInt(3),
+		LeaderRotationExternalValidatorsEpoch: big.NewInt(3),
 		LeaderRotationV2Epoch:                 EpochTBD,
 		FeeCollectEpoch:                       big.NewInt(2),
 		ValidatorCodeFixEpoch:                 big.NewInt(2),

--- a/p2p/stream/common/requestmanager/interface_test.go
+++ b/p2p/stream/common/requestmanager/interface_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/rlp"
+	types "github.com/harmony-one/harmony/common/types"
 	"github.com/harmony-one/harmony/p2p/stream/common/streammanager"
 	sttypes "github.com/harmony-one/harmony/p2p/stream/types"
 )
@@ -138,8 +139,8 @@ func makeDummyTestStreams(indexes []int) []sttypes.Stream {
 	return sts
 }
 
-func makeDummyStreamSets(indexes []int) *sttypes.SafeMap[sttypes.StreamID, *stream] {
-	m := sttypes.NewSafeMap[sttypes.StreamID, *stream]()
+func makeDummyStreamSets(indexes []int) *types.SafeMap[sttypes.StreamID, *stream] {
+	m := types.NewSafeMap[sttypes.StreamID, *stream]()
 
 	for _, index := range indexes {
 		st := &testStream{

--- a/p2p/stream/common/requestmanager/requestmanager.go
+++ b/p2p/stream/common/requestmanager/requestmanager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/ethereum/go-ethereum/event"
+	types "github.com/harmony-one/harmony/common/types"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p/stream/common/streammanager"
 	sttypes "github.com/harmony-one/harmony/p2p/stream/types"
@@ -20,10 +21,10 @@ import (
 // TODO: each peer is able to have a queue of requests instead of one request at a time.
 // TODO: add QoS evaluation for each stream
 type requestManager struct {
-	streams   *sttypes.SafeMap[sttypes.StreamID, *stream]  // All streams
-	available *sttypes.SafeMap[sttypes.StreamID, struct{}] // Streams that are available for request
-	pendings  *sttypes.SafeMap[uint64, *request]           // requests that are sent but not received response
-	waitings  requestQueues                                // double linked list of requests that are on the waiting list
+	streams   *types.SafeMap[sttypes.StreamID, *stream]  // All streams
+	available *types.SafeMap[sttypes.StreamID, struct{}] // Streams that are available for request
+	pendings  *types.SafeMap[uint64, *request]           // requests that are sent but not received response
+	waitings  requestQueues                              // double linked list of requests that are on the waiting list
 
 	// Stream events
 	sm         streammanager.Reader
@@ -56,9 +57,9 @@ func newRequestManager(sm streammanager.ReaderSubscriber) *requestManager {
 	logger := utils.Logger().With().Str("module", "request manager").Logger()
 
 	return &requestManager{
-		streams:   sttypes.NewSafeMap[sttypes.StreamID, *stream](),
-		available: sttypes.NewSafeMap[sttypes.StreamID, struct{}](),
-		pendings:  sttypes.NewSafeMap[uint64, *request](),
+		streams:   types.NewSafeMap[sttypes.StreamID, *stream](),
+		available: types.NewSafeMap[sttypes.StreamID, struct{}](),
+		pendings:  types.NewSafeMap[uint64, *request](),
 		waitings:  newRequestQueues(),
 
 		sm:          sm,
@@ -355,7 +356,7 @@ func (rm *requestManager) refreshStreams() {
 	}
 }
 
-func checkStreamUpdates(exists *sttypes.SafeMap[sttypes.StreamID, *stream], targets []sttypes.Stream) (added []sttypes.Stream, removed []*stream) {
+func checkStreamUpdates(exists *types.SafeMap[sttypes.StreamID, *stream], targets []sttypes.Stream) (added []sttypes.Stream, removed []*stream) {
 	targetM := make(map[sttypes.StreamID]sttypes.Stream)
 
 	for _, target := range targets {
@@ -401,9 +402,9 @@ func (rm *requestManager) close() {
 	rm.pendings.Iterate(func(key uint64, req *request) {
 		req.doneWithResponse(responseData{err: ErrClosed})
 	})
-	rm.streams = sttypes.NewSafeMap[sttypes.StreamID, *stream]()
-	rm.available = sttypes.NewSafeMap[sttypes.StreamID, struct{}]()
-	rm.pendings = sttypes.NewSafeMap[uint64, *request]()
+	rm.streams = types.NewSafeMap[sttypes.StreamID, *stream]()
+	rm.available = types.NewSafeMap[sttypes.StreamID, struct{}]()
+	rm.pendings = types.NewSafeMap[uint64, *request]()
 	rm.waitings = newRequestQueues()
 	close(rm.stopC)
 }

--- a/p2p/stream/common/requestmanager/requestmanager_test.go
+++ b/p2p/stream/common/requestmanager/requestmanager_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	types "github.com/harmony-one/harmony/common/types"
 	sttypes "github.com/harmony-one/harmony/p2p/stream/types"
 	"github.com/pkg/errors"
 )
@@ -368,7 +369,7 @@ func TestRequestManager_Concurrency(t *testing.T) {
 func TestGenReqID(t *testing.T) {
 	retry := 100000
 	rm := &requestManager{
-		pendings: sttypes.NewSafeMap[uint64, *request](),
+		pendings: types.NewSafeMap[uint64, *request](),
 	}
 
 	for i := 0; i != retry; i++ {
@@ -382,7 +383,7 @@ func TestGenReqID(t *testing.T) {
 
 func TestCheckStreamUpdates(t *testing.T) {
 	tests := []struct {
-		exists            *sttypes.SafeMap[sttypes.StreamID, *stream]
+		exists            *types.SafeMap[sttypes.StreamID, *stream]
 		targets           []sttypes.Stream
 		expAddedIndexes   []int
 		expRemovedIndexes []int


### PR DESCRIPTION
## Issue
This PR resolves the issue where multi-BLS key leaders occasionally triggered multiple block proposals simultaneously. The fix introduces a Proposal Manager and a Queue System to ensure only one block proposal is processed at a time, enhancing the stability and consistency of the block proposal process.

