### PR TITLE
Refactor Stream Protocol ID, Add New Protocol for Epoch Sync to P2P Host

### DIFF
--- a/hmy/downloader/downloader.go
+++ b/hmy/downloader/downloader.go
@@ -18,6 +18,7 @@ import (
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/p2p/stream/common/streammanager"
 	"github.com/harmony-one/harmony/p2p/stream/protocols/sync"
+	"github.com/harmony-one/harmony/shard"
 )
 
 type (
@@ -56,6 +57,7 @@ func NewDownloader(host p2p.Host, bc core.BlockChain, nodeConfig *nodeconfig.Con
 		BeaconNode:   isBeaconNode,
 		Validator:    nodeConfig.Role() == nodeconfig.Validator,
 		Explorer:     nodeConfig.Role() == nodeconfig.ExplorerNode,
+		EpochChain:   !isBeaconNode && bc.ShardID() == shard.BeaconChainShardID,
 		SmSoftLowCap: config.SmSoftLowCap,
 		SmHardLowCap: config.SmHardLowCap,
 		SmHiCap:      config.SmHiCap,

--- a/p2p/stream/common/streammanager/interface_test.go
+++ b/p2p/stream/common/streammanager/interface_test.go
@@ -18,7 +18,7 @@ var _ StreamManager = &streamManager{}
 
 var (
 	myPeerID    = makePeerID(0)
-	testProtoID = sttypes.ProtoID("harmony/sync/unitest/0/1.0.0/1")
+	testProtoID = sttypes.ProtoID("harmony/sync/unitest/0/1.0.0")
 )
 
 const (

--- a/p2p/stream/common/streammanager/streammanager_test.go
+++ b/p2p/stream/common/streammanager/streammanager_test.go
@@ -264,7 +264,7 @@ func TestStreamSet_numStreamsWithMinProtoID(t *testing.T) {
 		pid1    = testProtoID
 		numPid1 = 5
 
-		pid2    = sttypes.ProtoID("harmony/sync/unitest/0/1.0.1/1")
+		pid2    = sttypes.ProtoID("harmony/sync/unitest/0/1.0.1")
 		numPid2 = 10
 	)
 

--- a/p2p/stream/protocols/sync/protocol_test.go
+++ b/p2p/stream/protocols/sync/protocol_test.go
@@ -16,13 +16,14 @@ func TestProtocol_Match(t *testing.T) {
 		targetID protocol.ID
 		exp      bool
 	}{
-		{"harmony/sync/unitest/0/1.0.1/1", true},
-		{"harmony/sync/unitest/0/1.0.1/0", true},
+		{"harmony/sync/unitest/0/1.0", true},
+		{"harmony/sync/unitest/1/1.0.1", false},
+		{"harmony/sync/unitest/0/1.2-alpha", true},
 		{"h123456", false},
-		{"harmony/sync/unitest/0/0.9.9/1", false},
-		{"harmony/epoch/unitest/0/1.0.1/1", false},
-		{"harmony/sync/mainnet/0/1.0.1/1", false},
-		{"harmony/sync/unitest/1/1.0.1/1", false},
+		{"harmony/sync/unitest/0/0.9.9", false},
+		{"harmony/epochsync/unitest/0/1.0", false},
+		{"harmony/sync/mainnet/0/1.0.1", false},
+		{"harmony/sync/unitest/1/1.0.1", false},
 	}
 
 	for i, test := range tests {

--- a/p2p/stream/types/interface.go
+++ b/p2p/stream/types/interface.go
@@ -11,10 +11,9 @@ import (
 type Protocol interface {
 	p2ptypes.LifeCycle
 
-	Specifier() string
 	Version() *version.Version
 	ProtoID() ProtoID
-	// ShardProtoID() ProtoID
+	ServiceID() string
 	IsBeaconValidator() bool
 	Match(id protocol.ID) bool
 	HandleStream(st libp2p_network.Stream)

--- a/p2p/stream/types/utils.go
+++ b/p2p/stream/types/utils.go
@@ -20,10 +20,10 @@ const (
 	ProtoIDCommonPrefix = "harmony"
 
 	// ProtoIDFormat is the format of stream protocol ID
-	ProtoIDFormat = "%s/%s/%s/%d/%s/%d"
+	ProtoIDFormat = "%s/%s/%s/%d/%s"
 
 	// protoIDNumElem is the number of elements of the ProtoID. See comments in ProtoID
-	protoIDNumElem = 6
+	protoIDNumElem = 5
 )
 
 // ProtoID is the protocol id for streaming, an alias of libp2p stream protocol ID。
@@ -40,11 +40,10 @@ type ProtoID libp2p_proto.ID
 // TODO: move this to service wise module since different protocol might have different
 // protoID information
 type ProtoSpec struct {
-	Service           string
-	NetworkType       nodeconfig.NetworkType
-	ShardID           nodeconfig.ShardID
-	Version           *version.Version
-	IsBeaconValidator bool
+	Service     string
+	NetworkType nodeconfig.NetworkType
+	ShardID     nodeconfig.ShardID
+	Version     *version.Version
 }
 
 // ToProtoID convert a ProtoSpec to ProtoID.
@@ -54,7 +53,7 @@ func (spec ProtoSpec) ToProtoID() ProtoID {
 		versionStr = spec.Version.String()
 	}
 	s := fmt.Sprintf(ProtoIDFormat, ProtoIDCommonPrefix, spec.Service,
-		spec.NetworkType, spec.ShardID, versionStr, bool2int(spec.IsBeaconValidator))
+		spec.NetworkType, spec.ShardID, versionStr)
 	return ProtoID(s)
 }
 
@@ -65,12 +64,11 @@ func ProtoIDToProtoSpec(id ProtoID) (ProtoSpec, error) {
 		return ProtoSpec{}, errors.New("unexpected protocol size")
 	}
 	var (
-		prefix        = comps[0]
-		service       = comps[1]
-		networkType   = comps[2]
-		shardIDStr    = comps[3]
-		versionStr    = comps[4]
-		beaconnodeStr = comps[5]
+		prefix      = comps[0]
+		service     = comps[1]
+		networkType = comps[2]
+		shardIDStr  = comps[3]
+		versionStr  = comps[4]
 	)
 	shardID, err := strconv.Atoi(shardIDStr)
 	if err != nil {
@@ -83,16 +81,11 @@ func ProtoIDToProtoSpec(id ProtoID) (ProtoSpec, error) {
 	if err != nil {
 		return ProtoSpec{}, errors.Wrap(err, "unexpected version string")
 	}
-	isBeaconNode, err := strconv.Atoi(beaconnodeStr)
-	if err != nil {
-		return ProtoSpec{}, errors.Wrap(err, "invalid beacon node flag")
-	}
 	return ProtoSpec{
-		Service:           service,
-		NetworkType:       nodeconfig.NetworkType(networkType),
-		ShardID:           nodeconfig.ShardID(uint32(shardID)),
-		Version:           version,
-		IsBeaconValidator: int2bool(isBeaconNode),
+		Service:     service,
+		NetworkType: nodeconfig.NetworkType(networkType),
+		ShardID:     nodeconfig.ShardID(uint32(shardID)),
+		Version:     version,
 	}, nil
 }
 
@@ -101,15 +94,4 @@ func GenReqID() uint64 {
 	var rnd [8]byte
 	rand.Read(rnd[:])
 	return binary.BigEndian.Uint64(rnd[:])
-}
-
-func bool2int(b bool) int {
-	if b {
-		return 1
-	}
-	return 0
-}
-
-func int2bool(i int) bool {
-	return i > 0
 }


### PR DESCRIPTION
Previously, only shard nodes had an epoch chain, and epoch sync relied on a separate protocol ID while attempting to discover beacon peers based on the last part of the protocol ID. This approach was flawed because stream connections were later rejected due to protocol ID mismatches.  

This PR resolves the issue by introducing a dedicated protocol for beacon validators to handle the epoch sync. As a result, the P2P host for beacon validators now supports multiple protocols:  
- One for the **beacon chain**  
- Another for the **epoch chain**  

Each protocol operates independently, with its own **stream manager** and **set of discovered nodes**, ensuring proper synchronization and preventing connection rejections due to protocol mismatches.  