### PR TITLE
Fix: ensure proper mutex locking around stream read operations

### DIFF
--- a/p2p/stream/types/stream.go
+++ b/p2p/stream/types/stream.go
@@ -315,7 +315,9 @@ func (st *BaseStream) ReadBytes() (content []byte, err error) {
 
 	// 3. Read message content (blocking)
 	content = make([]byte, size)
+	st.lock.Lock()
 	bytesRead, err := io.ReadFull(st.reader, content)
+	st.lock.Unlock()
 	if err != nil {
 		// Log network errors specifically
 		if netErr, ok := err.(net.Error); ok {
@@ -372,7 +374,9 @@ func (st *BaseStream) ReadBytesWithProgress(progressTracker *ProgressTracker) (c
 
 	// 1. Read message length prefix (blocking, no timeout - wait indefinitely for size)
 	lengthBuf := make([]byte, sizeBytes)
+	st.lock.Lock()
 	_, err = io.ReadFull(st.reader, lengthBuf)
+	st.lock.Unlock()
 	if err != nil {
 		if err == io.EOF {
 			utils.Logger().Debug().


### PR DESCRIPTION
fix for data race:

==================
WARNING: DATA RACE
Write at 0x00c046159080 by goroutine 24815:
  bufio.(*Reader).reset()
      /home/uladzislau/.gvm/gos/go1.24.2/src/bufio/bufio.go:88 +0x1ec
  bufio.(*Reader).Reset()
      /home/uladzislau/.gvm/gos/go1.24.2/src/bufio/bufio.go:84 +0x169
  github.com/harmony-one/harmony/p2p/stream/types.(*BaseStream).Close()
      /home/uladzislau/.gvm/pkgsets/go1.24.2/global/src/github.com/harmony-one/harmony/p2p/stream/types/stream.go:134 +0xdd
  github.com/harmony-one/harmony/p2p/stream/protocols/sync.(*syncStream).Close()
      /home/uladzislau/.gvm/pkgsets/go1.24.2/global/src/github.com/harmony-one/harmony/p2p/stream/protocols/sync/sync_stream.go:175 +0x1ca
  github.com/harmony-one/harmony/p2p/stream/protocols/sync.(*Protocol).RemoveStream()
      /home/uladzislau/.gvm/pkgsets/go1.24.2/global/src/github.com/harmony-one/harmony/p2p/stream/protocols/sync/protocol.go:392 +0x8d
  github.com/harmony-one/harmony/api/service/synchronize/stagedstreamsync.(*StageBlockHashes).runBlockHashWorkerLoop.func1()
      /home/uladzislau/.gvm/pkgsets/go1.24.2/global/src/github.com/harmony-one/harmony/api/service/synchronize/stagedstreamsync/stage_blockhashes.go:259 +0x4cb
Previous read at 0x00c046159080 by goroutine 18689:
  bufio.(*Reader).Read()
      /home/uladzislau/.gvm/gos/go1.24.2/src/bufio/bufio.go:228 +0x250
  io.ReadAtLeast()
      /home/uladzislau/.gvm/gos/go1.24.2/src/io/io.go:335 +0xca
  io.ReadFull()
      /home/uladzislau/.gvm/gos/go1.24.2/src/io/io.go:354 +0x2d5
  github.com/harmony-one/harmony/p2p/stream/types.(*BaseStream).ReadBytesWithProgress()
      /home/uladzislau/.gvm/pkgsets/go1.24.2/global/src/github.com/harmony-one/harmony/p2p/stream/types/stream.go:375 +0x292
  github.com/harmony-one/harmony/p2p/stream/protocols/sync.(*syncStream).readMsg()
      /home/uladzislau/.gvm/pkgsets/go1.24.2/global/src/github.com/harmony-one/harmony/p2p/stream/protocols/sync/sync_stream.go:444 +0x8d
  github.com/harmony-one/harmony/p2p/stream/protocols/sync.(*syncStream).readMsgLoop()
      /home/uladzislau/.gvm/pkgsets/go1.24.2/global/src/github.com/harmony-one/harmony/p2p/stream/protocols/sync/sync_stream.go:76 +0x71
