### PR TITLE
feat(core): EOA sender validation (EIP-3607)

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/harmony-one/harmony/core/state"
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/core/vm"
 	"github.com/harmony-one/harmony/internal/utils"
@@ -90,6 +91,7 @@ type Message interface {
 
 	Nonce() uint64
 	SkipNonceChecks() bool
+	SkipFromEOACheck() bool
 	Data() []byte
 	Type() types.TransactionType
 	BlockNum() *big.Int
@@ -204,6 +206,14 @@ func (st *StateTransition) preCheck() error {
 			return ErrNonceTooLow
 		}
 	}
+
+	// Ensure that the sender is an EOA (EIP-3607)
+	if !st.msg.SkipFromEOACheck() {
+		if codeHash := st.state.GetCodeHash(st.msg.From()); codeHash != state.EmptyCodeHash && codeHash != (common.Hash{}) { // getCodeHash returns EmptyCodeHash for unused accounts
+			return ErrSenderNotEOA
+		}
+	}
+
 	return st.buyGas()
 }
 

--- a/core/state_transition_test.go
+++ b/core/state_transition_test.go
@@ -232,7 +232,7 @@ func TestPreCheck(t *testing.T) {
 		setup         func(db *state.DB, addr common.Address)
 	}{
 		{
-			name: "NonceTooHigh",
+			name: "NonceTooHigh", // nonce is 0, but expected is 2
 			msg: types.NewMessage(
 				crypto.PubkeyToAddress(key.PublicKey),
 				nil,
@@ -247,7 +247,7 @@ func TestPreCheck(t *testing.T) {
 			expectedError: ErrNonceTooHigh,
 		},
 		{
-			name: "NonceTooLow",
+			name: "NonceTooLow", // nonce is 1, but expected is 0
 			msg: types.NewMessage(
 				crypto.PubkeyToAddress(key.PublicKey),
 				nil,
@@ -265,7 +265,7 @@ func TestPreCheck(t *testing.T) {
 			},
 		},
 		{
-			name: "SenderNotEOA",
+			name: "SenderNotEOA", // sender has a code hash, thus not an EOA
 			msg: types.NewMessage(
 				crypto.PubkeyToAddress(key.PublicKey),
 				nil,
@@ -281,7 +281,7 @@ func TestPreCheck(t *testing.T) {
 			setup:         setCode,
 		},
 		{
-			name: "SuccessfulPreCheck",
+			name: "SuccessfulPreCheck", // all checks pass
 			msg: types.NewMessage(
 				crypto.PubkeyToAddress(key.PublicKey),
 				nil,
@@ -296,7 +296,7 @@ func TestPreCheck(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name: "SkipNonceChecks",
+			name: "SkipNonceChecks", // skip nonce checks
 			msg: types.NewMessage(
 				crypto.PubkeyToAddress(key.PublicKey),
 				nil,
@@ -311,7 +311,7 @@ func TestPreCheck(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name: "SkipFromEOACheck",
+			name: "SkipFromEOACheck", // skip EOA check
 			msg: types.NewMessage(
 				crypto.PubkeyToAddress(key.PublicKey),
 				nil,
@@ -327,7 +327,7 @@ func TestPreCheck(t *testing.T) {
 			setup:         setCode,
 		},
 		{
-			name: "SkipBothChecks",
+			name: "SkipBothChecks", // skip both checks
 			msg: types.NewMessage(
 				crypto.PubkeyToAddress(key.PublicKey),
 				nil,
@@ -341,6 +341,45 @@ func TestPreCheck(t *testing.T) {
 			),
 			expectedError: nil,
 			setup:         setCode,
+		},
+
+		// staking messages
+		{
+			name: "StakingWithCodeHash", // staking message with code hash
+			msg: types.NewStakingMessage(
+				crypto.PubkeyToAddress(key.PublicKey),
+				0,
+				21000,
+				big.NewInt(1),
+				[]byte{},
+				big.NewInt(1000),
+			),
+			expectedError: nil,
+			setup:         setCode,
+		},
+		{
+			name: "StakingWithoutCodeHash", // staking message without code hash
+			msg: types.NewStakingMessage(
+				crypto.PubkeyToAddress(key.PublicKey),
+				0,
+				21000,
+				big.NewInt(1),
+				[]byte{},
+				big.NewInt(1000),
+			),
+			expectedError: nil,
+		},
+		{
+			name: "StakingNonceTooHigh", // staking message with nonce too high
+			msg: types.NewStakingMessage(
+				crypto.PubkeyToAddress(key.PublicKey),
+				2,
+				21000,
+				big.NewInt(1),
+				[]byte{},
+				big.NewInt(1000),
+			),
+			expectedError: ErrNonceTooHigh,
 		},
 	}
 

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -102,6 +102,9 @@ var (
 	ErrBlacklistTo = errors.New("`to` address of transaction in blacklist")
 
 	ErrAllowedTxs = errors.New("transaction allowed whitelist check failed.")
+
+	// ErrSenderNotEOA is returned if the transaction sender is a contract.
+	ErrSenderNotEOA = errors.New("sender not an eoa")
 )
 
 var (

--- a/core/types/eth_transaction.go
+++ b/core/types/eth_transaction.go
@@ -358,13 +358,14 @@ func (tx *EthTransaction) IsEthCompatible() bool {
 // XXX Rename message to something less arbitrary?
 func (tx *EthTransaction) AsMessage(s Signer) (Message, error) {
 	msg := Message{
-		nonce:           tx.data.AccountNonce,
-		gasLimit:        tx.data.GasLimit,
-		gasPrice:        new(big.Int).Set(tx.data.Price),
-		to:              tx.data.Recipient,
-		value:           tx.data.Amount,
-		data:            tx.data.Payload,
-		skipNonceChecks: false,
+		nonce:            tx.data.AccountNonce,
+		gasLimit:         tx.data.GasLimit,
+		gasPrice:         new(big.Int).Set(tx.data.Price),
+		to:               tx.data.Recipient,
+		value:            tx.data.Amount,
+		data:             tx.data.Payload,
+		skipNonceChecks:  false,
+		skipFromEOACheck: false,
 	}
 
 	var err error

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -474,13 +474,14 @@ func (tx *Transaction) ConvertToEth() *EthTransaction {
 // XXX Rename message to something less arbitrary?
 func (tx *Transaction) AsMessage(s Signer) (Message, error) {
 	msg := Message{
-		nonce:           tx.data.AccountNonce,
-		gasLimit:        tx.data.GasLimit,
-		gasPrice:        new(big.Int).Set(tx.data.Price),
-		to:              tx.data.Recipient,
-		value:           tx.data.Amount,
-		data:            tx.data.Payload,
-		skipNonceChecks: false,
+		nonce:            tx.data.AccountNonce,
+		gasLimit:         tx.data.GasLimit,
+		gasPrice:         new(big.Int).Set(tx.data.Price),
+		to:               tx.data.Recipient,
+		value:            tx.data.Amount,
+		data:             tx.data.Payload,
+		skipNonceChecks:  false,
+		skipFromEOACheck: false,
 	}
 
 	var err error
@@ -708,55 +709,34 @@ type Message struct {
 	txType   TransactionType
 }
 
-//type Message struct {
-//	To                    *common.Address
-//	From                  common.Address
-//	Nonce                 uint64
-//	Value                 *big.Int
-//	GasLimit              uint64
-//	GasPrice              *big.Int
-//	GasFeeCap             *big.Int
-//	GasTipCap             *big.Int
-//	Data                  []byte
-//	AccessList            types.AccessList
-//	BlobGasFeeCap         *big.Int
-//	BlobHashes            []common.Hash
-//	SetCodeAuthorizations []types.SetCodeAuthorization
-//
-//	// When SkipNonceChecks is true, the message nonce is not checked against the
-//	// account nonce in state.
-//	// This field will be set to true for operations like RPC eth_call.
-//	SkipNonceChecks bool
-//
-//	// When SkipFromEOACheck is true, the message sender is not checked to be an EOA.
-//	SkipFromEOACheck bool
-//}
-
 // NewMessage returns new message.
-func NewMessage(from common.Address, to *common.Address, nonce uint64, amount *big.Int, gasLimit uint64, gasPrice *big.Int, data []byte, skipNonceChecks bool) Message {
+func NewMessage(from common.Address, to *common.Address, nonce uint64, amount *big.Int, gasLimit uint64, gasPrice *big.Int, data []byte, skipNonceChecks, skipFromEOACheck bool) Message {
 	return Message{
-		from:            from,
-		to:              to,
-		nonce:           nonce,
-		value:           amount,
-		gasLimit:        gasLimit,
-		gasPrice:        gasPrice,
-		data:            data,
-		skipNonceChecks: skipNonceChecks,
+		from:             from,
+		to:               to,
+		nonce:            nonce,
+		value:            amount,
+		gasLimit:         gasLimit,
+		gasPrice:         gasPrice,
+		data:             data,
+		skipNonceChecks:  skipNonceChecks,
+		skipFromEOACheck: skipFromEOACheck,
 	}
 }
 
 // NewStakingMessage returns new message of staking type
 // always need checkNonce
+// TODO (sun): allow staking transactions to bypass EIP-3607 check
 func NewStakingMessage(from common.Address, nonce uint64, gasLimit uint64, gasPrice *big.Int, data []byte, blockNum *big.Int) Message {
 	return Message{
-		from:            from,
-		nonce:           nonce,
-		gasLimit:        gasLimit,
-		gasPrice:        new(big.Int).Set(gasPrice),
-		data:            data,
-		skipNonceChecks: false,
-		blockNum:        blockNum,
+		from:             from,
+		nonce:            nonce,
+		gasLimit:         gasLimit,
+		gasPrice:         new(big.Int).Set(gasPrice),
+		data:             data,
+		blockNum:         blockNum,
+		skipNonceChecks:  false,
+		skipFromEOACheck: true,
 	}
 }
 
@@ -798,6 +778,11 @@ func (m Message) Data() []byte {
 // CheckNonce returns checkNonce of Message.
 func (m Message) SkipNonceChecks() bool {
 	return m.skipNonceChecks
+}
+
+// SkipFromEOACheck returns skipFromEOACheck of Message.
+func (m Message) SkipFromEOACheck() bool {
+	return m.skipFromEOACheck
 }
 
 // Type returns the type of message

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -724,9 +724,8 @@ func NewMessage(from common.Address, to *common.Address, nonce uint64, amount *b
 	}
 }
 
-// NewStakingMessage returns new message of staking type
-// always need checkNonce
-// TODO (sun): allow staking transactions to bypass EIP-3607 check
+// NewStakingMessage returns new message of staking type.
+// It requires to check the nonce and skip the EOA check.
 func NewStakingMessage(from common.Address, nonce uint64, gasLimit uint64, gasPrice *big.Int, data []byte, blockNum *big.Int) Message {
 	return Message{
 		from:             from,

--- a/rpc/harmony/types.go
+++ b/rpc/harmony/types.go
@@ -72,7 +72,7 @@ func (args *CallArgs) ToMessage(globalGasCap *big.Int) types.Message {
 		data = []byte(*args.Data)
 	}
 
-	msg := types.NewMessage(addr, args.To, 0, value, gas, gasPrice, data, true)
+	msg := types.NewMessage(addr, args.To, 0, value, gas, gasPrice, data, true, true)
 	return msg
 }
 


### PR DESCRIPTION
### Changes
- Implemented core logic for EOA validation based on EIP-3607
- Added unit tests to cover EOA validation and `preCheck` functionality

### Cause
This update enhances security by preventing contract accounts from sending transactions directly, aligning with the EIP-3607 standard. It addresses inconsistencies in sender validation logic within the core module. Notably, staking messages are still exempt from the EOA check, as Harmony permits multisig accounts (which are non-EOAs) to send staking messages.

### How to Test
- Run `make go-test` to verify all unit tests pass
- Run `go test -run ^TestPreCheck$ github.com/harmony-one/harmony/core ` for the specific unit test

### Notes:
This PR was based on an earlier version (#4840) but has been updated and cleaned up.