### PR TITLE
update harmony and bootnode version

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -91,7 +91,8 @@ var (
 )
 
 func printVersion(me string) {
-	fmt.Fprintf(os.Stderr, "Harmony (C) 2024. %v, version %v-%v (%v %v)\n", path.Base(me), version, commit, builtBy, builtAt)
+	currentYear := time.Now().Year()
+	fmt.Fprintf(os.Stderr, "Harmony (C) %d. %v, version %v-%v (%v %v)\n", currentYear, path.Base(me), version, commit, builtBy, builtAt)
 }
 
 func main() {

--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -84,14 +84,20 @@ func NewConnLogger(l log.Logger) *ConnLogger {
 }
 
 var (
-	version string
-	builtBy string
-	builtAt string
-	commit  string
+	version  string
+	builtBy  string
+	builtAt  string
+	commit   string
+	commitAt string
 )
 
 func printVersion(me string) {
-	currentYear := time.Now().Year()
+	commitYear, err := time.Parse("2006-01-02T15:04:05-0700", commitAt)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing commit date: %v\n", err)
+		os.Exit(1)
+	}
+	var currentYear = commitYear.Year()
 	fmt.Fprintf(os.Stderr, "Harmony (C) %d. %v, version %v-%v (%v %v)\n", currentYear, path.Base(me), version, commit, builtBy, builtAt)
 }
 
@@ -181,7 +187,7 @@ func main() {
 
 	nt := nodeConfigs.NetworkType(*networkType)
 	nodeConfigs.SetNetworkType(nt)
-	harmonyConfigs.VersionMetaData = append(harmonyConfigs.VersionMetaData, path.Base(os.Args[0]), version, commit, builtBy, builtAt)
+	harmonyConfigs.VersionMetaData = append(harmonyConfigs.VersionMetaData, path.Base(os.Args[0]), version, commit, commitAt, builtBy, builtAt)
 	nodeConfigs.SetVersion(harmonyConfigs.GetHarmonyVersion())
 	nodeConfigs.SetPeerID(host.GetID())
 	hc := harmonyConfigs.GetDefaultConfigCopy()

--- a/cmd/config/version.go
+++ b/cmd/config/version.go
@@ -3,13 +3,10 @@ package config
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/harmony-one/harmony/internal/cli"
 	"github.com/spf13/cobra"
-)
-
-const (
-	versionFormat = "Harmony (C) 2023. %v, version %v-%v (%v %v)"
 )
 
 var VersionMetaData []interface{}
@@ -36,6 +33,8 @@ func VersionFlag() cli.BoolFlag {
 }
 
 func GetHarmonyVersion() string {
+	currentYear := time.Now().Year()
+	versionFormat := fmt.Sprintf("Harmony (C) %d. %%v, version %%v-%%v (%%v %%v)", currentYear)
 	return fmt.Sprintf(versionFormat, VersionMetaData[:5]...) // "harmony", version, commit, builtBy, builtAt
 }
 

--- a/cmd/config/version.go
+++ b/cmd/config/version.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path"
 	"time"
 
 	"github.com/harmony-one/harmony/internal/cli"
@@ -33,9 +34,22 @@ func VersionFlag() cli.BoolFlag {
 }
 
 func GetHarmonyVersion() string {
-	currentYear := time.Now().Year()
+	var version, commit, builtBy, builtAt, commitAt string
+	version = VersionMetaData[1].(string)
+	commit = VersionMetaData[2].(string)
+	commitAt = VersionMetaData[3].(string)
+	builtBy = VersionMetaData[4].(string)
+	builtAt = VersionMetaData[5].(string)
+
+	//Harmony (C) 2025. harmony, version v8507-v2024.3.1-85-g735e68a31-dirty (soph@ 2025-01-21T14:07:44+0700)
+	commitYear, err := time.Parse("2006-01-02T15:04:05-0700", commitAt)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing commit date: %v\n", err)
+		os.Exit(1)
+	}
+	var currentYear = commitYear.Year()
 	versionFormat := fmt.Sprintf("Harmony (C) %d. %%v, version %%v-%%v (%%v %%v)", currentYear)
