### PR TITLE
feat: tload and tstore opcodes for transient storage (EIP-1153) 

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1170,7 +1170,7 @@ func (db *DB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 //
 // - reset transient storage (1153)
 //
-// todo(sun): Berlin fork
+// todo(sun): berlin fork
 // - add sender to access list (2929)
 // - add destination to access list (2929)
 // - add precompiles to access list (2929)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -154,7 +154,7 @@ func (p *StateProcessor) Process(
 		startTime := time.Now()
 		// Iterate over and process the individual transactions
 		for i, tx := range block.Transactions() {
-			statedb.Prepare(tx.Hash(), block.Hash(), i)
+			statedb.SetTxContext(tx.Hash(), block.Hash(), i)
 			receipt, cxReceipt, stakeMsgs, _, err := ApplyTransaction(
 				p.bc, &beneficiary, gp, statedb, header, tx, usedGas, cfg,
 			)
@@ -177,7 +177,7 @@ func (p *StateProcessor) Process(
 		// Iterate over and process the staking transactions
 		L := len(block.Transactions())
 		for i, tx := range block.StakingTransactions() {
-			statedb.Prepare(tx.Hash(), block.Hash(), i+L)
+			statedb.SetTxContext(tx.Hash(), block.Hash(), i+L)
 			receipt, _, err := ApplyStakingTransaction(
 				p.bc, &beneficiary, gp, statedb, header, tx, usedGas, cfg,
 			)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -207,6 +207,7 @@ func (st *StateTransition) preCheck() error {
 	return st.buyGas()
 }
 
+// todo(sun): clear transient storage (and access list?)
 // TransitionDb will transition the state by applying the current message and
 // returning the result including the used gas. It returns an error if failed.
 // An error indicates a consensus issue.
@@ -309,6 +310,8 @@ func (st *StateTransition) collectGas() {
 func (st *StateTransition) gasUsed() uint64 {
 	return st.initialGas - st.gas
 }
+
+// todo(sun): do transient storage and access lists need to be cleared?
 
 // StakingTransitionDb will transition the state by applying the staking message and
 // returning the result including the used gas. It returns an error if failed.

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -24,7 +24,7 @@ import (
 	"github.com/harmony-one/harmony/internal/params"
 )
 
-// todo(sun): update the config to enable eip1153
+// todo(sun): enable eip1153 (london fork)
 // EnableEIP enables the given EIP on the config.
 // This operation writes in-place, and callers need to ensure that the globally
 // defined jump tables are not polluted.

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -20,9 +20,11 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/internal/params"
 )
 
+// todo(sun): update the config to enable eip1153
 // EnableEIP enables the given EIP on the config.
 // This operation writes in-place, and callers need to ensure that the globally
 // defined jump tables are not polluted.
@@ -34,6 +36,8 @@ func EnableEIP(eipNum int, jt *JumpTable) error {
 		enable1884(jt)
 	case 1344:
 		enable1344(jt)
+	case 1153:
+		enable1153(jt)
 	default:
 		return fmt.Errorf("undefined eip %d", eipNum)
 	}
@@ -95,4 +99,56 @@ func opChainID(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memo
 // enable2200 applies EIP-2200 (Rebalance net-metered SSTORE)
 func enable2200(jt *JumpTable) {
 	jt[SSTORE].dynamicGas = gasSStoreEIP2200
+}
+
+// enable1153 applies EIP-1153 "Transient Storage"
+// - Adds TLOAD that reads from transient storage
+// - Adds TSTORE that writes to transient storage
+func enable1153(jt *JumpTable) {
+	jt[TLOAD] = operation{
+		execute:     opTload,
+		constantGas: params.WarmStorageReadCostEIP2929,
+		minStack:    minStack(1, 1),
+		maxStack:    maxStack(1, 1),
+	}
+
+	jt[TSTORE] = operation{
+		execute:     opTstore,
+		constantGas: params.WarmStorageReadCostEIP2929,
+		minStack:    minStack(2, 0),
+		maxStack:    maxStack(2, 0),
+	}
+}
+
+// opTload implements TLOAD opcode
+func opTload(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
+	loc := stack.peek()
+
+	keyBuf := make([]byte, 32)
+	key := common.BytesToHash(loc.FillBytes(keyBuf))
+
+	val := interpreter.evm.StateDB.GetTransientState(contract.Address(), key)
+	valBuf := make([]byte, 32)
+	val.Big().FillBytes(valBuf)
+
+	loc.SetBytes(valBuf)
+	return nil, nil
+}
+
+// opTstore implements TSTORE opcode
+func opTstore(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
+	if interpreter.readOnly {
+		return nil, errWriteProtection
+	}
+
+	keyBuf := make([]byte, 32)
+	stack.pop().FillBytes(keyBuf)
+	key := common.Hash(keyBuf)
+
+	valBuf := make([]byte, 32)
+	stack.pop().FillBytes(valBuf)
+	val := common.Hash(valBuf)
+
+	interpreter.evm.StateDB.SetTransientState(contract.Address(), key, val)
+	return nil, nil
 }

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -24,7 +24,6 @@ import (
 	"github.com/harmony-one/harmony/internal/params"
 )
 
-// todo(sun): enable eip1153 (london fork)
 // EnableEIP enables the given EIP on the config.
 // This operation writes in-place, and callers need to ensure that the globally
 // defined jump tables are not polluted.

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -639,3 +639,10 @@ func TestCreate2Addreses(t *testing.T) {
 
 	}
 }
+
+// todo(sun): test the following cases:
+// tload then store
+// ensure if config does not set eip1153, then the ops don't load
+func TestOpTstoreAndTload(t *testing.T) {
+
+}

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -25,7 +25,10 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/harmony-one/harmony/core/state"
 	"github.com/harmony-one/harmony/internal/params"
 )
 
@@ -640,9 +643,48 @@ func TestCreate2Addreses(t *testing.T) {
 	}
 }
 
-// todo(sun): test the following cases:
-// tload then store
-// ensure if config does not set eip1153, then the ops don't load
 func TestOpTstoreAndTload(t *testing.T) {
+	// initialize context, evm, statedb, etc.
+	var (
+		stateDB, _     = state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
+		env            = NewEVM(Context{}, stateDB, params.TestChainConfig, Config{})
+		stack          = newstack()
+		memory         = NewMemory()
+		evmInterpreter = NewEVMInterpreter(env, env.vmConfig)
+		caller         = common.Address{}
+		to             = common.Address{1}
+		contractRef    = vm.AccountRef(caller)
+		contract       = NewContract(contractRef, vm.AccountRef(to), new(big.Int), 0)
+		value          = common.Hex2Bytes("12345")
+	)
 
+	stateDB.CreateAccount(caller)
+	stateDB.CreateAccount(to)
+	env.interpreter = evmInterpreter
+	pc := uint64(0)
+
+	// push to value then location to the stack
+	stack.push(new(big.Int).SetBytes(value))
+	stack.push(new(big.Int))
+
+	// call tstore and ensure stack length is 0
+	opTstore(&pc, evmInterpreter, contract, memory, stack)
+	if stack.len() != 0 {
+		t.Fatal("stack should be empty")
+	}
+
+	// push location to the stack
+	stack.push(new(big.Int))
+
+	// call tload and ensure stack length is 1
+	opTload(&pc, evmInterpreter, contract, memory, stack)
+	if stack.len() != 1 {
+		t.Fatal("stack should have a single element")
+	}
+
+	// ensure the value read is same as the original value
+	val := stack.peek()
+	if !bytes.Equal(value, val.Bytes()) {
+		t.Fatalf("wrong value loaded to the stack")
+	}
 }

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -59,6 +59,9 @@ type StateDB interface {
 	GetState(common.Address, common.Hash) common.Hash
 	SetState(common.Address, common.Hash, common.Hash)
 
+	GetTransientState(addr common.Address, key common.Hash) common.Hash
+	SetTransientState(addr common.Address, key, value common.Hash)
+
 	Suicide(common.Address) bool
 	HasSuicided(common.Address) bool
 

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -72,6 +72,8 @@ type StateDB interface {
 	// is defined according to EIP161 (balance = nonce = code = 0).
 	Empty(common.Address) bool
 
+	Prepare()
+
 	RevertToSnapshot(int)
 	Snapshot() int
 

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -119,6 +119,8 @@ const (
 	MSIZE
 	GAS
 	JUMPDEST
+	TLOAD  // 0x5c
+	TSTORE // 0x5d
 )
 
 // 0x60 range.
@@ -297,6 +299,8 @@ var opCodeToString = map[OpCode]string{
 	MSIZE:    "MSIZE",
 	GAS:      "GAS",
 	JUMPDEST: "JUMPDEST",
+	TLOAD:    "TLOAD",
+	TSTORE:   "TSTORE",
 
 	// 0x60 range - push.
 	PUSH1:  "PUSH1",
@@ -462,6 +466,8 @@ var stringToOp = map[string]OpCode{
 	"MSIZE":          MSIZE,
 	"GAS":            GAS,
 	"JUMPDEST":       JUMPDEST,
+	"TLOAD":          TLOAD,
+	"TSTORE":         TSTORE,
 	"PUSH1":          PUSH1,
 	"PUSH2":          PUSH2,
 	"PUSH3":          PUSH3,

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -91,8 +91,6 @@ func setDefaults(cfg *Config) {
 	}
 }
 
-// todo(sun): unit tests for the following
-
 // Execute executes the code using the input as call data during the execution.
 // It returns the EVM's return value, the new state and an error if it failed.
 //

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -91,6 +91,8 @@ func setDefaults(cfg *Config) {
 	}
 }
 
+// todo(sun): unit tests for the following
+
 // Execute executes the code using the input as call data during the execution.
 // It returns the EVM's return value, the new state and an error if it failed.
 //
@@ -111,7 +113,9 @@ func Execute(code, input []byte, cfg *Config) ([]byte, *state.DB, error) {
 		sender  = vm.AccountRef(cfg.Origin)
 	)
 
-	// todo(sun): clear transient storage (and access list?)
+	// Execute the preparatory steps for state transition which includes:
+	// - reset transient storage(eip 1153)
+	vmenv.StateDB.Prepare()
 
 	cfg.State.CreateAccount(address)
 	// set the receiver's (the executing contract) code for execution.
@@ -143,7 +147,9 @@ func Create(input []byte, cfg *Config) ([]byte, common.Address, uint64, error) {
 		sender = vm.AccountRef(cfg.Origin)
 	)
 
-	// todo(sun): clear transient storage (and access list?)
+	// Execute the preparatory steps for state transition which includes:
+	// - reset transient storage(eip 1153)
+	vmenv.StateDB.Prepare()
 
 	// Call the code with the given configuration.
 	code, address, leftOverGas, err := vmenv.Create(
@@ -167,7 +173,9 @@ func Call(address common.Address, input []byte, cfg *Config) ([]byte, uint64, er
 
 	sender := cfg.State.GetOrNewStateObject(cfg.Origin)
 
-	// todo(sun): clear transient storage (and access list?)
+	// Execute the preparatory steps for state transition which includes:
+	// - reset transient storage(eip 1153)
+	vmenv.StateDB.Prepare()
 
 	// Call the code with the given configuration.
 	ret, leftOverGas, err := vmenv.Call(

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -110,6 +110,9 @@ func Execute(code, input []byte, cfg *Config) ([]byte, *state.DB, error) {
 		vmenv   = NewEnv(cfg)
 		sender  = vm.AccountRef(cfg.Origin)
 	)
+
+	// todo(sun): clear transient storage (and access list?)
+
 	cfg.State.CreateAccount(address)
 	// set the receiver's (the executing contract) code for execution.
 	cfg.State.SetCode(address, code, false)
@@ -140,6 +143,8 @@ func Create(input []byte, cfg *Config) ([]byte, common.Address, uint64, error) {
 		sender = vm.AccountRef(cfg.Origin)
 	)
 
+	// todo(sun): clear transient storage (and access list?)
+
 	// Call the code with the given configuration.
 	code, address, leftOverGas, err := vmenv.Create(
 		sender,
@@ -161,6 +166,9 @@ func Call(address common.Address, input []byte, cfg *Config) ([]byte, uint64, er
 	vmenv := NewEnv(cfg)
 
 	sender := cfg.State.GetOrNewStateObject(cfg.Origin)
+
+	// todo(sun): clear transient storage (and access list?)
+
 	// Call the code with the given configuration.
 	ret, leftOverGas, err := vmenv.Call(
 		sender,

--- a/hmy/tracer.go
+++ b/hmy/tracer.go
@@ -380,7 +380,7 @@ traceLoop:
 		}
 		// Generate the next state snapshot fast without tracing
 		msg, _ := tx.AsMessage(signer)
-		statedb.Prepare(tx.Hash(), blockHash, i)
+		statedb.SetTxContext(tx.Hash(), blockHash, i)
 		statedb.SetTxHashETH(tx.ConvertToEth().Hash())
 		vmctx := core.NewEVMContext(msg, block.Header(), hmy.BlockChain, nil)
 		res, err := hmy.TraceTx(ctx, msg, vmctx, statedb, config)
@@ -466,7 +466,7 @@ func (hmy *Harmony) TraceBlock(ctx context.Context, block *types.Block, config *
 				msg, _ := txs[task.index].AsMessage(signer)
 				vmctx := core.NewEVMContext(msg, block.Header(), hmy.BlockChain, nil)
 				tx := txs[task.index]
-				task.statedb.Prepare(tx.Hash(), blockHash, task.index)
+				task.statedb.SetTxContext(tx.Hash(), blockHash, task.index)
 				task.statedb.SetTxHashETH(tx.ConvertToEth().Hash())
 				res, err := hmy.TraceTx(ctx, msg, vmctx, task.statedb, config)
 				if err != nil {
@@ -489,7 +489,7 @@ func (hmy *Harmony) TraceBlock(ctx context.Context, block *types.Block, config *
 		}
 		// Generate the next state snapshot fast without tracing
 		msg, _ := tx.AsMessage(signer)
-		statedb.Prepare(tx.Hash(), block.Hash(), i)
+		statedb.SetTxContext(tx.Hash(), block.Hash(), i)
 		statedb.SetTxHashETH(tx.ConvertToEth().Hash())
 		vmctx := core.NewEVMContext(msg, block.Header(), hmy.BlockChain, nil)
 

--- a/internal/params/protocol_params.go
+++ b/internal/params/protocol_params.go
@@ -86,6 +86,11 @@ const (
 	// SstoreClearRefundEIP2200 ...
 	SstoreClearRefundEIP2200 uint64 = 15000 // Once per SSTORE operation for clearing an originally existing storage slot
 
+	// todo(sun): implement eip2929
+	ColdAccountAccessCostEIP2929 uint64 = 2600 // COLD_ACCOUNT_ACCESS_COST
+	ColdSloadCostEIP2929         uint64 = 2100 // COLD_SLOAD_COST
+	WarmStorageReadCostEIP2929   uint64 = 100  // WARM_STORAGE_READ_COST
+
 	// JumpdestGas ...
 	JumpdestGas uint64 = 1 // Refunded gas, once per SSTORE operation if the zeroness changes to zero.
 	// EpochDuration ...

--- a/node/harmony/worker/worker.go
+++ b/node/harmony/worker/worker.go
@@ -133,7 +133,7 @@ func (w *Worker) CommitSortedTransactions(
 		}
 
 		// Start executing the transaction
-		w.current.state.Prepare(tx.Hash(), common.Hash{}, len(w.current.txs))
+		w.current.state.SetTxContext(tx.Hash(), common.Hash{}, len(w.current.txs))
 		err := w.commitTransaction(tx, coinbase)
 
 		sender, _ := common2.AddressToBech32(from)
@@ -228,7 +228,7 @@ func (w *Worker) CommitTransactions(
 			}
 
 			// Start executing the transaction
-			w.current.state.Prepare(tx.Hash(), common.Hash{}, len(w.current.txs)+len(w.current.stakingTxs))
+			w.current.state.SetTxContext(tx.Hash(), common.Hash{}, len(w.current.txs)+len(w.current.stakingTxs))
 			// THESE CODE ARE DUPLICATED AS ABOVE>>
 			if err := w.commitStakingTransaction(tx, coinbase); err != nil {
 				txID := tx.Hash().Hex()

--- a/rpc/harmony/tracer.go
+++ b/rpc/harmony/tracer.go
@@ -169,7 +169,7 @@ func (s *PublicTracerService) TraceTransaction(ctx context.Context, hash common.
 		return nil, err
 	}
 	// Trace the transaction and return
-	statedb.Prepare(tx.ConvertToEth().Hash(), block.Hash(), int(index))
+	statedb.SetTxContext(tx.ConvertToEth().Hash(), block.Hash(), int(index))
 	return s.hmy.TraceTx(ctx, msg, vmctx, statedb, config)
 }
 

--- a/test/chain/chain/chain_makers.go
+++ b/test/chain/chain/chain_makers.go
@@ -101,7 +101,7 @@ func (b *BlockGen) AddTxWithChain(bc core.BlockChain, tx *types.Transaction) {
 	if b.gasPool == nil {
 		b.SetCoinbase(common.Address{})
 	}
-	b.statedb.Prepare(tx.Hash(), common.Hash{}, len(b.txs))
+	b.statedb.SetTxContext(tx.Hash(), common.Hash{}, len(b.txs))
 	coinbase := b.header.Coinbase()
 	gasUsed := b.header.GasUsed()
 	receipt, _, _, _, err := core.ApplyTransaction(bc, &coinbase, b.gasPool, b.statedb, b.header, tx, &gasUsed, vm.Config{})


### PR DESCRIPTION
### Changes
- Implemented `TLOAD` and `TSTORE` opcodes.
- Implemented new `DB.Prepare()` method to clean up transient storage before state transitions.
- `core/state/statedb.go`: Renamed `DB.Prepare(...)` to `DB.SetTxContext(...)`

### Cause
This PR introduces two opcodes (`TLOAD` (0x5C) and `TSTORE` (0x5D)) to the EVM. The opcodes are more efficient to execute than the `SSTORE` and `SLOAD` opcodes because the original value never needs to be loaded from storage. The gas accounting rules are also simpler, since no refunds are required. More details on the motivation can be found [here](https://eips.ethereum.org/EIPS/eip-1153).

### Notes:
- `TransientStorage` struct within state db, as well as the unit tests, has already been implemented in #4374.
- EIP 1153 depends on EIP-2200 (#3356) and EIP-3529.
- The EIP (and the opcodes) need to be enabled in future PR.