### PR TITLE
EIP-3855: Add PUSH0 OpCode

### DIFF
--- a/core/blockchain_impl.go
+++ b/core/blockchain_impl.go
@@ -759,6 +759,9 @@ func (bc *BlockChainImpl) State() (*state.DB, error) {
 }
 
 func (bc *BlockChainImpl) StateAt(root common.Hash) (*state.DB, error) {
+	if bc.stateCache == nil {
+		return nil, fmt.Errorf("stateCache is nil, blockchain not properly initialized")
+	}
 	return state.New(root, bc.stateCache, bc.snaps)
 }
 

--- a/core/blockchain_leader_rotation.go
+++ b/core/blockchain_leader_rotation.go
@@ -54,7 +54,8 @@ func (bc *BlockChainImpl) buildLeaderRotationMeta(curHeader *block.Header) error
 		return nil
 	}
 	if curHeader.NumberU64() == 0 {
-		return errors.New("current header is genesis")
+		// Skip building leader rotation meta for genesis block
+		return nil
 	}
 	curPubKey, err := bc.getLeaderPubKeyFromCoinbase(curHeader)
 	if err != nil {

--- a/core/evm_test.go
+++ b/core/evm_test.go
@@ -47,7 +47,10 @@ func getTestEnvironment(testBankKey ecdsa.PrivateKey) (*BlockChainImpl, *state.D
 
 	// fake blockchain
 	cacheConfig := &CacheConfig{SnapshotLimit: 0}
-	chain, _ := NewBlockChain(database, nil, nil, cacheConfig, gspec.Config, engine, vm.Config{})
+	chain, err := NewBlockChain(database, nil, nil, cacheConfig, gspec.Config, engine, vm.Config{})
+	if err != nil {
+		panic(fmt.Sprintf("failed to create blockchain: %v", err))
+	}
 	db, _ := chain.StateAt(genesis.Root())
 
 	// make a fake block header (use epoch 1 so that locked tokens can be tested)

--- a/core/vm/analysis.go
+++ b/core/vm/analysis.go
@@ -43,7 +43,10 @@ func codeBitmap(code []byte) bitvec {
 	for pc := uint64(0); pc < uint64(len(code)); {
 		op := OpCode(code[pc])
 
-		if op >= PUSH1 && op <= PUSH32 {
+		if op == PUSH0 {
+			// PUSH0 doesn't read any bytes, just increment pc
+			pc++
+		} else if op >= PUSH1 && op <= PUSH32 {
 			numbits := op - PUSH1 + 1
 			pc++
 			for ; numbits >= 8; numbits -= 8 {

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -37,6 +37,8 @@ func EnableEIP(eipNum int, jt *JumpTable) error {
 		enable1344(jt)
 	case 1153:
 		enable1153(jt)
+	case 3855:
+		enable3855(jt)
 	default:
 		return fmt.Errorf("undefined eip %d", eipNum)
 	}
@@ -150,4 +152,16 @@ func opTstore(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memor
 
 	interpreter.evm.StateDB.SetTransientState(contract.Address(), key, val)
 	return nil, nil
+}
+
+// enable3855 applies EIP-3855 (PUSH0 opcode)
+// - Adds PUSH0 opcode that pushes the value 0 onto the stack
+func enable3855(jt *JumpTable) {
+	jt[PUSH0] = operation{
+		execute:     opPush0,
+		constantGas: GasQuickStep,
+		minStack:    minStack(0, 1),
+		maxStack:    maxStack(0, 1),
+		valid:       true,
+	}
 }

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -955,6 +955,13 @@ func makeLog(size int) executionFunc {
 	}
 }
 
+// opPush0 pushes the value 0 onto the stack
+func opPush0(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
+	stack.push(interpreter.intPool.getZero())
+	*pc++
+	return nil, nil
+}
+
 // opPush1 is a specialized version of pushN
 func opPush1(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	var (

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -111,6 +111,18 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 		default:
 			jt = frontierInstructionSet
 		}
+		// Enable epoch-based EIPs
+		epochBasedEIPs := []int{}
+		if evm.ChainConfig().IsEIP3855(evm.EpochNumber) {
+			epochBasedEIPs = append(epochBasedEIPs, 3855)
+		}
+		// Enable all epoch-based EIPs
+		for _, eip := range epochBasedEIPs {
+			if err := EnableEIP(eip, &jt); err != nil {
+				utils.Logger().Error().Int("eip", eip).Err(err).Msg("Epoch-based EIP activation failed")
+			}
+		}
+		// Enable manually specified extra EIPs
 		for i, eip := range cfg.ExtraEips {
 			if err := EnableEIP(eip, &jt); err != nil {
 				// Disable it, so caller can check if it's activated or not

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -26,7 +26,7 @@ type OpCode byte
 // IsPush specifies if an opcode is a PUSH opcode.
 func (op OpCode) IsPush() bool {
 	switch op {
-	case PUSH1, PUSH2, PUSH3, PUSH4, PUSH5, PUSH6, PUSH7, PUSH8, PUSH9, PUSH10, PUSH11, PUSH12, PUSH13, PUSH14, PUSH15, PUSH16, PUSH17, PUSH18, PUSH19, PUSH20, PUSH21, PUSH22, PUSH23, PUSH24, PUSH25, PUSH26, PUSH27, PUSH28, PUSH29, PUSH30, PUSH31, PUSH32:
+	case PUSH0, PUSH1, PUSH2, PUSH3, PUSH4, PUSH5, PUSH6, PUSH7, PUSH8, PUSH9, PUSH10, PUSH11, PUSH12, PUSH13, PUSH14, PUSH15, PUSH16, PUSH17, PUSH18, PUSH19, PUSH20, PUSH21, PUSH22, PUSH23, PUSH24, PUSH25, PUSH26, PUSH27, PUSH28, PUSH29, PUSH30, PUSH31, PUSH32:
 		return true
 	}
 	return false
@@ -121,6 +121,7 @@ const (
 	JUMPDEST
 	TLOAD  // 0x5c
 	TSTORE // 0x5d
+	PUSH0  = 0x5f
 )
 
 // 0x60 range.
@@ -301,6 +302,7 @@ var opCodeToString = map[OpCode]string{
 	JUMPDEST: "JUMPDEST",
 	TLOAD:    "TLOAD",
 	TSTORE:   "TSTORE",
+	PUSH0:    "PUSH0",
 
 	// 0x60 range - push.
 	PUSH1:  "PUSH1",
@@ -468,6 +470,7 @@ var stringToOp = map[string]OpCode{
 	"JUMPDEST":       JUMPDEST,
 	"TLOAD":          TLOAD,
 	"TSTORE":         TSTORE,
+	"PUSH0":          PUSH0,
 	"PUSH1":          PUSH1,
 	"PUSH2":          PUSH2,
 	"PUSH3":          PUSH3,

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -83,6 +83,7 @@ var (
 		HIP32Epoch:                            big.NewInt(2152), // 2024-10-31 13:02 UTC
 		IsOneSecondEpoch:                      EpochTBD,
 		EIP2537PrecompileEpoch:                EpochTBD,
+		EIP3855Epoch:                          EpochTBD,
 	}
 
 	// TestnetChainConfig contains the chain parameters to run a node on the harmony test network.
@@ -133,6 +134,7 @@ var (
 		TestnetExternalEpoch:                  big.NewInt(3044),
 		IsOneSecondEpoch:                      EpochTBD,
 		EIP2537PrecompileEpoch:                EpochTBD,
+		EIP3855Epoch:                          EpochTBD,
 	}
 	// PangaeaChainConfig contains the chain parameters for the Pangaea network.
 	// All features except for CrossLink are enabled at launch.
@@ -183,6 +185,7 @@ var (
 		TestnetExternalEpoch:                  EpochTBD,
 		IsOneSecondEpoch:                      EpochTBD,
 		EIP2537PrecompileEpoch:                EpochTBD,
+		EIP3855Epoch:                          EpochTBD,
 	}
 
 	// PartnerChainConfig contains the chain parameters for the Partner network.
@@ -285,6 +288,7 @@ var (
 		TestnetExternalEpoch:                  EpochTBD,
 		IsOneSecondEpoch:                      EpochTBD,
 		EIP2537PrecompileEpoch:                EpochTBD,
+		EIP3855Epoch:                          EpochTBD,
 	}
 
 	// LocalnetChainConfig contains the chain parameters to run for local development.
@@ -335,6 +339,7 @@ var (
 		TestnetExternalEpoch:                  EpochTBD,
 		IsOneSecondEpoch:                      big.NewInt(4),
 		EIP2537PrecompileEpoch:                EpochTBD,
+		EIP3855Epoch:                          EpochTBD,
 	}
 
 	// AllProtocolChanges ...
@@ -388,6 +393,7 @@ var (
 		big.NewInt(0),
 		big.NewInt(0),
 		big.NewInt(0), // EIP2537PrecompileEpoch
+		big.NewInt(0), // EIP3855Epoch
 	}
 
 	// TestChainConfig ...
@@ -441,6 +447,7 @@ var (
 		big.NewInt(0),
 		big.NewInt(0),
 		big.NewInt(0), // EIP2537PrecompileEpoch
+		big.NewInt(0), // EIP3855Epoch
 	}
 
 	// TestRules ...
@@ -570,6 +577,9 @@ type ChainConfig struct {
 
 	// EIP2537PrecompileEpoch is the first epoch to support the EIP-2537 precompiles
 	EIP2537PrecompileEpoch *big.Int `json:"eip2537-precompile-epoch,omitempty"`
+
+	// EIP3855Epoch is the first epoch to support EIP-3855 (PUSH0 opcode)
+	EIP3855Epoch *big.Int `json:"eip3855-epoch,omitempty"`
 
 	// ChainIdFixEpoch is the first epoch to return ethereum compatible chain id by ChainID() op code
 	ChainIdFixEpoch *big.Int `json:"chain-id-fix-epoch,omitempty"`
@@ -863,6 +873,12 @@ func (c *ChainConfig) IsCrossShardXferPrecompile(epoch *big.Int) bool {
 // precompiles are available in the EVM
 func (c *ChainConfig) IsEIP2537Precompile(epoch *big.Int) bool {
 	return isForked(c.EIP2537PrecompileEpoch, epoch)
+}
+
+// IsEIP3855 determines whether EIP-3855 (PUSH0 opcode)
+// is available in the EVM
+func (c *ChainConfig) IsEIP3855(epoch *big.Int) bool {
+	return isForked(c.EIP3855Epoch, epoch)
 }
 
 // IsChainIdFix returns whether epoch is either equal to the ChainId Fix fork epoch or greater.

--- a/node/harmony/worker/worker_test.go
+++ b/node/harmony/worker/worker_test.go
@@ -37,7 +37,7 @@ func TestNewWorker(t *testing.T) {
 			Config:  chainConfig,
 			Factory: blockFactory,
 			Alloc:   core.GenesisAlloc{testBankAddress: {Balance: testBankFunds}},
-			ShardID: 10,
+			ShardID: 0,
 		}
 		engine = chain2.NewEngine()
 	)
@@ -45,10 +45,10 @@ func TestNewWorker(t *testing.T) {
 	genesis := gspec.MustCommit(database)
 	_ = genesis
 	cacheConfig := &core.CacheConfig{SnapshotLimit: 0}
-	chain, err := core.NewBlockChain(database, nil, &core.BlockChainImpl{}, cacheConfig, gspec.Config, engine, vm.Config{})
+	chain, err := core.NewBlockChain(database, nil, nil, cacheConfig, gspec.Config, engine, vm.Config{})
 
 	if err != nil {
-		t.Error(err)
+		t.Fatalf("failed to create blockchain: %v", err)
 	}
 	// Create a new worker
 	worker := New(chain, nil)


### PR DESCRIPTION
superceeded by https://github.com/harmony-one/harmony/pull/4969

[EIP-3855](https://eips.ethereum.org/EIPS/eip-3855) introduces a new Ethereum Virtual Machine (EVM) instruction called `PUSH0` that pushes the value zero onto the stack. Before this improvement, pushing zero required using `PUSH1 0`, which takes 2 bytes of bytecode and costs 3 gas at runtime. The new `PUSH0` opcode (represented by `0x5f`) accomplishes the same task using only 1 byte and costs just 2 gas, making smart contracts more efficient and cheaper to deploy and execute.

The motivation for this change comes from how frequently zero values are used in smart contracts. Many EVM operations need zero as an input parameter—for example, when making contract calls where you want to specify zero offsets or when using return data functions. Previously, every time a contract needed to push zero onto the stack, it had to use the more expensive `PUSH1 0` instruction. With `PUSH0`, developers can write more gas-efficient code, and the smaller bytecode size also reduces deployment costs.

This PR implements EIP-3855 and can be activated at a specific epoch through the `EIP3855Epoch` configuration parameter. When enabled, the EVM interpreter includes the `PUSH0` opcode in its jump table, allowing smart contracts to use this more efficient instruction. This is part of Harmony's ongoing effort to align with Ethereum improvements while maintaining its own epoch-based upgrade mechanism.
