### PR TITLE
Fix staged stream sync RLP decoding to handle both extblock and BlockWithSig formats

### DIFF
--- a/api/service/synchronize/stagedstreamsync/stage_bodies.go
+++ b/api/service/synchronize/stagedstreamsync/stage_bodies.go
@@ -469,14 +469,27 @@ func (b *StageBodies) verifyBlockAndExtractReceiptsData(batchBlockBytes [][]byte
 		if blockBytes == nil {
 			continue
 		}
-		if err := rlp.DecodeBytes(blockBytes, &block); err != nil {
-			b.configs.logger.Error().
-				Uint64("block number", i).
-				Msg("block size invalid")
-			return ErrInvalidBlockBytes
-		}
-		if sigBytes != nil {
-			block.SetCurrentCommitSig(sigBytes)
+		var err error
+		// Try to decode as *types.Block first (extblock format)
+		if err = rlp.DecodeBytes(blockBytes, &block); err != nil {
+			// Fallback: try to decode as BlockWithSig format
+			var bws core.BlockWithSig
+			if err = rlp.DecodeBytes(blockBytes, &bws); err != nil {
+				b.configs.logger.Error().
+					Uint64("block number", i).
+					Err(err).
+					Msg("block RLP decode failed")
+				return ErrInvalidBlockBytes
+			}
+			block = bws.Block
+			if block != nil {
+				block.SetCurrentCommitSig(bws.CommitSigAndBitmap)
+			}
+		} else {
+			// Successfully decoded as *types.Block, set signature from response if available
+			if sigBytes != nil {
+				block.SetCurrentCommitSig(sigBytes)
+			}
 		}
 
 		// if block.NumberU64() != i {

--- a/api/service/synchronize/stagedstreamsync/stage_receipts.go
+++ b/api/service/synchronize/stagedstreamsync/stage_receipts.go
@@ -267,10 +267,19 @@ func (r *StageReceipts) runReceiptWorkerLoop(ctx context.Context, rdm *receiptDo
 				return
 			}
 			var block *types.Block
-			if err := rlp.DecodeBytes(blockBytes, &block); err != nil {
-				return
-			}
-			if sigBytes != nil {
+			var decodeErr error
+			// Try to decode as *types.Block first (extblock format)
+			if decodeErr = rlp.DecodeBytes(blockBytes, &block); decodeErr != nil {
+				// Fallback: try to decode as BlockWithSig format
+				var bws core.BlockWithSig
+				if decodeErr = rlp.DecodeBytes(blockBytes, &bws); decodeErr != nil {
+					return
+				}
+				block = bws.Block
+				if block != nil {
+					block.SetCurrentCommitSig(bws.CommitSigAndBitmap)
+				}
+			} else if sigBytes != nil {
 				block.SetCurrentCommitSig(sigBytes)
 			}
 			if block.NumberU64() != bn {

--- a/api/service/synchronize/stagedstreamsync/stage_states.go
+++ b/api/service/synchronize/stagedstreamsync/stage_states.go
@@ -151,16 +151,26 @@ func (stg *StageStates) Exec(ctx context.Context, firstCycle bool, invalidBlockR
 		}
 
 		var block *types.Block
-		if err := rlp.DecodeBytes(blockBytes, &block); err != nil {
-			stg.configs.logger.Error().
-				Uint64("block number", i).
-				Msg("block size invalid")
-			s.state.protocol.StreamFailed(streamID, "invalid block is received from stream")
-			invalidBlockHash := common.Hash{}
-			reverter.RevertTo(stg.configs.bc.CurrentBlock().NumberU64(), i, invalidBlockHash, streamID)
-			return ErrInvalidBlockBytes
-		}
-		if sigBytes != nil {
+		var decodeErr error
+		// Try to decode as *types.Block first (extblock format)
+		if decodeErr = rlp.DecodeBytes(blockBytes, &block); decodeErr != nil {
+			// Fallback: try to decode as BlockWithSig format
+			var bws core.BlockWithSig
+			if decodeErr = rlp.DecodeBytes(blockBytes, &bws); decodeErr != nil {
+				stg.configs.logger.Error().
+					Uint64("block number", i).
+					Err(decodeErr).
+					Msg("block RLP decode failed")
+				s.state.protocol.StreamFailed(streamID, "invalid block is received from stream")
+				invalidBlockHash := common.Hash{}
+				reverter.RevertTo(stg.configs.bc.CurrentBlock().NumberU64(), i, invalidBlockHash, streamID)
+				return ErrInvalidBlockBytes
+			}
+			block = bws.Block
+			if block != nil {
+				block.SetCurrentCommitSig(bws.CommitSigAndBitmap)
+			}
+		} else if sigBytes != nil {
 			block.SetCurrentCommitSig(sigBytes)
 		}
 

--- a/p2p/stream/protocols/sync/client.go
+++ b/p2p/stream/protocols/sync/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/p2p/stream/protocols/sync/message"
 	syncpb "github.com/harmony-one/harmony/p2p/stream/protocols/sync/message"
@@ -378,11 +379,24 @@ func (req *getBlocksByNumberRequest) getBlocksFromResponse(resp sttypes.Response
 	blocks := make([]*types.Block, 0, len(blockBytes))
 	for i, bb := range blockBytes {
 		var block *types.Block
-		if err := rlp.DecodeBytes(bb, &block); err != nil {
-			return nil, errors.Wrap(err, "[GetBlocksByNumResponse]")
-		}
-		if block != nil {
-			block.SetCurrentCommitSig(sigs[i])
+		var err error
+
+		// Try to decode as *types.Block first (extblock format)
+		if err = rlp.DecodeBytes(bb, &block); err != nil {
+			// Fallback: try to decode as BlockWithSig format
+			var bws core.BlockWithSig
+			if err = rlp.DecodeBytes(bb, &bws); err != nil {
+				return nil, errors.Wrap(err, "[GetBlocksByNumResponse]")
+			}
+			block = bws.Block
+			if block != nil {
+				block.SetCurrentCommitSig(bws.CommitSigAndBitmap)
+			}
+		} else {
+			// Successfully decoded as *types.Block, set signature from response
+			if block != nil {
+				block.SetCurrentCommitSig(sigs[i])
+			}
 		}
 		blocks = append(blocks, block)
 	}
@@ -567,11 +581,24 @@ func (req *getBlocksByHashesRequest) getBlocksFromResponse(resp sttypes.Response
 	blocks := make([]*types.Block, 0, len(blockBytes))
 	for i, bb := range blockBytes {
 		var block *types.Block
-		if err := rlp.DecodeBytes(bb, &block); err != nil {
-			return nil, errors.Wrap(err, "[GetBlocksByHashesResponse]")
-		}
-		if block != nil {
-			block.SetCurrentCommitSig(sigs[i])
+		var err error
+
+		// Try to decode as *types.Block first (extblock format)
+		if err = rlp.DecodeBytes(bb, &block); err != nil {
+			// Fallback: try to decode as BlockWithSig format
+			var bws core.BlockWithSig
+			if err = rlp.DecodeBytes(bb, &bws); err != nil {
+				return nil, errors.Wrap(err, "[GetBlocksByHashesResponse]")
+			}
+			block = bws.Block
+			if block != nil {
+				block.SetCurrentCommitSig(bws.CommitSigAndBitmap)
+			}
+		} else {
+			// Successfully decoded as *types.Block, set signature from response
+			if block != nil {
+				block.SetCurrentCommitSig(sigs[i])
+			}
 		}
 		blocks = append(blocks, block)
 	}


### PR DESCRIPTION
This PR fixes a critical issue where Harmony nodes get stuck during staged stream sync due to RLP decoding errors. The problem occurs when different peers send blocks in different RLP formats - some send the older extblock format while others send the newer BlockWithSig format. When nodes try to sync with peers that send blocks in the BlockWithSig format, they fail with "rlp: too few elements for types.extblock" errors because the staged stream sync was only trying to decode blocks as the extblock format. This causes sync to stall and nodes to get stuck.

This fix implements a fallback RLP decoding mechanism that tries to decode blocks in the extblock format first, and if that fails, falls back to the BlockWithSig format. This approach is already successfully used in DNS sync and epoch block processing, so we're applying the same proven pattern to staged stream sync.

This resolves the sync stalling issues and eliminates the getBlockHashes errors that were preventing nodes from completing their synchronization process. The fix is backward compatible and doesn't affect existing functionality.