### PR TITLE
fix(rpc): track auth HTTP/WS servers separately; cache method-filter …

### DIFF
--- a/eth/rpc/method_filter.go
+++ b/eth/rpc/method_filter.go
@@ -10,6 +10,12 @@ import (
 	"github.com/pelletier/go-toml"
 )
 
+// Compiled once: Match() runs per RPC method when filters are enabled.
+var (
+	methodFilterSimpleTokenPattern = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
+	methodFilterWildcardPattern    = regexp.MustCompile(`^[a-zA-Z0-9_*?]+$`)
+)
+
 type RpcMethodFilter struct {
 	Allow []string
 	Deny  []string
@@ -105,10 +111,10 @@ func Match(pattern string, value string) bool {
 			return isAllowed
 		}
 	}
-	// auto detect simple checking  or wildcard
-	if regexp.MustCompile(`^[a-zA-Z0-9_]+$`).MatchString(pattern) {
+	// auto detect simple checking or wildcard
+	if methodFilterSimpleTokenPattern.MatchString(pattern) {
 		return strings.EqualFold(pattern, value)
-	} else if regexp.MustCompile(`^[a-zA-Z0-9_*?]+$`).MatchString(pattern) {
+	} else if methodFilterWildcardPattern.MatchString(pattern) {
 		return MatchWildCard(pattern, value)
 	}
 	// by default we use regex matching

--- a/rpc/harmony/rpc.go
+++ b/rpc/harmony/rpc.go
@@ -48,8 +48,12 @@ var (
 
 	httpListener     net.Listener
 	httpHandler      *rpc.Server
+	httpAuthListener net.Listener
+	httpAuthHandler  *rpc.Server
 	wsListener       net.Listener
 	wsHandler        *rpc.Server
+	wsAuthListener   net.Listener
+	wsAuthHandler    *rpc.Server
 	httpEndpoint     = ""
 	httpAuthEndpoint = ""
 	wsEndpoint       = ""
@@ -131,6 +135,19 @@ func StopServers() error {
 		httpHandler.Stop()
 		httpHandler = nil
 	}
+	if httpAuthListener != nil {
+		if err := httpAuthListener.Close(); err != nil {
+			return err
+		}
+		httpAuthListener = nil
+		utils.Logger().Info().
+			Str("url", fmt.Sprintf("http://%s", httpAuthEndpoint)).
+			Msg("HTTP auth endpoint closed")
+	}
+	if httpAuthHandler != nil {
+		httpAuthHandler.Stop()
+		httpAuthHandler = nil
+	}
 	if wsListener != nil {
 		if err := wsListener.Close(); err != nil {
 			return err
@@ -143,6 +160,19 @@ func StopServers() error {
 	if wsHandler != nil {
 		wsHandler.Stop()
 		wsHandler = nil
+	}
+	if wsAuthListener != nil {
+		if err := wsAuthListener.Close(); err != nil {
+			return err
+		}
+		wsAuthListener = nil
+		utils.Logger().Info().
+			Str("url", fmt.Sprintf("ws://%s", wsAuthEndpoint)).
+			Msg("WebSocket auth endpoint closed")
+	}
+	if wsAuthHandler != nil {
+		wsAuthHandler.Stop()
+		wsAuthHandler = nil
 	}
 	return nil
 }
@@ -232,7 +262,7 @@ func startHTTP(apis []rpc.API, rmf *rpc.RpcMethodFilter, httpTimeouts rpc.HTTPTi
 }
 
 func startAuthHTTP(apis []rpc.API, rmf *rpc.RpcMethodFilter, httpTimeouts rpc.HTTPTimeouts) (err error) {
-	httpListener, httpHandler, err = rpc.StartHTTPEndpoint(
+	httpAuthListener, httpAuthHandler, err = rpc.StartHTTPEndpoint(
 		httpAuthEndpoint, apis, HTTPModules, rmf, httpOrigins, httpVirtualHosts, httpTimeouts,
 	)
 	if err != nil {
@@ -262,13 +292,13 @@ func startWS(apis []rpc.API, rmf *rpc.RpcMethodFilter) (err error) {
 }
 
 func startAuthWS(apis []rpc.API, rmf *rpc.RpcMethodFilter) (err error) {
-	wsListener, wsHandler, err = rpc.StartWSEndpoint(wsAuthEndpoint, apis, WSModules, rmf, wsOrigins, true)
+	wsAuthListener, wsAuthHandler, err = rpc.StartWSEndpoint(wsAuthEndpoint, apis, WSModules, rmf, wsOrigins, true)
 	if err != nil {
 		return err
 	}
 
 	utils.Logger().Info().
-		Str("url", fmt.Sprintf("ws://%s", wsListener.Addr())).
+		Str("url", fmt.Sprintf("ws://%s", wsAuthListener.Addr())).
 		Msg("WebSocket Auth-WS endpoint opened")
 	fmt.Printf("Started Auth-WS server at: %v\n", wsAuthEndpoint)
 	return nil


### PR DESCRIPTION
- **Harmony RPC:** Public and auth HTTP/WebSocket servers were stored in the same global httpListener / httpHandler / wsListener / wsHandler variables. Starting the auth server replaced the public server’s handles, so the public listeners could not be closed cleanly and StopServers only shut down the last-started pair. This change uses dedicated globals for auth and updates StopServers to close and stop both public and auth stacks.

- **Method filter:** Match() no longer calls regexp.MustCompile on every invocation for the simple-token vs wildcard auto-detect path; those patterns are compiled once at package init.