### PR TITLE
fix: improve crosslink heartbeat processing and reduce log noise

### DIFF
--- a/node/harmony/node_cross_link.go
+++ b/node/harmony/node_cross_link.go
@@ -55,10 +55,41 @@ func (node *Node) processCrossLinkHeartbeatMessage(msgPayload []byte) error {
 	if err != nil {
 		return errors.WithMessagef(err, "cannot decode crosslink heartbeat message, len: %d", len(msgPayload))
 	}
+
+	// Check if the heartbeat is for the current shard
 	cur := node.Blockchain().CurrentBlock()
 	shardID := cur.ShardID()
 	if hb.ShardID != shardID {
-		return errors.Errorf("invalid shard id: expected %d, got %d", shardID, hb.ShardID)
+		utils.Logger().Debug().
+			Uint32("expectedShard", shardID).
+			Uint32("heartbeatShard", hb.ShardID).
+			Msg("[ProcessCrossLinkHeartbeatMessage] heartbeat for different shard, ignoring")
+		return nil
+	}
+
+	// Check if epoch chain is synced to at least hb.Epoch before processing crosslink heartbeat
+	epochChain := node.EpochChain()
+	if epochChain == nil {
+		utils.Logger().Warn().Msg("[ProcessCrossLinkHeartbeatMessage] epoch chain not available, ignoring heartbeat")
+		return errors.New("epoch chain not available")
+	}
+
+	// Check if epoch chain current block is available
+	epochCurrentBlock := epochChain.CurrentBlock()
+	if epochCurrentBlock == nil {
+		utils.Logger().Warn().Msg("[ProcessCrossLinkHeartbeatMessage] epoch chain current block not available, ignoring heartbeat")
+		return errors.New("epoch chain current block not available")
+	}
+
+	// Check if epoch chain is synced to at least the heartbeat epoch
+	currentEpoch := epochCurrentBlock.Epoch()
+	currentEpochU64 := currentEpoch.Uint64()
+	if currentEpochU64 < hb.Epoch {
+		utils.Logger().Warn().
+			Uint64("currentEpoch", currentEpochU64).
+			Uint64("heartbeatEpoch", hb.Epoch).
+			Msg("[ProcessCrossLinkHeartbeatMessage] epoch chain not synced to heartbeat epoch, ignoring heartbeat")
+		return errors.Errorf("epoch chain not synced to heartbeat epoch: current=%d, heartbeat=%d", currentEpochU64, hb.Epoch)
 	}
 
 	// Outdated signal.


### PR DESCRIPTION
This PR addresses critical issues with crosslink heartbeat processing that were causing excessive log noise and improper error handling in multi-shard environments.
Beacon chain nodes broadcast crosslink heartbeat messages to all shards to maintain cross-shard synchronization. However, the existing implementation had two major problems. First, when a shard received heartbeats intended for other shards, it would log errors instead of handling this normal behavior gracefully. This created significant log spam in production environments since it's completely normal and expected for shard 1 to receive heartbeats intended for shard 2, 3, etc. Second, shards would attempt to process crosslink heartbeats before their epoch chain was properly synced, leading to committee verification failures and "pub key not found in committee" errors.
The solution implements proper epoch chain sync validation before processing heartbeats and changes the shard ID validation to return nil instead of error for cross-shard heartbeats. This ensures that crosslink heartbeat processing only occurs when the epoch chain is synced to the heartbeat's epoch, which is necessary for proper committee verification. The fix also replaces error logs with debug logs for normal cross-shard heartbeat behavior, eliminating unnecessary noise while maintaining proper error handling for actual issues.

