### PR TITLE
Reduce shard count from 4 to 2 across entire codebase

### DIFF
--- a/.hmy/wallet.ini
+++ b/.hmy/wallet.ini
@@ -4,7 +4,7 @@ bootnode = /ip4/100.26.90.187/tcp/9874/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvv
 bootnode = /ip4/54.213.43.194/tcp/9874/p2p/QmZJJx6AdaoEkGLrYG4JeLCKeCKDjnFz2wfHNHxAqFSGA9
 bootnode = /ip4/13.113.101.219/tcp/12019/p2p/QmQayinFSgMMw5cSpDUiD9pQ2WeP6WNmGxpZ6ou3mdVFJX
 bootnode = /ip4/99.81.170.167/tcp/12019/p2p/QmRVbTpEYup8dSaURZfF6ByrMTSKa4UyUzJhSjahFzRqNj
-shards = 4
+shards = 2
 network = mainnet
 
 [main.shard0.rpc]
@@ -14,14 +14,6 @@ rpc = s0.t.hmny.io:14555
 [main.shard1.rpc]
 rpc = l1.t.hmny.io:14555
 rpc = s1.t.hmny.io:14555
-
-[main.shard2.rpc]
-rpc = l2.t.hmny.io:14555
-rpc = s2.t.hmny.io:14555
-
-[main.shard3.rpc]
-rpc = l3.t.hmny.io:14555
-rpc = s3.t.hmny.io:14555
 
 [local]
 chain_id = 2
@@ -59,7 +51,7 @@ rpc = s1.b.hmny.io:14555
 chain_id = 3
 bootnode = /ip4/54.86.126.90/tcp/9889/p2p/Qmdfjtk6hPoyrH1zVD9PEH4zfWLo38dP2mDvvKXfh3tnEv
 bootnode = /ip4/52.40.84.2/tcp/9889/p2p/QmZJJx6AdaoEkGLrYG4JeLCKeCKDjnFz2wfHNHxAqFSGA9
-shards = 4
+shards = 2
 network = pangaea
 
 [pangaea.shard0.rpc]
@@ -69,11 +61,3 @@ rpc = s0.p.hmny.io:14555
 [pangaea.shard1.rpc]
 rpc = l1.p.hmny.io:14555
 rpc = s1.p.hmny.io:14555
-
-[pangaea.shard2.rpc]
-rpc = l2.p.hmny.io:14555
-rpc = s2.p.hmny.io:14555
-
-[pangaea.shard3.rpc]
-rpc = l3.p.hmny.io:14555
-rpc = s3.p.hmny.io:14555

--- a/cmd/config/config_migrations_test.go
+++ b/cmd/config/config_migrations_test.go
@@ -321,7 +321,7 @@ Version = "1.0.4"
 [ShardData]
   EnableShardData = false
   DiskCount = 8
-  ShardCount = 4
+  ShardCount = 2
   CacheTime = 10
   CacheSize = 512
 

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -107,7 +107,7 @@ Version = "1.0.4"
 [ShardData]
   EnableShardData = false
   DiskCount = 8
-  ShardCount = 4
+  ShardCount = 2
   CacheTime = 10
   CacheSize = 512
 

