### PR TITLE
[bootnode] - sync the http and ws setup with cli IP variable

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -107,8 +107,8 @@ func main() {
 
 	ip := flag.String("ip", "127.0.0.1", "IP of the node")
 	port := flag.String("port", "9876", "port of the node.")
-	httpPort := flag.Int("rpc_http_port", 9500, "port of the rpc http")
-	wsPort := flag.Int("rpc_ws_port", 9800, "port of the rpc ws")
+	httpPort := flag.Int("rpc_http_port", 9513, "port of the rpc http")
+	wsPort := flag.Int("rpc_ws_port", 9813, "port of the rpc ws")
 	console := flag.Bool("console_only", false, "Output to console only")
 	logFolder := flag.String("log_folder", "latest", "the folder collecting the logs of this execution")
 	logMaxSize := flag.Int("log_max_size", 100, "the max size in megabytes of the log file before it gets rotated")
@@ -210,7 +210,9 @@ func main() {
 	currentBootNode := bootnode.New(host, &hc)
 	rpcConfigs := currentBootNode.GetRPCServerConfig()
 	rpcConfigs.HTTPPort = *httpPort
+	rpcConfigs.HTTPIp = *ip
 	rpcConfigs.WSPort = *wsPort
+	rpcConfigs.WSIp = *ip
 
 	// TODO: enable boot services
 	/*


### PR DESCRIPTION
## Issue

I've put the same ip from the cli setup, because previously bootnode was listening only localhost aka 127.0.0.1 by default.

Additionally, I've moved default port from 9500 to 9513 and 9800 to 9813, because when we have both harmony and bootnode on the same server - we are starting to play the game who is faster for takeover the port after server reboot.

## Test

* I've installed my updated version on the one of devnet bootnodes and what I have, as you can see it is listening on the 0.0.0.0 as original config from the cli:
```
sudo netstat -plnt | grep bootnode
tcp        0      0 0.0.0.0:9020            0.0.0.0:*               LISTEN      6636/bootnode       
tcp6       0      0 :::9813                 :::*                    LISTEN      6636/bootnode       
tcp6       0      0 :::9513                 :::*                    LISTEN      6636/bootnode   
```

* Additionally, I was able to run curl request to the bootnode's RPC when I'm under VPN - it gives us possibilities to enhance our internal monitoring/integration tests in the future:
```
curl -H 'Content-Type:application/json' -X POST 'bootnodes_host:9513' -d '{"id":"1","jsonrpc":"2.0","method":"hmybootv2_getNodeMetadata","params":[]}' | jq
---
{
  "jsonrpc": "2.0",
  "id": "1",
  "result": {
    "network": "mainnet",
    "node-unix-start-time": 1744884005,
    "p2p-connectivity": {
      "connected": 2433,
      "not-connected": 5436,
      "total-known-peers": 7869
    },
    "peerid": "QmRdKvrGyWVxwXTcu4YiC5bPMLPqFSmneDG1jwuUnQcn2W",
    "version": "Harmony (C) 2025. bootnode, version v8688-v2025.4.0-15-g0b4aed9dd (uladzislau@ 2025-04-16T16:52:09+0300)"
  }
}
```