### PR TITLE
Optimize sync status checking with role-based strategies and early exit optimization

### DIFF
--- a/api/service/synchronize/legacysync/syncing.go
+++ b/api/service/synchronize/legacysync/syncing.go
@@ -1283,16 +1283,13 @@ func (ss *StateSync) GetParsedSyncStatus() (IsSynchronized bool, OtherHeight uin
 	return ParseResult(res)
 }
 
-// GetSyncStatusDoubleChecked return the sync status when enforcing a immediate query on DNS nodes
+// GetParsedSyncStatusDoubleChecked return the sync status when enforcing a immediate query on DNS nodes
 // with a double check to avoid false alarm.
-func (ss *StateSync) GetSyncStatusDoubleChecked() SyncCheckResult {
-	result := ss.isSynchronized(true)
-	return result
-}
-
 func (ss *StateSync) GetParsedSyncStatusDoubleChecked() (IsSynchronized bool, OtherHeight uint64, HeightDiff uint64) {
-	result := ss.isSynchronized(true)
-	return ParseResult(result)
+	res := ss.syncStatus.Get(func() SyncCheckResult {
+		return ss.isSynchronized(true)
+	})
+	return ParseResult(res)
 }
 
 // isSynchronized query the remote DNS node for the latest height to check what is the current

--- a/node/harmony/node_syncing.go
+++ b/node/harmony/node_syncing.go
@@ -287,7 +287,13 @@ func (node *Node) doSync(syncInstance ISync, syncingPeerProvider SyncingPeerProv
 		utils.Logger().Debug().Int("len", syncInstance.GetActivePeerNumber()).Msg("[SYNC] Get Active Peers")
 	}
 	// TODO: treat fake maximum height
-	if isSynchronized, _, _ := syncInstance.GetParsedSyncStatusDoubleChecked(); !isSynchronized {
+	var isSynchronized bool
+	if consensus.IsLeader() {
+		isSynchronized, _, _ = syncInstance.GetParsedSyncStatus()
+	} else {
+		isSynchronized, _, _ = syncInstance.GetParsedSyncStatusDoubleChecked()
+	}
+	if !isSynchronized {
 		if consensus.IsLeader() {
 			return
 		}


### PR DESCRIPTION
This PR introduces significant performance improvements to the sync status checking mechanism by implementing role-based sync strategies and optimizing the double-check process for nodes that are far behind the network.
The first major improvement implements different sync checking strategies based on node roles. Consensus leaders now use fast sync checks to minimize latency for block production which is required for 1-Second Finality, while non-leaders continue using double-check verification to ensure accuracy. This addresses the critical timing requirements for consensus leaders who need to produce blocks efficiently, while maintaining thorough verification for other nodes that can afford the extra validation time.
The second optimization adds an early exit mechanism for nodes that are significantly behind the network. When a node is more than 10 blocks behind (configurable via `tooFarBehindThreshold`), it now returns immediately without the 1-second double-check wait period. This prevents unnecessary delays since such nodes cannot realistically catch up within the double-check timeframe, improving overall system responsiveness.
Additionally, the double-check logic has been enhanced with improved height difference calculations, progress detection during wait periods, and better error handling.
