### PR TITLE
update devnet default settings, set  Min Peers to three

### DIFF
--- a/cmd/config/default.go
+++ b/cmd/config/default.go
@@ -261,14 +261,14 @@ var (
 		Downloader:           false,
 		StagedSync:           false,
 		StagedSyncCfg:        defaultStagedSyncConfig,
-		Concurrency:          2,
-		MinPeers:             2,
-		InitStreams:          2,
-		MaxAdvertiseWaitTime: 2, //minutes
-		DiscSoftLowCap:       2,
-		DiscHardLowCap:       2,
+		Concurrency:          3,
+		MinPeers:             3,
+		InitStreams:          3,
+		MaxAdvertiseWaitTime: 5, //minutes
+		DiscSoftLowCap:       3,
+		DiscHardLowCap:       3,
 		DiscHighCap:          1024,
-		DiscBatch:            4,
+		DiscBatch:            5,
 	}
 
 	defaultElseSyncConfig = harmonyconfig.SyncConfig{


### PR DESCRIPTION
In devnet, the explorer nodes are synced, but since they are limited to only two connections, they often end up connecting to other explorer nodes instead of validators. As a result, they never obtain the actual chain height and end up syncing with each other despite being out of sync. This PR increases the minimum number of connections from the current limit of two to three.