### PR TITLE
Fix Boot Node Data Store Creation Issue

### DIFF
--- a/p2p/discovery/discovery.go
+++ b/p2p/discovery/discovery.go
@@ -59,6 +59,7 @@ func (d *dhtDiscovery) Start() error {
 
 // Stop stop the dhtDiscovery service
 func (d *dhtDiscovery) Close() error {
+	d.dht.Close()
 	d.cancel()
 	return nil
 }


### PR DESCRIPTION
Main problem is described in the https://github.com/harmony-one/harmony/issues/4883

Fix helped on the devnet nodes, I've checked all 4 of them:
* service was running for 23 hours:
```
● bootnode.service - harmony bootnode service
   Loaded: loaded (/etc/systemd/system/bootnode.service; enabled; vendor preset: enabled)
   Active: active (running) since Wed 2025-04-16 07:10:06 CDT; 21h ago
 Main PID: 20726 (bootnode)
    Tasks: 10 (limit: 4915)
   CGroup: /system.slice/bootnode.service
           └─20726 /usr/sbin/bootnode -port 20220 -key boot1-devnet.key -ip 0.0.0.0 -max_conn_per_ip 20 -cmg_high_watermark 3600
```
* after restart it was able to stop in a matter of seconds, so it was a deadlock on the dht discovery part
* after restart is running smoothly with the previous leveldb without db corruption:
```
● bootnode.service - harmony bootnode service
   Loaded: loaded (/etc/systemd/system/bootnode.service; enabled; vendor preset: enabled)
   Active: active (running) since Thu 2025-04-17 04:55:28 CDT; 30min ago
 Main PID: 23078 (bootnode)
    Tasks: 9 (limit: 4915)
   CGroup: /system.slice/bootnode.service
           └─23078 /usr/sbin/bootnode -port 20220 -key boot1-devnet.key -ip 0.0.0.0 -max_conn_per_ip 20 -cmg_high_watermark 3600
Apr 17 04:55:28 dco-vals1-03 systemd[1]: Started harmony bootnode service.
Apr 17 04:55:29 dco-vals1-03 harmony[23078]: bootnode BN_MA=/ip4/0.0.0.0/tcp/20220/p2p/QmUeWnPRjTgLoSCYqif3Nrr9CReXc4SR4DWCT6NR65cMee
``` 