### PR TITLE
Add New Command to Makefile for Enhanced Localnet Debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ help:
 	@echo "trace-pointer - build the harmony binary & bootnode with pointer analysis"
 	@echo "debug - start a localnet with 2 shards (s0 rpc endpoint = localhost:9700; s1 rpc endpoint = localhost:9800)"
 	@echo "debug-kill - force kill the localnet"
+	@echo "debug-multi-bls - start a localnet with external validators and multi-BLS keys in the background"
+	@echo "debug-multi-bls-with-terminal - start a localnet with external validators and multi-BLS keys using screen, providing real-time logs and automatic cleanup on exit"
 	@echo "debug-ext - start a localnet with 2 shards and external (s0 rpc endpoint = localhost:9598; s1 rpc endpoint = localhost:9596)"
 	@echo "clean - remove node files & logs created by localnet"
 	@echo "distclean - remove node files & logs created by localnet, and all libs"

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,15 @@ debug-multi-bls:
 	echo sleep 10s before creating the external validator
 	sleep 10
 	bash ./test/build-localnet-validator.sh
+	
+debug-multi-bls-with-terminal:
+	# add VERBOSE=true before bash or run `export VERBOSE=true` on the shell level for have max logging
+	# add LEGACY_SYNC=true before bash  or run `export LEGACY_SYNC=true` on the shell level to switch to the legacy sync
+	screen -L -Logfile ./tmp_log/localnet_terminal.log -dmS localnet bash -c './test/debug.sh ./test/configs/local-multi-bls.txt 64 64; echo "Press any key to exit..."; read -n 1'
+	echo sleep 10s before creating the external validator
+	sleep 10
+	bash ./test/build-localnet-validator.sh
+	screen -r localnet
 
 clean:
 	rm -rf ./tmp_log*


### PR DESCRIPTION
This PR adds a new Makefile command, `debug-multi-bls-with-terminal`, to improve the debugging process for running a localnet with external validators and multiple BLS keys. Unlike the existing `debug-multi-bls` command, which runs the localnet in the background and requires manual process management to view logs or handle errors, the new command uses `screen` to run the localnet in the foreground, allowing developers to easily attach to the session (`screen -r localnet`) and view live logs. All logs are stored in `./tmp_log/localnet_terminal.log` for convenient access. Additionally, the localnet automatically shuts down when the terminal or `screen` session is closed, streamlining cleanup and making it easier to debug issues without manual intervention.