### PR TITLE
[WIP] Ensure Trusted Node Creation and Prevent Duplicate Streams

### DIFF
--- a/p2p/host.go
+++ b/p2p/host.go
@@ -428,12 +428,16 @@ func NewHost(cfg HostConfig) (Host, error) {
 			subLogger.Error().Err(err).Str("addr", addr).Msg("invalid trusted node addr")
 			continue
 		}
+
 		info, err := libp2p_peer.AddrInfoFromP2pAddr(peerAddr)
 		if err != nil {
 			subLogger.Error().Err(err).Str("addr", addr).Msg("failed to parse trusted node")
 			continue
 		}
 		h.trustedPeerIDs[info.ID] = struct{}{}
+
+		ps.AddAddrs(info.ID, info.Addrs, libp2p_peerstore.PermanentAddrTTL)
+		subLogger.Info().Interface("peerAddr", peerAddr).Msg("trusted node added to peerstore")
 	}
 
 	utils.Logger().Info().
@@ -544,8 +548,6 @@ func (host *HostV2) Start() error {
 	for _, proto := range host.streamProtos {
 		proto.Start()
 	}
-	// add trusted nodes
-	host.AddTrustedNodes()
 	// start discovery
 	return host.discovery.Start()
 }

--- a/p2p/stream/common/streammanager/streammanager.go
+++ b/p2p/stream/common/streammanager/streammanager.go
@@ -526,6 +526,10 @@ func (sm *streamManager) discoverAndSetupStream(discCtx context.Context) (int, e
 					Msg("failed to setup stream with trusted peer")
 				return
 			}
+
+			sm.logger.Info().
+				Interface("peerID", pid).
+				Msg("new stream set up with trusted peer")
 		}(pid)
 	}
 
@@ -541,6 +545,10 @@ func (sm *streamManager) discoverAndSetupStream(discCtx context.Context) (int, e
 
 	for peer := range peers {
 		if peer.ID == sm.host.ID() {
+			continue
+		}
+		if _, ok := sm.trustedPeers[peer.ID]; ok {
+			sm.logger.Info().Interface("peer", peer).Msg("skipping trusted peer")
 			continue
 		}
 		if sm.coolDownCache.Has(peer.ID) {
@@ -563,6 +571,9 @@ func (sm *streamManager) discoverAndSetupStream(discCtx context.Context) (int, e
 					Msg("failed to setup stream with peer")
 				return
 			}
+			sm.logger.Info().
+				Interface("peerID", pid).
+				Msg("new stream set up with peer")
 		}(peer.ID)
 	}
 


### PR DESCRIPTION
## Todo
- [ ] Utilize AddTrustedNode
- [ ] Ensure that trusted nodes are added regardless of the max limit (this might have to do with EOF issue)

## Summary
In `streammanager.go`, `discoverAndSetupStream` establishes application-level protocols with peers from the peer store, including setting up underlying protocol connections. Meanwhile, `AddTrustedNodes` in `host.go` handles protocol handshakes and adds trusted nodes to the peer store. Currently, `Start()` is invoked before `AddTrustedNodes`, so trusted nodes may be missing from the peer store when `discoverAndSetupStream` runs, causing them to be skipped. To fix this, trusted nodes should be added to the peer storage during host creation, ensuring they are available during stream setup. With this change, `AddTrustedNodes` becomes unnecessary and can be removed.

## EOF Issue
We suspect that `failed to negotiate security protocol: EOF` is triggered by resource exhaustion from an excessive number of connected peers. At present, thousands of nodes are subscribing to topics unrelated to the Harmony network, causing each Harmony node to maintain between 2,000 and 6,000 active connections. This load can overwhelm file descriptors, goroutines, and CPU/​memory resources, leading the connection manager to prune aggressively or reject new dials.

> **Note:** A dedicated PR () will address the root cause—unrestricted random subscriptions—to prevent off-topic peers from joining our PubSub mesh.

## Changes
`host.go`:
- Remove `AddTrustedNodes()`, which adds the peer to peer storage and sets up the connection, from the main loop.
- Add the trusted nodes to peer storage during new host creation, prior to stream connection.

`streammanager.go`:
- Handle the trusted node stream establishment.
- Skip trusted nodes during discovered peer stream connection.