### PR TITLE
Fix Explorer Node's Stream Connectivity Issues

### DIFF
--- a/p2p/stream/common/streammanager/streammanager.go
+++ b/p2p/stream/common/streammanager/streammanager.go
@@ -277,6 +277,11 @@ func (sm *streamManager) handleAddStream(st sttypes.Stream) error {
 		if sm.reservedStreams.size() < MaxReservedStreams {
 			if _, ok := sm.reservedStreams.get(id); !ok {
 				sm.reservedStreams.addStream(st)
+				sm.logger.Info().
+					Int("NumStreams", sm.streams.size()).
+					Int("NumReservedStreams", sm.reservedStreams.size()).
+					Interface("StreamID", id).
+					Msg("[StreamManager] added new stream to reserved list")
 			}
 			return nil
 		}
@@ -284,6 +289,10 @@ func (sm *streamManager) handleAddStream(st sttypes.Stream) error {
 	}
 
 	sm.streams.addStream(st)
+	sm.logger.Info().
+		Int("NumStreams", sm.streams.size()).
+		Interface("StreamID", id).
+		Msg("[StreamManager] added new stream to main streams list")
 
 	sm.addStreamFeed.Send(EvtStreamAdded{st})
 	addedStreamsCounterVec.With(prometheus.Labels{"topic": string(sm.myProtoID)}).Inc()
@@ -407,6 +416,11 @@ func (sm *streamManager) discover(ctx context.Context) (<-chan libp2p_peer.AddrI
 	if sm.config.HiCap-numStreams < sm.config.DiscBatch {
 		discBatch = sm.config.HiCap - numStreams
 	}
+	sm.logger.Debug().
+		Interface("protoID", protoID).
+		Int("numStreams", numStreams).
+		Int("discBatch", discBatch).
+		Msg("[StreamManager] discovering")
 	if discBatch < 0 {
 		return nil, nil
 	}

--- a/p2p/stream/protocols/sync/protocol.go
+++ b/p2p/stream/protocols/sync/protocol.go
@@ -262,7 +262,7 @@ func (p *Protocol) protoIDByVersion(v *version.Version) sttypes.ProtoID {
 		NetworkType:       p.config.Network,
 		ShardID:           p.config.ShardID,
 		Version:           v,
-		IsBeaconValidator: p.config.Validator && p.config.BeaconNode,
+		IsBeaconValidator: (p.config.Validator || p.config.Explorer) && p.config.BeaconNode,
 	}
 	return spec.ToProtoID()
 }


### PR DESCRIPTION
This PR addresses the connectivity issue of explorer nodes. It adds explorer nodes as a beacon node to protocol ID and let's them see other nodes with same protocol ID.