--- a/cmd/config/default.go
+++ b/cmd/config/default.go
@@ -129,7 +129,7 @@ var defaultConfig = harmonyconfig.HarmonyConfig{
 	ShardData: harmonyconfig.ShardDataConfig{
 		EnableShardData: false,
 		DiskCount:       8,
-		ShardCount:      4,
+		ShardCount:      2,
 		CacheTime:       10,
 		CacheSize:       512,
 	},

--- a/cmd/config/flags_test.go
+++ b/cmd/config/flags_test.go
@@ -181,7 +181,7 @@ func TestHarmonyFlags(t *testing.T) {
 				ShardData: harmonyconfig.ShardDataConfig{
 					EnableShardData: false,
 					DiskCount:       8,
-					ShardCount:      4,
+					ShardCount:      2,
 					CacheTime:       10,
 					CacheSize:       512,
 				},
@@ -1996,14 +1996,14 @@ func TestShardDataFlags(t *testing.T) {
 		{
 			args: []string{"--sharddata.enable",
 				"--sharddata.disk_count", "8",
-				"--sharddata.shard_count", "4",
+				"--sharddata.shard_count", "2",
 				"--sharddata.cache_time", "10",
 				"--sharddata.cache_size", "512",
 			},
 			expConfig: harmonyconfig.ShardDataConfig{
 				EnableShardData: true,
 				DiskCount:       8,
-				ShardCount:      4,
+				ShardCount:      2,
 				CacheTime:       10,
 				CacheSize:       512,
 			},

--- a/consensus/consensus_block_proposing.go
+++ b/consensus/consensus_block_proposing.go
@@ -17,7 +17,7 @@ import (
 
 // Constants of proposing a new block
 const (
-	IncomingReceiptsLimit = 6000 // 2000 * (numShards - 1)
+	IncomingReceiptsLimit = 2000 // 2000 * (numShards - 1)
 	SleepPeriod           = 20 * time.Millisecond
 )
 

--- a/core/vm/contracts_write_test.go
+++ b/core/vm/contracts_write_test.go
@@ -244,7 +244,7 @@ func testCrossShardXferPrecompile(test writeCapablePrecompileTest, t *testing.T)
 		t.Fatalf("Error while initializing state %s", err)
 	}
 	var env = NewEVM(Context{
-		NumShards: 4,
+		NumShards: 2,
 		Transfer:  transfer,
 		CanTransfer: func(_ StateDB, _ common.Address, _ *big.Int) bool {
 			return true

--- a/internal/chain/engine_test.go
+++ b/internal/chain/engine_test.go
@@ -46,7 +46,7 @@ const (
 	lastEpochInComm = 5
 	currentEpoch    = 5
 
-	numShard        = 4
+	numShard        = 2
 	numNodePerShard = 5
 
 	offenderShard      = doubleSignShardID

--- a/rosetta/infra/harmony-mainnet.conf
+++ b/rosetta/infra/harmony-mainnet.conf
@@ -99,7 +99,7 @@ Version = "2.5.13"
   CacheTime = 10
   DiskCount = 8
   EnableShardData = true
-  ShardCount = 4
+  ShardCount = 2
 
 [Sync]
   Concurrency = 7

--- a/rosetta/infra/harmony-pstn.conf
+++ b/rosetta/infra/harmony-pstn.conf
@@ -99,7 +99,7 @@ Version = "2.5.13"
   CacheTime = 10
   DiskCount = 8
   EnableShardData = false
-  ShardCount = 4
+  ShardCount = 2
 
 [Sync]
   Concurrency = 7

--- a/scripts/package/harmony-rclone.sh
+++ b/scripts/package/harmony-rclone.sh
@@ -12,7 +12,7 @@ This script will rclone the harmony db to datadir/archive directory.
 Usage: $ME [options] datadir shard
 
 datadir:    the root directory of the harmony db (default: /home/harmony)
-shard:      the shard number to sync (valid value: 0,1,2,3)
+shard:      the shard number to sync (valid value: 0,1)
 
 Options:
    -h       print this help message
@@ -49,7 +49,7 @@ if [ ! -d "$DATADIR" ]; then
 fi
 
 case "$SHARD" in
-   0|1|2|3) ;;
+   0|1) ;;
    *) usage "ERROR: invalid shard number: $SHARD" ;;
 esac
 

--- a/test/helpers/p2p.go
+++ b/test/helpers/p2p.go
@@ -34,8 +34,6 @@ func init() {
 		"hmy/testnet/0.0.1/client/beacon",
 		"hmy/testnet/0.0.1/node/beacon",
 		"hmy/testnet/0.0.1/node/shard/1",
-		"hmy/testnet/0.0.1/node/shard/2",
-		"hmy/testnet/0.0.1/node/shard/3",
 	}
 
 	Bootnodes = []string{


### PR DESCRIPTION
This PR addresses legacy configuration inconsistencies that have persisted since Harmony's shard reduction from 4 to 2 shards approximately two years ago. While these outdated configurations don't affect current functionality since the network has been operating on 2 shards, this cleanup ensures complete alignment across all system components and prevents potential confusion for developers and operators.
The changes primarily focus on updating configuration files that still referenced the old 4-shard architecture. This includes default configuration settings, test configurations, and Rosetta service configurations that were still using the legacy shard count. The consensus system constants have also been updated to reflect the current 2-shard topology, with the `IncomingReceiptsLimit` adjusted from 6000 to 2000 to match the reduced number of shards.
The wallet configuration has been cleaned up to remove references to the non-existent shards 2 and 3, now only supporting the active shards 0 and 1. This includes updating validation scripts and removing obsolete configuration sections. The test infrastructure has also been updated to reflect the current shard topology, ensuring that all development tools and testing frameworks work correctly with the actual 2-shard architecture.