### PR TITLE
Refactor advertisement logic with retries and dynamic sleep adjustments

### DIFF
--- a/p2p/stream/protocols/sync/protocol_test.go
+++ b/p2p/stream/protocols/sync/protocol_test.go
@@ -46,6 +46,7 @@ func TestProtocol_advertiseLoop(t *testing.T) {
 	p := &Protocol{
 		disc:   disc,
 		closeC: make(chan struct{}),
+		ctx:    context.Background(),
 	}
 
 	go p.advertiseLoop()


### PR DESCRIPTION
This PR updates the advertisement logic in the `Protocol` to make it more reliable and adaptive. It is manually tested the retry mechanism and sleep time changes. Everything seems to adjust correctly based on peer discoveries and network conditions. 

This PR adds these items:

- **Retry Mechanism**: 
  - If the advertisement fails, it will now retry up to 3 times with an increasing wait time between each try. This helps handle temporary network issues more smoothly.

- **Dynamic Timeout**: 
  - We’ve made the timeout for advertisement calls dynamic. It increases by 5 seconds after each try, giving more time if the process is taking longer.

- **Tracking Peer Discoveries**: 
  - Added a new counter to keep track of how many new peers are found during advertisement. This helps adjust the sleep time based on whether new peers are discovered.

- **Sleep Time Adjustments**:
  - The sleep time between advertisements is now based on whether new peers were found. If new peers are discovered, we add a little more wait time, and if not, the wait time is reduced. We also added some random jitter to prevent advertisements from syncing up across nodes.


