### PR TITLE
fix: eliminate redundant timeout warning logs and improve debugging context

### DIFF
--- a/internal/utils/timer.go
+++ b/internal/utils/timer.go
@@ -43,13 +43,14 @@ func (timeout *Timeout) Start(reason string) {
 
 // Stop stops the timeout clock
 func (timeout *Timeout) Stop() {
+	// Only log warning if we're stopping an active timeout without a reason
+	if timeout.state == Active && timeout.reason == "" {
+		Logger().Warn().
+			Dur("duration", timeout.d).
+			Msg("stopping active timeout without reason")
+	}
 	timeout.state = Inactive
 	timeout.start = time.Now()
-	if timeout.reason == "" {
-		Logger().Warn().
-			Str("reason", timeout.reason).
-			Msg("timeout reason was empty")
-	}
 	timeout.reason = ""
 }
 


### PR DESCRIPTION
Current timeout was generating repeated warning logs with the message "timeout reason was empty" from `internal/utils/timer.go:51`. These warnings were appearing frequently and cluttering the logs without providing useful debugging information. Now it only warns when stopping an active timeout that doesn't have a reason