### PR TITLE
Enhance P2P Layer: Stream Removal Tracking and Cooldown Handling

### DIFF
--- a/p2p/stream/common/streammanager/config.go
+++ b/p2p/stream/common/streammanager/config.go
@@ -12,6 +12,8 @@ const (
 	connectTimeout = 60 * time.Second
 	// MaxReservedStreams is the maximum number of reserved streams
 	MaxReservedStreams = 100
+	// RemovalCooldownDuration defines the cooldown period (in minutes) before a removed stream can reconnect.
+	RemovalCooldownDuration = 60 // 1 hour
 )
 
 // Config is the config for stream manager


### PR DESCRIPTION
This PR improves the P2P layer by introducing a cooldown mechanism for removed streams. Previously, when a stream was removed, the next peer discovery cycle could reconnect to the same stream immediately, potentially causing issues if the peer was invalid or unsynced. This could prevent our node from fully syncing.  

#### **Key Changes**  
✅ **Added `RemovalInfo` struct** to track the removal timestamp, expiration time, and removal count for each stream.  
✅ **Introduced `RemovalCooldownDuration`** (default: **60 minutes**) to enforce a cooldown period before a removed stream can be reconnected.  
✅ **Updated `streamManager.handleAddStream`** to check if a stream was recently removed before allowing reconnection.  
✅ **Ensured removed streams are stored in `removedStreams`** and properly marked when removal occurs.  
✅ **Refactored variable names and comments** for better clarity and maintainability.  