### PR TITLE
Fix Multi-BLS Key Validator Leader Rotation to Prevent Multiple Block Proposals

### DIFF
--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -522,6 +522,10 @@ func (consensus *Consensus) IsLeader() bool {
 // the node with the leader public key. This function assume it runs under lock.
 func (consensus *Consensus) isLeader() bool {
 	pub := consensus.getLeaderPubKey()
+	return consensus.isMyKey(pub)
+}
+
+func (consensus *Consensus) isMyKey(pub *bls.PublicKeyWrapper) bool {
 	if pub == nil {
 		return false
 	}


### PR DESCRIPTION
## Issue
This PR resolves an issue in the consensus module where multi-BLS key validators, upon retaining leadership, could create multiple block proposals and potentially crash the network. It adds the logic to verify if the leader has changed or if the previous leader belongs to the same node (multi-BLS key validator scenario) and ensures that the consensus does not re-trigger leadership actions unnecessarily for the same node. Also, it updates logs to better describe leader transitions and ensure clarity in network operation debugging.