### PR TITLE
Resolve Port Conflicts in Localnet Extra Nodes Configuration

### DIFF
--- a/test/configs/local-extra-nodes.txt
+++ b/test/configs/local-extra-nodes.txt
@@ -1,29 +1,29 @@
-# Shard 0 extra explorer nodes (ports 9301-9310)
+# Shard 0 extra explorer nodes (ports 4301-4310)
 # These ports calculate to:
-# 9301 -> RPC: 9801, Rosetta: 10001, WS: 10101, Prometheus: 10201
-# 9302 -> RPC: 9802, Rosetta: 10002, WS: 10102, Prometheus: 10202
-127.0.0.1 9301 explorer null 0
-127.0.0.1 9302 explorer null 0
-127.0.0.1 9303 explorer null 0
-127.0.0.1 9304 explorer null 0
-127.0.0.1 9305 explorer null 0
-127.0.0.1 9306 explorer null 0
-127.0.0.1 9307 explorer null 0
-127.0.0.1 9308 explorer null 0
-127.0.0.1 9309 explorer null 0
-127.0.0.1 9310 explorer null 0
+# 4301 -> RPC: 4801, Rosetta: 5001, WS: 5101, Prometheus: 5201
+# 4302 -> RPC: 4802, Rosetta: 5002, WS: 5102, Prometheus: 5202
+127.0.0.1 4301 explorer null 0
+127.0.0.1 4302 explorer null 0
+127.0.0.1 4303 explorer null 0
+127.0.0.1 4304 explorer null 0
+127.0.0.1 4305 explorer null 0
+127.0.0.1 4306 explorer null 0
+127.0.0.1 4307 explorer null 0
+127.0.0.1 4308 explorer null 0
+127.0.0.1 4309 explorer null 0
+127.0.0.1 4310 explorer null 0
 
-# Shard 1 extra explorer nodes (ports 9401-9410)
+# Shard 1 extra explorer nodes (ports 4401-4410)
 # These ports calculate to:
-# 9401 -> RPC: 9901, Rosetta: 10101, WS: 10201, Prometheus: 10301
-# 9402 -> RPC: 9902, Rosetta: 10102, WS: 10202, Prometheus: 10302
-127.0.0.1 9401 explorer null 1
-127.0.0.1 9402 explorer null 1
-127.0.0.1 9403 explorer null 1
-127.0.0.1 9404 explorer null 1
-127.0.0.1 9405 explorer null 1
-127.0.0.1 9406 explorer null 1
-127.0.0.1 9407 explorer null 1
-127.0.0.1 9408 explorer null 1
-127.0.0.1 9409 explorer null 1
-127.0.0.1 9410 explorer null 1
+# 4401 -> RPC: 4901, Rosetta: 5101, WS: 5201, Prometheus: 5301
+# 4402 -> RPC: 4902, Rosetta: 5102, WS: 5202, Prometheus: 5302
+127.0.0.1 4401 explorer null 1
+127.0.0.1 4402 explorer null 1
+127.0.0.1 4403 explorer null 1
+127.0.0.1 4404 explorer null 1
+127.0.0.1 4405 explorer null 1
+127.0.0.1 4406 explorer null 1
+127.0.0.1 4407 explorer null 1
+127.0.0.1 4408 explorer null 1
+127.0.0.1 4409 explorer null 1
+127.0.0.1 4410 explorer null 1

--- a/test/configs/local-extra-nodes.txt
+++ b/test/configs/local-extra-nodes.txt
@@ -1,21 +1,33 @@
-127.0.0.1 9021 explorer null 0
-127.0.0.1 9022 explorer null 0
-127.0.0.1 9023 explorer null 0
-127.0.0.1 9024 explorer null 0
-127.0.0.1 9025 explorer null 0
-127.0.0.1 9026 explorer null 0
-127.0.0.1 9027 explorer null 0
-127.0.0.1 9028 explorer null 0
-127.0.0.1 9029 explorer null 0
-127.0.0.1 9030 explorer null 0
+# Shard 0 extra explorer nodes (ports 9301-9310)
+# These ports calculate to:
+# 9301 -> RPC: 9801, Rosetta: 10001, WS: 10101, Prometheus: 10201
+# 9302 -> RPC: 9802, Rosetta: 10002, WS: 10102, Prometheus: 10202
+# etc.
+# This avoids conflicts with existing shard 0 nodes (9000, 9004, 9008, 9120)
+127.0.0.1 9301 explorer null 0
+127.0.0.1 9302 explorer null 0
+127.0.0.1 9303 explorer null 0
+127.0.0.1 9304 explorer null 0
+127.0.0.1 9305 explorer null 0
+127.0.0.1 9306 explorer null 0
+127.0.0.1 9307 explorer null 0
+127.0.0.1 9308 explorer null 0
+127.0.0.1 9309 explorer null 0
+127.0.0.1 9310 explorer null 0
 
