### PR TITLE
Implement NTP offset updates for block timestamps every minute

### DIFF
--- a/api/service/ntp/local_time.go
+++ b/api/service/ntp/local_time.go
@@ -1,0 +1,10 @@
+package ntptime
+
+import "time"
+
+type LocalTime struct {
+}
+
+func (LocalTime) Now() time.Time {
+	return time.Now()
+}

--- a/api/service/ntp/local_time.go
+++ b/api/service/ntp/local_time.go
@@ -2,6 +2,8 @@ package ntptime
 
 import "time"
 
+// LocalTime implements NTPTime using the local system clock without any correction.
+// Used as a fallback when NTP is unavailable (e.g. localnet).
 type LocalTime struct {
 }
 

--- a/api/service/ntp/service.go
+++ b/api/service/ntp/service.go
@@ -1,0 +1,100 @@
+package ntptime
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/beevik/ntp"
+	"github.com/harmony-one/harmony/internal/utils"
+)
+
+type NTPTime interface {
+	Now() time.Time
+}
+
+type inner interface {
+	Query(addr string) (*ntp.Response, error)
+}
+
+type ntpInner struct {
+}
+
+func (ntpInner) Query(addr string) (*ntp.Response, error) {
+	rsp, err := ntp.QueryWithOptions(addr, ntp.QueryOptions{})
+	if err != nil {
+		return nil, err
+	}
+	err = rsp.Validate()
+	if err != nil {
+		return nil, err
+	}
+	return rsp, nil
+}
+
+type ntpTimeImpl struct {
+	mu     sync.RWMutex
+	offset time.Duration
+	addr   string
+	inner  inner
+}
+
+func TryNew(addr string, tries uint) (*ntpTimeImpl, error) {
+	return tryNew(addr, tries, ntpInner{})
+}
+
+func tryNew(addr string, tries uint, inner inner) (*ntpTimeImpl, error) {
+	if tries == 0 {
+		return newNTPTime(addr, inner)
+	}
+	rs, err := newNTPTime(addr, inner)
+	if err != nil {
+		return tryNew(addr, tries-1, inner)
+	}
+	return rs, nil
+}
+
+func newNTPTime(addr string, inner inner) (*ntpTimeImpl, error) {
+	a := &ntpTimeImpl{
+		mu:    sync.RWMutex{},
+		addr:  addr,
+		inner: inner,
+	}
+	tm, err := inner.Query(addr)
+	if err != nil {
+		return nil, err
+	}
+	a.offset = tm.ClockOffset
+	return a, nil
+}
+
+func (a *ntpTimeImpl) Run(ctx context.Context, duration time.Duration) {
+	for {
+		timer := time.NewTimer(duration)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return
+		case <-timer.C:
+			tm, err := a.inner.Query(a.addr)
+			if err != nil {
+				utils.Logger().Info().Msgf("Failed to run NTP time provider: %v", err)
+				continue
+			}
+			a.mu.Lock()
+			a.offset = tm.ClockOffset
+			a.mu.Unlock()
+		}
+	}
+}
+
+func (a *ntpTimeImpl) Now() time.Time {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return time.Now().Add(a.offset)
+}

--- a/api/service/ntp/service.go
+++ b/api/service/ntp/service.go
@@ -9,10 +9,12 @@ import (
 	"github.com/harmony-one/harmony/internal/utils"
 )
 
+// NTPTime returns the current time, optionally corrected by an NTP clock offset.
 type NTPTime interface {
 	Now() time.Time
 }
 
+// inner abstracts the NTP query so it can be replaced in tests.
 type inner interface {
 	Query(addr string) (*ntp.Response, error)
 }
@@ -32,13 +34,16 @@ func (ntpInner) Query(addr string) (*ntp.Response, error) {
 	return rsp, nil
 }
 
+// ntpTimeImpl holds the latest clock offset measured against an NTP server
+// and applies it to every Now() call.
 type ntpTimeImpl struct {
 	mu     sync.RWMutex
-	offset time.Duration
+	offset time.Duration // difference between NTP time and local clock
 	addr   string
 	inner  inner
 }
 
