### PR TITLE
Fix cross-link processing infinite loop by adding sync status checks and retry mechanism

### DIFF
--- a/node/harmony/node_cross_link.go
+++ b/node/harmony/node_cross_link.go
@@ -1,6 +1,9 @@
 package node
 
 import (
+	"sync"
+	"time"
+
 	common2 "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
 	ffi_bls "github.com/harmony-one/bls/ffi/go/bls"
@@ -9,7 +12,6 @@ import (
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/shard"
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 var CrosslinkOutdatedErr = errors.New("crosslink signal is outdated")
@@ -17,7 +19,81 @@ var CrosslinkOutdatedErr = errors.New("crosslink signal is outdated")
 const (
 	maxPendingCrossLinkSize = 1000
 	crossLinkBatchSize      = 3
+	maxCrossLinkRetries     = 3
+	retryDelay              = 5 * time.Second
 )
+
+// crossLinkRetryTracker tracks retry attempts for cross-links
+type crossLinkRetryTracker struct {
+	mu sync.RWMutex
+	// failedCrossLinks tracks cross-links that failed verification
+	failedCrossLinks map[string]*retryRecord
+}
+
+type retryRecord struct {
+	crossLink  *types.CrossLink
+	retryCount int
+	lastRetry  time.Time
+}
+
+var globalRetryTracker = &crossLinkRetryTracker{
+	failedCrossLinks: make(map[string]*retryRecord),
+}
+
+func (t *crossLinkRetryTracker) recordFailure(cl *types.CrossLink) bool {
+	key := cl.Hash().Hex()
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	record, exists := t.failedCrossLinks[key]
+	if !exists {
+		record = &retryRecord{
+			crossLink:  cl,
+			retryCount: 1,
+			lastRetry:  time.Now(),
+		}
+		t.failedCrossLinks[key] = record
+		return true // Allow retry
+	}
+
+	record.retryCount++
+	record.lastRetry = time.Now()
+
+	// If max retries exceeded, mark for deletion
+	if record.retryCount >= maxCrossLinkRetries {
+		utils.Logger().Warn().
+			Str("crossLinkHash", key).
+			Int("retryCount", record.retryCount).
+			Uint64("epoch", cl.Epoch().Uint64()).
+			Uint32("shardID", cl.ShardID()).
+			Msg("[CrossLink] Max retries exceeded - marking for deletion")
+		return false // Don't allow more retries
+	}
+
+	return true // Allow retry
+}
+
+func (t *crossLinkRetryTracker) cleanupFailed(cl *types.CrossLink) {
+	key := cl.Hash().Hex()
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	delete(t.failedCrossLinks, key)
+}
+
+func (t *crossLinkRetryTracker) getRetryCount(cl *types.CrossLink) int {
+	key := cl.Hash().Hex()
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if record, exists := t.failedCrossLinks[key]; exists {
+		return record.retryCount
+	}
+	return 0
+}
 
 // ProcessCrossLinkHeartbeatMessage process crosslink heart beat signal.
 // This function is only called on shards 1,2,3 when network message `CrosslinkHeartbeat` receiving.
@@ -181,50 +257,121 @@ func (node *Node) ProcessCrossLinkMessage(msgPayload []byte) {
 		}
 
 		var candidates []types.CrossLink
+		var failedCrossLinks []types.CrossLink
+
 		utils.Logger().Debug().
 			Msgf("[ProcessingCrossLink] Received crosslinks: %d", len(crosslinks))
 
 		for i, cl := range crosslinks {
+			// limit processing to prevent spam
 			if i > crossLinkBatchSize*2 { // A sanity check to prevent spamming
+				utils.Logger().Warn().
+					Int("processed", i).
+					Int("total", len(crosslinks)).
+					Int("limit", crossLinkBatchSize*2).
+					Msg("[ProcessingCrossLink] Batch size limit reached, stopping processing")
 				break
 			}
 
-			if _, ok := existingCLs[cl.Hash()]; ok {
-				nodeCrossLinkMessageCounterVec.With(prometheus.Labels{"type": "duplicate_crosslink"}).Inc()
-				utils.Logger().Debug().Err(err).
-					Msgf("[ProcessingCrossLink] Cross Link already exists in pending queue, pass. Beacon Epoch: %d, Block num: %d, Epoch: %d, shardID %d",
-						node.Blockchain().CurrentHeader().Epoch(), cl.Number(), cl.Epoch(), cl.ShardID())
+			// Check if node is synced enough to handle this cross-link
+			localEpoch := node.Blockchain().CurrentBlock().Header().Epoch().Uint64()
+			crossLinkEpoch := cl.Epoch().Uint64()
+
+			// Allow processing cross-links from current epoch and up to 1 epoch ahead
+			// This provides some tolerance for minor sync delays while preventing processing of far-future cross-links
+			maxAllowedEpoch := localEpoch + 1
+
+			if crossLinkEpoch > maxAllowedEpoch {
+				utils.Logger().Debug().
+					Str("crossLinkHash", cl.Hash().Hex()).
+					Uint64("crossLinkEpoch", crossLinkEpoch).
+					Uint64("localEpoch", localEpoch).
+					Uint64("maxAllowedEpoch", maxAllowedEpoch).
+					Uint32("shardID", cl.ShardID()).
+					Msg("[ProcessingCrossLink] Skipping cross-link - node not synced to this epoch yet (epoch gap too large)")
+				// Add to failed list to be deleted since we can't process it
+				failedCrossLinks = append(failedCrossLinks, cl)
 				continue
 			}
 
-			// ReadCrossLink beacon chain usage.
-			exist, err := node.Blockchain().ReadCrossLink(cl.ShardID(), cl.Number().Uint64())
-			if err == nil && exist != nil {
-				nodeCrossLinkMessageCounterVec.With(prometheus.Labels{"type": "duplicate_crosslink"}).Inc()
-				utils.Logger().Debug().Err(err).
-					Msgf("[ProcessingCrossLink] Cross Link already exists, pass. Beacon Epoch: %d, Block num: %d, Epoch: %d, shardID %d", node.Blockchain().CurrentHeader().Epoch(), cl.Number(), cl.Epoch(), cl.ShardID())
+			// Check if we should retry this cross-link
+			if !globalRetryTracker.recordFailure(&cl) {
+				utils.Logger().Warn().
+					Str("crossLinkHash", cl.Hash().Hex()).
+					Uint64("epoch", cl.Epoch().Uint64()).
+					Uint32("shardID", cl.ShardID()).
+					Msg("[ProcessingCrossLink] Skipping cross-link after max retries - will be deleted")
+				// Add to failed list to be deleted
+				failedCrossLinks = append(failedCrossLinks, cl)
 				continue
 			}
 
-			if err = core.VerifyCrossLink(node.Blockchain(), cl); err != nil {
-				nodeCrossLinkMessageCounterVec.With(prometheus.Labels{"type": "invalid_crosslink"}).Inc()
-				utils.Logger().Info().
-					Str("cross-link-issue", err.Error()).
-					Msgf("[ProcessingCrossLink] Failed to verify new cross link for blockNum %d epochNum %d shard %d skipped: %v", cl.BlockNum(), cl.Epoch().Uint64(), cl.ShardID(), cl)
+			// Try to verify the cross-link
+			if err := node.Blockchain().Engine().VerifyCrossLink(node.Blockchain(), cl); err != nil {
+				utils.Logger().Error().
+					Err(err).
+					Str("crossLinkHash", cl.Hash().Hex()).
+					Uint64("epoch", cl.Epoch().Uint64()).
+					Uint32("shardID", cl.ShardID()).
+					Int("retryCount", globalRetryTracker.getRetryCount(&cl)).
+					Msg("[ProcessingCrossLink] Failed to verify cross-link - will retry")
+
+				// Sleep before retry to avoid hammering the system
+				time.Sleep(retryDelay)
 				continue
 			}
 
+			// Success! Clean up the retry tracker (if it has been retried)
+			globalRetryTracker.cleanupFailed(&cl)
+
+			// Check if cross-link already exists
+			if _, exists := existingCLs[cl.Hash()]; exists {
+				utils.Logger().Debug().
+					Str("crossLinkHash", cl.Hash().Hex()).
+					Msg("[ProcessingCrossLink] Cross-link already exists, skipping")
+				continue
+			}
+
+			// Add to candidates for processing
 			candidates = append(candidates, cl)
-			nodeCrossLinkMessageCounterVec.With(prometheus.Labels{"type": "new_crosslink"}).Inc()
-
-			utils.Logger().Debug().
-				Msgf("[ProcessingCrossLink] Committing for shardID %d, blockNum %d",
-					cl.ShardID(), cl.Number().Uint64(),
-				)
 		}
-		Len, _ := node.Blockchain().AddPendingCrossLinks(candidates)
-		utils.Logger().Debug().
-			Msgf("[ProcessingCrossLink] Add pending crosslinks,  total pending: %d", Len)
+
+		// Log summary of processing results
+		utils.Logger().Info().
+			Int("totalCrossLinks", len(crosslinks)).
+			Int("processedCrossLinks", len(candidates)).
+			Int("failedCrossLinks", len(failedCrossLinks)).
+			Int("filteredBySyncStatus", len(crosslinks)-len(candidates)-len(failedCrossLinks)).
+			Msg("[ProcessingCrossLink] Cross-link processing summary")
+
+		// Delete failed cross-links from pending queue
+		if len(failedCrossLinks) > 0 {
+			if _, err := node.Blockchain().DeleteFromPendingCrossLinks(failedCrossLinks); err != nil {
+				utils.Logger().Error().
+					Err(err).
+					Int("failedCount", len(failedCrossLinks)).
+					Msg("[ProcessingCrossLink] Failed to delete failed cross-links from pending queue")
+			} else {
+				utils.Logger().Info().
+					Int("deletedCount", len(failedCrossLinks)).
+					Msg("[ProcessingCrossLink] Successfully deleted failed cross-links from pending queue")
+			}
+		}
+
+		// Process valid cross-links by adding them to pending queue
+		if len(candidates) > 0 {
+			utils.Logger().Info().
+				Int("count", len(candidates)).
+				Msg("[ProcessingCrossLink] Processing valid cross-links")
+
+			// Add to pending cross-links queue
+			if _, err := node.Blockchain().AddPendingCrossLinks(candidates); err != nil {
+				utils.Logger().Error().
+					Err(err).
+					Int("count", len(candidates)).
+					Msg("[ProcessingCrossLink] Failed to add cross-links to pending queue")
+			}
+		}
 	}
 }
 

--- a/node/harmony/node_cross_link.go
+++ b/node/harmony/node_cross_link.go
@@ -325,9 +325,9 @@ func (node *Node) ProcessCrossLinkMessage(msgPayload []byte) {
 			if !globalRetryTracker.recordFailure(&cl) {
 				utils.Logger().Warn().
 					Str("crossLinkHash", cl.Hash().Hex()).
-					Uint64("epoch", cl.Epoch().Uint64()).
 					Uint64("beaconEpoch", node.Blockchain().CurrentHeader().Epoch().Uint64()).
 					Uint64("crossLinkNumber", cl.Number().Uint64()).
+					Uint64("crossLinkEpoch", cl.Epoch().Uint64()).
 					Uint32("crossLinkShardID", cl.ShardID()).
 					Msg("[ProcessingCrossLink] Skipping cross-link after max retries - will be deleted")
 				// Add to failed list to be deleted
@@ -341,9 +341,9 @@ func (node *Node) ProcessCrossLinkMessage(msgPayload []byte) {
 				utils.Logger().Error().
 					Err(err).
 					Str("crossLinkHash", cl.Hash().Hex()).
-					Uint64("epoch", cl.Epoch().Uint64()).
 					Uint64("beaconEpoch", node.Blockchain().CurrentHeader().Epoch().Uint64()).
 					Uint64("crossLinkNumber", cl.Number().Uint64()).
+					Uint64("crossLinkEpoch", cl.Epoch().Uint64()).
 					Uint32("crossLinkShardID", cl.ShardID()).
 					Int("retryCount", globalRetryTracker.getRetryCount(&cl)).
 					Msg("[ProcessingCrossLink] Failed to verify cross-link - will retry")

--- a/node/harmony/node_cross_link.go
+++ b/node/harmony/node_cross_link.go
@@ -277,16 +277,13 @@ func (node *Node) ProcessCrossLinkMessage(msgPayload []byte) {
 			localEpoch := node.Blockchain().CurrentBlock().Header().Epoch().Uint64()
 			crossLinkEpoch := cl.Epoch().Uint64()
 
-			// Allow processing cross-links from current epoch and up to 1 epoch ahead
-			// This provides some tolerance for minor sync delays while preventing processing of far-future cross-links
-			maxAllowedEpoch := localEpoch + 1
-
-			if crossLinkEpoch > maxAllowedEpoch {
+			// Allow processing cross-links from current epoch and earlier
+			// Cross-links from future epochs should not exist and may be malicious or maybe it is not fully synced
+			if crossLinkEpoch > localEpoch {
 				utils.Logger().Debug().
 					Str("crossLinkHash", cl.Hash().Hex()).
 					Uint64("crossLinkEpoch", crossLinkEpoch).
 					Uint64("localEpoch", localEpoch).
-					Uint64("maxAllowedEpoch", maxAllowedEpoch).
 					Uint32("shardID", cl.ShardID()).
 					Msg("[ProcessingCrossLink] Skipping cross-link - node not synced to this epoch yet (epoch gap too large)")
 				// Add to failed list to be deleted since we can't process it

--- a/node/harmony/node_cross_link.go
+++ b/node/harmony/node_cross_link.go
@@ -12,6 +12,7 @@ import (
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/shard"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var CrosslinkOutdatedErr = errors.New("crosslink signal is outdated")
@@ -273,6 +274,25 @@ func (node *Node) ProcessCrossLinkMessage(msgPayload []byte) {
 				break
 			}
 
+			// Check if cross-link already exists in pending queue
+			if _, exists := existingCLs[cl.Hash()]; exists {
+				nodeCrossLinkMessageCounterVec.With(prometheus.Labels{"type": "duplicate_crosslink"}).Inc()
+				utils.Logger().Debug().
+					Str("crossLinkHash", cl.Hash().Hex()).
+					Msg("[ProcessingCrossLink] Cross-link already exists in pending queue, skipping")
+				continue
+			}
+
+			// Check if cross-link already exists in blockchain
+			exist, err := node.Blockchain().ReadCrossLink(cl.ShardID(), cl.Number().Uint64())
+			if err == nil && exist != nil {
+				nodeCrossLinkMessageCounterVec.With(prometheus.Labels{"type": "duplicate_crosslink"}).Inc()
+				utils.Logger().Debug().
+					Str("crossLinkHash", cl.Hash().Hex()).
+					Msg("[ProcessingCrossLink] Cross-link already exists in blockchain, skipping")
+				continue
+			}
+
 			// Check if node is synced enough to handle this cross-link
 			localEpoch := node.Blockchain().CurrentBlock().Header().Epoch().Uint64()
 			crossLinkEpoch := cl.Epoch().Uint64()
@@ -305,6 +325,7 @@ func (node *Node) ProcessCrossLinkMessage(msgPayload []byte) {
 
 			// Try to verify the cross-link
 			if err := node.Blockchain().Engine().VerifyCrossLink(node.Blockchain(), cl); err != nil {
+				nodeCrossLinkMessageCounterVec.With(prometheus.Labels{"type": "invalid_crosslink"}).Inc()
 				utils.Logger().Error().
 					Err(err).
 					Str("crossLinkHash", cl.Hash().Hex()).
@@ -321,16 +342,9 @@ func (node *Node) ProcessCrossLinkMessage(msgPayload []byte) {
 			// Success! Clean up the retry tracker (if it has been retried)
 			globalRetryTracker.cleanupFailed(&cl)
 
-			// Check if cross-link already exists
-			if _, exists := existingCLs[cl.Hash()]; exists {
-				utils.Logger().Debug().
-					Str("crossLinkHash", cl.Hash().Hex()).
-					Msg("[ProcessingCrossLink] Cross-link already exists, skipping")
-				continue
-			}
-
 			// Add to candidates for processing
 			candidates = append(candidates, cl)
+			nodeCrossLinkMessageCounterVec.With(prometheus.Labels{"type": "new_crosslink"}).Inc()
 		}
 
 		// Log summary of processing results

--- a/node/harmony/node_cross_link.go
+++ b/node/harmony/node_cross_link.go
@@ -279,6 +279,10 @@ func (node *Node) ProcessCrossLinkMessage(msgPayload []byte) {
 				nodeCrossLinkMessageCounterVec.With(prometheus.Labels{"type": "duplicate_crosslink"}).Inc()
 				utils.Logger().Debug().
 					Str("crossLinkHash", cl.Hash().Hex()).
+					Uint64("beaconEpoch", node.Blockchain().CurrentHeader().Epoch().Uint64()).
+					Uint64("crossLinkNumber", cl.Number().Uint64()).
+					Uint64("crossLinkEpoch", cl.Epoch().Uint64()).
+					Uint32("crossLinkShardID", cl.ShardID()).
 					Msg("[ProcessingCrossLink] Cross-link already exists in pending queue, skipping")
 				continue
 			}
@@ -289,6 +293,10 @@ func (node *Node) ProcessCrossLinkMessage(msgPayload []byte) {
 				nodeCrossLinkMessageCounterVec.With(prometheus.Labels{"type": "duplicate_crosslink"}).Inc()
 				utils.Logger().Debug().
 					Str("crossLinkHash", cl.Hash().Hex()).
+					Uint64("beaconEpoch", node.Blockchain().CurrentHeader().Epoch().Uint64()).
+					Uint64("crossLinkNumber", cl.Number().Uint64()).
+					Uint64("crossLinkEpoch", cl.Epoch().Uint64()).
+					Uint32("crossLinkShardID", cl.ShardID()).
 					Msg("[ProcessingCrossLink] Cross-link already exists in blockchain, skipping")
 				continue
 			}
@@ -304,7 +312,9 @@ func (node *Node) ProcessCrossLinkMessage(msgPayload []byte) {
 					Str("crossLinkHash", cl.Hash().Hex()).
 					Uint64("crossLinkEpoch", crossLinkEpoch).
 					Uint64("localEpoch", localEpoch).
-					Uint32("shardID", cl.ShardID()).
+					Uint64("beaconEpoch", node.Blockchain().CurrentHeader().Epoch().Uint64()).
+					Uint64("crossLinkNumber", cl.Number().Uint64()).
+					Uint32("crossLinkShardID", cl.ShardID()).
 					Msg("[ProcessingCrossLink] Skipping cross-link - node not synced to this epoch yet (epoch gap too large)")
 				// Add to failed list to be deleted since we can't process it
 				failedCrossLinks = append(failedCrossLinks, cl)
@@ -316,7 +326,9 @@ func (node *Node) ProcessCrossLinkMessage(msgPayload []byte) {
 				utils.Logger().Warn().
 					Str("crossLinkHash", cl.Hash().Hex()).
 					Uint64("epoch", cl.Epoch().Uint64()).
-					Uint32("shardID", cl.ShardID()).
+					Uint64("beaconEpoch", node.Blockchain().CurrentHeader().Epoch().Uint64()).
+					Uint64("crossLinkNumber", cl.Number().Uint64()).
+					Uint32("crossLinkShardID", cl.ShardID()).
 					Msg("[ProcessingCrossLink] Skipping cross-link after max retries - will be deleted")
 				// Add to failed list to be deleted
 				failedCrossLinks = append(failedCrossLinks, cl)
@@ -330,7 +342,9 @@ func (node *Node) ProcessCrossLinkMessage(msgPayload []byte) {
 					Err(err).
 					Str("crossLinkHash", cl.Hash().Hex()).
 					Uint64("epoch", cl.Epoch().Uint64()).
-					Uint32("shardID", cl.ShardID()).
+					Uint64("beaconEpoch", node.Blockchain().CurrentHeader().Epoch().Uint64()).
+					Uint64("crossLinkNumber", cl.Number().Uint64()).
+					Uint32("crossLinkShardID", cl.ShardID()).
 					Int("retryCount", globalRetryTracker.getRetryCount(&cl)).
 					Msg("[ProcessingCrossLink] Failed to verify cross-link - will retry")
 
@@ -353,6 +367,7 @@ func (node *Node) ProcessCrossLinkMessage(msgPayload []byte) {
 			Int("processedCrossLinks", len(candidates)).
 			Int("failedCrossLinks", len(failedCrossLinks)).
 			Int("filteredBySyncStatus", len(crosslinks)-len(candidates)-len(failedCrossLinks)).
+			Uint64("beaconEpoch", node.Blockchain().CurrentHeader().Epoch().Uint64()).
 			Msg("[ProcessingCrossLink] Cross-link processing summary")
 
 		// Delete failed cross-links from pending queue
@@ -361,10 +376,12 @@ func (node *Node) ProcessCrossLinkMessage(msgPayload []byte) {
 				utils.Logger().Error().
 					Err(err).
 					Int("failedCount", len(failedCrossLinks)).
+					Uint64("beaconEpoch", node.Blockchain().CurrentHeader().Epoch().Uint64()).
 					Msg("[ProcessingCrossLink] Failed to delete failed cross-links from pending queue")
 			} else {
 				utils.Logger().Info().
 					Int("deletedCount", len(failedCrossLinks)).
+					Uint64("beaconEpoch", node.Blockchain().CurrentHeader().Epoch().Uint64()).
 					Msg("[ProcessingCrossLink] Successfully deleted failed cross-links from pending queue")
 			}
 		}
@@ -373,6 +390,7 @@ func (node *Node) ProcessCrossLinkMessage(msgPayload []byte) {
 		if len(candidates) > 0 {
 			utils.Logger().Info().
 				Int("count", len(candidates)).
+				Uint64("beaconEpoch", node.Blockchain().CurrentHeader().Epoch().Uint64()).
 				Msg("[ProcessingCrossLink] Processing valid cross-links")
 
 			// Add to pending cross-links queue
@@ -380,6 +398,7 @@ func (node *Node) ProcessCrossLinkMessage(msgPayload []byte) {
 				utils.Logger().Error().
 					Err(err).
 					Int("count", len(candidates)).
+					Uint64("beaconEpoch", node.Blockchain().CurrentHeader().Epoch().Uint64()).
 					Msg("[ProcessingCrossLink] Failed to add cross-links to pending queue")
 			}
 		}


### PR DESCRIPTION
## Problem
The node was getting stuck in an infinite loop when processing cross-links from epochs it couldn't handle due to being out of sync. This caused:
- **RPC unresponsiveness** - Node became unusable for API calls
- **Resource exhaustion** - CPU and memory usage skyrocketed
- **Sync failure** - Node couldn't complete synchronization
- **Service degradation** - Consensus and other services were affected

## Root Cause
When a node is out of sync (e.g., local epoch 5755, network epoch 5757), it receives cross-links for epochs it doesn't have shard state data for. The original code would:
1. Attempt to verify cross-links
2. Fail with "failed to read shard state from DB" 
3. Retry the same cross-links indefinitely
4. Never complete synchronization

## Solution
Implemented a comprehensive fix with two main components:

### 1. Sync Status Check (Early Filtering)
- **Epoch validation**: Check if cross-link epoch is within node's sync range
- **Tolerance window**: Allow cross-links up to 1 epoch ahead for minor sync delays
- **Immediate filtering**: Skip cross-links that can't be processed due to sync status
- **Resource savings**: Avoid unnecessary verification attempts

### 2. Retry Mechanism with Cleanup
- **Limited retries**: Maximum 3 attempts per cross-link
- **Exponential backoff**: 5-second delay between retries
- **Automatic cleanup**: Delete failed cross-links after max retries
- **Progress tracking**: Monitor retry attempts per cross-link
