### PR TITLE
Add retry mechanism for leader nodes in staged stream sync downloader

### DIFF
--- a/api/service/synchronize/stagedstreamsync/downloader.go
+++ b/api/service/synchronize/stagedstreamsync/downloader.go
@@ -320,6 +320,11 @@ func (d *Downloader) handleDownload(trigger func()) {
 
 	// if it's leader, skip syncing for now
 	if d.stagedSyncInstance.consensus != nil && d.stagedSyncInstance.consensus.IsLeader() {
+		// Retry sync after 1 seconds
+		go func() {
+			time.Sleep(1 * time.Second)
+			trigger()
+		}()
 		return
 	}
 


### PR DESCRIPTION
Leader nodes were skipping synchronization entirely when `handleDownload` was called, which could lead to synchronization gaps or missed sync opportunities. This PR adds a retry mechanism for leader nodes in the staged stream sync downloader to ensure continuous synchronization attempts.