### PR TITLE
Fix a Logic Bug Preventing Download Triggers

### DIFF
--- a/api/service/stagedstreamsync/downloaders.go
+++ b/api/service/stagedstreamsync/downloaders.go
@@ -63,7 +63,7 @@ func (ds *Downloaders) Close() {
 // DownloadAsync triggers a download
 func (ds *Downloaders) DownloadAsync(shardID uint32) {
 	d, ok := ds.ds[shardID]
-	if !ok && d != nil {
+	if ok && d != nil {
 		d.DownloadAsync()
 	}
 }


### PR DESCRIPTION
This PR corrects the condition in `DownloadAsync` to ensure the `downloader` for a shard is invoked when present