### PR TITLE
Fix DNS Sync Instance Creation Issue

### DIFF
--- a/node/harmony/node.go
+++ b/node/harmony/node.go
@@ -149,7 +149,7 @@ func (node *Node) SyncInstance() ISync {
 func (node *Node) GetOrCreateSyncInstance(initiate bool) ISync {
 	if initiate && node.stateSync == nil {
 		utils.Logger().Info().Msg("initializing legacy state sync")
-		node.stateSync = node.createStateSync(node.Beaconchain())
+		node.stateSync = node.createStateSync(node.Blockchain())
 	}
 	return node.stateSync
 }

--- a/node/harmony/node_syncing.go
+++ b/node/harmony/node_syncing.go
@@ -361,7 +361,7 @@ func (node *Node) supportSyncing() {
 		return
 	}
 
-	if !node.NodeConfig.StagedSync && node.stateSync == nil {
+	if node.stateSync == nil {
 		node.stateSync = node.createStateSync(node.Blockchain())
 		utils.Logger().Debug().Msg("[SYNC] initialized state sync")
 	}


### PR DESCRIPTION
The PR that removed Staged DNS Sync was intended to create a Sync Instance regardless of the StagedSync flag value. However, we overlooked removing the condition check. This PR resolves the issue with DNS sync instance creation.