### PR TITLE
Prefer trusted peers for streams

### DIFF
--- a/p2p/host.go
+++ b/p2p/host.go
@@ -77,6 +77,10 @@ type Host interface {
 	ListPeer(topic string) []libp2p_peer.ID
 	ListTopic() []string
 	ListBlockedPeer() []libp2p_peer.ID
+	// TrustedPeers returns ids of trusted peers
+	TrustedPeers() []libp2p_peer.ID
+	// IsTrustedPeer checks whether a peer is trusted
+	IsTrustedPeer(id libp2p_peer.ID) bool
 }
 
 // Peer is the object for a p2p peer (node)
@@ -385,20 +389,35 @@ func NewHost(cfg HostConfig) (Host, error) {
 	security := security.NewManager(cfg.MaxConnPerIP, int(cfg.MaxPeers), banned)
 	// has to save the private key for host
 	h := &HostV2{
-		h:             p2pHost,
-		pubsub:        pubsub,
-		joined:        map[string]*libp2p_pubsub.Topic{},
-		self:          *self,
-		trustedNodes:  cfg.TrustedNodes,
-		priKey:        key,
-		discovery:     disc,
-		security:      security,
-		onConnections: ConnectCallbacks{},
-		onDisconnects: DisconnectCallbacks{},
-		logger:        &subLogger,
-		ctx:           ctx,
-		cancel:        cancel,
-		banned:        banned,
+		h:              p2pHost,
+		pubsub:         pubsub,
+		joined:         map[string]*libp2p_pubsub.Topic{},
+		self:           *self,
+		trustedNodes:   cfg.TrustedNodes,
+		trustedPeerIDs: make(map[libp2p_peer.ID]struct{}),
+		priKey:         key,
+		discovery:      disc,
+		security:       security,
+		onConnections:  ConnectCallbacks{},
+		onDisconnects:  DisconnectCallbacks{},
+		logger:         &subLogger,
+		ctx:            ctx,
+		cancel:         cancel,
+		banned:         banned,
+	}
+
+	for _, addr := range cfg.TrustedNodes {
+		peerAddr, err := ma.NewMultiaddr(addr)
+		if err != nil {
+			subLogger.Error().Err(err).Str("addr", addr).Msg("invalid trusted node addr")
+			continue
+		}
+		info, err := libp2p_peer.AddrInfoFromP2pAddr(peerAddr)
+		if err != nil {
+			subLogger.Error().Err(err).Str("addr", addr).Msg("failed to parse trusted node")
+			continue
+		}
+		h.trustedPeerIDs[info.ID] = struct{}{}
 	}
 
 	utils.Logger().Info().
@@ -475,23 +494,24 @@ func connectionManager(low int, high int) (libp2p_config.Option, error) {
 
 // HostV2 is the version 2 p2p host
 type HostV2 struct {
-	h             libp2p_host.Host
-	pubsub        *libp2p_pubsub.PubSub
-	joined        map[string]*libp2p_pubsub.Topic
-	streamProtos  []sttypes.Protocol
-	self          Peer
-	trustedNodes  []string
-	priKey        libp2p_crypto.PrivKey
-	lock          sync.Mutex
-	discovery     discovery.Discovery
-	security      security.Security
-	logger        *zerolog.Logger
-	blocklist     libp2p_pubsub.Blacklist
-	onConnections ConnectCallbacks
-	onDisconnects DisconnectCallbacks
-	ctx           context.Context
-	cancel        func()
-	banned        *blockedpeers.Manager
+	h              libp2p_host.Host
+	pubsub         *libp2p_pubsub.PubSub
+	joined         map[string]*libp2p_pubsub.Topic
+	streamProtos   []sttypes.Protocol
+	self           Peer
+	trustedNodes   []string
+	trustedPeerIDs map[libp2p_peer.ID]struct{}
+	priKey         libp2p_crypto.PrivKey
+	lock           sync.Mutex
+	discovery      discovery.Discovery
+	security       security.Security
+	logger         *zerolog.Logger
+	blocklist      libp2p_pubsub.Blacklist
+	onConnections  ConnectCallbacks
+	onDisconnects  DisconnectCallbacks
+	ctx            context.Context
+	cancel         func()
+	banned         *blockedpeers.Manager
 }
 
 // PubSub ..
@@ -703,6 +723,19 @@ func (host *HostV2) ListPeer(topic string) []libp2p_peer.ID {
 // ListBlockedPeer returns list of blocked peer
 func (host *HostV2) ListBlockedPeer() []libp2p_peer.ID {
 	return host.banned.Keys()
+}
+
+func (host *HostV2) TrustedPeers() []libp2p_peer.ID {
+	peers := make([]libp2p_peer.ID, 0, len(host.trustedPeerIDs))
+	for id := range host.trustedPeerIDs {
+		peers = append(peers, id)
+	}
+	return peers
+}
+
+func (host *HostV2) IsTrustedPeer(id libp2p_peer.ID) bool {
+	_, ok := host.trustedPeerIDs[id]
+	return ok
 }
 
 // GetPeerCount ...

--- a/p2p/stream/common/streammanager/config.go
+++ b/p2p/stream/common/streammanager/config.go
@@ -1,6 +1,10 @@
 package streammanager
 
-import "time"
+import (
+	"time"
+
+	libp2p_peer "github.com/libp2p/go-libp2p/core/peer"
+)
 
 const (
 	// checkInterval is the default interval for checking stream number. If the stream
@@ -27,4 +31,6 @@ type Config struct {
 	HiCap int
 	// DiscBatch is the size of each discovery
 	DiscBatch int
+	// TrustedPeers are peer IDs considered trusted
+	TrustedPeers map[libp2p_peer.ID]struct{}
 }

--- a/p2p/stream/common/streammanager/streammanager.go
+++ b/p2p/stream/common/streammanager/streammanager.go
@@ -49,6 +49,7 @@ type streamManager struct {
 	removedStreams *sttypes.SafeMap[sttypes.StreamID, *RemovalInfo]
 	// reserved streams
 	reservedStreams *streamSet
+	trustedPeers    map[libp2p_peer.ID]struct{}
 	// libp2p utilities
 	host         host
 	pf           peerFinder
@@ -131,6 +132,7 @@ func newStreamManager(pid sttypes.ProtoID, host host, pf peerFinder, handleStrea
 		streams:         newStreamSet(),
 		reservedStreams: newStreamSet(),
 		removedStreams:  sttypes.NewSafeMap[sttypes.StreamID, *RemovalInfo](),
+		trustedPeers:    c.TrustedPeers,
 		host:            host,
 		pf:              pf,
 		handleStream:    handleStream,
@@ -386,14 +388,16 @@ func (sm *streamManager) handleRemoveStream(id sttypes.StreamID, reason string, 
 		Str("reason", reason).
 		Msg("[StreamManager] removed stream from main streams list")
 
-	info, exist := sm.removedStreams.Get(id)
-	if !exist {
-		info = &RemovalInfo{
-			count: 0,
+	if _, trusted := sm.trustedPeers[libp2p_peer.ID(id)]; !trusted {
+		info, exist := sm.removedStreams.Get(id)
+		if !exist {
+			info = &RemovalInfo{count: 0}
+			sm.removedStreams.Set(id, info)
 		}
-		sm.removedStreams.Set(id, info)
+		info.MarkAsRemoved(criticalErr)
+	} else {
+		go sm.setupStreamWithPeer(sm.ctx, libp2p_peer.ID(id))
 	}
-	info.MarkAsRemoved(criticalErr)
 
 	// try to replace removed streams from reserved list
 	sm.removeStreamFeed.Send(EvtStreamRemoved{id})
@@ -450,40 +454,67 @@ func (sm *streamManager) removeAllStreamOnClose() {
 }
 
 func (sm *streamManager) discoverAndSetupStream(discCtx context.Context) (int, error) {
-	peers, err := sm.discover(discCtx)
-	if err != nil {
-		return 0, errors.Wrap(err, "failed to discover")
-	}
-	discoverCounterVec.With(prometheus.Labels{"topic": string(sm.myProtoID)}).Inc()
-
 	connecting := 0
-	for peer := range peers {
-		if peer.ID == sm.host.ID() {
+
+	for pid := range sm.trustedPeers {
+		if pid == sm.host.ID() {
 			continue
 		}
-		if sm.coolDownCache.Has(peer.ID) {
-			// If the peer has the same ID and was just connected, skip.
+		if sm.coolDownCache.Has(pid) {
 			continue
 		}
-		if _, ok := sm.streams.get(sttypes.StreamID(peer.ID)); ok {
+		if _, ok := sm.streams.get(sttypes.StreamID(pid)); ok {
 			continue
 		}
-		if _, ok := sm.reservedStreams.get(sttypes.StreamID(peer.ID)); ok {
+		if _, ok := sm.reservedStreams.get(sttypes.StreamID(pid)); ok {
 			continue
 		}
-		discoveredPeersCounterVec.With(prometheus.Labels{"topic": string(sm.myProtoID)}).Inc()
-		connecting += 1
-		go func(pid libp2p_peer.ID) {
-			// The ctx here is using the module context instead of discover context
-			err := sm.setupStreamWithPeer(sm.ctx, pid)
+		connecting++
+		go func(id libp2p_peer.ID) {
+			err := sm.setupStreamWithPeer(sm.ctx, id)
 			if err != nil {
-				sm.coolDownCache.Add(pid)
+				sm.coolDownCache.Add(id)
 				sm.logger.Warn().Err(err).
-					Interface("peerID", pid).
-					Msg("failed to setup stream with peer")
+					Interface("peerID", id).
+					Msg("failed to setup stream with trusted peer")
 				return
 			}
-		}(peer.ID)
+		}(pid)
+	}
+
+	if sm.streams.size()+connecting < sm.config.HardLoCap {
+		peers, err := sm.discover(discCtx)
+		if err != nil {
+			return connecting, errors.Wrap(err, "failed to discover")
+		}
+		discoverCounterVec.With(prometheus.Labels{"topic": string(sm.myProtoID)}).Inc()
+
+		for peer := range peers {
+			if peer.ID == sm.host.ID() {
+				continue
+			}
+			if sm.coolDownCache.Has(peer.ID) {
+				continue
+			}
+			if _, ok := sm.streams.get(sttypes.StreamID(peer.ID)); ok {
+				continue
+			}
+			if _, ok := sm.reservedStreams.get(sttypes.StreamID(peer.ID)); ok {
+				continue
+			}
+			discoveredPeersCounterVec.With(prometheus.Labels{"topic": string(sm.myProtoID)}).Inc()
+			connecting += 1
+			go func(pid libp2p_peer.ID) {
+				err := sm.setupStreamWithPeer(sm.ctx, pid)
+				if err != nil {
+					sm.coolDownCache.Add(pid)
+					sm.logger.Warn().Err(err).
+						Interface("peerID", pid).
+						Msg("failed to setup stream with peer")
+					return
+				}
+			}(peer.ID)
+		}
 	}
 	return connecting, nil
 }

--- a/p2p/stream/protocols/sync/protocol.go
+++ b/p2p/stream/protocols/sync/protocol.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/go-version"
 	libp2p_host "github.com/libp2p/go-libp2p/core/host"
 	libp2p_network "github.com/libp2p/go-libp2p/core/network"
+	libp2p_peer "github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/rs/zerolog"
 )
@@ -99,6 +100,13 @@ func NewProtocol(config Config) *Protocol {
 		HardLoCap: config.SmHardLowCap,
 		HiCap:     config.SmHiCap,
 		DiscBatch: config.DiscBatch,
+		TrustedPeers: func() map[libp2p_peer.ID]struct{} {
+			tmp := make(map[libp2p_peer.ID]struct{})
+			for _, id := range config.Host.TrustedPeers() {
+				tmp[id] = struct{}{}
+			}
+			return tmp
+		}(),
 	}
 	sp.sm = streammanager.NewStreamManager(sp.ProtoID(), config.Host, config.Discovery,
 		sp.HandleStream, smConfig)


### PR DESCRIPTION
- ensure Host exposes trusted peer set
- track trusted peers in stream manager config
- keep trusted peers by reconnecting instead of banning
- attempt connecting to trusted peers before discovering others