### PR TITLE
Add timestamp checks for block header validation

### DIFF
--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -39,6 +39,8 @@ const (
 	epochCtxCache    = 20
 	vrfBeta          = 32 // 32 bytes randomness
 	vrfProof         = 96 // 96 bytes proof (bls sig)
+	// Maximum allowed future skew for block timestamps.
+	allowedFutureBlockTime = 15 * time.Second
 )
 
 type engineImpl struct {
@@ -63,6 +65,18 @@ func (e *engineImpl) VerifyHeader(chain engine.ChainReader, header *block.Header
 	parentHeader := chain.GetHeader(header.ParentHash(), header.Number().Uint64()-1)
 	if parentHeader == nil {
 		return engine.ErrUnknownAncestor
+	}
+	// Apply timestamp rules only when the corresponding fork is active.
+	if chain.Config().IsTimestampValidation(header.Epoch()) {
+		// Keep block timestamps strictly increasing.
+		if header.Time().Cmp(parentHeader.Time()) <= 0 {
+			return errors.New("timestamp older than parent")
+		}
+		// Reject blocks that are too far in the future relative to local wall clock.
+		limit := big.NewInt(time.Now().Add(allowedFutureBlockTime).Unix())
+		if header.Time().Cmp(limit) > 0 {
+			return engine.ErrFutureBlock
+		}
 	}
 	if seal {
 		if err := e.VerifySeal(chain, header); err != nil {

--- a/internal/chain/engine_test.go
+++ b/internal/chain/engine_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/trie"
 	bls_core "github.com/harmony-one/bls/ffi/go/bls"
@@ -322,8 +323,14 @@ func (bc *fakeBlockChain) CurrentBlock() *types.Block {
 func (bc *fakeBlockChain) CurrentHeader() *block.Header {
 	return bc.currentBlock.Header()
 }
-func (bc *fakeBlockChain) GetBlock(hash common.Hash, number uint64) *types.Block    { return nil }
-func (bc *fakeBlockChain) GetHeader(hash common.Hash, number uint64) *block.Header  { return nil }
+func (bc *fakeBlockChain) GetBlock(hash common.Hash, number uint64) *types.Block { return nil }
+func (bc *fakeBlockChain) GetHeader(hash common.Hash, number uint64) *block.Header {
+	header := bc.currentBlock.Header()
+	if header != nil && header.Hash() == hash && header.Number().Uint64() == number {
+		return header
+	}
+	return nil
+}
 func (bc *fakeBlockChain) GetHeaderByHash(hash common.Hash) *block.Header           { return nil }
 func (bc *fakeBlockChain) GetReceiptsByHash(hash common.Hash) types.Receipts        { return nil }
 func (bc *fakeBlockChain) ContractCode(hash common.Hash) ([]byte, error)            { return []byte{}, nil }
@@ -351,7 +358,7 @@ func (bc *fakeBlockChain) ReadValidatorInformation(addr common.Address) (*stakin
 	return nil, nil
 }
 func (bc *fakeBlockChain) Config() *params.ChainConfig {
-	return params.LocalnetChainConfig
+	return &bc.config
 }
 func (cr *fakeBlockChain) StateAt(root common.Hash) (*state.DB, error) {
 	return nil, nil
@@ -393,5 +400,65 @@ func makeVoteData(kp blsKeyPair, block *types.Block) slash.Vote {
 		SignerPubKeys:   []bls.SerializedPublicKey{kp.Pub()},
 		BlockHeaderHash: block.Hash(),
 		Signature:       kp.Sign(block),
+	}
+}
+
+func TestVerifyHeaderTimestampValidation(t *testing.T) {
+	chain := makeFakeBlockChain()
+	eng := NewEngine()
+
+	parent := chain.CurrentHeader()
+	parent.SetTime(big.NewInt(time.Now().Unix()))
+
+	mkChild := func(ts int64) *block.Header {
+		h := blockfactory.NewTestHeader()
+		h.SetParentHash(parent.Hash())
+		h.SetNumber(new(big.Int).Add(parent.Number(), big.NewInt(1)))
+		h.SetEpoch(parent.Epoch())
+		h.SetTime(big.NewInt(ts))
+		return h
+	}
+
+	if err := eng.VerifyHeader(chain, mkChild(parent.Time().Int64()+1), false); err != nil {
+		t.Fatalf("expected valid timestamp, got %v", err)
+	}
+
+	if err := eng.VerifyHeader(chain, mkChild(parent.Time().Int64()), false); err == nil {
+		t.Fatal("expected error for non-increasing timestamp")
+	}
+
+	if err := eng.VerifyHeader(chain, mkChild(time.Now().Add(allowedFutureBlockTime+time.Second).Unix()), false); err != engine.ErrFutureBlock {
+		t.Fatalf("expected ErrFutureBlock, got %v", err)
+	}
+}
+
+func TestVerifyHeaderTimestampValidationBackwardCompatibleBeforeFork(t *testing.T) {
+	chain := makeFakeBlockChain()
+	eng := NewEngine()
+
+	// Keep activation epoch above the header epoch.
+	chain.config.TimestampValidationEpoch = big.NewInt(100)
+
+	parent := chain.CurrentHeader()
+	parent.SetEpoch(big.NewInt(5))
+	parent.SetTime(big.NewInt(time.Now().Unix()))
+
+	mkChild := func(ts int64) *block.Header {
+		h := blockfactory.NewTestHeader()
+		h.SetParentHash(parent.Hash())
+		h.SetNumber(new(big.Int).Add(parent.Number(), big.NewInt(1)))
+		h.SetEpoch(parent.Epoch())
+		h.SetTime(big.NewInt(ts))
+		return h
+	}
+
+	older := mkChild(parent.Time().Int64() - 1)
+	if err := eng.VerifyHeader(chain, older, false); err != nil {
+		t.Fatalf("expected old timestamp allowed pre-fork, got %v", err)
+	}
+
+	future := mkChild(time.Now().Add(allowedFutureBlockTime + time.Minute).Unix())
+	if err := eng.VerifyHeader(chain, future, false); err != nil {
+		t.Fatalf("expected future timestamp allowed pre-fork, got %v", err)
 	}
 }

--- a/internal/chain/engine_test.go
+++ b/internal/chain/engine_test.go
@@ -407,8 +407,12 @@ func TestVerifyHeaderTimestampValidation(t *testing.T) {
 	chain := makeFakeBlockChain()
 	eng := NewEngine()
 
-	parent := chain.CurrentHeader()
+	parent := blockfactory.NewTestHeader()
+	parent.SetNumber(big.NewInt(doubleSignBlockNumber))
+	parent.SetEpoch(big.NewInt(currentEpoch))
 	parent.SetTime(big.NewInt(time.Now().Unix()))
+	chain.currentBlock = *types.NewBlockWithHeader(parent)
+	parent = chain.CurrentHeader()
 
 	mkChild := func(ts int64) *block.Header {
 		h := blockfactory.NewTestHeader()
@@ -439,9 +443,12 @@ func TestVerifyHeaderTimestampValidationBackwardCompatibleBeforeFork(t *testing.
 	// Keep activation epoch above the header epoch.
 	chain.config.TimestampValidationEpoch = big.NewInt(100)
 
-	parent := chain.CurrentHeader()
+	parent := blockfactory.NewTestHeader()
+	parent.SetNumber(big.NewInt(doubleSignBlockNumber))
 	parent.SetEpoch(big.NewInt(5))
 	parent.SetTime(big.NewInt(time.Now().Unix()))
+	chain.currentBlock = *types.NewBlockWithHeader(parent)
+	parent = chain.CurrentHeader()
 
 	mkChild := func(ts int64) *block.Header {
 		h := blockfactory.NewTestHeader()

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -81,6 +81,7 @@ var (
 		LeaderRotationV2Epoch:                 EpochTBD,
 		DevnetExternalEpoch:                   EpochTBD,
 		TestnetExternalEpoch:                  EpochTBD,
+		TimestampValidationEpoch:              EpochTBD,
 		IsOneSecondEpoch:                      EpochTBD,
 		EIP2537PrecompileEpoch:                EpochTBD,
 		EIP1153TransientStorageEpoch:          EpochTBD,
@@ -133,6 +134,7 @@ var (
 		LeaderRotationV2Epoch:                 EpochTBD,
 		DevnetExternalEpoch:                   EpochTBD,
 		TestnetExternalEpoch:                  big.NewInt(3044),
+		TimestampValidationEpoch:              EpochTBD,
 		IsOneSecondEpoch:                      EpochTBD,
 		EIP2537PrecompileEpoch:                EpochTBD,
 		EIP1153TransientStorageEpoch:          big.NewInt(6280),
@@ -185,6 +187,7 @@ var (
 		LeaderRotationV2Epoch:                 EpochTBD,
 		DevnetExternalEpoch:                   EpochTBD,
 		TestnetExternalEpoch:                  EpochTBD,
+		TimestampValidationEpoch:              EpochTBD,
 		IsOneSecondEpoch:                      EpochTBD,
 		EIP2537PrecompileEpoch:                EpochTBD,
 		EIP1153TransientStorageEpoch:          EpochTBD,
@@ -238,6 +241,7 @@ var (
 		LeaderRotationV2Epoch:                 EpochTBD,
 		DevnetExternalEpoch:                   big.NewInt(144),
 		TestnetExternalEpoch:                  EpochTBD,
+		TimestampValidationEpoch:              EpochTBD,
 		IsOneSecondEpoch:                      big.NewInt(17436),
 		EIP2537PrecompileEpoch:                EpochTBD,
 		EIP1153TransientStorageEpoch:          big.NewInt(35626),
@@ -291,6 +295,7 @@ var (
 		LeaderRotationV2Epoch:                 EpochTBD,
 		DevnetExternalEpoch:                   EpochTBD,
 		TestnetExternalEpoch:                  EpochTBD,
+		TimestampValidationEpoch:              EpochTBD,
 		IsOneSecondEpoch:                      EpochTBD,
 		EIP2537PrecompileEpoch:                EpochTBD,
 		EIP1153TransientStorageEpoch:          EpochTBD,
@@ -343,6 +348,7 @@ var (
 		LeaderRotationV2Epoch:                 EpochTBD,
 		DevnetExternalEpoch:                   EpochTBD,
 		TestnetExternalEpoch:                  EpochTBD,
+		TimestampValidationEpoch:              big.NewInt(0),
 		IsOneSecondEpoch:                      big.NewInt(4),
 		EIP2537PrecompileEpoch:                EpochTBD,
 		EIP1153TransientStorageEpoch:          EpochTBD,
@@ -394,6 +400,7 @@ var (
 		big.NewInt(2),                      // HIP30Epoch
 		big.NewInt(0),                      // DevnetExternalEpoch
 		big.NewInt(0),                      // TestnetExternalEpoch
+		big.NewInt(0),                      // TimestampValidationEpoch
 		big.NewInt(0),                      // BlockGas30MEpoch
 		big.NewInt(2),                      // MaxRateEpoch
 		big.NewInt(0),                      // TopMaxRateEpoch
@@ -448,6 +455,7 @@ var (
 		big.NewInt(2),        // HIP30Epoch
 		big.NewInt(0),        // DevnetExternalEpoch
 		big.NewInt(0),        // TestnetExternalEpoch
+		big.NewInt(0),        // TimestampValidationEpoch
 		big.NewInt(0),        // BlockGas30MEpoch
 		big.NewInt(2),        // MaxRateEpoch
 		big.NewInt(0),        // TopMaxRateEpoch
@@ -629,6 +637,10 @@ type ChainConfig struct {
 
 	TestnetExternalEpoch *big.Int `json:"testnet-external-epoch,omitempty"`
 
+	// TimestampValidationEpoch is the first epoch to enforce strict monotonic
+	// and future-bounded block timestamp checks during header verification.
+	TimestampValidationEpoch *big.Int `json:"timestamp-validation-epoch,omitempty"`
+
 	BlockGas30MEpoch *big.Int `json:"block-gas-30m-epoch,omitempty"`
 
 	// MaxRateEpoch will make sure the validator max-rate is at least equal to the minRate + the validator max-rate-increase
@@ -777,6 +789,11 @@ func (c *ChainConfig) IsTwoSeconds(epoch *big.Int) bool {
 
 func (c *ChainConfig) IsOneSecond(epoch *big.Int) bool {
 	return isForked(c.IsOneSecondEpoch, epoch)
+}
+
+// IsTimestampValidation determines whether timestamp hardfork checks are enabled.
+func (c *ChainConfig) IsTimestampValidation(epoch *big.Int) bool {
+	return isForked(c.TimestampValidationEpoch, epoch)
 }
 
 // IsSixtyPercent determines whether it is the epoch to reduce internal voting power to 60%


### PR DESCRIPTION
This PR adds timestamp validation in block header verification. When the timestamp validation fork is active for a header epoch, the node enforces two rules: 
- the child block timestamp must be strictly greater than the parent timestamp
- the child timestamp must not exceed local wall clock time by more than the configured future-skew tolerance (15 seconds).

The validation is applied only after activation epoch is reached, which keeps behavior unchanged before activation and supports a coordinated network rollout. The validation model is compatible with prolonged block production gaps. There is no maximum allowed delta between parent and child timestamps, so recovery after multi-minute pauses is unaffected as long as the new block timestamp is monotonic and not excessively ahead of local node time.