### PR TITLE
Add Stream Health Monitoring and Improve Request Handling

### DIFF
--- a/p2p/stream/common/requestmanager/config.go
+++ b/p2p/stream/common/requestmanager/config.go
@@ -7,6 +7,12 @@ const (
 	// throttle to do request every 100 milliseconds
 	throttleInterval = 100 * time.Millisecond
 
+	// StreamMonitorInterval monitors stream connections every 1000 milliseconds
+	StreamMonitorInterval = 1000 * time.Millisecond
+
+	// StreamTimeoutThreshold defines stream timeout duration
+	StreamTimeoutThreshold = 30 * time.Second
+
 	// number of request to be done in each throttle loop
 	throttleBatch = 16
 

--- a/p2p/stream/common/requestmanager/requestmanager_test.go
+++ b/p2p/stream/common/requestmanager/requestmanager_test.go
@@ -82,6 +82,42 @@ func TestRequestManager_NewStream(t *testing.T) {
 	}
 }
 
+// TestRequestManager_NoStream_CancelRequests verifies that when all streams are removed,
+// the request is canceled after exceeding the StreamTimeoutThreshold.
+func TestRequestManager_NoStream_CancelRequests(t *testing.T) {
+	delayF := makeDefaultDelayFunc(500 * time.Millisecond)
+	respF := makeDefaultResponseFunc()
+	ts := newTestSuite(delayF, respF, 3)
+	ts.Start()
+	defer ts.Close()
+
+	req := makeTestRequest(100)
+	ctx := context.Background()
+
+	// Simulate all streams being removed
+	ts.RemoveAllStreams()
+
+	// Perform async request
+	resC := ts.rm.doRequestAsync(ctx, req)
+
+	// Wait for the timeout threshold
+	time.Sleep(StreamTimeoutThreshold + time.Second)
+
+	// Retrieve response
+	res := <-resC
+
+	// Validate results
+	if res.err == context.Canceled {
+		t.Fatalf("unexpected error: %v", res.err)
+	}
+	if res.err == nil {
+		t.Fatalf("expected request to be canceled but got no error")
+	}
+	if res.stID == "" {
+		t.Fatalf("expected canceled request to have a stream ID, but got empty")
+	}
+}
+
 // For request assigned to the stream being removed, the request will be rescheduled.
 func TestRequestManager_RemoveStream(t *testing.T) {
 	delayF := makeOnceBlockDelayFunc(150 * time.Millisecond)
@@ -512,6 +548,13 @@ func (ts *testSuite) Start() {
 func (ts *testSuite) Close() {
 	ts.rm.Close()
 	ts.cancel()
+}
+
+func (ts *testSuite) RemoveAllStreams() {
+	streams := ts.sm.GetStreams()
+	for _, st := range streams {
+		ts.sm.rmStream(st.ID())
+	}
 }
 
 func (ts *testSuite) pickOneOccupiedStream() sttypes.StreamID {

--- a/p2p/stream/common/requestmanager/requestmanager_test.go
+++ b/p2p/stream/common/requestmanager/requestmanager_test.go
@@ -107,14 +107,14 @@ func TestRequestManager_NoStream_CancelRequests(t *testing.T) {
 	res := <-resC
 
 	// Validate results
-	if res.err == context.Canceled {
-		t.Fatalf("unexpected error: %v", res.err)
-	}
 	if res.err == nil {
 		t.Fatalf("expected request to be canceled but got no error")
 	}
-	if res.stID == "" {
-		t.Fatalf("expected canceled request to have a stream ID, but got empty")
+	if res.err != ErrNoAvailableStream {
+		t.Errorf("unexpected error: %v", res.err)
+	}
+	if res.stID != "" {
+		t.Errorf("canceled request shouldn't have a stream ID")
 	}
 }
 

--- a/p2p/stream/common/requestmanager/types.go
+++ b/p2p/stream/common/requestmanager/types.go
@@ -15,6 +15,10 @@ var (
 
 	// ErrClosed is request error that the module is closed during request
 	ErrClosed = errors.New("request manager module closed")
+
+	// ErrNoAvailableStream indicates that a request cannot be processed
+	// because there are no active streams available.
+	ErrNoAvailableStream = errors.New("no available stream")
 )
 
 // stream is the wrapped version of sttypes.Stream.


### PR DESCRIPTION
This PR introduces the `monitorStreamHealth` function to enhance the request manager's ability to detect and handle situations where no active streams are available. It acts as a watchdog by continuously checking the stream list and, if no connections remain for a predefined threshold, it cancels all pending requests to prevent overload and unnecessary waiting. This change helps ensure that requests do not remain indefinitely in the queue when no valid peers are reachable.  

Additionally, a test has been added to verify that when all streams are removed, pending requests are correctly canceled with an appropriate error.