### PR TITLE
Add Stream Removal Reason

### DIFF
--- a/api/service/stagedstreamsync/adapter.go
+++ b/api/service/stagedstreamsync/adapter.go
@@ -27,7 +27,7 @@ type syncProtocol interface {
 	GetByteCodes(ctx context.Context, hs []common.Hash, bytes uint64, opts ...syncproto.Option) (codes [][]byte, stid sttypes.StreamID, err error)
 	GetTrieNodes(ctx context.Context, root common.Hash, paths []*message.TrieNodePathSet, bytes uint64, opts ...syncproto.Option) (nodes [][]byte, stid sttypes.StreamID, err error)
 
-	RemoveStream(stID sttypes.StreamID) // If a stream delivers invalid data, remove the stream
+	RemoveStream(stID sttypes.StreamID, reason string) // If a stream delivers invalid data, remove the stream
 	StreamFailed(stID sttypes.StreamID, reason string)
 	SubscribeAddStreamEvent(ch chan<- streammanager.EvtStreamAdded) event.Subscription
 	NumStreams() int

--- a/api/service/stagedstreamsync/short_range_helper.go
+++ b/api/service/stagedstreamsync/short_range_helper.go
@@ -202,9 +202,9 @@ func (sh *srHelper) doGetBlocksByHashesRequest(ctx context.Context, hashes []com
 	return blocks, stid, nil
 }
 
-func (sh *srHelper) removeStreams(sts []sttypes.StreamID) {
+func (sh *srHelper) removeStreams(sts []sttypes.StreamID, reason string) {
 	for _, st := range sts {
-		sh.syncProtocol.RemoveStream(st)
+		sh.syncProtocol.RemoveStream(st, reason)
 	}
 }
 

--- a/api/service/stagedstreamsync/stage_blockhashes.go
+++ b/api/service/stagedstreamsync/stage_blockhashes.go
@@ -153,7 +153,7 @@ func (bh *StageBlockHashes) downloadBlockHashes(ctx context.Context, bns []uint6
 		bh.configs.logger.Warn().
 			Interface("bns", bns).
 			Msg("[StageBlockHashes] downloadBlockHashes Nil Response")
-		bh.configs.protocol.RemoveStream(stid)
+		bh.configs.protocol.RemoveStream(stid, "nil block hashes")
 		return []common.Hash{}, stid, errors.New("nil response for hashes")
 	}
 	bh.configs.logger.Info().
@@ -174,7 +174,7 @@ func (bh *StageBlockHashes) downloadBlockHashes(ctx context.Context, bns []uint6
 			Int("received size", len(hashes)).
 			Interface("stid", stid).
 			Msg("[StageBlockHashes] received less hashes than requested, target stream is not synced!")
-		bh.configs.protocol.RemoveStream(stid)
+		bh.configs.protocol.RemoveStream(stid, "expected more hashes")
 		return []common.Hash{}, stid, errors.New("not synced stream")
 	}
 	return hashes, stid, err
@@ -238,7 +238,7 @@ func (bh *StageBlockHashes) runBlockHashWorkerLoop(ctx context.Context,
 
 				// Check if any hash is zero
 				if bh.containsZeroHash(hashes) {
-					bh.configs.protocol.RemoveStream(stid) // Remove immediately
+					bh.configs.protocol.RemoveStream(stid, "stream response contains zero hashes") // Remove immediately
 					return
 				}
 
@@ -370,7 +370,7 @@ func (bh *StageBlockHashes) calculateFinalBlockHashes(
 		for i, blockNumber := range batch {
 			if i >= len(hashes) || finalHashes[blockNumber] != hashes[i] {
 				invalidStreams[stid] = struct{}{}
-				bh.configs.protocol.RemoveStream(stid)
+				bh.configs.protocol.RemoveStream(stid, "calculateFinalBlockHashes - invalid stream")
 				break
 			}
 		}

--- a/api/service/stagedstreamsync/syncing.go
+++ b/api/service/stagedstreamsync/syncing.go
@@ -563,7 +563,7 @@ func (s *StagedStreamSync) estimateCurrentNumber(ctx context.Context) (uint64, e
 					// Mark stream failure if it's not due to context cancelation or deadline
 					s.protocol.StreamFailed(stid, "getCurrentNumber request failed")
 				} else {
-					s.protocol.RemoveStream(stid)
+					s.protocol.RemoveStream(stid, "getCurrentNumber request failed many times")
 				}
 				return
 			}

--- a/hmy/downloader/adapter.go
+++ b/hmy/downloader/adapter.go
@@ -18,7 +18,7 @@ type syncProtocol interface {
 	GetBlockHashes(ctx context.Context, bns []uint64, opts ...syncproto.Option) ([]common.Hash, sttypes.StreamID, error)
 	GetBlocksByHashes(ctx context.Context, hs []common.Hash, opts ...syncproto.Option) ([]*types.Block, sttypes.StreamID, error)
 
-	RemoveStream(stID sttypes.StreamID) // If a stream delivers invalid data, remove the stream
+	RemoveStream(stID sttypes.StreamID, reason string) // If a stream delivers invalid data, remove the stream
 	SubscribeAddStreamEvent(ch chan<- streammanager.EvtStreamAdded) event.Subscription
 	NumStreams() int
 }

--- a/hmy/downloader/adapter_test.go
+++ b/hmy/downloader/adapter_test.go
@@ -271,7 +271,7 @@ func (sp *testSyncProtocol) GetBlocksByHashes(ctx context.Context, hs []common.H
 	return res, sp.nextStreamID(), nil
 }
 
-func (sp *testSyncProtocol) RemoveStream(target sttypes.StreamID) {
+func (sp *testSyncProtocol) RemoveStream(target sttypes.StreamID, reason string) {
 	sp.lock.Lock()
 	defer sp.lock.Unlock()
 

--- a/hmy/downloader/longrange.go
+++ b/hmy/downloader/longrange.go
@@ -104,7 +104,7 @@ func (lsi *lrSyncIter) estimateCurrentNumber() (uint64, error) {
 				lsi.logger.Err(err).Str("streamID", string(stid)).
 					Msg("getCurrentNumber request failed. Removing stream")
 				if !errors.Is(err, context.Canceled) {
-					lsi.p.RemoveStream(stid)
+					lsi.p.RemoveStream(stid, "getCurrentNumber request failed")
 				}
 				return
 			}
@@ -218,7 +218,7 @@ func (lsi *lrSyncIter) processBlocks(results []*blockResult, targetBN uint64) {
 			pl["error"] = err.Error()
 			longRangeFailInsertedBlockCounterVec.With(pl).Inc()
 
-			lsi.p.RemoveStream(results[i].stid)
+			lsi.p.RemoveStream(results[i].stid, "invalid block")
 			lsi.gbm.HandleInsertError(results, i)
 			return
 		}
@@ -264,7 +264,7 @@ func (w *getBlocksWorker) workLoop(ctx context.Context) {
 		blocks, stid, err := w.doBatch(ctx, batch)
 		if err != nil {
 			if !errors.Is(err, context.Canceled) {
-				w.protocol.RemoveStream(stid)
+				w.protocol.RemoveStream(stid, "doBatch failed")
 			}
 			err = errors.Wrap(err, "request error")
 			w.gbm.HandleRequestError(batch, err, stid)

--- a/p2p/stream/common/streammanager/events_test.go
+++ b/p2p/stream/common/streammanager/events_test.go
@@ -59,7 +59,7 @@ func TestStreamManager_SubscribeRemoveStreamEvent(t *testing.T) {
 	sm.Start()
 	time.Sleep(defTestWait)
 
-	err := sm.RemoveStream(makeStreamID(1))
+	err := sm.RemoveStream(makeStreamID(1), "test stream remove subscribe")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/p2p/stream/common/streammanager/interface.go
+++ b/p2p/stream/common/streammanager/interface.go
@@ -28,7 +28,7 @@ type ReaderSubscriber interface {
 // Operator handles new stream or remove stream
 type Operator interface {
 	NewStream(stream sttypes.Stream) error
-	RemoveStream(stID sttypes.StreamID) error
+	RemoveStream(stID sttypes.StreamID, reason string) error
 }
 
 // Subscriber is the interface to support stream event subscription

--- a/p2p/stream/common/streammanager/streammanager_test.go
+++ b/p2p/stream/common/streammanager/streammanager_test.go
@@ -222,7 +222,7 @@ func TestStreamManager_HandleRemoveStream(t *testing.T) {
 		sm.Start()
 		time.Sleep(defTestWait)
 
-		err := sm.RemoveStream(test.id)
+		err := sm.RemoveStream(test.id, "test stream removal")
 		if assErr := assertError(err, test.expErr); assErr != nil {
 			t.Errorf("Test %v: %v", i, assErr)
 		}
@@ -243,7 +243,7 @@ func TestStreamManager_HandleRemoveStream_Disc(t *testing.T) {
 	// Remove DiscBatch - HardLoCap + 1 streams
 	num := 0
 	for _, st := range sm.streams.slice() {
-		if err := sm.RemoveStream(st.ID()); err != nil {
+		if err := sm.RemoveStream(st.ID(), "test handle remove"); err != nil {
 			t.Error(err)
 		}
 		num++

--- a/p2p/stream/protocols/sync/client_test.go
+++ b/p2p/stream/protocols/sync/client_test.go
@@ -818,7 +818,7 @@ func (sm *testStreamManager) NewStream(stream sttypes.Stream) error {
 	return nil
 }
 
-func (sm *testStreamManager) RemoveStream(stID sttypes.StreamID) error {
+func (sm *testStreamManager) RemoveStream(stID sttypes.StreamID, reason string) error {
 	for i, id := range sm.streamIDs {
 		if id == stID {
 			sm.streamIDs = append(sm.streamIDs[:i], sm.streamIDs[i+1:]...)

--- a/p2p/stream/protocols/sync/protocol.go
+++ b/p2p/stream/protocols/sync/protocol.go
@@ -375,13 +375,14 @@ func (p *Protocol) protoIDByVersion(v *version.Version) sttypes.ProtoID {
 
 // RemoveStream removes the stream of the given stream ID
 // TODO: add reason to parameters
-func (p *Protocol) RemoveStream(stID sttypes.StreamID) {
+func (p *Protocol) RemoveStream(stID sttypes.StreamID, reason string) {
 	st, exist := p.sm.GetStreamByID(stID)
 	if exist && st != nil {
 		//TODO: log this incident with reason
 		st.Close()
 		p.logger.Info().
 			Str("stream ID", string(stID)).
+			Str("reason", reason).
 			Msg("stream removed")
 	}
 }
@@ -399,6 +400,7 @@ func (p *Protocol) StreamFailed(stID sttypes.StreamID, reason string) {
 			st.Close()
 			p.logger.Warn().
 				Str("stream ID", string(st.ID())).
+				Str("reason", "too many failures").
 				Msg("stream removed")
 		}
 	}

--- a/p2p/stream/protocols/sync/stream.go
+++ b/p2p/stream/protocols/sync/stream.go
@@ -156,7 +156,7 @@ func (st *syncStream) Close() error {
 		// Already closed by another goroutine. Directly return
 		return nil
 	}
-	if err := st.protocol.sm.RemoveStream(st.ID()); err != nil {
+	if err := st.protocol.sm.RemoveStream(st.ID(), "force close"); err != nil {
 		st.logger.Err(err).Str("stream ID", string(st.ID())).
 			Msg("failed to remove sync stream on close")
 	}


### PR DESCRIPTION
This PR improves logging and observability by adding reason strings whenever a stream is removed. It covers the P2P layer, the sync downloader, and staged stream sync. Each stream removal now clearly logs why it happened, such as invalid blocks, connectivity issues, or missing responses.

Previously, it was hard to trace the cause of stream closures, which made investigations slower. With this change, we can quickly identify issues in the logs and improve troubleshooting for sync and networking problems.