### PR TITLE
Reduced block production timeout

### DIFF
--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -337,6 +337,12 @@ func (consensus *Consensus) onCommit(recvMsg *FBFTMessage) {
 		if maxWaitTime > waitTime {
 			waitTime = maxWaitTime
 		}
+		if consensus.Blockchain().Config().IsOneSecond(consensus.Blockchain().CurrentBlock().Epoch()) {
+			waitTime = time.Until(consensus.NextBlockDue) - 200*time.Millisecond
+			if waitTime < 0 {
+				waitTime = 0
+			}
+		}
 		go consensus.finalCommit(waitTime, viewID, consensus.isLeader())
 
 		consensus.msgSender.StopRetry(msg_pb.MessageType_PREPARED)


### PR DESCRIPTION
Reduced block production timeout. On my local machine produced 1639 block for 1664 seconds which is no more than 1.5% deviation for the ideal scenario