### PR TITLE
fix(CI) - pin goimports and gencodec versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,11 @@ install:
   - (cd $GOPATH/src/github.com/harmony-one/bls; make BLS_SWAP_G=1 -j4)
 #  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.41.1
   - make go-get
-  - go install golang.org/x/tools/cmd/goimports@latest
-  - go install github.com/harmony-ek/gencodec@latest
+  - go install golang.org/x/tools/cmd/goimports@v0.30.0
+  - go install github.com/fjl/gencodec@v0.1.0
   - echo "[WARN] - workaround for the GOPATH:"
+  # sometimes Travis decides to respect GOPATH and creates a symlink, thus we have || true for such cases
+  - rm $GOPATH/src/github.com/harmony-one/harmony || true;
   - mv /home/travis/build/harmony-one/harmony $GOPATH/src/github.com/harmony-one/
 script:
   - ${TEST}


### PR DESCRIPTION
## Issue


Both latest goimports and gencodec dependencies wants to have `golang.org/x/tools@v0.31.0` library, which supports only golang >= 1.23, but we are running 1.22.5.

Solution is consisted of 2 parts:
* pin goimports version to the 0.30.0 - previous latest and supports 1.22.5, thanks @Frozen for the fix
* start to use [gencodec@v0.1.0](https://github.com/fjl/gencodec/releases/tag/v0.1.0) :
  * no more vendors folder - previous reason to fork original repo
  * v0.1.0 release supports go 1.22.5

Additionally:
* travis ci time to time creates symlink from `$GOPATH/src/github.com/harmony-one/` to the `/home/travis/gopath/src/github.com/harmony-one/harmony` and it is crashing all our relative paths -solution is to remove if it exists
 
## Test

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
