### PR TITLE
Handle Future Blocks and Partially Synced Peers Gracefully During Epoch Sync

### DIFF
--- a/api/service/stagedstreamsync/short_range_helper.go
+++ b/api/service/stagedstreamsync/short_range_helper.go
@@ -179,9 +179,10 @@ func (sh *srHelper) doGetBlocksByNumbersRequest(ctx context.Context, bns []uint6
 	blocks, stid, err := sh.syncProtocol.GetBlocksByNumber(ctx, bns)
 	if err != nil {
 		sh.logger.Warn().Err(err).
+			Interface("block numbers", bns).
 			Str("stream", string(stid)).
-			Msg(WrapStagedSyncMsg("failed to doGetBlockHashesRequest"))
-		return nil, stid, err
+			Msg(WrapStagedSyncMsg("failed to doGetBlocksByNumbersRequest"))
+		return blocks, stid, err
 	}
 	return blocks, stid, nil
 }

--- a/api/service/stagedstreamsync/stage_epoch.go
+++ b/api/service/stagedstreamsync/stage_epoch.go
@@ -147,6 +147,7 @@ func (sr *StageEpoch) doShortRangeSyncForEpochSync(ctx context.Context, s *Stage
 	n := 0
 	for _, block := range blocks {
 		if block == nil {
+			sr.configs.logger.Debug().Msg("Skipped a nil block during epoch sync")
 			continue
 		}
 		_, err := s.state.bc.InsertChain([]*types.Block{block}, true)

--- a/api/service/stagedstreamsync/stage_epoch.go
+++ b/api/service/stagedstreamsync/stage_epoch.go
@@ -23,6 +23,8 @@ type StageEpochCfg struct {
 	logger zerolog.Logger
 }
 
+var blockNotFoundPattern = regexp.MustCompile(`block (\d+) not found$`)
+
 func NewStageEpoch(cfg StageEpochCfg) *StageEpoch {
 	return &StageEpoch{
 		configs: cfg,
@@ -133,7 +135,6 @@ func (sr *StageEpoch) doShortRangeSyncForEpochSync(ctx context.Context, s *Stage
 			return 0, nil
 		}
 		// Check if the requested blocks are future blocks or the remote peer is not fully synced
-		blockNotFoundPattern := regexp.MustCompile(`block (\d+) not found$`)
 		matches := blockNotFoundPattern.FindStringSubmatch(err.Error())
 		if len(matches) == 0 {
 			return 0, errors.Wrap(err, "getBlocksChain")


### PR DESCRIPTION
This PR improves the robustness of the epoch sync mechanism by handling cases where:
- The requested block is in the future, or
- The remote peer is not fully synced and doesn't have the requested block.

Previously, such scenarios would trigger repeated errors and retries, resulting in excessive error logs and unnecessary load on stream connections.
With this update, the code detects these cases and skips or partially applies blocks, allowing epoch sync to continue without flooding logs or overloading the system.