### PR TITLE
Prevent Explorer Nodes from Adding Future Blocks

### DIFF
--- a/node/harmony/node_explorer.go
+++ b/node/harmony/node_explorer.go
@@ -46,7 +46,7 @@ func (node *Node) explorerMessageHandler(ctx context.Context, msg *msg_pb.Messag
 		// If a future block is received, it logs a warning and discards the block
 		// TODO: can be done with isRightBlockNumAndViewID(recvMsg)
 		if recvMsg.BlockNum != node.Blockchain().CurrentBlock().NumberU64()+1 {
-			utils.Logger().Warn().
+			utils.Logger().Debug().
 				Uint64("Received BlockNum", recvMsg.BlockNum).
 				Uint64("Current Block Number", node.Blockchain().CurrentBlock().NumberU64()).
 				Msg("[Explorer] received a future block on COMMIT phase")
@@ -99,7 +99,7 @@ func (node *Node) explorerMessageHandler(ctx context.Context, msg *msg_pb.Messag
 		// If a future block is received, it logs a warning and discards the block
 		// TODO: can be done with isRightBlockNumAndViewID(recvMsg)
 		if recvMsg.BlockNum != node.Blockchain().CurrentBlock().NumberU64()+1 {
-			utils.Logger().Warn().
+			utils.Logger().Debug().
 				Uint64("Received BlockNum", recvMsg.BlockNum).
 				Uint64("Current Block Number", node.Blockchain().CurrentBlock().NumberU64()).
 				Msg("[Explorer] received a future block on PREPARE phase")

--- a/node/harmony/node_explorer.go
+++ b/node/harmony/node_explorer.go
@@ -48,7 +48,7 @@ func (node *Node) explorerMessageHandler(ctx context.Context, msg *msg_pb.Messag
 		if recvMsg.BlockNum != node.Blockchain().CurrentBlock().NumberU64()+1 {
 			utils.Logger().Warn().
 				Uint64("Received BlockNum", recvMsg.BlockNum).
-				Uint64("Consensus BlockNum", node.GetConsensusBlockNum()).
+				Uint64("Current Block Number", node.Blockchain().CurrentBlock().NumberU64()).
 				Msg("[Explorer] received a future block on COMMIT phase")
 			return nil
 		}
@@ -101,7 +101,7 @@ func (node *Node) explorerMessageHandler(ctx context.Context, msg *msg_pb.Messag
 		if recvMsg.BlockNum != node.Blockchain().CurrentBlock().NumberU64()+1 {
 			utils.Logger().Warn().
 				Uint64("Received BlockNum", recvMsg.BlockNum).
-				Uint64("Consensus BlockNum", node.GetConsensusBlockNum()).
+				Uint64("Current Block Number", node.Blockchain().CurrentBlock().NumberU64()).
 				Msg("[Explorer] received a future block on PREPARE phase")
 			return nil
 		}

--- a/node/harmony/node_explorer.go
+++ b/node/harmony/node_explorer.go
@@ -45,10 +45,10 @@ func (node *Node) explorerMessageHandler(ctx context.Context, msg *msg_pb.Messag
 		}
 		// If a future block is received, it logs a warning and discards the block
 		// TODO: can be done with isRightBlockNumAndViewID(recvMsg)
-		if recvMsg.BlockNum != node.Blockchain().CurrentBlock().NumberU64()+1 {
+		if current := node.Blockchain().CurrentBlock().NumberU64(); recvMsg.BlockNum != current+1 {
 			utils.Logger().Debug().
 				Uint64("Received BlockNum", recvMsg.BlockNum).
-				Uint64("Current Block Number", node.Blockchain().CurrentBlock().NumberU64()).
+				Uint64("Current Block Number", current).
 				Msg("[Explorer] received a future block on COMMIT phase")
 			return nil
 		}
@@ -98,10 +98,10 @@ func (node *Node) explorerMessageHandler(ctx context.Context, msg *msg_pb.Messag
 		}
 		// If a future block is received, it logs a warning and discards the block
 		// TODO: can be done with isRightBlockNumAndViewID(recvMsg)
-		if recvMsg.BlockNum != node.Blockchain().CurrentBlock().NumberU64()+1 {
+		if current := node.Blockchain().CurrentBlock().NumberU64(); recvMsg.BlockNum != current+1 {
 			utils.Logger().Debug().
 				Uint64("Received BlockNum", recvMsg.BlockNum).
-				Uint64("Current Block Number", node.Blockchain().CurrentBlock().NumberU64()).
+				Uint64("Current Block Number", current).
 				Msg("[Explorer] received a future block on PREPARE phase")
 			return nil
 		}


### PR DESCRIPTION
This PR ensures that explorer nodes do not accept future blocks that are not the immediate next block during the COMMIT and PREPARE phase. Previously, there was no strict check on whether a received block was sequential, which could lead to inconsistencies.