### PR TITLE
Limit P2P Stream Goroutines

### DIFF
--- a/p2p/stream/common/requestmanager/config.go
+++ b/p2p/stream/common/requestmanager/config.go
@@ -25,4 +25,7 @@ const (
 
 	// maxWaitingSize is the maximum requests that are in waiting list
 	maxWaitingSize = 1024
+
+	// writeConcurrency is the maximum concurrent writes to streams
+	writeConcurrency = 32
 )

--- a/p2p/stream/common/streammanager/config.go
+++ b/p2p/stream/common/streammanager/config.go
@@ -15,6 +15,9 @@ const (
 	// RemovalCooldownDuration defines the cooldown period (in minutes) before a removed stream can reconnect.
 	RemovalCooldownDuration    = 5 * time.Minute
 	MaxRemovalCooldownDuration = 60 * time.Minute
+
+	// setupConcurrency limits concurrent stream setup goroutines
+	setupConcurrency = 16
 )
 
 // Config is the config for stream manager


### PR DESCRIPTION
- throttle concurrent setup of new streams
- throttle concurrent writes in request manager