### PR TITLE
Fix Macos Linux Static Build

### DIFF
--- a/scripts/linux_executable_from_macos.sh
+++ b/scripts/linux_executable_from_macos.sh
@@ -28,7 +28,7 @@ fi
 if ! docker image inspect "$DOCKER_IMAGE" > /dev/null 2>&1; then
     echo "Building Docker image '$DOCKER_IMAGE'..."
     pushd "$PROJECT_ROOT/scripts/macos_docker"
-    docker build -t "$DOCKER_IMAGE" -f Dockerfile .
+    docker build --platform linux/amd64 -t "$DOCKER_IMAGE" -f Dockerfile .
     popd
 else
     echo "Docker image '$DOCKER_IMAGE' already exists. Skipping build."
@@ -36,7 +36,7 @@ fi
 
 # Run the container in the background
 echo "Running Docker container..."
-CONTAINER_ID=$(docker run -d "$DOCKER_IMAGE" tail -f /dev/null)
+CONTAINER_ID=$(docker run --platform linux/amd64 -d "$DOCKER_IMAGE" tail -f /dev/null)
 trap 'docker stop "$CONTAINER_ID" > /dev/null; docker rm "$CONTAINER_ID" > /dev/null' EXIT  # Ensure cleanup on exit
 
 # Copy project files into the container


### PR DESCRIPTION
## Summary
This PR updates the Docker build process to produce `x86_64`-compatible Linux static binaries. Previously, builds were generated using the host's default `arm` architecture (on M1/M2 Macs), resulting in binaries that could not be executed on `x86_64` systems.

## Changes
- Added `--platform=linux/amd64` to the Docker build command.
- Ensures that the resulting binary is built for `x86_64`, regardless of the host architecture.

## Notes on Performance
Docker uses `qemu` to emulate `x86_64` when building `amd64` images on ARM-based Macs (like M1/M2). This emulation introduces noticeable build-time overhead compared to native builds.

## Result (`file harmony`)
- Previous: `ELF 64-bit LSB executable, ARM aarch64`
→ Not executable on our deployment machines.
- Current: `ELF 64-bit LSB executable, x86-64`
→ Executes as expected.