### PR TITLE
Add RPC Auth Rate Limit

### DIFF
--- a/rosetta/services/call_service.go
+++ b/rosetta/services/call_service.go
@@ -92,7 +92,7 @@ func NewCallAPIService(
 	return &CallAPIService{
 		hmy:                 hmy,
 		publicContractAPI:   rpc2.NewPublicContractAPI(hmy, rpc2.V2, limiterEnable, rateLimit, evmCallTimeout),
-		publicStakingAPI:    rpc2.NewPublicStakingAPI(hmy, rpc2.V2),
+		publicStakingAPI:    rpc2.NewPublicStakingAPI(hmy, rpc2.V2, limiterEnable),
 		publicBlockChainAPI: rpc2.NewPublicBlockchainAPI(hmy, rpc2.V2, limiterEnable, rateLimit),
 	}
 }

--- a/rpc/harmony/blockchain.go
+++ b/rpc/harmony/blockchain.go
@@ -57,20 +57,36 @@ const (
 func NewPublicBlockchainAPI(hmy *hmy.Harmony, version Version, limiterEnable bool, limit int) rpc.API {
 	var limiter *rate.Limiter
 	if limiterEnable {
-		limiter = rate.NewLimiter(rate.Limit(limit), limit)
-		name := reflect.TypeOf(limiter).Elem().Name()
-		rpcRateLimitCounterVec.With(prometheus.Labels{
-			"limiter_name": name,
-		}).Add(float64(0))
+		if limit > 0 {
+			limiter = rate.NewLimiter(rate.Limit(limit), limit)
+			name := reflect.TypeOf(limiter).Elem().Name()
+			rpcRateLimitCounterVec.With(prometheus.Labels{
+				"limiter_name": name,
+			}).Add(float64(0))
+		} else {
+			utils.Logger().Warn().
+				Int("rpc_ratelimit", limit).
+				Msg("Disabling RPC rate limiter due to non-positive RequestsPerSecond")
+		}
+	}
+
+	var limiterGetStakingNetworkInfo *rate.Limiter
+	var limiterGetSuperCommittees *rate.Limiter
+	var limiterGetCurrentUtilityMetrics *rate.Limiter
+	if limiterEnable {
+		// TEMP SOLUTION to rpc node spamming issue
+		limiterGetStakingNetworkInfo = rate.NewLimiter(5, 10)
+		limiterGetSuperCommittees = rate.NewLimiter(5, 10)
+		limiterGetCurrentUtilityMetrics = rate.NewLimiter(5, 10)
 	}
 
 	s := &PublicBlockchainService{
 		hmy:                             hmy,
 		version:                         version,
 		limiter:                         limiter,
-		limiterGetStakingNetworkInfo:    rate.NewLimiter(5, 10),
-		limiterGetSuperCommittees:       rate.NewLimiter(5, 10),
-		limiterGetCurrentUtilityMetrics: rate.NewLimiter(5, 10),
+		limiterGetStakingNetworkInfo:    limiterGetStakingNetworkInfo,
+		limiterGetSuperCommittees:       limiterGetSuperCommittees,
+		limiterGetCurrentUtilityMetrics: limiterGetCurrentUtilityMetrics,
 	}
 	s.helper = s.newHelper()
 

--- a/rpc/harmony/contract.go
+++ b/rpc/harmony/contract.go
@@ -45,7 +45,13 @@ func NewPublicContractAPI(
 ) rpc.API {
 	var limiter *rate.Limiter
 	if limiterEnable {
-		limiter = rate.NewLimiter(rate.Limit(limit), limit)
+		if limit > 0 {
+			limiter = rate.NewLimiter(rate.Limit(limit), limit)
+		} else {
+			utils.Logger().Warn().
+				Int("rpc_ratelimit", limit).
+				Msg("Disabling RPC rate limiter due to non-positive RequestsPerSecond")
+		}
 	}
 
 	return rpc.API{

--- a/rpc/harmony/pool.go
+++ b/rpc/harmony/pool.go
@@ -40,7 +40,13 @@ type PublicPoolService struct {
 func NewPublicPoolAPI(hmy *hmy.Harmony, version Version, limiterEnable bool, limit int) rpc.API {
 	var limiter *rate.Limiter
 	if limiterEnable {
-		limiter = rate.NewLimiter(rate.Limit(limit), limit)
+		if limit > 0 {
+			limiter = rate.NewLimiter(rate.Limit(limit), limit)
+		} else {
+			utils.Logger().Warn().
+				Int("rpc_ratelimit", limit).
+				Msg("Disabling RPC rate limiter due to non-positive RequestsPerSecond")
+		}
 	}
 	return rpc.API{
 		Namespace: version.Namespace(),

--- a/rpc/harmony/rpc.go
+++ b/rpc/harmony/rpc.go
@@ -149,8 +149,8 @@ func StopServers() error {
 
 func getAuthAPIs(hmy *hmy.Harmony, debugEnable bool, rateLimiterEnable bool, ratelimit int) []rpc.API {
 	return []rpc.API{
-		NewPublicTraceAPI(hmy, Debug), // Debug version means geth trace rpc
-		NewPublicTraceAPI(hmy, Trace), // Trace version means parity trace rpc
+		NewPublicTraceAPI(hmy, Debug, rateLimiterEnable, ratelimit), // Debug version means geth trace rpc
+		NewPublicTraceAPI(hmy, Trace, rateLimiterEnable, ratelimit), // Trace version means parity trace rpc
 	}
 }
 

--- a/rpc/harmony/rpc.go
+++ b/rpc/harmony/rpc.go
@@ -180,8 +180,8 @@ func getAPIs(hmy *hmy.Harmony, config nodeconfig.RPCServerConfig) []rpc.API {
 
 	if config.StakingRPCsEnabled {
 		publicAPIs = append(publicAPIs,
-			NewPublicStakingAPI(hmy, V1),
-			NewPublicStakingAPI(hmy, V2),
+			NewPublicStakingAPI(hmy, V1, config.RateLimiterEnabled),
+			NewPublicStakingAPI(hmy, V2, config.RateLimiterEnabled),
 		)
 	}
 

--- a/rpc/harmony/staking.go
+++ b/rpc/harmony/staking.go
@@ -40,8 +40,17 @@ type PublicStakingService struct {
 }
 
 // NewPublicStakingAPI creates a new API for the RPC interface
-func NewPublicStakingAPI(hmy *hmy.Harmony, version Version) rpc.API {
+func NewPublicStakingAPI(hmy *hmy.Harmony, version Version, limiterEnable bool) rpc.API {
 	viCache, _ := lru.New(validatorInfoCacheSize)
+	var limiterGetAllValidatorInformation *rate.Limiter
+	var limiterGetAllDelegationInformation *rate.Limiter
+	var limiterGetDelegationsByValidator *rate.Limiter
+	if limiterEnable {
+		// TEMP SOLUTION to rpc node spamming issue
+		limiterGetAllValidatorInformation = rate.NewLimiter(1, 3)
+		limiterGetAllDelegationInformation = rate.NewLimiter(1, 3)
+		limiterGetDelegationsByValidator = rate.NewLimiter(5, 20)
+	}
 	return rpc.API{
 		Namespace: version.Namespace(),
 		Version:   APIVersion,
@@ -49,9 +58,9 @@ func NewPublicStakingAPI(hmy *hmy.Harmony, version Version) rpc.API {
 			hmy:                                hmy,
 			version:                            version,
 			validatorInfoCache:                 viCache,
-			limiterGetAllValidatorInformation:  rate.NewLimiter(1, 3),
-			limiterGetAllDelegationInformation: rate.NewLimiter(1, 3),
-			limiterGetDelegationsByValidator:   rate.NewLimiter(5, 20),
+			limiterGetAllValidatorInformation:  limiterGetAllValidatorInformation,
+			limiterGetAllDelegationInformation: limiterGetAllDelegationInformation,
+			limiterGetDelegationsByValidator:   limiterGetDelegationsByValidator,
 		},
 		Public: true,
 	}

--- a/rpc/harmony/tracer.go
+++ b/rpc/harmony/tracer.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -32,6 +33,9 @@ import (
 	"github.com/harmony-one/harmony/eth/rpc"
 	"github.com/harmony-one/harmony/hmy"
 	"github.com/harmony-one/harmony/hmy/tracers"
+	"github.com/harmony-one/harmony/internal/utils"
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/time/rate"
 )
 
 const (
@@ -55,11 +59,23 @@ var (
 type PublicTracerService struct {
 	hmy     *hmy.Harmony
 	version Version
+	limiter *rate.Limiter
 }
 
 // NewPublicTraceAPI creates a new API for the RPC interface
-func NewPublicTraceAPI(hmy *hmy.Harmony, version Version) rpc.API {
-	var service interface{} = &PublicTracerService{hmy, version}
+func NewPublicTraceAPI(hmy *hmy.Harmony, version Version, limiterEnable bool, limit int) rpc.API {
+	var limiter *rate.Limiter
+	if limiterEnable {
+		if limit > 0 {
+			limiter = rate.NewLimiter(rate.Limit(limit), limit)
+		} else {
+			utils.Logger().Warn().
+				Int("rpc_ratelimit", limit).
+				Msg("Disabling RPC rate limiter due to non-positive RequestsPerSecond")
+		}
+	}
+
+	var service interface{} = &PublicTracerService{hmy: hmy, version: version, limiter: limiter}
 	if version == Trace {
 		service = &PublicParityTracerService{service.(*PublicTracerService)}
 	}
@@ -71,11 +87,31 @@ func NewPublicTraceAPI(hmy *hmy.Harmony, version Version) rpc.API {
 	}
 }
 
+func (s *PublicTracerService) wait(ctx context.Context) error {
+	if s.limiter == nil {
+		return nil
+	}
+	deadlineCtx, cancel := context.WithTimeout(ctx, DefaultRateLimiterWaitTimeout)
+	defer cancel()
+	if !s.limiter.Allow() {
+		name := reflect.TypeOf(s.limiter).Elem().Name()
+		rpcRateLimitCounterVec.With(prometheus.Labels{
+			"limiter_name": name,
+		}).Inc()
+	}
+	return s.limiter.Wait(deadlineCtx)
+}
+
 // TraceChain returns the structured logs created during the execution of EVM
 // between two blocks (excluding start) and returns them as a JSON object.
 func (s *PublicTracerService) TraceChain(ctx context.Context, start, end rpc.BlockNumber, config *tracers.TraceConfig) (*rpc.Subscription, error) {
 	timer := DoMetricRPCRequest(TraceChain)
 	defer DoRPCRequestDuration(TraceChain, timer)
+
+	if err := s.wait(ctx); err != nil {
+		DoMetricRPCQueryInfo(TraceChain, RateLimitedNumber)
+		return nil, err
+	}
 
 	// TODO (JL): Make API available after DoS testing
 	return nil, ErrNotAvailable
@@ -109,6 +145,11 @@ func (s *PublicTracerService) TraceBlockByNumber(ctx context.Context, number rpc
 	timer := DoMetricRPCRequest(TraceBlockByNumber)
 	defer DoRPCRequestDuration(TraceBlockByNumber, timer)
 
+	if err := s.wait(ctx); err != nil {
+		DoMetricRPCQueryInfo(TraceBlockByNumber, RateLimitedNumber)
+		return nil, err
+	}
+
 	// Fetch the block that we want to trace
 	block := s.hmy.BlockChain.GetBlockByNumber(uint64(number))
 
@@ -120,6 +161,11 @@ func (s *PublicTracerService) TraceBlockByNumber(ctx context.Context, number rpc
 func (s *PublicTracerService) TraceBlockByHash(ctx context.Context, hash common.Hash, config *tracers.TraceConfig) ([]*hmy.TxTraceResult, error) {
 	timer := DoMetricRPCRequest(TraceBlockByHash)
 	defer DoRPCRequestDuration(TraceBlockByHash, timer)
+
+	if err := s.wait(ctx); err != nil {
+		DoMetricRPCQueryInfo(TraceBlockByHash, RateLimitedNumber)
+		return nil, err
+	}
 
 	block := s.hmy.BlockChain.GetBlockByHash(hash)
 	if block == nil {
@@ -135,6 +181,11 @@ func (s *PublicTracerService) TraceBlock(ctx context.Context, blob []byte, confi
 	timer := DoMetricRPCRequest(TraceBlock)
 	defer DoRPCRequestDuration(TraceBlock, timer)
 
+	if err := s.wait(ctx); err != nil {
+		DoMetricRPCQueryInfo(TraceBlock, RateLimitedNumber)
+		return nil, err
+	}
+
 	block := new(types.Block)
 	if err := rlp.Decode(bytes.NewReader(blob), block); err != nil {
 		DoMetricRPCQueryInfo(TraceBlock, FailedNumber)
@@ -148,6 +199,11 @@ func (s *PublicTracerService) TraceBlock(ctx context.Context, blob []byte, confi
 func (s *PublicTracerService) TraceTransaction(ctx context.Context, hash common.Hash, config *tracers.TraceConfig) (interface{}, error) {
 	timer := DoMetricRPCRequest(TraceTransaction)
 	defer DoRPCRequestDuration(TraceTransaction, timer)
+
+	if err := s.wait(ctx); err != nil {
+		DoMetricRPCQueryInfo(TraceTransaction, RateLimitedNumber)
+		return nil, err
+	}
 
 	// Retrieve the transaction and assemble its EVM context
 	tx, blockHash, _, index := rawdb.ReadTransaction(s.hmy.ChainDb(), hash)
@@ -187,6 +243,11 @@ func (s *PublicTracerService) TraceTransaction(ctx context.Context, hash common.
 func (s *PublicTracerService) TraceCall(ctx context.Context, args CallArgs, blockNr rpc.BlockNumber, config *tracers.TraceCallConfig) (interface{}, error) {
 	timer := DoMetricRPCRequest(TraceCall)
 	defer DoRPCRequestDuration(TraceCall, timer)
+
+	if err := s.wait(ctx); err != nil {
+		DoMetricRPCQueryInfo(TraceCall, RateLimitedNumber)
+		return nil, err
+	}
 
 	// First try to retrieve the state
 	statedb, header, err := s.hmy.StateAndHeaderByNumber(ctx, blockNr)


### PR DESCRIPTION
This PR extends rate limiting to the auth-only tracer/debug endpoints (debug_*trace* / trace_*). Previously, these were served via the auth path but were not throttled. The tracer service now includes an optional `x/time/rate.Limiter` and applies it to tracer RPC methods using the same `wait/timeout` and Prometheus accounting pattern as the other RPC rate-limited services.