### PR TITLE
Fully Disable Libp2p Resource Manager by Setting ResourceManager to nil

### DIFF
--- a/p2p/host.go
+++ b/p2p/host.go
@@ -266,6 +266,8 @@ func NewHost(cfg HostConfig) (Host, error) {
 			return nil, fmt.Errorf("failed to open resource manager: %w", err)
 		}
 		p2pHostConfig = append(p2pHostConfig, libp2p.ResourceManager(rmgr))
+	} else {
+		p2pHostConfig = append(p2pHostConfig, libp2p.ResourceManager(nil))
 	}
 
 	// Set host security


### PR DESCRIPTION
This PR ensures the libp2p resource manager is fully disabled by explicitly passing `libp2p.ResourceManager(nil)` in the host configuration. Although the existing configuration flag (`ResourceMgrEnabled = false`) was intended to disable the resource manager, libp2p enables it by default unless explicitly set to `nil`. This change prevents connection blocks caused by default resource limits, ensuring unrestricted P2P communication during development or when custom resource control is not required.
