### PR TITLE
refactor: CI - fallback to the master branch in harmony-test if same branch name doesn't exitst

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,9 @@ install:
   # default working directory with source code is automatically set to
   #   /home/travis/gopath/src/github.com/harmony-one/harmony
   # https://docs.travis-ci.com/user/languages/go/#go-import-path
-  - echo $TRAVIS_PULL_REQUEST_BRANCH
-  - TEST_REPO_BRANCH="master"
   - git clone https://github.com/harmony-one/mcl.git $GOPATH/src/github.com/harmony-one/mcl
   - git clone https://github.com/harmony-one/bls.git $GOPATH/src/github.com/harmony-one/bls
-  - git clone --branch $TEST_REPO_BRANCH https://github.com/harmony-one/harmony-test.git $GOPATH/src/github.com/harmony-one/harmony-test
+  - git clone https://github.com/harmony-one/harmony-test.git $GOPATH/src/github.com/harmony-one/harmony-test
   - (cd $GOPATH/src/github.com/harmony-one/mcl; make -j4)
   - (cd $GOPATH/src/github.com/harmony-one/bls; make BLS_SWAP_G=1 -j4)
 #  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.41.1

--- a/Makefile
+++ b/Makefile
@@ -227,13 +227,9 @@ travis_go_checker:
 	bash ./scripts/travis_go_checker.sh
 
 travis_rpc_checker:
-	# value from command line will override this value, use point test to non-default
-	TEST_REPO_BRANCH='master'
 	bash ./scripts/travis_rpc_checker.sh
 
 travis_rosetta_checker:
-	# value from command line will override this value, use point test to non-default
-	TEST_REPO_BRANCH='master'
 	bash ./scripts/travis_rosetta_checker.sh
 
 debug_external: clean

--- a/scripts/travis_rosetta_checker.sh
+++ b/scripts/travis_rosetta_checker.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-TEST_REPO_BRANCH=${TEST_REPO_BRANCH:-master}
 # handle for the Travis build run:
 # * uses TRAVIS_PULL_REQUEST_SLUG if PR is done from fork
 # * uses TRAVIS_PULL_REQUEST_BRANCH for RP branch
@@ -29,12 +28,18 @@ if [[ -z "$MAIN_REPO_BRANCH" ]]; then
     fi
 fi
 
-echo "[harmony-test repo] - working on '${TEST_REPO_BRANCH}' branch"
 echo "[harmony repo] - working on '${MAIN_REPO_BRANCH}' branch"
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 echo "Working dir is ${DIR}"
 echo "GOPATH is ${GOPATH}"
 cd "${GOPATH}/src/github.com/harmony-one/harmony-test"
+# fallback to master if branch is not on remote
+# Current solution expects that your harmony-test repo branch with the same name exists
+# or it will use master by default
+TEST_REPO_BRANCH=${MAIN_REPO_BRANCH}
+TEST_REPO_BRANCH=$(git ls-remote --exit-code --heads origin "${TEST_REPO_BRANCH}" >/dev/null 2>&1 \
+    && echo "${TEST_REPO_BRANCH}" || echo "master")
+echo "[harmony-test repo] - working on '${TEST_REPO_BRANCH}' branch"
 # cover possible force pushes to remote branches - just rebase local on top of origin
 git fetch origin "${TEST_REPO_BRANCH}"
 git checkout "${TEST_REPO_BRANCH}"

--- a/scripts/travis_rpc_checker.sh
+++ b/scripts/travis_rpc_checker.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-TEST_REPO_BRANCH=${TEST_REPO_BRANCH:-master}
 # handle for the Travis build run:
 # * uses TRAVIS_PULL_REQUEST_SLUG if PR is done from fork
 # * uses TRAVIS_PULL_REQUEST_BRANCH for RP branch
@@ -29,12 +28,18 @@ if [[ -z "$MAIN_REPO_BRANCH" ]]; then
     fi
 fi
 
-echo "[harmony-test repo] - working on '${TEST_REPO_BRANCH}' branch"
 echo "[harmony repo] - working on '${MAIN_REPO_BRANCH}' branch"
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 echo "Working dir is ${DIR}"
 echo "GOPATH is ${GOPATH}"
 cd "${GOPATH}/src/github.com/harmony-one/harmony-test"
+# Current solution expects that your harmony-test repo branch with the same name exists
+# or it will use master by default
+TEST_REPO_BRANCH=${MAIN_REPO_BRANCH}
+# fallback to master if branch is not on remote
+TEST_REPO_BRANCH=$(git ls-remote --exit-code --heads origin "${TEST_REPO_BRANCH}" >/dev/null 2>&1 \
+    && echo "${TEST_REPO_BRANCH}" || echo "master")
+echo "[harmony-test repo] - working on '${TEST_REPO_BRANCH}' branch"
 # cover possible force pushes to remote branches - just rebase local on top of origin
 git fetch origin "${TEST_REPO_BRANCH}"
 git checkout "${TEST_REPO_BRANCH}"


### PR DESCRIPTION
What was done:
* turn back logic where we are expecting harmony-test repo to have the branch with the same name, if not  fallback to `master` by default
* remove all `TEST_REPO_BRANCH` mentions
* remove - `echo $TRAVIS_PULL_REQUEST_BRANCH` in `.travisci.yml`, because it doesn't give us any extra information in print
 
## Issue

<!-- link to the issue number or description of the issue -->

## Test

Tested locally against both situations:
* harmony-test branch exist, e.x. - feature/effective-gas-price
```
$ make travis_rpc_checker
bash ./scripts/travis_rpc_checker.sh
[harmony repo] - working on 'feature/effective-gas-price' branch
Working dir is  /fullpath/github.com/harmony-one/harmony/scripts
GOPATH is  /fullpath/go1.22.5/global
[harmony-test repo] - working on 'feature/effective-gas-price' branch
From https://github.com/harmony-one/harmony-test
 * branch            feature/effective-gas-price -> FETCH_HEAD
Switched to branch 'feature/effective-gas-price'
Your branch is up to date with 'origin/feature/effective-gas-price'.
...

```
* harmony-test branch doesn't exist:
```
$ make travis_rpc_checker
bash ./scripts/travis_rpc_checker.sh
[harmony repo] - working on 'refactor/fallback_to_master_on_harmony_test_repo' branch
Working dir is /fullpath/github.com/harmony-one/harmony/scripts
GOPATH is /fullpath/global
[harmony-test repo] - working on 'master' branch

```
### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
