### PR TITLE
Refactor stage body download loop to use pull-based worker model with robust error handling

### DIFF
--- a/api/service/stagedstreamsync/downloader.go
+++ b/api/service/stagedstreamsync/downloader.go
@@ -355,6 +355,9 @@ func (d *Downloader) handleDownload(initSync *bool, trigger func()) {
 			Bool("initSync", *initSync).
 			Msg(WrapStagedSyncMsg("sync loop failed"))
 
+		// Wait for enough available streams before retrying
+		d.waitForEnoughStreams(d.config.MinStreams)
+
 		// Retry sync after 5 seconds
 		go func() {
 			time.Sleep(5 * time.Second)

--- a/api/service/stagedstreamsync/stage_blockhashes.go
+++ b/api/service/stagedstreamsync/stage_blockhashes.go
@@ -176,6 +176,7 @@ func (bh *StageBlockHashes) downloadBlockHashes(ctx context.Context, bns []uint6
 			Int("received size", len(hashes)).
 			Interface("stid", stid).
 			Msg("[StageBlockHashes] received less hashes than requested, target stream is not synced!")
+		bh.configs.protocol.RemoveStream(stid)
 		return []common.Hash{}, stid, errors.New("not synced stream")
 	}
 	return hashes, stid, err

--- a/api/service/stagedstreamsync/syncing.go
+++ b/api/service/stagedstreamsync/syncing.go
@@ -580,7 +580,6 @@ func (s *StagedStreamSync) estimateCurrentNumber(ctx context.Context) (uint64, e
 	wg.Wait()
 	close(errChan) // Close the error channel when done
 
-
 	// Check if the context was canceled and return an error accordingly
 	select {
 	case <-ctx.Done():

--- a/p2p/stream/common/requestmanager/config.go
+++ b/p2p/stream/common/requestmanager/config.go
@@ -16,6 +16,9 @@ const (
 	// number of request to be done in each throttle loop
 	throttleBatch = 16
 
+	// PendingRequestTimeout is the pending request timeout
+	PendingRequestTimeout = 60 * time.Second
+
 	// deliverTimeout is the timeout for a response delivery. If the response cannot be delivered
 	// within timeout because blocking of the channel, the response will be dropped.
 	deliverTimeout = 5 * time.Second

--- a/p2p/stream/common/requestmanager/requestmanager.go
+++ b/p2p/stream/common/requestmanager/requestmanager.go
@@ -130,7 +130,6 @@ func (rm *requestManager) DeliverResponse(stID sttypes.StreamID, resp sttypes.Re
 	go func() {
 		select {
 		case rm.deliveryC <- sd:
-			return // Success
 		case <-time.After(deliverTimeout):
 			rm.logger.Error().Msg("WARNING: delivery timeout. Possible stuck in loop")
 		}

--- a/p2p/stream/common/requestmanager/requestmanager.go
+++ b/p2p/stream/common/requestmanager/requestmanager.go
@@ -156,7 +156,7 @@ func (rm *requestManager) monitorStreamHealth() {
 	}
 
 	// No streams left, check if timeout has passed
-	if now.Sub(rm.lastActiveStreamTime) <= StreamTimeoutThreshold {
+	if rm.lastActiveStreamTime.IsZero() || now.Sub(rm.lastActiveStreamTime) <= StreamTimeoutThreshold {
 		return
 	}
 

--- a/p2p/stream/common/streammanager/streamset.go
+++ b/p2p/stream/common/streammanager/streamset.go
@@ -7,6 +7,12 @@ import (
 	"github.com/pkg/errors"
 )
 
+var (
+	// ErrNoAvailableStream indicates that a request cannot be processed
+	// because there are no active streams available.
+	ErrNoAvailableStream = errors.New("no available stream")
+)
+
 // streamSet is the concurrency safe stream set.
 type streamSet struct {
 	streams    map[sttypes.StreamID]sttypes.Stream
@@ -101,7 +107,7 @@ func (ss *streamSet) popStream() (sttypes.Stream, error) {
 	defer ss.lock.Unlock()
 
 	if len(ss.streams) == 0 {
-		return nil, errors.New("no available stream")
+		return nil, ErrNoAvailableStream
 	}
 	for id, stream := range ss.streams {
 		delete(ss.streams, id)


### PR DESCRIPTION
This PR refactors the stage block body download loop to implement a more robust pull-based worker model. The current implementation can deadlock in edge cases, particularly when workers fail during processing of the final batches. These changes address several reliability issues while maintaining the same core functionality.

The key improvement is the transition to a pull-based model where workers explicitly request tasks when they're ready to process them. This eliminates coordination issues and busy waiting that were present in the previous implementation. Workers now synchronize directly with the dispatcher through unbuffered channels, creating a more natural flow of work distribution. The dispatcher only prepares tasks when workers are ready to receive them, preventing any task queue buildup.

Error handling has been made more robust, particularly for edge cases involving worker failures. When workers fail during processing (especially during final batches), the system now properly handles task retries through gbm's existing retry mechanism. The implementation includes proper tracking of active workers and ensures clean termination when all work is completed. A new atomic counter accurately tracks worker status, allowing the dispatcher to exit immediately when no workers remain or when all tasks are finished.