### PR TITLE
Fix Stream Request Manager Deadlock, Optimize Stage Block Bodies

### DIFF
--- a/api/service/stagedstreamsync/short_range_helper.go
+++ b/api/service/stagedstreamsync/short_range_helper.go
@@ -157,9 +157,6 @@ func (sh *srHelper) prepareBlockHashNumbers(curNumber uint64) []uint64 {
 }
 
 func (sh *srHelper) doGetBlockHashesRequest(ctx context.Context, bns []uint64, acceptPartially bool) ([]common.Hash, sttypes.StreamID, error) {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
 	hashes, stid, err := sh.syncProtocol.GetBlockHashes(ctx, bns)
 	if err != nil {
 		sh.logger.Warn().Err(err).
@@ -179,9 +176,6 @@ func (sh *srHelper) doGetBlockHashesRequest(ctx context.Context, bns []uint64, a
 }
 
 func (sh *srHelper) doGetBlocksByNumbersRequest(ctx context.Context, bns []uint64) ([]*types.Block, sttypes.StreamID, error) {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
 	blocks, stid, err := sh.syncProtocol.GetBlocksByNumber(ctx, bns)
 	if err != nil {
 		sh.logger.Warn().Err(err).
@@ -193,9 +187,6 @@ func (sh *srHelper) doGetBlocksByNumbersRequest(ctx context.Context, bns []uint6
 }
 
 func (sh *srHelper) doGetBlocksByHashesRequest(ctx context.Context, hashes []common.Hash, wl []sttypes.StreamID) ([]*types.Block, sttypes.StreamID, error) {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
 	blocks, stid, err := sh.syncProtocol.GetBlocksByHashes(ctx, hashes, syncProto.WithWhitelist(wl))
 	if err != nil {
 		sh.logger.Warn().Err(err).Str("stream", string(stid)).Msg("failed to getBlockByHashes")

--- a/api/service/stagedstreamsync/stage_bodies.go
+++ b/api/service/stagedstreamsync/stage_bodies.go
@@ -256,7 +256,7 @@ func (b *StageBodies) runDownloadLoop(ctx context.Context, tx kv.RwTx, gbm *down
 					return
 				}
 				if err := handleTask(workerID, task); err != nil {
-					return
+					continue
 				}
 			}
 		}
@@ -417,6 +417,7 @@ func (b *StageBodies) runBlockWorker(ctx context.Context,
 		for _, bb := range blockBytes {
 			if len(bb) <= 1 {
 				validBlocks = false
+				break
 			}
 		}
 		if !validBlocks {

--- a/api/service/stagedstreamsync/stage_bodies.go
+++ b/api/service/stagedstreamsync/stage_bodies.go
@@ -165,10 +165,11 @@ func (b *StageBodies) identifySyncedStreams(ctx context.Context, targetHeight ui
 	)
 
 	numStreams := b.configs.protocol.NumStreams()
-	wg.Add(numStreams)
 
 	// ask all streams for height
 	for i := 0; i < numStreams; i++ {
+		wg.Add(1)
+
 		go func() {
 			defer wg.Done()
 
@@ -532,9 +533,6 @@ badBlockDownloadLoop:
 }
 
 func (b *StageBodies) downloadBlocks(ctx context.Context, bns []uint64) ([]*types.Block, sttypes.StreamID, error) {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
 	blocks, stid, err := b.configs.protocol.GetBlocksByNumber(ctx, bns)
 	if err != nil {
 		return nil, stid, err
@@ -559,9 +557,6 @@ func validateGetBlocksResult(requested []uint64, result []*types.Block) error {
 }
 
 func (b *StageBodies) downloadRawBlocks(ctx context.Context, bns []uint64) ([][]byte, [][]byte, sttypes.StreamID, error) {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
 	return b.configs.protocol.GetRawBlocksByNumber(ctx, bns)
 }
 
@@ -595,9 +590,6 @@ func (b *StageBodies) fetchBlockHashes(ctx context.Context, tx kv.RwTx, bns []ui
 }
 
 func (b *StageBodies) downloadRawBlocksByHashes(ctx context.Context, tx kv.RwTx, bns []uint64) ([][]byte, [][]byte, sttypes.StreamID, error) {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
 	if len(bns) == 0 {
 		return nil, nil, "", errors.New("empty batch of block numbers")
 	}

--- a/api/service/stagedstreamsync/stage_receipts.go
+++ b/api/service/stagedstreamsync/stage_receipts.go
@@ -321,9 +321,6 @@ func (r *StageReceipts) runReceiptWorkerLoop(ctx context.Context, rdm *receiptDo
 }
 
 func (r *StageReceipts) downloadReceipts(ctx context.Context, hs []common.Hash) ([]types.Receipts, sttypes.StreamID, error) {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
 	receipts, stid, err := r.configs.protocol.GetReceipts(ctx, hs)
 	if err != nil {
 		return nil, stid, err

--- a/api/service/stagedstreamsync/stage_statesync.go
+++ b/api/service/stagedstreamsync/stage_statesync.go
@@ -221,9 +221,6 @@ func (sss *StageStateSync) runStateWorkerLoop(ctx context.Context, sdm *StateDow
 }
 
 func (sss *StageStateSync) downloadStates(ctx context.Context, nodes []common.Hash, codes []common.Hash) ([][]byte, sttypes.StreamID, error) {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
 	hashes := append(codes, nodes...)
 	data, stid, err := sss.configs.protocol.GetNodeData(ctx, hashes)
 	if err != nil {

--- a/api/service/stagedstreamsync/stage_statesync_full.go
+++ b/api/service/stagedstreamsync/stage_statesync_full.go
@@ -402,9 +402,6 @@ func (sss *StageFullStateSync) downloadByteCodes(ctx context.Context, sdm *FullS
 // 	codes []common.Hash,
 // 	storages *storageTaskBundle) ([][]byte, sttypes.StreamID, error) {
 
-// 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-// 	defer cancel()
-
 // 	// if there is any account task, first we have to complete that
 // 	if len(accounts) > 0 {
 

--- a/api/service/stagedstreamsync/staged_stream_sync.go
+++ b/api/service/stagedstreamsync/staged_stream_sync.go
@@ -374,10 +374,7 @@ func New(
 
 // doGetCurrentNumberRequest returns estimated current block number and corresponding stream
 func (sss *StagedStreamSync) doGetCurrentNumberRequest(ctx context.Context) (uint64, sttypes.StreamID, error) {
-	ctxReq, cancel := context.WithTimeout(ctx, 60*time.Second)
-	defer cancel()
-
-	bn, stid, err := sss.protocol.GetCurrentBlockNumber(ctxReq, syncproto.WithHighPriority())
+	bn, stid, err := sss.protocol.GetCurrentBlockNumber(ctx, syncproto.WithHighPriority())
 	if err != nil {
 		return 0, stid, err
 	}
@@ -386,9 +383,6 @@ func (sss *StagedStreamSync) doGetCurrentNumberRequest(ctx context.Context) (uin
 
 // doGetBlockByNumberRequest returns block by its number and corresponding stream
 func (sss *StagedStreamSync) doGetBlockByNumberRequest(ctx context.Context, bn uint64) (*types.Block, sttypes.StreamID, error) {
-	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
-	defer cancel()
-
 	blocks, stid, err := sss.protocol.GetBlocksByNumber(ctx, []uint64{bn}, syncproto.WithHighPriority())
 	if err != nil || len(blocks) != 1 {
 		return nil, stid, err

--- a/api/service/stagedstreamsync/staged_stream_sync.go
+++ b/api/service/stagedstreamsync/staged_stream_sync.go
@@ -374,10 +374,10 @@ func New(
 
 // doGetCurrentNumberRequest returns estimated current block number and corresponding stream
 func (sss *StagedStreamSync) doGetCurrentNumberRequest(ctx context.Context) (uint64, sttypes.StreamID, error) {
-	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	ctxReq, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 
-	bn, stid, err := sss.protocol.GetCurrentBlockNumber(ctx, syncproto.WithHighPriority())
+	bn, stid, err := sss.protocol.GetCurrentBlockNumber(ctxReq, syncproto.WithHighPriority())
 	if err != nil {
 		return 0, stid, err
 	}

--- a/p2p/stream/common/requestmanager/config.go
+++ b/p2p/stream/common/requestmanager/config.go
@@ -8,7 +8,7 @@ const (
 	throttleInterval = 100 * time.Millisecond
 
 	// StreamMonitorInterval monitors stream connections every 1000 milliseconds
-	StreamMonitorInterval = 5000 * time.Millisecond
+	StreamMonitorInterval = 1000 * time.Millisecond
 
 	// NoStreamTimeout defines no stream timeout duration
 	NoStreamTimeout = 60 * time.Second

--- a/p2p/stream/common/requestmanager/config.go
+++ b/p2p/stream/common/requestmanager/config.go
@@ -8,16 +8,16 @@ const (
 	throttleInterval = 100 * time.Millisecond
 
 	// StreamMonitorInterval monitors stream connections every 1000 milliseconds
-	StreamMonitorInterval = 1000 * time.Millisecond
+	StreamMonitorInterval = 5000 * time.Millisecond
 
-	// StreamTimeoutThreshold defines stream timeout duration
-	StreamTimeoutThreshold = 30 * time.Second
+	// NoStreamTimeout defines no stream timeout duration
+	NoStreamTimeout = 60 * time.Second
 
 	// number of request to be done in each throttle loop
 	throttleBatch = 16
 
 	// PendingRequestTimeout is the pending request timeout
-	PendingRequestTimeout = 60 * time.Second
+	PendingRequestTimeout = 180 * time.Second
 
 	// deliverTimeout is the timeout for a response delivery. If the response cannot be delivered
 	// within timeout because blocking of the channel, the response will be dropped.

--- a/p2p/stream/common/requestmanager/requestmanager.go
+++ b/p2p/stream/common/requestmanager/requestmanager.go
@@ -535,9 +535,9 @@ func (rm *requestManager) close() {
 	rm.pendings.Iterate(func(key uint64, req *request) {
 		req.doneWithResponse(responseData{err: ErrClosed})
 	})
-	rm.streams = sttypes.NewSafeMap[sttypes.StreamID, *stream]()
-	rm.available = sttypes.NewSafeMap[sttypes.StreamID, struct{}]()
-	rm.pendings = sttypes.NewSafeMap[uint64, *request]()
+	rm.streams.Clear()
+	rm.available.Clear()
+	rm.pendings.Clear()
 	rm.waitings = newRequestQueues()
 	close(rm.stopC)
 }

--- a/p2p/stream/common/requestmanager/requestmanager_test.go
+++ b/p2p/stream/common/requestmanager/requestmanager_test.go
@@ -83,7 +83,7 @@ func TestRequestManager_NewStream(t *testing.T) {
 }
 
 // TestRequestManager_NoStream_CancelRequests verifies that when all streams are removed,
-// the request is canceled after exceeding the StreamTimeoutThreshold.
+// the request is canceled after exceeding the NoStreamTimeout.
 func TestRequestManager_NoStream_CancelRequests(t *testing.T) {
 	delayF := makeDefaultDelayFunc(500 * time.Millisecond)
 	respF := makeDefaultResponseFunc()
@@ -101,7 +101,7 @@ func TestRequestManager_NoStream_CancelRequests(t *testing.T) {
 	resC := ts.rm.doRequestAsync(ctx, req)
 
 	// Wait for the timeout threshold
-	time.Sleep(StreamTimeoutThreshold + time.Second)
+	time.Sleep(NoStreamTimeout + time.Second)
 
 	// Retrieve response
 	res := <-resC

--- a/p2p/stream/common/requestmanager/types.go
+++ b/p2p/stream/common/requestmanager/types.go
@@ -203,10 +203,9 @@ func (rl *requestQueue) pop() *request {
 	if elem == nil {
 		return nil
 	}
-	rl.l.Remove(elem)
-
 	req := elem.Value.(*request)
 	delete(rl.elemM, req)
+	rl.l.Remove(elem)
 	return req
 }
 


### PR DESCRIPTION
This PR introduces several key improvements and fixes to the stream request and block download systems to enhance the stability, performance, and observability of the staged sync protocol.

The most notable addition is the new `isDownloading` flag, which provides better visibility into the download loop’s state, helping to prevent early termination during active work and improve stage reliability. Along with this, the request queue logic has been fixed to correctly remove elements after popping, addressing a bug that could lead to stale or duplicated work items.

Stream request handling has been refactored to separate health checks and request lifecycle management into distinct routines. This change not only simplifies the main request path but also improves responsiveness and failure recovery when streams go offline. We've also revised timeout configurations in the request manager to reduce unnecessary context cancellations, especially under high load or slower networks.

Furthermore, the context used for stream protocol has been isolated to avoid affecting long-lived sync operations, and the protocol-level context timeouts for staged stream sync have been removed to prevent premature cancellations. The `stage block hashes` process now properly propagates errors to its caller, improving error visibility and debugging.

These updates are part of our ongoing effort to make staged sync more robust and maintainable.
