### PR TITLE
Scope Discovery: Custom Kad-DHT + Connection Gating

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -176,6 +176,7 @@ func main() {
 		DialTimeout:                     time.Minute,
 		Muxer:                           *muxer,
 		NoRelay:                         *noRelay,
+		IsBootNode:                      true,
 	})
 	if err != nil {
 		utils.FatalErrMsg(err, "cannot initialize network")

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -613,6 +613,7 @@ func createGlobalConfig(hc harmonyconfig.HarmonyConfig) (*nodeconfig.ConfigType,
 		DialTimeout:                     hc.P2P.DialTimeout,
 		Muxer:                           hc.P2P.Muxer,
 		NoRelay:                         hc.P2P.NoRelay,
+		IsBootNode:                      false,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot create P2P network host")

--- a/p2p/discovery/discovery.go
+++ b/p2p/discovery/discovery.go
@@ -2,10 +2,10 @@ package discovery
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/harmony-one/harmony/internal/utils"
-	dht "github.com/libp2p/go-libp2p-kad-dht"
 	libp2p_dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p/core/discovery"
 	libp2p_host "github.com/libp2p/go-libp2p/core/host"
@@ -21,14 +21,16 @@ type Discovery interface {
 	Close() error
 	Advertise(ctx context.Context, ns string) (time.Duration, error)
 	FindPeers(ctx context.Context, ns string, peerLimit int) (<-chan libp2p_peer.AddrInfo, error)
-	GetRawDiscovery() discovery.Discovery
+	GetRawDiscovery() []discovery.Discovery
+	// todo(sun): revert in phase 2
+	// GetRawDiscovery() discovery.Discovery
 }
 
 // dhtDiscovery is a wrapper of libp2p dht discovery service. It implements Discovery
 // interface.
 type dhtDiscovery struct {
-	dht  *libp2p_dht.IpfsDHT
-	disc discovery.Discovery
+	dht  []*libp2p_dht.IpfsDHT
+	disc []discovery.Discovery
 	host libp2p_host.Host
 
 	opt    DHTConfig
@@ -38,11 +40,15 @@ type dhtDiscovery struct {
 }
 
 // NewDHTDiscovery creates a new dhtDiscovery that implements Discovery interface.
-func NewDHTDiscovery(ctx context.Context, cancel context.CancelFunc, host libp2p_host.Host, dht *dht.IpfsDHT, opt DHTConfig) (Discovery, error) {
-	d := libp2p_dis.NewRoutingDiscovery(dht)
+func NewDHTDiscovery(ctx context.Context, cancel context.CancelFunc, host libp2p_host.Host, opt DHTConfig, dhts ...*libp2p_dht.IpfsDHT) (Discovery, error) {
+	var d []discovery.Discovery
+	for _, dht := range dhts {
+		d = append(d, libp2p_dis.NewRoutingDiscovery(dht))
+	}
+
 	logger := utils.Logger().With().Str("module", "discovery").Logger()
 	return &dhtDiscovery{
-		dht:    dht,
+		dht:    dhts,
 		disc:   d,
 		host:   host,
 		opt:    opt,
@@ -54,28 +60,97 @@ func NewDHTDiscovery(ctx context.Context, cancel context.CancelFunc, host libp2p
 
 // Start bootstrap the dht discovery service.
 func (d *dhtDiscovery) Start() error {
-	return d.dht.Bootstrap(d.ctx)
+	for _, dht := range d.dht {
+		if err := dht.Bootstrap(d.ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+
+	// todo(sun): revert in phase 2
+	// return d.dht.Bootstrap(d.ctx)
 }
 
 // Stop stop the dhtDiscovery service
 func (d *dhtDiscovery) Close() error {
-	d.dht.Close()
+	for _, dht := range d.dht {
+		if err := dht.Close(); err != nil {
+			return err
+		}
+	}
 	d.cancel()
 	return nil
+
+	// todo(sun): revert in phase 2
+	// d.dht.Close()
+	// d.cancel()
+	// return nil
 }
 
 // Advertise advertises a service
 func (d *dhtDiscovery) Advertise(ctx context.Context, ns string) (time.Duration, error) {
-	return d.disc.Advertise(ctx, ns)
+	var lastDur time.Duration
+	var lastErr error
+	for _, disc := range d.disc {
+		lastDur, lastErr = disc.Advertise(ctx, ns)
+		if lastErr != nil {
+			break
+		}
+	}
+	return lastDur, lastErr
+
+	// todo(sun): revert in phase 2
+	// return d.disc.Advertise(ctx, ns)
 }
 
 // FindPeers discovers peers providing a service
 func (d *dhtDiscovery) FindPeers(ctx context.Context, ns string, peerLimit int) (<-chan libp2p_peer.AddrInfo, error) {
-	opt := discovery.Limit(peerLimit)
-	return d.disc.FindPeers(ctx, ns, opt)
+	mergedChan := make(chan libp2p_peer.AddrInfo)
+	var wg sync.WaitGroup
+	limitOpt := discovery.Limit(peerLimit)
+
+	// loop through each discovery instance (harmony and legacy, in bootnode's case)
+	for _, disc := range d.disc {
+		wg.Add(1)
+
+		// launch a goroutine for each DHT query
+		go func(disc discovery.Discovery) {
+			defer wg.Done()
+			peerChan, err := disc.FindPeers(ctx, ns, limitOpt)
+			if err != nil {
+				d.logger.Error().Err(err).Msg("Discovery failed in one of the DHTs")
+				return
+			}
+
+			// read peers from the current DHT chan and forward to the merged chan
+			for peer := range peerChan {
+				select {
+				case mergedChan <- peer:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}(disc)
+	}
+
+	// close the merged chan onceboth DHT queries are completed
+	go func() {
+		wg.Wait()
+		close(mergedChan)
+	}()
+
+	// immediately return merged chan
+	return mergedChan, nil
+
+	// todo(sun): revert in phase 2
+	// opt := discovery.Limit(peerLimit)
+	// return d.disc.FindPeers(ctx, ns, opt)
 }
 
 // GetRawDiscovery get the raw discovery to be used for libp2p pubsub options
-func (d *dhtDiscovery) GetRawDiscovery() discovery.Discovery {
+// todo(sun): libp2p pubsub option only accepts a single discover.Discovery as option
+// todo(sun): revert in phase 2
+// func (d *dhtDiscovery) GetRawDiscovery() discovery.Discovery {
+func (d *dhtDiscovery) GetRawDiscovery() []discovery.Discovery {
 	return d.disc
 }

--- a/p2p/stream/protocols/sync/protocol_test.go
+++ b/p2p/stream/protocols/sync/protocol_test.go
@@ -107,6 +107,8 @@ func (disc *testDiscovery) FindPeers(ctx context.Context, ns string, peerLimit i
 	return nil, nil
 }
 
-func (disc *testDiscovery) GetRawDiscovery() discovery.Discovery {
+// todo(sun): revert in phase 2
+// func (disc *testDiscovery) GetRawDiscovery() discovery.Discovery {
+func (disc *testDiscovery) GetRawDiscovery() []discovery.Discovery {
 	return nil
 }


### PR DESCRIPTION
## Problems
1. Nodes discover unrelated ecosystems via broad/public discovery, leading to thousands of extra peers and off-namespace PubSub subscriptions.
2. Resource pressure (FDs/CPU/memory) correlates with dial failures like failed to negotiate security protocol: `EOF`.

## Rationale
A custom Kad-DHT protocol prefix isolates our routing table from the public DHT and keeps discovery Harmony-only.

Connection gating blocks or immediately tears down non-Harmony peers at the transport layer (pre-dial/accept and post-identify), preserving capacity for legitimate Harmony traffic.

## Changes
- Add config for a Harmony-scoped DHT prefix (default: `/harmony/kad/1.0.0`) and use only configured Harmony bootnodes.
- Implement connection gating:
  - Pre-dial / inbound-accept policy to allow only vetted peers/addresses (e.g., Harmony bootnodes/validators).
  - Post-identify filter: require advertised Harmony protocol IDs / chain marker; close non-conforming peers and purge their addrs from the peerstore.
  - Basic metrics/logging for gated/closed peers to validate effectiveness.

Notes:
No changes to PubSub topics, scoring, or connmgr here (follow-ups if needed).

## Rollout
1. Bootnodes first: enable dual-prefix (old + new) to avoid partitions.
2. Validators/regular nodes: switch to the new prefix; verify peer counts and dial success.
3. Converge (a new PR required): remove the old prefix on bootnodes after majority adoption.
4. Enable connection gating in “observe” or permissive mode (log only), then tighten to enforce close policies once metrics look healthy.

## Success criteria
- [ ] Peerstore and active connections drop to expected ranges; off-namespace subscriptions materially reduced.
- [ ] Non-Harmony peers are rejected at connect or immediately post-identify (visible in gating metrics).
- [ ] Dial success rate to Harmony peers improves; handshake EOFs materially reduced.