### PR TITLE
Set YaMux as Priority

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -125,7 +125,7 @@ func main() {
 	resourceManagerMemoryLimitBytes := flag.Uint64("resmgr-memory-limit-bytes", 0, "memory limit for p2p resource manager")
 	resourceManagerFileDescriptorsLimit := flag.Uint64("resmgr-file-descriptor-limit", 0, "file descriptor limit for p2p resource manager")
 	noTransportSecurity := flag.Bool("no_transport_security", false, "disable TLS encrypted transport")
-	muxer := flag.String("muxer", "mplexC6, yamux", "protocol muxer to mux per-protocol streams (mplex, mplexC6, yamux)")
+	muxer := flag.String("muxer", "yamux, mplexC6", "protocol muxer to mux per-protocol streams (yamux, mplex, mplexC6)")
 	userAgent := flag.String("user_agent", defUserAgent, "explicitly set the user-agent, so we can differentiate from other Go libp2p users")
 	noRelay := flag.Bool("no_relay", true, "no relay services, direct connections between peers only")
 	networkType := flag.String("network", "mainnet", "network type (mainnet, testnet, pangaea, partner, stressnet, devnet, localnet)")

--- a/cmd/config/flags.go
+++ b/cmd/config/flags.go
@@ -693,7 +693,7 @@ var (
 	}
 	muxerFlag = cli.StringFlag{
 		Name:     "p2p.muxer",
-		Usage:    "protocol muxer to mux per-protocol streams, should be comma separated string (mplex, mplexC6, yamux)",
+		Usage:    "protocol muxer to mux per-protocol streams, should be comma separated string (yamux, mplex, mplexC6)",
 		DefValue: defaultConfig.P2P.Muxer,
 	}
 	noRelayFlag = cli.BoolFlag{

--- a/internal/configs/bootnode/bootnode.go
+++ b/internal/configs/bootnode/bootnode.go
@@ -91,7 +91,7 @@ type P2pConfig struct {
 	UserAgent string
 	// p2p dial timeout
 	DialTimeout time.Duration
-	// P2P multiplexer type, should be comma separated (mplex, mplexC6, yamux)
+	// P2P multiplexer type, should be comma separated (yamux, mplex, mplexC6)
 	Muxer string
 	// No relay services, direct connections between peers only
 	NoRelay bool

--- a/internal/configs/harmony/harmony.go
+++ b/internal/configs/harmony/harmony.go
@@ -142,7 +142,7 @@ type P2pConfig struct {
 	UserAgent string
 	// p2p dial timeout
 	DialTimeout time.Duration
-	// P2P multiplexer type, should be comma separated (mplex, mplexC6, yamux)
+	// P2P multiplexer type, should be comma separated (yamux, mplex, mplexC6)
 	Muxer string
 	// No relay services, direct connections between peers only
 	NoRelay bool

--- a/internal/configs/node/network.go
+++ b/internal/configs/node/network.go
@@ -94,7 +94,7 @@ const (
 	// DefaultDialTimeout dial timeout
 	DefaultDialTimeout = time.Minute
 	// DefaultMuxerType P2P multiplexer type
-	DefaultMuxer = "mplexC6, yamux"
+	DefaultMuxer = "yamux, mplexC6"
 	// DefaultNoRelay disables p2p host relay
 	DefaultNoRelay = true
 )


### PR DESCRIPTION
This PR sets yamux as priority but it fallbacks to mplex when the remote does not support yamux.