-127.0.0.1 9101 explorer null 1
-127.0.0.1 9102 explorer null 1
-127.0.0.1 9103 explorer null 1
-127.0.0.1 9104 explorer null 1
-127.0.0.1 9105 explorer null 1
-127.0.0.1 9106 explorer null 1
-127.0.0.1 9107 explorer null 1
-127.0.0.1 9108 explorer null 1
-127.0.0.1 9109 explorer null 1
-127.0.0.1 9110 explorer null 1
+# Shard 1 extra explorer nodes (ports 9401-9410)
+# These ports calculate to:
+# 9401 -> RPC: 9901, Rosetta: 10101, WS: 10201, Prometheus: 10301
+# 9402 -> RPC: 9902, Rosetta: 10102, WS: 10202, Prometheus: 10302
+# etc.
+# This avoids conflicts with existing shard 1 nodes (9002, 9006, 9010, 9122)
+127.0.0.1 9401 explorer null 1
+127.0.0.1 9402 explorer null 1
+127.0.0.1 9403 explorer null 1
+127.0.0.1 9404 explorer null 1
+127.0.0.1 9405 explorer null 1
+127.0.0.1 9406 explorer null 1
+127.0.0.1 9407 explorer null 1
+127.0.0.1 9408 explorer null 1
+127.0.0.1 9409 explorer null 1
+127.0.0.1 9410 explorer null 1

--- a/test/configs/local-extra-nodes.txt
+++ b/test/configs/local-extra-nodes.txt
@@ -2,8 +2,6 @@
 # These ports calculate to:
 # 9301 -> RPC: 9801, Rosetta: 10001, WS: 10101, Prometheus: 10201
 # 9302 -> RPC: 9802, Rosetta: 10002, WS: 10102, Prometheus: 10202
-# etc.
-# This avoids conflicts with existing shard 0 nodes (9000, 9004, 9008, 9120)
 127.0.0.1 9301 explorer null 0
 127.0.0.1 9302 explorer null 0
 127.0.0.1 9303 explorer null 0
@@ -19,8 +17,6 @@
 # These ports calculate to:
 # 9401 -> RPC: 9901, Rosetta: 10101, WS: 10201, Prometheus: 10301
 # 9402 -> RPC: 9902, Rosetta: 10102, WS: 10202, Prometheus: 10302
-# etc.
-# This avoids conflicts with existing shard 1 nodes (9002, 9006, 9010, 9122)
 127.0.0.1 9401 explorer null 1
 127.0.0.1 9402 explorer null 1
 127.0.0.1 9403 explorer null 1


### PR DESCRIPTION
This PR fixes port conflicts that occur when adding extra nodes to the running localnet for staged stream sync testing. The issue was that the extra nodes configuration was using port ranges that conflicted with the calculated ports of existing nodes.
When Harmony nodes use the legacy `--port` flag, they automatically calculate all other service ports (RPC, Rosetta, WebSocket, Prometheus) by adding offsets to the base port. The original extra nodes configuration used ports 9101-9110 for shard 1, which calculated to Rosetta port 9801, causing conflicts with existing nodes and resulting in `"bind: address already in use"` errors.
The fix updates the extra nodes configuration to use higher, non-conflicting port ranges. Shard 0 extra nodes now use ports 9301-9310, and shard 1 extra nodes use ports 9401-9410. This ensures that all calculated service ports fall in ranges that don't conflict with existing localnet nodes, allowing the extra nodes to start successfully and enabling proper staged stream sync testing with additional unsynced nodes.