### PR TITLE
feat(localnet) - add a possibillity to run extra nodes in already running localnet

### DIFF
--- a/test/configs/local-extra-nodes.txt
+++ b/test/configs/local-extra-nodes.txt
@@ -1,0 +1,21 @@
+127.0.0.1 9021 explorer null 0
+127.0.0.1 9022 explorer null 0
+127.0.0.1 9023 explorer null 0
+127.0.0.1 9024 explorer null 0
+127.0.0.1 9025 explorer null 0
+127.0.0.1 9026 explorer null 0
+127.0.0.1 9027 explorer null 0
+127.0.0.1 9028 explorer null 0
+127.0.0.1 9029 explorer null 0
+127.0.0.1 9030 explorer null 0
+
+127.0.0.1 9101 explorer null 1
+127.0.0.1 9102 explorer null 1
+127.0.0.1 9103 explorer null 1
+127.0.0.1 9104 explorer null 1
+127.0.0.1 9105 explorer null 1
+127.0.0.1 9106 explorer null 1
+127.0.0.1 9107 explorer null 1
+127.0.0.1 9108 explorer null 1
+127.0.0.1 9109 explorer null 1
+127.0.0.1 9110 explorer null 1

--- a/test/debug.sh
+++ b/test/debug.sh
@@ -4,12 +4,18 @@ unset -v configfile
 configfile=$1
 Localnet_Blocks_Per_Epoch=$2
 Localnet_Blocks_Per_Epoch_V2=$3
+CLEAN_START=${4:-true}
 
-./test/kill_node.sh
-rm -rf tmp_log/* 2> /dev/null
-rm *.rlp 2> /dev/null
-rm -rf .dht* 2> /dev/null
-rm -rf .ps* 2> /dev/null
+if [ "${CLEAN_START}" != false ]; then
+  ./test/kill_node.sh
+  rm -rf tmp_log/* 2> /dev/null
+  rm *.rlp 2> /dev/null
+  rm -rf .dht* 2> /dev/null
+  rm -rf .ps* 2> /dev/null
+  CLEAN_START_OPT=(-X "true")
+else
+  CLEAN_START_OPT=(-X "false")
+fi
 scripts/go_executable_build.sh -S || exit 1  # dynamic builds are faster for debug iteration...
 LEGACY_SYNC=${LEGACY_SYNC:-"false"}
 if [ "${LEGACY_SYNC}" == "true" ]; then
@@ -31,7 +37,9 @@ fi
 
 if [ "${VERBOSE}" = "true" ]; then
     echo "[WARN] - running with verbose logs"
-    ./test/deploy.sh -v -B -D 600000 "${BLOCK_PER_EPOCH_OPT[@]}" "${BLOCK_PER_EPOCH_V2_OPT[@]}" "${SYNC_OPT[@]}" "${configfile}"
+    ./test/deploy.sh -v -B -D 600000 "${BLOCK_PER_EPOCH_OPT[@]}" "${BLOCK_PER_EPOCH_V2_OPT[@]}" \
+        "${SYNC_OPT[@]}" "${CLEAN_START_OPT[@]}"  "${configfile}"
 else
-    ./test/deploy.sh -B -D 600000 "${BLOCK_PER_EPOCH_OPT[@]}" "${BLOCK_PER_EPOCH_V2_OPT[@]}" "${SYNC_OPT[@]}" "${configfile}"
+    ./test/deploy.sh -B -D 600000 "${BLOCK_PER_EPOCH_OPT[@]}" "${BLOCK_PER_EPOCH_V2_OPT[@]}" \
+        "${SYNC_OPT[@]}" "${CLEAN_START_OPT[@]}" "${configfile}"
 fi

--- a/test/wait_till_n_epoch.sh
+++ b/test/wait_till_n_epoch.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+#wait for epoch N
+epoch=$(hmy blockchain latest-headers --node="http://localhost:9500" | jq -r '.["result"]["beacon-chain-header"]["epoch"]')
+while (( epoch < "${1}" )); do
+	echo "Not yet on epoch ${1} .. waiting 30s"
+	epoch=$(hmy blockchain latest-headers --node="http://localhost:9500" | jq -r '.["result"]["beacon-chain-header"]["epoch"]')
+	sleep 30
+done
+echo "we are on the epoch ${1}, let's proceed"


### PR DESCRIPTION
What was done in details:
- Makefile - new debug-add-extra-nodes-to-the-running-network command will wait for EPOCH_TO_WAIT and run EXTRA_NODES_FILE for the existing localnet
- test/debug.sh - new positional argument CLEAN_START, if false - disables deletion and removal of running localnet, default value is always true
- test/deploy.sh - new named argument CLEAN_START if false - disables bootnode creation, finds its p2p multiaddress and starts a set new nodes as addition for existng
- test/wait_till_n_epoch.sh - simple waiter for the N epoch

How to use it:
1. Run the normal localnet - `make debug-multi-bls
2. Run the extra nodes - `make debug-add-extra-nodes-to-the-running-network EPOCH_TO_WAIT=3`