### PR TITLE
Fix RPC rate limiter configuration handling

### DIFF
--- a/rosetta/services/call_service.go
+++ b/rosetta/services/call_service.go
@@ -92,7 +92,7 @@ func NewCallAPIService(
 	return &CallAPIService{
 		hmy:                 hmy,
 		publicContractAPI:   rpc2.NewPublicContractAPI(hmy, rpc2.V2, limiterEnable, rateLimit, evmCallTimeout),
-		publicStakingAPI:    rpc2.NewPublicStakingAPI(hmy, rpc2.V2),
+		publicStakingAPI:    rpc2.NewPublicStakingAPI(hmy, rpc2.V2, limiterEnable),
 		publicBlockChainAPI: rpc2.NewPublicBlockchainAPI(hmy, rpc2.V2, limiterEnable, rateLimit),
 	}
 }

--- a/rpc/harmony/blockchain.go
+++ b/rpc/harmony/blockchain.go
@@ -57,20 +57,36 @@ const (
 func NewPublicBlockchainAPI(hmy *hmy.Harmony, version Version, limiterEnable bool, limit int) rpc.API {
 	var limiter *rate.Limiter
 	if limiterEnable {
-		limiter = rate.NewLimiter(rate.Limit(limit), limit)
-		name := reflect.TypeOf(limiter).Elem().Name()
-		rpcRateLimitCounterVec.With(prometheus.Labels{
-			"limiter_name": name,
-		}).Add(float64(0))
+		if limit > 0 {
+			limiter = rate.NewLimiter(rate.Limit(limit), limit)
+			name := reflect.TypeOf(limiter).Elem().Name()
+			rpcRateLimitCounterVec.With(prometheus.Labels{
+				"limiter_name": name,
+			}).Add(float64(0))
+		} else {
+			utils.Logger().Warn().
+				Int("rpc_ratelimit", limit).
+				Msg("Disabling RPC rate limiter due to non-positive RequestsPerSecond")
+		}
+	}
+
+	var limiterGetStakingNetworkInfo *rate.Limiter
+	var limiterGetSuperCommittees *rate.Limiter
+	var limiterGetCurrentUtilityMetrics *rate.Limiter
+	if limiterEnable {
+		// TEMP SOLUTION to rpc node spamming issue
+		limiterGetStakingNetworkInfo = rate.NewLimiter(5, 10)
+		limiterGetSuperCommittees = rate.NewLimiter(5, 10)
+		limiterGetCurrentUtilityMetrics = rate.NewLimiter(5, 10)
 	}
 
 	s := &PublicBlockchainService{
 		hmy:                             hmy,
 		version:                         version,
 		limiter:                         limiter,
-		limiterGetStakingNetworkInfo:    rate.NewLimiter(5, 10),
-		limiterGetSuperCommittees:       rate.NewLimiter(5, 10),
-		limiterGetCurrentUtilityMetrics: rate.NewLimiter(5, 10),
+		limiterGetStakingNetworkInfo:    limiterGetStakingNetworkInfo,
+		limiterGetSuperCommittees:       limiterGetSuperCommittees,
+		limiterGetCurrentUtilityMetrics: limiterGetCurrentUtilityMetrics,
 	}
 	s.helper = s.newHelper()
 

--- a/rpc/harmony/contract.go
+++ b/rpc/harmony/contract.go
@@ -45,7 +45,13 @@ func NewPublicContractAPI(
 ) rpc.API {
 	var limiter *rate.Limiter
 	if limiterEnable {
-		limiter = rate.NewLimiter(rate.Limit(limit), limit)
+		if limit > 0 {
+			limiter = rate.NewLimiter(rate.Limit(limit), limit)
+		} else {
+			utils.Logger().Warn().
+				Int("rpc_ratelimit", limit).
+				Msg("Disabling RPC rate limiter due to non-positive RequestsPerSecond")
+		}
 	}
 
 	return rpc.API{

--- a/rpc/harmony/pool.go
+++ b/rpc/harmony/pool.go
@@ -40,7 +40,13 @@ type PublicPoolService struct {
 func NewPublicPoolAPI(hmy *hmy.Harmony, version Version, limiterEnable bool, limit int) rpc.API {
 	var limiter *rate.Limiter
 	if limiterEnable {
-		limiter = rate.NewLimiter(rate.Limit(limit), limit)
+		if limit > 0 {
+			limiter = rate.NewLimiter(rate.Limit(limit), limit)
+		} else {
+			utils.Logger().Warn().
+				Int("rpc_ratelimit", limit).
+				Msg("Disabling RPC rate limiter due to non-positive RequestsPerSecond")
+		}
 	}
 	return rpc.API{
 		Namespace: version.Namespace(),

--- a/rpc/harmony/rpc.go
+++ b/rpc/harmony/rpc.go
@@ -180,8 +180,8 @@ func getAPIs(hmy *hmy.Harmony, config nodeconfig.RPCServerConfig) []rpc.API {
 
 	if config.StakingRPCsEnabled {
 		publicAPIs = append(publicAPIs,
-			NewPublicStakingAPI(hmy, V1),
-			NewPublicStakingAPI(hmy, V2),
+			NewPublicStakingAPI(hmy, V1, config.RateLimiterEnabled),
+			NewPublicStakingAPI(hmy, V2, config.RateLimiterEnabled),
 		)
 	}
 

--- a/rpc/harmony/staking.go
+++ b/rpc/harmony/staking.go
@@ -40,8 +40,17 @@ type PublicStakingService struct {
 }
 
 // NewPublicStakingAPI creates a new API for the RPC interface
-func NewPublicStakingAPI(hmy *hmy.Harmony, version Version) rpc.API {
+func NewPublicStakingAPI(hmy *hmy.Harmony, version Version, limiterEnable bool) rpc.API {
 	viCache, _ := lru.New(validatorInfoCacheSize)
+	var limiterGetAllValidatorInformation *rate.Limiter
+	var limiterGetAllDelegationInformation *rate.Limiter
+	var limiterGetDelegationsByValidator *rate.Limiter
+	if limiterEnable {
+		// TEMP SOLUTION to rpc node spamming issue
+		limiterGetAllValidatorInformation = rate.NewLimiter(1, 3)
+		limiterGetAllDelegationInformation = rate.NewLimiter(1, 3)
+		limiterGetDelegationsByValidator = rate.NewLimiter(5, 20)
+	}
 	return rpc.API{
 		Namespace: version.Namespace(),
 		Version:   APIVersion,
@@ -49,9 +58,9 @@ func NewPublicStakingAPI(hmy *hmy.Harmony, version Version) rpc.API {
 			hmy:                                hmy,
 			version:                            version,
 			validatorInfoCache:                 viCache,
-			limiterGetAllValidatorInformation:  rate.NewLimiter(1, 3),
-			limiterGetAllDelegationInformation: rate.NewLimiter(1, 3),
-			limiterGetDelegationsByValidator:   rate.NewLimiter(5, 20),
+			limiterGetAllValidatorInformation:  limiterGetAllValidatorInformation,
+			limiterGetAllDelegationInformation: limiterGetAllDelegationInformation,
+			limiterGetDelegationsByValidator:   limiterGetDelegationsByValidator,
 		},
 		Public: true,
 	}


### PR DESCRIPTION
This PR updates limiter construction and wires staking limiter flag. It hardens the RPC rate-limiting behavior to make `--rpc.ratelimiter` / `--rpc.ratelimit` consistent and safe. In particular, rate limiters are now constructed only when rate limiting is enabled and `RequestsPerSecond` is positive; otherwise the node logs a warning and avoids misconfigured limiter instances.

It also fixes an inconsistency where some “temp” per-method limiter instances (used for RPC spamming mitigation) were being created regardless of `rpc.ratelimiter`. Those limiters now respect the enable flag, so turning rate limiting off truly disables all RPC throttling logic added in these services.