### PR TITLE
feat(hmy_tests) - enable new test job for each PR and new commits to main and dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   - TEST="bash ./scripts/travis_go_checker.sh"
   - TEST="bash ./scripts/travis_rpc_checker.sh"
   - TEST="bash ./scripts/travis_rosetta_checker.sh"
+  - TEST="bash ./scripts/travis_pyhmy_checker.sh"
 
 # We enable Travis on the main/dev branches or forked repositories here.
 # PRs workflow isn't affected by this condition

--- a/scripts/travis_pyhmy_checker.sh
+++ b/scripts/travis_pyhmy_checker.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -e
+
+# handle for the Travis build run:
+# * uses TRAVIS_PULL_REQUEST_SLUG if PR is done from fork
+# * uses TRAVIS_PULL_REQUEST_BRANCH for RP branch
+# * uses TRAVIS_BRANCH for simple branch builds
+if [[ -z ${TRAVIS_PULL_REQUEST_SLUG} ]]; then
+    MAIN_REPO_ORG='harmony-one'
+else
+    MAIN_REPO_ORG=${TRAVIS_PULL_REQUEST_SLUG%/*}
+    echo "[WARN] - working on the fork - ${MAIN_REPO_ORG}"
+fi
+
+MAIN_REPO_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-${TRAVIS_BRANCH}}
+# handle for the local run, covers:
+# * branch exist on remote - will use it in the tests
+# * branch exists locally - will use dev as base branch in test
+if [[ -z "$MAIN_REPO_BRANCH" ]]; then
+    MAIN_REPO_BRANCH=${MAIN_REPO_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
+    git ls-remote --exit-code --heads origin "${MAIN_REPO_BRANCH}" >/dev/null 2>&1 || EXIT_CODE=$?
+    if [[ $EXIT_CODE == '0' ]]; then
+        echo "[INFO] - Git branch '$MAIN_REPO_BRANCH' exists in the remote repository"
+    elif [[ $EXIT_CODE == '2' ]]; then
+        echo "[WARN] - Git branch '$MAIN_REPO_BRANCH' does not exist in the remote repository, using" \
+            "'dev' branch as a workaround for a local-only branch"
+        MAIN_REPO_BRANCH='dev'
+    fi
+fi
+
+echo "[harmony repo] - working on '${MAIN_REPO_BRANCH}' branch"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+echo "Working dir is ${DIR}"
+echo "GOPATH is ${GOPATH}"
+cd "${GOPATH}/src/github.com/harmony-one/harmony-test"
+# Current solution expects that your harmony-test repo branch with the same name exists
+# or it will use master by default
+TEST_REPO_BRANCH=${MAIN_REPO_BRANCH}
+# fallback to master if branch is not on remote
+TEST_REPO_BRANCH=$(git ls-remote --exit-code --heads origin "${TEST_REPO_BRANCH}" >/dev/null 2>&1 \
+    && echo "${TEST_REPO_BRANCH}" || echo "master")
+echo "[harmony-test repo] - working on '${TEST_REPO_BRANCH}' branch"
+# cover possible force pushes to remote branches - just rebase local on top of origin
+git fetch origin "${TEST_REPO_BRANCH}"
+git checkout "${TEST_REPO_BRANCH}"
+git pull --rebase=true
+cd localnet
+docker build --build-arg MAIN_REPO_BRANCH="${MAIN_REPO_BRANCH}" --progress plain \
+    --build-arg MAIN_REPO_ORG="${MAIN_REPO_ORG}" -t harmonyone/localnet-test .
+# WARN: this is the place where LOCAL repository is provided to the harmony-tests repo
+docker run -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test -p


### PR DESCRIPTION
## Issue

Main idea of this PR is to enable pyhmy test suite run on the each run, this will help to verify that one of widely used SDK is up and running and haven't been broken by changes in the main repo.

~Additionally, I've disabled cache, because it look like it is just eating our time rn~, ignore this, looks like it is working, I've tested - https://app.travis-ci.com/github/harmony-one/harmony/builds/275141167 vs https://app.travis-ci.com/github/harmony-one/harmony/builds/275140927

Note: please merge this RP only after merge of:
* https://github.com/harmony-one/pyhmy/pull/41
* https://github.com/harmony-one/harmony-test/pull/43

## Test

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
