### PR TITLE
Add a Configurable Bootstrap Timeout for DHT Discovery

### DIFF
--- a/cmd/config/default.go
+++ b/cmd/config/default.go
@@ -49,6 +49,7 @@ var defaultConfig = harmonyconfig.HarmonyConfig{
 		DialTimeout:                     nodeconfig.DefaultDialTimeout,
 		Muxer:                           nodeconfig.DefaultMuxer,
 		NoRelay:                         nodeconfig.DefaultNoRelay,
+		DiscBootstrapTimeout:            nodeconfig.DefaultDiscBootstrapTimeout,
 	},
 	HTTP: harmonyconfig.HttpConfig{
 		Enabled:        true,

--- a/cmd/config/flags.go
+++ b/cmd/config/flags.go
@@ -60,6 +60,7 @@ var (
 		p2pKeyFileFlag,
 		p2pDHTDataStoreFlag,
 		p2pDiscoveryConcurrencyFlag,
+		p2pDiscBootstrapTimeoutFlag,
 		legacyKeyFileFlag,
 		p2pDisablePrivateIPScanFlag,
 		maxConnPerIPFlag,
@@ -631,6 +632,11 @@ var (
 		Usage:    "the pubsub's DHT discovery concurrency num (default with raw libp2p dht option)",
 		DefValue: defaultConfig.P2P.DiscConcurrency,
 	}
+	p2pDiscBootstrapTimeoutFlag = cli.DurationFlag{
+		Name:     "p2p.disc.bootstrap-timeout",
+		Usage:    "timeout for the DHT bootstrap process",
+		DefValue: defaultConfig.P2P.DiscBootstrapTimeout,
+	}
 	p2pDisablePrivateIPScanFlag = cli.BoolFlag{
 		Name:     "p2p.no-private-ip-scan",
 		Usage:    "disable scanning of private ip4/6 addresses by DHT",
@@ -727,6 +733,10 @@ func applyP2PFlags(cmd *cobra.Command, config *harmonyconfig.HarmonyConfig) {
 
 	if cli.IsFlagChanged(cmd, p2pDiscoveryConcurrencyFlag) {
 		config.P2P.DiscConcurrency = cli.GetIntFlagValue(cmd, p2pDiscoveryConcurrencyFlag)
+	}
+
+	if cli.IsFlagChanged(cmd, p2pDiscBootstrapTimeoutFlag) {
+		config.P2P.DiscBootstrapTimeout = cli.GetDurationFlagValue(cmd, p2pDiscBootstrapTimeoutFlag)
 	}
 
 	if cli.IsFlagChanged(cmd, maxConnPerIPFlag) {

--- a/internal/cli/flag.go
+++ b/internal/cli/flag.go
@@ -4,6 +4,8 @@
 package cli
 
 import (
+	"time"
+
 	"github.com/spf13/pflag"
 )
 
@@ -130,6 +132,23 @@ func (f IntSliceFlag) RegisterTo(fs *pflag.FlagSet) error {
 	return markHiddenOrDeprecated(fs, f.Name, f.Deprecated, f.Hidden)
 }
 
+// DurationFlag is the flag with duration value
+type DurationFlag struct {
+	Name       string
+	Shorthand  string
+	Usage      string
+	Deprecated string
+	Hidden     bool
+
+	DefValue time.Duration
+}
+
+// RegisterTo register the duration flag to FlagSet
+func (f DurationFlag) RegisterTo(fs *pflag.FlagSet) error {
+	fs.DurationP(f.Name, f.Shorthand, f.DefValue, f.Usage)
+	return markHiddenOrDeprecated(fs, f.Name, f.Deprecated, f.Hidden)
+}
+
 func markHiddenOrDeprecated(fs *pflag.FlagSet, name string, deprecated string, hidden bool) error {
 	if len(deprecated) != 0 {
 		// TODO: after totally removed node.sh, change MarkHidden to MarkDeprecated
@@ -159,6 +178,8 @@ func getFlagName(flag Flag) string {
 	case Int64Flag:
 		return f.Name
 	case Uint64Flag:
+		return f.Name
+	case DurationFlag:
 		return f.Name
 	}
 	return ""

--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -82,6 +84,11 @@ func GetUint64FlagValue(cmd *cobra.Command, flag Uint64Flag) uint64 {
 	return getUint64FlagValue(cmd.Flags(), flag)
 }
 
+// GetDurationFlagValue get the duration value for the given DurationFlag from the local flags of the cobra command.
+func GetDurationFlagValue(cmd *cobra.Command, flag DurationFlag) time.Duration {
+	return getDurationFlagValue(cmd.Flags(), flag)
+}
+
 // GetIntPersistentFlagValue get the int value for the given IntFlag from the persistent
 // flags of the cobra command.
 func GetIntPersistentFlagValue(cmd *cobra.Command, flag IntFlag) int {
@@ -153,6 +160,15 @@ func getIntSliceFlagValue(fs *pflag.FlagSet, flag IntSliceFlag) []int {
 	if err != nil {
 		handleParseError(err)
 		return nil
+	}
+	return val
+}
+
+func getDurationFlagValue(fs *pflag.FlagSet, flag DurationFlag) time.Duration {
+	val, err := fs.GetDuration(flag.Name)
+	if err != nil {
+		handleParseError(err)
+		return 0
 	}
 	return val
 }

--- a/internal/configs/bootnode/bootnode.go
+++ b/internal/configs/bootnode/bootnode.go
@@ -95,6 +95,8 @@ type P2pConfig struct {
 	Muxer string
 	// No relay services, direct connections between peers only
 	NoRelay bool
+	// Timeout for the initial DHT bootstrap process
+	DiscBootstrapTimeout time.Duration
 }
 
 type GeneralConfig struct {

--- a/internal/configs/harmony/harmony.go
+++ b/internal/configs/harmony/harmony.go
@@ -146,6 +146,8 @@ type P2pConfig struct {
 	Muxer string
 	// No relay services, direct connections between peers only
 	NoRelay bool
+	// Timeout for the initial DHT bootstrap process
+	DiscBootstrapTimeout time.Duration
 }
 
 type GeneralConfig struct {

--- a/internal/configs/node/network.go
+++ b/internal/configs/node/network.go
@@ -93,6 +93,8 @@ const (
 	DefaultUserAgent = ""
 	// DefaultDialTimeout dial timeout
 	DefaultDialTimeout = time.Minute
+	// DefaultDiscBootstrapTimeout is the timeout for DHT bootstrap
+	DefaultDiscBootstrapTimeout = 30 * time.Second
 	// DefaultMuxerType P2P multiplexer type
 	DefaultMuxer = "mplex, yamux"
 	// DefaultNoRelay disables p2p host relay

--- a/p2p/discovery/discovery.go
+++ b/p2p/discovery/discovery.go
@@ -54,7 +54,18 @@ func NewDHTDiscovery(ctx context.Context, cancel context.CancelFunc, host libp2p
 
 // Start bootstrap the dht discovery service.
 func (d *dhtDiscovery) Start() error {
-	return d.dht.Bootstrap(d.ctx)
+	ctx := d.ctx
+	if d.opt.BootstrapTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, d.opt.BootstrapTimeout)
+		defer cancel()
+	}
+	start := time.Now()
+	err := d.dht.Bootstrap(ctx)
+	if err == nil {
+		d.logger.Debug().Dur("duration", time.Since(start)).Msg("dht bootstrap completed")
+	}
+	return err
 }
 
 // Stop stop the dhtDiscovery service

--- a/p2p/discovery/option.go
+++ b/p2p/discovery/option.go
@@ -1,6 +1,8 @@
 package discovery
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 
 	p2ptypes "github.com/harmony-one/harmony/p2p/types"
@@ -15,7 +17,10 @@ type DHTConfig struct {
 	BootNodes       []string
 	DataStoreFile   *string // File path to store DHT data. Shall be only used for bootstrap nodes.
 	DiscConcurrency int
-	DHT             *dht.IpfsDHT
+	// BootstrapTimeout defines how long the DHT bootstrap should run. Zero
+	// means using the passed in context without additional timeout.
+	BootstrapTimeout time.Duration
+	DHT              *dht.IpfsDHT
 }
 
 // GetLibp2pRawOptions get the raw libp2p options as a slice.

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -107,6 +107,7 @@ type HostConfig struct {
 	TrustedNodes                    []string
 	DataStoreFile                   *string
 	DiscConcurrency                 int
+	DiscBootstrapTimeout            time.Duration
 	MaxConnPerIP                    int
 	DisablePrivateIPScan            bool
 	MaxPeers                        int64
@@ -315,9 +316,10 @@ func NewHost(cfg HostConfig) (Host, error) {
 
 	// DHT
 	opt := discovery.DHTConfig{
-		BootNodes:       cfg.BootNodes,
-		DataStoreFile:   cfg.DataStoreFile,
-		DiscConcurrency: cfg.DiscConcurrency,
+		BootNodes:        cfg.BootNodes,
+		DataStoreFile:    cfg.DataStoreFile,
+		DiscConcurrency:  cfg.DiscConcurrency,
+		BootstrapTimeout: cfg.DiscBootstrapTimeout,
 	}
 	opts, err := opt.GetLibp2pRawOptions()
 	if err != nil {

--- a/p2p/stream/common/streammanager/streammanager.go
+++ b/p2p/stream/common/streammanager/streammanager.go
@@ -504,11 +504,7 @@ func (sm *streamManager) discover(ctx context.Context) (<-chan libp2p_peer.AddrI
 		return nil, nil
 	}
 
-	ctx2, cancel := context.WithTimeout(ctx, discTimeout)
-	go func() { // avoid context leak
-		<-time.After(discTimeout)
-		cancel()
-	}()
+	ctx2, _ := context.WithTimeout(ctx, discTimeout)
 	return sm.pf.FindPeers(ctx2, string(sm.myProtoID), discBatch)
 }
 


### PR DESCRIPTION
This pull request introduces a configurable timeout for the DHT bootstrap process, enhancing the flexibility and observability of peer discovery in the network. A new `DiscBootstrapTimeout` field has been added to both the host and configuration structures, with a default value set to 30 seconds. This allows operators to better tune the duration of the DHT bootstrap according to their environment or performance needs.

To support this configurability, a new CLI flag `--p2p.disc.bootstrap-timeout` has been registered. This flag is now part of the default configuration and can be set via the command line, giving users a straightforward way to adjust the timeout without modifying the codebase. Additionally, the bootstrap duration is now logged, providing useful diagnostics for monitoring and debugging DHT discovery behavior.

The PR also includes a cleanup in the stream manager’s peer discovery logic. Specifically, an unnecessary goroutine was removed to simplify the control flow. This change reduces complexity and improves the maintainability of the peer discovery process without altering its functionality.
