### PR TITLE
[Bootnode] - Fix Data Corruption Issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,9 +76,11 @@ blspass.txt
 # local test db
 db-127.0.0.1-*
 
-# dht storage
+# dht and peer storage
 .dht
 .dht-*
+.ps
+.ps-*
 .tern-port
 
 # testdata

--- a/Makefile
+++ b/Makefile
@@ -80,10 +80,9 @@ trace-pointer:
 	bash ./scripts/go_executable_build.sh -t
 
 debug:
-	rm -rf .dht-127.0.0.1*
 	# uncomment the following lines to enable debug logging for libp2p, it produces a lot of logs, so disabled by default
-	#export GOLOG_LOG_LEVEL=debug
-	#export GOLOG_OUTPUT=stdout
+	# export GOLOG_LOG_LEVEL=debug
+	# export GOLOG_OUTPUT=stdout
 	# add VERBOSE=true before bash or run `export VERBOSE=true` on the shell level for have max logging
 	# add LEGACY_SYNC=true before bash  or run `export LEGACY_SYNC=true` on the shell level to switch to the legacy sync
 	bash ./test/debug.sh ./test/configs/local-resharding.txt
@@ -128,6 +127,7 @@ debug-multi-bls-multi-ext-node:
 
 clean:
 	rm -rf ./tmp_log/*
+	rm -rf ./.ps*
 	rm -rf ./.dht*
 	rm -rf ./db-*
 	rm -rf ./latest

--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -155,7 +155,7 @@ func main() {
 	}
 
 	// For bootstrap nodes, we shall keep .dht file.
-	dataStorePath := fmt.Sprintf(".dht-%s-%s", *ip, *port)
+	dataStorePath := fmt.Sprintf("%s-%s", *ip, *port)
 	selfPeer := p2p.Peer{IP: *ip, Port: *port}
 
 	host, err := p2p.NewHost(p2p.HostConfig{

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -142,10 +142,10 @@ func init() {
 // NewHost ..
 func NewHost(cfg HostConfig) (Host, error) {
 	var (
-		self   = cfg.Self
-		key    = cfg.BLSKey
-		pub    = cfg.BLSKey.GetPublic()
-		psPath = cfg.DataStoreFile
+		self          = cfg.Self
+		key           = cfg.BLSKey
+		pub           = cfg.BLSKey.GetPublic()
+		dataStorePath = cfg.DataStoreFile
 	)
 
 	pubKey := key.GetPublic()
@@ -159,6 +159,13 @@ func NewHost(cfg HostConfig) (Host, error) {
 	listenAddr := libp2p.ListenAddrStrings(
 		addr, // regular tcp connections
 	)
+
+	var psPath *string
+	if dataStorePath != nil {
+		newPath := fmt.Sprintf(".ps-%s", *dataStorePath)
+		psPath = &newPath
+	}
+
 	datastore, err := createDatastore(psPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create data store: %w", err)
@@ -246,8 +253,9 @@ func NewHost(cfg HostConfig) (Host, error) {
 		/*
 			libp2p.ConnectionGater(connGtr), // TODO use connection gater to monitor the connections
 			libp2p.ResourceManager(nil), // TODO use resource manager interface to manage resources per peer better
-			libp2p.Peerstore(ps), // TODO add extended peer store
 		*/
+		// LevelDB backed peerstore
+		libp2p.Peerstore(ps),
 		// Connection manager
 		connMngr,
 		// NAT manager
@@ -321,6 +329,12 @@ func NewHost(cfg HostConfig) (Host, error) {
 		DataStoreFile:   cfg.DataStoreFile,
 		DiscConcurrency: cfg.DiscConcurrency,
 	}
+
+	if dataStorePath != nil {
+		newPath := fmt.Sprintf(".dht-%s", *dataStorePath)
+		*opt.DataStoreFile = newPath
+	}
+
 	opts, err := opt.GetLibp2pRawOptions()
 	if err != nil {
 		cancel()

--- a/test/debug.sh
+++ b/test/debug.sh
@@ -9,6 +9,7 @@ Localnet_Blocks_Per_Epoch_V2=$3
 rm -rf tmp_log/* 2> /dev/null
 rm *.rlp 2> /dev/null
 rm -rf .dht* 2> /dev/null
+rm -rf .ps* 2> /dev/null
 scripts/go_executable_build.sh -S || exit 1  # dynamic builds are faster for debug iteration...
 LEGACY_SYNC=${LEGACY_SYNC:-"false"}
 if [ "${LEGACY_SYNC}" == "true" ]; then


### PR DESCRIPTION
Issue: https://github.com/harmony-one/harmony/issues/4883

## Fixes
- Separate peerstore and DHT directories. Previously both services wrote to the same path, risking data corruption.
- Persist data in dedicated folders: `.ps-<ip>-<port>` for peer storage and `.dht-<ip>-<port>` for DHT. Both had been using `.dht-<ip>-<port>`.
- Integrate the existing persistent datastore — which already holds the public and private keys — into the P2P host creation so it also manages peers. Previously, because it wasn’t hooked up, we spun up a separate in-memory store and abandoned the persistent one, leaving it unused and never closing properly.
- Remove the redundant datastore cleanup from the `debug` Makefile task, since it’s already handled by `debug.sh`.

## Completed
- [x] Test devnet bootnodes