-	return fmt.Sprintf(versionFormat, VersionMetaData[:5]...) // "harmony", version, commit, builtBy, builtAt
+	return fmt.Sprintf(versionFormat, path.Base(os.Args[0]), version, commit, builtBy, builtAt)
 }
 
 func PrintVersion() {

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -60,10 +60,11 @@ import (
 
 // Version string variables
 var (
-	version string
-	builtBy string
-	builtAt string
-	commit  string
+	version  string
+	builtBy  string
+	builtAt  string
+	commit   string
+	commitAt string
 )
 
 // Host
@@ -98,7 +99,7 @@ Examples usage:
 }
 
 func init() {
-	harmonyConfigs.VersionMetaData = append(harmonyConfigs.VersionMetaData, "harmony", version, commit, builtBy, builtAt)
+	harmonyConfigs.VersionMetaData = append(harmonyConfigs.VersionMetaData, "harmony", version, commit, commitAt, builtBy, builtAt)
 	harmonyConfigs.Init(rootCmd)
 }
 

--- a/scripts/go_executable_build.sh
+++ b/scripts/go_executable_build.sh
@@ -105,6 +105,7 @@ function build_only
 
    VERSION=$(git rev-list --count HEAD)
    COMMIT=$(git describe --always --long --dirty)
+   COMMITAT=$( git show -s --format=%cd --date=format:%Y-%m-%dT%H:%M:%S%z HEAD)
    BUILTAT=$(date +%FT%T%z)
    BUILTBY=${USER}@
    local build=$1
@@ -117,12 +118,12 @@ function build_only
          rm -f $BINDIR/$bin
          echo "building ${SRC[$bin]}"
          if [ "$DEBUG" == "true" ]; then
-            env GOOS=$GOOS GOARCH=$GOARCH go build $VERBOSE -gcflags="${GO_GCFLAGS}" -ldflags="-X main.version=v${VERSION} -X main.commit=${COMMIT} -X main.builtAt=${BUILTAT} -X main.builtBy=${BUILTBY}" -o $BINDIR/$bin $RACE $TRACEPTR ${SRC[$bin]}
+            env GOOS=$GOOS GOARCH=$GOARCH go build $VERBOSE -gcflags="${GO_GCFLAGS}" -ldflags="-X main.version=v${VERSION} -X main.commit=${COMMIT} -X main.commitAt=${COMMITAT} -X main.builtAt=${BUILTAT} -X main.builtBy=${BUILTBY}" -o $BINDIR/$bin $RACE $TRACEPTR ${SRC[$bin]}
          else
             if [ "$STATIC" == "true" ]; then
-               env GOOS=$GOOS GOARCH=$GOARCH go build $VERBOSE -gcflags="${GO_GCFLAGS}" -ldflags="-X main.version=v${VERSION} -X main.commit=${COMMIT} -X main.builtAt=${BUILTAT} -X main.builtBy=${BUILTBY}  -w -extldflags \"-static -lm\"" -o $BINDIR/$bin $RACE $TRACEPTR ${SRC[$bin]}
+               env GOOS=$GOOS GOARCH=$GOARCH go build $VERBOSE -gcflags="${GO_GCFLAGS}" -ldflags="-X main.version=v${VERSION} -X main.commit=${COMMIT} -X main.commitAt=${COMMITAT} -X main.builtAt=${BUILTAT} -X main.builtBy=${BUILTBY}  -w -extldflags \"-static -lm\"" -o $BINDIR/$bin $RACE $TRACEPTR ${SRC[$bin]}
             else
-               env GOOS=$GOOS GOARCH=$GOARCH go build $VERBOSE -gcflags="${GO_GCFLAGS}" -ldflags="-X main.version=v${VERSION} -X main.commit=${COMMIT} -X main.builtAt=${BUILTAT} -X main.builtBy=${BUILTBY}" -o $BINDIR/$bin $RACE $TRACEPTR ${SRC[$bin]}
+               env GOOS=$GOOS GOARCH=$GOARCH go build $VERBOSE -gcflags="${GO_GCFLAGS}" -ldflags="-X main.version=v${VERSION} -X main.commit=${COMMIT} -X main.commitAt=${COMMITAT} -X main.builtAt=${BUILTAT} -X main.builtBy=${BUILTBY}" -o $BINDIR/$bin $RACE $TRACEPTR ${SRC[$bin]}
             fi
          fi
          if [ "$(uname -s)" == "Linux" ]; then

--- a/scripts/go_executable_build.sh
+++ b/scripts/go_executable_build.sh
@@ -105,7 +105,7 @@ function build_only
 
    VERSION=$(git rev-list --count HEAD)
    COMMIT=$(git describe --always --long --dirty)
-   COMMITAT=$( git show -s --format=%cd --date=format:%Y-%m-%dT%H:%M:%S%z HEAD)
+   COMMITAT=$(git show -s --format=%cd --date=format:%Y-%m-%dT%H:%M:%S%z HEAD)
    BUILTAT=$(date +%FT%T%z)
    BUILTBY=${USER}@
    local build=$1


### PR DESCRIPTION
updated the show version of bootnode and harmony binary to dynamically use the current year from the last commit
```
~$ bin/bootnode -version
Harmony (C) 2025. bootnode, version v8508-v2024.3.1-86-g0b5c9ed07 (soph@ 2025-01-21T14:43:16+0700)
~$ bin/harmony -V
Harmony (C) 2025. harmony, version v8508-v2024.3.1-86-g0b5c9ed07 (soph@ 2025-01-21T14:43:16+0700)
```