### PR TITLE
Clean up Waiting Requests as well to Avoid Goroutine Leaks

### DIFF
--- a/p2p/stream/common/requestmanager/requestmanager.go
+++ b/p2p/stream/common/requestmanager/requestmanager.go
@@ -535,6 +535,14 @@ func (rm *requestManager) close() {
 	rm.pendings.Iterate(func(key uint64, req *request) {
 		req.doneWithResponse(responseData{err: ErrClosed})
 	})
+	// clean up waiting requests as well to avoid goroutine leaks
+	for {
+		req := rm.popRequestFromWaitings()
+		if req == nil {
+			break
+		}
+		req.doneWithResponse(responseData{err: ErrClosed})
+	}
 	rm.streams.Clear()
 	rm.available.Clear()
 	rm.pendings.Clear()

--- a/p2p/stream/protocols/sync/sync_stream.go
+++ b/p2p/stream/protocols/sync/sync_stream.go
@@ -79,9 +79,13 @@ func (st *syncStream) readMsgLoop() {
 				}
 				return
 			}
-			if msg != nil {
-				st.deliverMsg(msg)
+			if msg == nil {
+				if err := st.Close("remote closed stream", false); err != nil {
+					st.logger.Err(err).Msg("failed to close sync stream")
+				}
+				return
 			}
+			st.deliverMsg(msg)
 		}
 	}
 }
@@ -176,9 +180,6 @@ func (st *syncStream) CloseOnExit() error {
 	if !notClosed {
 		// Already closed by another goroutine. Directly return
 		return nil
-	}
-	if err := st.BaseStream.Close(); err != nil {
-		//TODO: log closure error
 	}
 	close(st.closeC)
 	return st.BaseStream.CloseOnExit()


### PR DESCRIPTION
This PR cleans up all of the waiting requests in RequestManager's close method to prevent lingering goroutines when the manager shuts down.