### PR TITLE
Optimize and Clean-Up Stages in Staged Stream Sync, Thread Safe P2P Stream

### DIFF
--- a/api/service/stagedstreamsync/beacon_helper.go
+++ b/api/service/stagedstreamsync/beacon_helper.go
@@ -176,10 +176,6 @@ func (bh *beaconHelper) getNextBlock(expBN uint64) *types.Block {
 		if b.NumberU64() < expBN {
 			continue
 		}
-		// if b.NumberU64() > expBN {
-		// 	bh.lastMileCache.push(b)
-		// 	return nil
-		// }
 		return b
 	}
 	return nil

--- a/api/service/stagedstreamsync/beacon_helper.go
+++ b/api/service/stagedstreamsync/beacon_helper.go
@@ -75,7 +75,7 @@ func (bh *beaconHelper) loop() {
 		case <-t.C:
 			bh.insertAsync()
 
-		case b, ok := <-bh.blockC:
+		case b, ok := <-bh.blockC: // for side chain, it receives last block of each epoch
 			if !ok {
 				return // blockC closed. Node exited
 			}

--- a/api/service/stagedstreamsync/beacon_helper.go
+++ b/api/service/stagedstreamsync/beacon_helper.go
@@ -176,10 +176,10 @@ func (bh *beaconHelper) getNextBlock(expBN uint64) *types.Block {
 		if b.NumberU64() < expBN {
 			continue
 		}
-		if b.NumberU64() > expBN {
-			bh.lastMileCache.push(b)
-			return nil
-		}
+		// if b.NumberU64() > expBN {
+		// 	bh.lastMileCache.push(b)
+		// 	return nil
+		// }
 		return b
 	}
 	return nil

--- a/api/service/stagedstreamsync/downloader.go
+++ b/api/service/stagedstreamsync/downloader.go
@@ -73,7 +73,7 @@ func NewDownloader(host p2p.Host,
 		Logger()
 
 	var bh *beaconHelper
-	if config.BHConfig != nil && bc.ShardID() == shard.BeaconChainShardID {
+	if config.BHConfig != nil {
 		bh = newBeaconHelper(bc, logger, config.BHConfig.BlockC, config.BHConfig.InsertHook)
 	}
 

--- a/api/service/stagedstreamsync/downloader.go
+++ b/api/service/stagedstreamsync/downloader.go
@@ -73,7 +73,7 @@ func NewDownloader(host p2p.Host,
 		Logger()
 
 	var bh *beaconHelper
-	if config.BHConfig != nil {
+	if config.BHConfig != nil && !isBeaconNode && bc.ShardID() == shard.BeaconChainShardID {
 		bh = newBeaconHelper(bc, logger, config.BHConfig.BlockC, config.BHConfig.InsertHook)
 	}
 

--- a/api/service/stagedstreamsync/short_range_helper.go
+++ b/api/service/stagedstreamsync/short_range_helper.go
@@ -19,7 +19,7 @@ type srHelper struct {
 	logger       zerolog.Logger
 }
 
-func (sh *srHelper) getHashChain(ctx context.Context, bns []uint64) ([]common.Hash, []sttypes.StreamID, error) {
+func (sh *srHelper) getHashChain(ctx context.Context, bns []uint64, partially bool) ([]common.Hash, []sttypes.StreamID, error) {
 	results := newBlockHashResults(bns)
 
 	concurrency := sh.config.Concurrency
@@ -34,7 +34,7 @@ func (sh *srHelper) getHashChain(ctx context.Context, bns []uint64) ([]common.Ha
 		go func(index int) {
 			defer wg.Done()
 
-			hashes, stid, err := sh.doGetBlockHashesRequest(ctx, bns, false)
+			hashes, stid, err := sh.doGetBlockHashesRequest(ctx, bns, partially)
 			if err != nil {
 				sh.logger.Warn().Err(err).Str("StreamID", string(stid)).
 					Msg(WrapStagedSyncMsg("doGetBlockHashes return error"))

--- a/api/service/stagedstreamsync/stage_blockhashes.go
+++ b/api/service/stagedstreamsync/stage_blockhashes.go
@@ -31,10 +31,9 @@ type StageBlockHashesCfg struct {
 	concurrency int
 	protocol    syncProtocol
 	//bgProcRunning bool
-	isBeaconShard bool
-	cachedb       kv.RwDB
-	logProgress   bool
-	logger        zerolog.Logger
+	cachedb     kv.RwDB
+	logProgress bool
+	logger      zerolog.Logger
 }
 
 func NewStageBlockHashes(cfg StageBlockHashesCfg) *StageBlockHashes {
@@ -43,14 +42,13 @@ func NewStageBlockHashes(cfg StageBlockHashesCfg) *StageBlockHashes {
 	}
 }
 
-func NewStageBlockHashesCfg(bc core.BlockChain, db kv.RwDB, concurrency int, protocol syncProtocol, isBeaconShard bool, logger zerolog.Logger, logProgress bool) StageBlockHashesCfg {
+func NewStageBlockHashesCfg(bc core.BlockChain, db kv.RwDB, concurrency int, protocol syncProtocol, logger zerolog.Logger, logProgress bool) StageBlockHashesCfg {
 	return StageBlockHashesCfg{
-		bc:            bc,
-		db:            db,
-		concurrency:   concurrency,
-		protocol:      protocol,
-		isBeaconShard: isBeaconShard,
-		logProgress:   logProgress,
+		bc:          bc,
+		db:          db,
+		concurrency: concurrency,
+		protocol:    protocol,
+		logProgress: logProgress,
 		logger: logger.With().
 			Str("stage", "StageBlockHashes").
 			Str("mode", "long range").

--- a/api/service/stagedstreamsync/stage_bodies.go
+++ b/api/service/stagedstreamsync/stage_bodies.go
@@ -29,7 +29,6 @@ type StageBodiesCfg struct {
 	blockDBs             []kv.RwDB
 	concurrency          int
 	protocol             syncProtocol
-	isBeaconShard        bool
 	extractReceiptHashes bool
 	logProgress          bool
 	logger               zerolog.Logger
@@ -46,14 +45,13 @@ func NewStageBodies(cfg StageBodiesCfg) *StageBodies {
 	}
 }
 
-func NewStageBodiesCfg(bc core.BlockChain, db kv.RwDB, blockDBs []kv.RwDB, concurrency int, protocol syncProtocol, isBeaconShard bool, extractReceiptHashes bool, logger zerolog.Logger, logProgress bool) StageBodiesCfg {
+func NewStageBodiesCfg(bc core.BlockChain, db kv.RwDB, blockDBs []kv.RwDB, concurrency int, protocol syncProtocol, extractReceiptHashes bool, logger zerolog.Logger, logProgress bool) StageBodiesCfg {
 	return StageBodiesCfg{
 		bc:                   bc,
 		db:                   db,
 		blockDBs:             blockDBs,
 		concurrency:          concurrency,
 		protocol:             protocol,
-		isBeaconShard:        isBeaconShard,
 		extractReceiptHashes: extractReceiptHashes,
 		logger: logger.With().
 			Str("stage", "StageBodies").

--- a/api/service/stagedstreamsync/stage_epoch.go
+++ b/api/service/stagedstreamsync/stage_epoch.go
@@ -108,11 +108,12 @@ func (sr *StageEpoch) doShortRangeSyncForEpochSync(ctx context.Context, s *Stage
 		}
 	}
 	curBN := s.state.bc.CurrentBlock().NumberU64()
+	curEpoch := s.state.bc.CurrentHeader().Epoch().Uint64()
 	bns := make([]uint64, 0, BlocksPerRequest)
 	// in epoch chain, we have only the last block of each epoch, so, the current
 	// block's epoch number shows the last epoch we have. We should start
 	// from next epoch then
-	loopEpoch := s.state.bc.CurrentHeader().Epoch().Uint64() + 1
+	loopEpoch := curEpoch + 1
 	for len(bns) < BlocksPerRequest {
 		blockNum := shard.Schedule.EpochLastBlock(loopEpoch)
 		if blockNum > curBN {

--- a/api/service/stagedstreamsync/stage_receipts.go
+++ b/api/service/stagedstreamsync/stage_receipts.go
@@ -21,14 +21,13 @@ type StageReceipts struct {
 }
 
 type StageReceiptsCfg struct {
-	bc            core.BlockChain
-	db            kv.RwDB
-	blockDBs      []kv.RwDB
-	concurrency   int
-	protocol      syncProtocol
-	isBeaconShard bool
-	logProgress   bool
-	logger        zerolog.Logger
+	bc          core.BlockChain
+	db          kv.RwDB
+	blockDBs    []kv.RwDB
+	concurrency int
+	protocol    syncProtocol
+	logProgress bool
+	logger      zerolog.Logger
 }
 
 func NewStageReceipts(cfg StageReceiptsCfg) *StageReceipts {
@@ -37,14 +36,13 @@ func NewStageReceipts(cfg StageReceiptsCfg) *StageReceipts {
 	}
 }
 
-func NewStageReceiptsCfg(bc core.BlockChain, db kv.RwDB, blockDBs []kv.RwDB, concurrency int, protocol syncProtocol, isBeaconShard bool, logger zerolog.Logger, logProgress bool) StageReceiptsCfg {
+func NewStageReceiptsCfg(bc core.BlockChain, db kv.RwDB, blockDBs []kv.RwDB, concurrency int, protocol syncProtocol, logger zerolog.Logger, logProgress bool) StageReceiptsCfg {
 	return StageReceiptsCfg{
-		bc:            bc,
-		db:            db,
-		blockDBs:      blockDBs,
-		concurrency:   concurrency,
-		protocol:      protocol,
-		isBeaconShard: isBeaconShard,
+		bc:          bc,
+		db:          db,
+		blockDBs:    blockDBs,
+		concurrency: concurrency,
+		protocol:    protocol,
 		logger: logger.With().
 			Str("stage", "StageReceipts").
 			Str("mode", "long range").

--- a/api/service/stagedstreamsync/stage_short_range.go
+++ b/api/service/stagedstreamsync/stage_short_range.go
@@ -112,7 +112,7 @@ func (sr *StageShortRange) doShortRangeSync(ctx context.Context, s *StageState) 
 	}
 	curBN := sr.configs.bc.CurrentBlock().NumberU64()
 	blkNums := sh.prepareBlockHashNumbers(curBN)
-	hashChain, whitelist, err := sh.getHashChain(ctx, blkNums)
+	hashChain, whitelist, err := sh.getHashChain(ctx, blkNums, true)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 			return 0, nil

--- a/api/service/stagedstreamsync/staged_stream_sync.go
+++ b/api/service/stagedstreamsync/staged_stream_sync.go
@@ -358,6 +358,7 @@ func New(
 		joinConsensus:     joinConsensus,
 		gbm:               nil,
 		status:            status,
+		initSync:          true,
 		inserted:          0,
 		config:            config,
 		logger:            logger,

--- a/api/service/stagedstreamsync/staged_stream_sync.go
+++ b/api/service/stagedstreamsync/staged_stream_sync.go
@@ -60,35 +60,33 @@ func (ib *InvalidBlock) addBadStream(bsID sttypes.StreamID) {
 }
 
 type StagedStreamSync struct {
-	bc                core.BlockChain
-	consensus         *consensus.Consensus
-	db                kv.RwDB
-	protocol          syncProtocol
-	gbm               *downloadManager // initialized when finished get block number
-	isEpochChain      bool
-	isBeaconValidator bool
-	isBeaconShard     bool
-	isExplorer        bool
-	isValidator       bool
-	joinConsensus     bool
-	inserted          int
-	config            Config
-	logger            zerolog.Logger
-	status            *status //TODO: merge this with currentSyncCycle
-	initSync          bool    // if sets to true, node start long range syncing
-	UseMemDB          bool
-	revertPoint       *uint64 // used to run stages
-	prevRevertPoint   *uint64 // used to get value from outside of staged sync after cycle (for example to notify RPCDaemon)
-	invalidBlock      InvalidBlock
-	currentStage      uint
-	LogProgress       bool
-	currentCycle      SyncCycle // current cycle
-	stages            []*Stage
-	revertOrder       []*Stage
-	pruningOrder      []*Stage
-	timings           []Timing
-	logPrefixes       []string
-
+	bc                            core.BlockChain
+	consensus                     *consensus.Consensus
+	db                            kv.RwDB
+	protocol                      syncProtocol
+	gbm                           *downloadManager // initialized when finished get block number
+	isEpochChain                  bool
+	isBeaconValidator             bool
+	isBeaconShard                 bool
+	isExplorer                    bool
+	isValidator                   bool
+	joinConsensus                 bool
+	inserted                      int
+	config                        Config
+	logger                        zerolog.Logger
+	status                        *status //TODO: merge this with currentSyncCycle
+	initSync                      bool    // if sets to true, node start long range syncing
+	UseMemDB                      bool
+	revertPoint                   *uint64 // used to run stages
+	prevRevertPoint               *uint64 // used to get value from outside of staged sync after cycle (for example to notify RPCDaemon)
+	invalidBlock                  InvalidBlock
+	currentStage                  uint
+	currentCycle                  SyncCycle // current cycle
+	stages                        []*Stage
+	revertOrder                   []*Stage
+	pruningOrder                  []*Stage
+	timings                       []Timing
+	logPrefixes                   []string
 	evtDownloadFinished           event.Feed // channel for each download task finished
 	evtDownloadFinishedSubscribed bool
 	evtDownloadStarted            event.Feed // channel for each download has started
@@ -299,9 +297,9 @@ func New(
 	consensus *consensus.Consensus,
 	db kv.RwDB,
 	stagesList []*Stage,
+	protocol syncProtocol,
 	isEpochChain bool,
 	isBeaconShard bool,
-	protocol syncProtocol,
 	isBeaconValidator bool,
 	isExplorer bool,
 	isValidator bool,

--- a/api/service/stagedstreamsync/syncing.go
+++ b/api/service/stagedstreamsync/syncing.go
@@ -390,8 +390,8 @@ func (s *StagedStreamSync) doSync(downloaderContext context.Context) (uint64, in
 
 		totalInserted += n
 
-		// if it's not long range sync, skip loop
-		if n == 0 { //|| !initSync {
+		// if there is no more blocks to add, skip loop
+		if n == 0 {
 			break
 		}
 	}

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -945,7 +945,7 @@ func setupStagedSyncService(node *node.Node, host p2p.Host, hc harmonyconfig.Har
 
 	// If we are running side chain, we will need to do some extra works for beacon
 	// sync.
-	if !node.IsRunningBeaconChain() {
+	if len(blockchains) > 1 {
 		sConfig.BHConfig = &stagedstreamsync.BeaconHelperConfig{
 			BlockC:     node.BeaconBlockChannel,
 			InsertHook: node.BeaconSyncHook,

--- a/p2p/stream/common/requestmanager/interface_test.go
+++ b/p2p/stream/common/requestmanager/interface_test.go
@@ -115,7 +115,7 @@ func (st *testStream) CloseOnExit() error {
 	return nil
 }
 
-func (st *testStream) Failures() int {
+func (st *testStream) Failures() int32 {
 	return 0
 }
 

--- a/p2p/stream/common/streammanager/interface_test.go
+++ b/p2p/stream/common/streammanager/interface_test.go
@@ -71,7 +71,7 @@ func (st *testStream) ReadBytes() ([]byte, error) {
 	return nil, nil
 }
 
-func (st *testStream) Failures() int {
+func (st *testStream) Failures() int32 {
 	return 0
 }
 

--- a/p2p/stream/protocols/sync/protocol.go
+++ b/p2p/stream/protocols/sync/protocol.go
@@ -392,7 +392,7 @@ func (p *Protocol) StreamFailed(stID sttypes.StreamID, reason string) {
 		st.AddFailedTimes(FaultRecoveryThreshold)
 		p.logger.Info().
 			Str("stream ID", string(st.ID())).
-			Int("num failures", st.Failures()).
+			Int32("num failures", st.Failures()).
 			Str("reason", reason).
 			Msg("stream failed")
 		if st.Failures() >= MaxStreamFailures {

--- a/p2p/stream/types/stream.go
+++ b/p2p/stream/types/stream.go
@@ -22,7 +22,7 @@ type Stream interface {
 	ReadBytes() ([]byte, error)
 	Close() error
 	CloseOnExit() error
-	Failures() int
+	Failures() int32
 	AddFailedTimes(faultRecoveryThreshold time.Duration)
 	ResetFailedTimes()
 }

--- a/p2p/stream/types/stream.go
+++ b/p2p/stream/types/stream.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"io"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	libp2p_network "github.com/libp2p/go-libp2p/core/network"
@@ -42,15 +41,17 @@ type BaseStream struct {
 
 	failures        int32
 	lastFailureTime time.Time
+	failureLock     sync.Mutex
 }
 
 // NewBaseStream creates BaseStream as the wrapper of libp2p Stream
 func NewBaseStream(st libp2p_network.Stream) *BaseStream {
 	reader := bufio.NewReader(st)
 	return &BaseStream{
-		raw:      st,
-		reader:   reader,
-		failures: 0,
+		raw:             st,
+		reader:          reader,
+		failures:        0,
+		lastFailureTime: time.Now(),
 	}
 }
 
@@ -85,17 +86,23 @@ func (st *BaseStream) Close() error {
 	return nil
 }
 
-func (st *BaseStream) Failures() int {
-	return int(atomic.LoadInt32(&st.failures))
+func (st *BaseStream) Failures() int32 {
+	st.failureLock.Lock()
+	defer st.failureLock.Unlock()
+	return st.failures
 }
 
 func (st *BaseStream) AddFailedTimes(faultRecoveryThreshold time.Duration) {
-	atomic.AddInt32(&st.failures, 1)
+	st.failureLock.Lock()
+	defer st.failureLock.Unlock()
+	st.failures += 1
 	st.lastFailureTime = time.Now()
 }
 
 func (st *BaseStream) ResetFailedTimes() {
-	atomic.StoreInt32(&st.failures, 0)
+	st.failureLock.Lock()
+	defer st.failureLock.Unlock()
+	st.failures = 0
 }
 
 const (
@@ -126,13 +133,8 @@ func (st *BaseStream) WriteBytes(b []byte) (err error) {
 	defer st.writeLock.Unlock()
 	_, err = st.raw.Write(message[:size])
 	if err != nil {
-		// try to reconnect and write again
-		if errC := st.reconnect(); errC == nil {
-			_, err = st.raw.Write(message[:size])
-		}
-		if err != nil {
-			return err
-		}
+		st.raw.Reset()
+		return err
 	}
 	bytesWriteCounter.Add(float64(size))
 	return nil
@@ -153,14 +155,9 @@ func (st *BaseStream) ReadBytes() (cb []byte, err error) {
 	sb := make([]byte, sizeBytes)
 	_, err = st.reader.Read(sb)
 	if err != nil {
-		// try to reconnect and read again
-		if errC := st.reconnect(); errC == nil {
-			_, err = st.reader.Read(sb)
-		}
-		if err != nil {
-			err = errors.Wrap(err, "read size")
-			return
-		}
+		st.raw.Reset()
+		err = errors.Wrap(err, "read size")
+		return
 	}
 	bytesReadCounter.Add(sizeBytes)
 	size := bytesToInt(sb)
@@ -173,12 +170,13 @@ func (st *BaseStream) ReadBytes() (cb []byte, err error) {
 
 	n, err := io.ReadFull(st.reader, cb)
 	if err != nil {
+		st.raw.Reset()
 		err = errors.Wrap(err, "read content")
 		return
 	}
 	bytesReadCounter.Add(float64(n))
 	if n != size {
-		err = errors.New("ReadBytes sanity failed: byte size")
+		err = errors.Errorf("read %d bytes but expected %d", n, size)
 		return
 	}
 	return


### PR DESCRIPTION
This PR improves the reliability and clarity of the sync process. The P2P stream is now thread-safe and resets automatically on failure, which helps prevent sync hangs. Short range sync was updated to accept partial blocks and properly break the loop when done, improving flexibility and performance during catch-up.

Several refactors and clean-ups were made to staged sync: initSync now uses internal parameters instead of external variables, and the unused LogProgress option was removed. We also fixed DB path handling for stream sync and re-added last mile blocks to ensure full chain coverage.

On the beacon side, we cleaned up redundant shard checks, fixed beacon helper initialization, and clarified internal comments. Minor improvements include fixing stream failure type handling and simplifying epoch tracking with a dedicated variable.