+// TryNew creates an ntpTimeImpl, retrying up to tries times on failure.
 func TryNew(addr string, tries uint) (*ntpTimeImpl, error) {
 	return tryNew(addr, tries, ntpInner{})
 }
@@ -68,6 +73,8 @@ func newNTPTime(addr string, inner inner) (*ntpTimeImpl, error) {
 	return a, nil
 }
 
+// Run periodically refreshes the NTP clock offset every duration.
+// It should be started in a goroutine and will run until ctx is cancelled.
 func (a *ntpTimeImpl) Run(ctx context.Context, duration time.Duration) {
 	for {
 		timer := time.NewTimer(duration)
@@ -93,6 +100,7 @@ func (a *ntpTimeImpl) Run(ctx context.Context, duration time.Duration) {
 	}
 }
 
+// Now returns the current local time corrected by the latest NTP offset.
 func (a *ntpTimeImpl) Now() time.Time {
 	a.mu.RLock()
 	defer a.mu.RUnlock()

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	_ "net/http/pprof"
@@ -13,14 +14,13 @@ import (
 	"syscall"
 	"time"
 
-	reward "github.com/harmony-one/harmony/staking/reward"
-
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/harmony-one/bls/ffi/go/bls"
 	"github.com/harmony-one/harmony/api/service"
 	"github.com/harmony-one/harmony/api/service/crosslink_sending"
+	ntptime "github.com/harmony-one/harmony/api/service/ntp"
 	"github.com/harmony-one/harmony/api/service/pprof"
 	"github.com/harmony-one/harmony/api/service/prometheus"
 	syncService "github.com/harmony-one/harmony/api/service/synchronize/stagedstreamsync"
@@ -50,6 +50,7 @@ import (
 	"github.com/harmony-one/harmony/p2p"
 	rpc_common "github.com/harmony-one/harmony/rpc/harmony/common"
 	"github.com/harmony-one/harmony/shard"
+	reward "github.com/harmony-one/harmony/staking/reward"
 	"github.com/harmony-one/harmony/webhooks"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -246,8 +247,21 @@ func setupNodeAndRun(hc harmonyconfig.HarmonyConfig) {
 	nodeconfig.GetDefaultConfig().IsOffline = nodeConfig.IsOffline
 	nodeconfig.GetDefaultConfig().SyncClient = nodeConfig.SyncClient
 
+	var ntpService ntptime.NTPTime = ntptime.LocalTime{}
 	// Check NTP and time accuracy
 	// It skips the time accuracy check on the localnet since all nodes are running on the same machine
+	switch hc.Network.NetworkType {
+	case nodeconfig.Localnet:
+		ntpService = ntptime.LocalTime{}
+	default:
+		impl, err := ntptime.TryNew(nodeConfig.NtpServer, 3)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error initializing NTP time provider: %v\n", err)
+		} else {
+			go impl.Run(context.Background(), time.Minute)
+			ntpService = impl
+		}
+	}
 	if hc.Network.NetworkType != nodeconfig.Localnet {
 		clockAccuracyResp, err := ntp.CheckLocalTimeAccurate(nodeConfig.NtpServer)
 		if !clockAccuracyResp.IsAccurate() {
@@ -263,6 +277,7 @@ func setupNodeAndRun(hc harmonyconfig.HarmonyConfig) {
 			utils.Logger().Warn().Err(err).Msg("Check Local Time Accuracy Error")
 		}
 	}
+	currentNode.Consensus.Registry().SetNTPTime(ntpService)
 
 	// Parse RPC config
 	nodeConfig.RPCServer = hc.ToRPCServerConfig()

--- a/consensus/consensus_block_proposing.go
+++ b/consensus/consensus_block_proposing.go
@@ -34,7 +34,7 @@ func (consensus *Consensus) ProposeNewBlock(commitSigs chan []byte) (*types.Bloc
 
 	// Update worker's current header and
 	// state data in preparation to propose/process new transactions
-	env, err := worker.UpdateCurrent()
+	env, err := worker.UpdateCurrent(consensus.registry.Now())
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to update worker")
 	}

--- a/consensus/consensus_block_proposing.go
+++ b/consensus/consensus_block_proposing.go
@@ -34,7 +34,13 @@ func (consensus *Consensus) ProposeNewBlock(commitSigs chan []byte) (*types.Bloc
 
 	// Update worker's current header and
 	// state data in preparation to propose/process new transactions
-	env, err := worker.UpdateCurrent(consensus.registry.Now())
+	var blockTime time.Time
+	if consensus.Blockchain().Config().IsNTP(nowEpoch) {
+		blockTime = consensus.registry.Now()
+	} else {
+		blockTime = time.Now()
+	}
+	env, err := worker.UpdateCurrent(blockTime)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to update worker")
 	}

--- a/consensus/consensus_block_proposing.go
+++ b/consensus/consensus_block_proposing.go
@@ -33,7 +33,10 @@ func (consensus *Consensus) ProposeNewBlock(commitSigs chan []byte) (*types.Bloc
 	defer utils.AnalysisEnd("ProposeNewBlock", nowEpoch, blockNow)
 
 	// Update worker's current header and
-	// state data in preparation to propose/process new transactions
+	// state data in preparation to propose/process new transactions.
+	// After NTPEpoch, use the NTP-corrected clock stored in the registry
+	// so that the block timestamp reflects true wall-clock time even when
+	// the local system clock drifts.
 	var blockTime time.Time
 	if consensus.Blockchain().Config().IsNTP(nowEpoch) {
 		blockTime = consensus.registry.Now()

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -88,6 +88,7 @@ var (
 		EIP7939CLZEpoch:                       EpochTBD,
 		EIP5656McopyEpoch:                     EpochTBD,
 		EIP6780Epoch:                          EpochTBD,
+		NTPEpoch:                              EpochTBD,
 	}
 
 	// TestnetChainConfig contains the chain parameters to run a node on the harmony test network.
@@ -144,6 +145,7 @@ var (
 		EIP7939CLZEpoch:                       EpochTBD,
 		EIP5656McopyEpoch:                     EpochTBD,
 		EIP6780Epoch:                          EpochTBD,
+		NTPEpoch:                              EpochTBD,
 	}
 	// PangaeaChainConfig contains the chain parameters for the Pangaea network.
 	// All features except for CrossLink are enabled at launch.
@@ -199,6 +201,7 @@ var (
 		EIP1153TransientStorageEpoch:          EpochTBD,
 		EIP7939CLZEpoch:                       EpochTBD,
 		EIP5656McopyEpoch:                     EpochTBD,
+		NTPEpoch:                              EpochTBD,
 	}
 
 	// PartnerChainConfig contains the chain parameters for the Partner network.
@@ -256,6 +259,7 @@ var (
 		EIP7939CLZEpoch:                       EpochTBD,
 		EIP5656McopyEpoch:                     EpochTBD,
 		EIP6780Epoch:                          EpochTBD,
+		NTPEpoch:                              EpochTBD,
 	}
 
 	// StressnetChainConfig contains the chain parameters for the Stress test network.
@@ -312,6 +316,7 @@ var (
 		EIP1153TransientStorageEpoch:          EpochTBD,
 		EIP7939CLZEpoch:                       EpochTBD,
 		EIP5656McopyEpoch:                     EpochTBD,
+		NTPEpoch:                              EpochTBD,
 	}
 
 	// LocalnetChainConfig contains the chain parameters to run for local development.
@@ -367,6 +372,7 @@ var (
 		EIP1153TransientStorageEpoch:          EpochTBD,
 		EIP7939CLZEpoch:                       EpochTBD,
 		EIP5656McopyEpoch:                     EpochTBD,
+		NTPEpoch:                              EpochTBD,
 	}
 
 	// AllProtocolChanges ...
@@ -425,6 +431,7 @@ var (
 		big.NewInt(0),                      // EIP7939CLZEpoch
 		big.NewInt(0),                      // EIP5656McopyEpoch
 		big.NewInt(0),                      // EIP6780Epoch
+		big.NewInt(0),                      // NTPEpoch
 	}
 
 	// TestChainConfig ...
@@ -483,6 +490,7 @@ var (
 		big.NewInt(0),        // EIP7939CLZEpoch
 		big.NewInt(0),        // EIP5656McopyEpoch
 		big.NewInt(0),        // EIP6780Epoch
+		big.NewInt(0),        // NTPEpoch
 	}
 
 	// TestRules ...
@@ -685,6 +693,9 @@ type ChainConfig struct {
 	EIP5656McopyEpoch *big.Int `json:"eip5656-mcopy-epoch,omitempty"`
 	// EIP6780Epoch is the first epoch to support EIP-6780 (deactivate SELFDESTRUCT)
 	EIP6780Epoch *big.Int `json:"eip6780-epoch,omitempty"`
+
+	// NTPEpoch is the first epoch to use NTP-corrected time for block timestamps
+	NTPEpoch *big.Int `json:"ntp-epoch,omitempty"`
 }
 
 // String implements the fmt.Stringer interface.
@@ -950,6 +961,11 @@ func (c *ChainConfig) IsEIP5656Mcopy(epoch *big.Int) bool {
 // IsEIP6780 determines whether EIP-6780 (deactivate SELFDESTRUCT) is active
 func (c *ChainConfig) IsEIP6780(epoch *big.Int) bool {
 	return isForked(c.EIP6780Epoch, epoch)
+}
+
+// IsNTP determines whether NTP-corrected time should be used for block timestamps
+func (c *ChainConfig) IsNTP(epoch *big.Int) bool {
+	return isForked(c.NTPEpoch, epoch)
 }
 
 // IsChainIdFix returns whether epoch is either equal to the ChainId Fix fork epoch or greater.

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -3,9 +3,11 @@ package registry
 import (
 	"math/big"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	bls_core "github.com/harmony-one/bls/ffi/go/bls"
+	ntptime "github.com/harmony-one/harmony/api/service/ntp"
 	"github.com/harmony-one/harmony/consensus/engine"
 	"github.com/harmony-one/harmony/consensus/quorum"
 	"github.com/harmony-one/harmony/core"
@@ -32,11 +34,14 @@ type Registry struct {
 	addressToBLSKey AddressToBLSKey
 	worker          *worker.Worker
 	quorum          quorum.Decider
+	ntpTime         ntptime.NTPTime
 }
 
 // New creates a new registry.
 func New() *Registry {
-	return &Registry{}
+	return &Registry{
+		ntpTime: ntptime.LocalTime{},
+	}
 }
 
 // SetBlockchain sets the blockchain to registry.
@@ -233,6 +238,23 @@ func (r *Registry) GetQuorum() quorum.Decider {
 	defer r.mu.Unlock()
 
 	return r.quorum
+}
+
+// SetNTPTime sets the NTP time provider in the registry.
+func (r *Registry) SetNTPTime(tp ntptime.NTPTime) *Registry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.ntpTime = tp
+	return r
+}
+
+// Now returns the current NTP-corrected time.
+func (r *Registry) Now() time.Time {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.ntpTime.Now()
 }
 
 type FindCommitteeByID interface {

--- a/node/harmony/node_newblock_test.go
+++ b/node/harmony/node_newblock_test.go
@@ -3,6 +3,7 @@ package node
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/harmony-one/harmony/consensus"
@@ -60,7 +61,7 @@ func TestFinalizeNewBlockAsync(t *testing.T) {
 
 	node := New(host, consensusObj, nil, nil, reg)
 
-	node.Worker.UpdateCurrent()
+	node.Worker.UpdateCurrent(time.Now())
 
 	txs := make(map[common.Address]types.Transactions)
 	stks := staking.StakingTransactions{}
@@ -80,7 +81,7 @@ func TestFinalizeNewBlockAsync(t *testing.T) {
 
 	node.Blockchain().InsertChain(types.Blocks{block}, false)
 
-	node.Worker.UpdateCurrent()
+	node.Worker.UpdateCurrent(time.Now())
 
 	_, err = node.Worker.FinalizeNewBlock(
 		commitSigs, func() uint64 { return 0 }, common.Address{}, nil, nil,

--- a/node/harmony/worker/worker.go
+++ b/node/harmony/worker/worker.go
@@ -355,10 +355,11 @@ func (w *Worker) CommitReceipts(receiptsList []*types.CXReceiptsProof) error {
 }
 
 // UpdateCurrent updates the current environment with the current state and header.
-func (w *Worker) UpdateCurrent() (Environment, error) {
+// now is the current time (optionally NTP-corrected) used for the block timestamp.
+func (w *Worker) UpdateCurrent(now time.Time) (Environment, error) {
 	parent := w.chain.CurrentHeader()
 	num := parent.Number()
-	timestamp := time.Now().Unix()
+	timestamp := now.Unix()
 
 	epoch := GetNewEpoch(w.chain)
 	header := w.factory.NewHeader(epoch).With().


### PR DESCRIPTION
This pull request introduces a new abstraction for time management in the Harmony node, allowing the system to use NTP-corrected time instead of relying solely on the local system clock. The changes provide a pluggable interface for time retrieval, integrate NTP time synchronization into the node setup, and propagate the use of this time source throughout the consensus and worker logic.

Key changes include:

**NTP Time Abstraction and Implementation:**
* Added a new `NTPTime` interface and its implementations (`LocalTime` for local system time and `ntpTimeImpl` for NTP-synchronized time) in `api/service/ntp`, with logic to periodically synchronize time from an NTP server and provide the current corrected time. [[1]](diffhunk://#diff-e56d6b90d1b1cadd2cfffd760b77b5090cfb25082ea66d9e4dacce0eae525ba1R1-R10) [[2]](diffhunk://#diff-dcaefa4872eedbdd1952e79aa50c18e292443640c7e4c2783e360137f86c0d04R1-R100)

**Node Initialization and Registry Integration:**
* Modified node setup (`cmd/harmony/main.go`) to initialize and select the appropriate time provider (NTP or local) based on network type, and inject it into the node's registry. The NTP provider is run in the background to keep time updated. [[1]](diffhunk://#diff-864c5118b935b2cb1b63e6a371f24a9390844972ba6bf01cb739160ab1b2e018R4) [[2]](diffhunk://#diff-864c5118b935b2cb1b63e6a371f24a9390844972ba6bf01cb739160ab1b2e018L16-R23) [[3]](diffhunk://#diff-864c5118b935b2cb1b63e6a371f24a9390844972ba6bf01cb739160ab1b2e018R53) [[4]](diffhunk://#diff-864c5118b935b2cb1b63e6a371f24a9390844972ba6bf01cb739160ab1b2e018R250-R264) [[5]](diffhunk://#diff-864c5118b935b2cb1b63e6a371f24a9390844972ba6bf01cb739160ab1b2e018R280)
* Updated the `Registry` struct to store the `NTPTime` provider and expose a `Now()` method for retrieving the current time, as well as a setter for the time provider. [[1]](diffhunk://#diff-65826eb54aee793bab6f7d95d2b19f177755a8dbae8f3a92a0b22cb11b56c0cdR6-R10) [[2]](diffhunk://#diff-65826eb54aee793bab6f7d95d2b19f177755a8dbae8f3a92a0b22cb11b56c0cdR37-R44) [[3]](diffhunk://#diff-65826eb54aee793bab6f7d95d2b19f177755a8dbae8f3a92a0b22cb11b56c0cdR243-R259)

**Consensus and Worker Usage:**
* Changed the consensus block proposing logic to use the registry's NTP-corrected time when updating the worker's environment.
* Updated the `Worker.UpdateCurrent` method to accept the current time as a parameter, enabling the use of the NTP-corrected time for block timestamps.

**Testing Adjustments:**
* Updated tests to pass the current time explicitly to `Worker.UpdateCurrent`, ensuring compatibility with the new interface. [[1]](diffhunk://#diff-7b7a7bbf21ecd52ded3c885b3196967bf6d8d8a597cf2c547933657d73a2e80cR6) [[2]](diffhunk://#diff-7b7a7bbf21ecd52ded3c885b3196967bf6d8d8a597cf2c547933657d73a2e80cL63-R64) [[3]](diffhunk://#diff-7b7a7bbf21ecd52ded3c885b3196967bf6d8d8a597cf2c547933657d73a2e80cL83-R84)