### PR TITLE
fix legacy structLog JSON encoding

### DIFF
--- a/hmy/tracers/logger/logger.go
+++ b/hmy/tracers/logger/logger.go
@@ -81,6 +81,33 @@ type StructLog struct {
 	CallerAddress   common.Address `json:"callerAddress"`
 }
 
+// structLogLegacy stores a structured log emitted by the EVM while replaying a
+// transaction in debug mode.
+type structLogLegacy struct {
+	Pc            uint64             `json:"pc"`
+	Op            string             `json:"op"`
+	Gas           uint64             `json:"gas"`
+	GasCost       uint64             `json:"gasCost"`
+	Depth         int                `json:"depth"`
+	Error         string             `json:"error,omitempty"`
+	Stack         *[]string          `json:"stack,omitempty"`
+	ReturnData    string             `json:"returnData,omitempty"`
+	Memory        *[]string          `json:"memory,omitempty"`
+	Storage       *map[string]string `json:"storage,omitempty"`
+	RefundCounter uint64             `json:"refund,omitempty"`
+}
+
+// formatMemoryWord encodes a memory chunk as a 32-byte, 0x-prefixed hex word.
+// Short chunks are right-padded with zero bytes to 32 bytes.
+func formatMemoryWord(chunk []byte) string {
+	if len(chunk) == 32 {
+		return hexutil.Encode(chunk)
+	}
+	var word [32]byte
+	copy(word[:], chunk)
+	return hexutil.Encode(word[:])
+}
+
 // overrides for gencodec
 type structLogMarshaling struct {
 	Gas         math.HexOrDecimal64
@@ -102,6 +129,50 @@ func (s *StructLog) ErrorString() string {
 		return s.Err.Error()
 	}
 	return ""
+}
+
+// toLegacyJSON converts the StructLog into the legacy JSON-encoded form used
+// by tracing tools that rely on the historical geth structLog shape.
+func (s *StructLog) toLegacyJSON() json.RawMessage {
+	msg := structLogLegacy{
+		Pc:            s.Pc,
+		Op:            s.Op.String(),
+		Gas:           s.Gas,
+		GasCost:       s.GasCost,
+		Depth:         s.Depth,
+		Error:         s.ErrorString(),
+		RefundCounter: s.RefundCounter,
+	}
+	if s.Stack != nil {
+		stack := make([]string, len(s.Stack))
+		for i, stackValue := range s.Stack {
+			stack[i] = stackValue.Hex()
+		}
+		msg.Stack = &stack
+	}
+	if len(s.ReturnData) > 0 {
+		msg.ReturnData = hexutil.Encode(s.ReturnData)
+	}
+	if len(s.Memory) > 0 {
+		memory := make([]string, 0, (len(s.Memory)+31)/32)
+		for i := 0; i < len(s.Memory); i += 32 {
+			end := i + 32
+			if end > len(s.Memory) {
+				end = len(s.Memory)
+			}
+			memory = append(memory, formatMemoryWord(s.Memory[i:end]))
+		}
+		msg.Memory = &memory
+	}
+	if len(s.Storage) > 0 {
+		storage := make(map[string]string)
+		for i, storageValue := range s.Storage {
+			storage[i.Hex()] = storageValue.Hex()
+		}
+		msg.Storage = &storage
+	}
+	element, _ := json.Marshal(msg)
+	return element
 }
 
 // StructLogger is an EVM state logger and implements EVMLogger.
@@ -248,14 +319,13 @@ func (l *StructLogger) GetResult() (json.RawMessage, error) {
 	failed := l.err != nil
 	returnData := common.CopyBytes(l.output)
 	// Return data when successful and revert reason when reverted, otherwise empty.
-	returnVal := fmt.Sprintf("%x", returnData)
 	if failed && l.err != vm.ErrExecutionReverted {
-		returnVal = ""
+		returnData = []byte{}
 	}
 	rs := &ExecutionResult{
 		Gas:         l.usedGas,
 		Failed:      failed,
-		ReturnValue: returnVal,
+		ReturnValue: hexutil.Bytes(returnData),
 		StructLogs:  formatLogs(l.StructLogs()),
 	}
 	fmt.Printf("StructLogger*GetResult: %+v\n", rs)
@@ -411,7 +481,7 @@ func (*mdLogger) CaptureTxEnd(restGas uint64) {}
 type ExecutionResult struct {
 	Gas         uint64         `json:"gas"`
 	Failed      bool           `json:"failed"`
-	ReturnValue string         `json:"returnValue"`
+	ReturnValue hexutil.Bytes  `json:"returnValue"`
 	StructLogs  []StructLogRes `json:"structLogs"`
 }
 
@@ -423,7 +493,7 @@ type StructLogRes struct {
 	Gas           uint64             `json:"gas"`
 	GasCost       uint64             `json:"gasCost"`
 	Depth         int                `json:"depth"`
-	Error         string             `json:"error,omitempty"`
+	Error         *string            `json:"error,omitempty"`
 	Stack         *[]string          `json:"stack,omitempty"`
 	Memory        *[]string          `json:"memory,omitempty"`
 	Storage       *map[string]string `json:"storage,omitempty"`
@@ -443,11 +513,13 @@ func formatLogs(logs []StructLog) []StructLogRes {
 			Gas:           trace.Gas,
 			GasCost:       trace.GasCost,
 			Depth:         trace.Depth,
-			Error:         trace.ErrorString(),
 			RefundCounter: trace.RefundCounter,
 
 			CallerAddress:   trace.CallerAddress,
 			ContractAddress: trace.ContractAddress,
+		}
+		if errStr := trace.ErrorString(); errStr != "" {
+			formatted[index].Error = &errStr
 		}
 		if trace.Stack != nil {
 			stack := make([]string, len(trace.Stack))
@@ -458,15 +530,23 @@ func formatLogs(logs []StructLog) []StructLogRes {
 		}
 		if trace.Memory != nil {
 			memory := make([]string, 0, (len(trace.Memory)+31)/32)
-			for i := 0; i+32 <= len(trace.Memory); i += 32 {
-				memory = append(memory, fmt.Sprintf("%x", trace.Memory[i:i+32]))
+			for i := 0; i < len(trace.Memory); i += 32 {
+				end := i + 32
+				if end > len(trace.Memory) {
+					end = len(trace.Memory)
+				}
+				// Pad each memory word out to 32 bytes before hex encoding to
+				// match go-ethereum's legacy structLog JSON format.
+				word := make([]byte, 32)
+				copy(word, trace.Memory[i:end])
+				memory = append(memory, hexutil.Bytes(word).String())
 			}
 			formatted[index].Memory = &memory
 		}
 		if trace.Storage != nil {
 			storage := make(map[string]string)
 			for i, storageValue := range trace.Storage {
-				storage[fmt.Sprintf("%x", i)] = fmt.Sprintf("%x", storageValue)
+				storage[i.Hex()] = storageValue.Hex()
 			}
 			formatted[index].Storage = &storage
 		}

--- a/hmy/tracers/logger/logger_test.go
+++ b/hmy/tracers/logger/logger_test.go
@@ -18,11 +18,12 @@ package logger
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/harmony-one/harmony/core/state"
 	"github.com/harmony-one/harmony/core/vm"
 	"github.com/harmony-one/harmony/internal/params"
@@ -83,14 +84,26 @@ func TestStructLogMarshalingOmitEmpty(t *testing.T) {
 		log  *StructLog
 		want string
 	}{
-		{"empty err and no fields", &StructLog{},
-			`{"pc":0,"op":0,"gas":"0x0","gasCost":"0x0","memSize":0,"stack":null,"depth":0,"refund":0,"contractAddress":"0x0000000000000000000000000000000000000000","callerAddress":"0x0000000000000000000000000000000000000000","opName":"STOP"}`},
-		{"with err", &StructLog{Err: fmt.Errorf("this failed")},
-			`{"pc":0,"op":0,"gas":"0x0","gasCost":"0x0","memSize":0,"stack":null,"depth":0,"refund":0,"contractAddress":"0x0000000000000000000000000000000000000000","callerAddress":"0x0000000000000000000000000000000000000000","opName":"STOP","error":"this failed"}`},
-		{"with mem", &StructLog{Memory: make([]byte, 2), MemorySize: 2},
-			`{"pc":0,"op":0,"gas":"0x0","gasCost":"0x0","memory":"0x0000","memSize":2,"stack":null,"depth":0,"refund":0,"contractAddress":"0x0000000000000000000000000000000000000000","callerAddress":"0x0000000000000000000000000000000000000000","opName":"STOP"}`},
-		{"with 0-size mem", &StructLog{Memory: make([]byte, 0)},
-			`{"pc":0,"op":0,"gas":"0x0","gasCost":"0x0","memSize":0,"stack":null,"depth":0,"refund":0,"contractAddress":"0x0000000000000000000000000000000000000000","callerAddress":"0x0000000000000000000000000000000000000000","opName":"STOP"}`},
+		{
+			name: "empty err and no fields",
+			log:  &StructLog{},
+			want: `{"pc":0,"op":0,"gas":"0x0","gasCost":"0x0","memSize":0,"stack":null,"depth":0,"refund":0,"contractAddress":"0x0000000000000000000000000000000000000000","callerAddress":"0x0000000000000000000000000000000000000000","opName":"STOP"}`,
+		},
+		{
+			name: "with err",
+			log:  &StructLog{Err: vm.ErrExecutionReverted},
+			want: `{"pc":0,"op":0,"gas":"0x0","gasCost":"0x0","memSize":0,"stack":null,"depth":0,"refund":0,"contractAddress":"0x0000000000000000000000000000000000000000","callerAddress":"0x0000000000000000000000000000000000000000","opName":"STOP","error":"execution reverted"}`,
+		},
+		{
+			name: "with mem",
+			log:  &StructLog{Memory: make([]byte, 2), MemorySize: 2},
+			want: `{"pc":0,"op":0,"gas":"0x0","gasCost":"0x0","memory":"0x0000","memSize":2,"stack":null,"depth":0,"refund":0,"contractAddress":"0x0000000000000000000000000000000000000000","callerAddress":"0x0000000000000000000000000000000000000000","opName":"STOP"}`,
+		},
+		{
+			name: "with 0-size mem",
+			log:  &StructLog{Memory: make([]byte, 0)},
+			want: `{"pc":0,"op":0,"gas":"0x0","gasCost":"0x0","memSize":0,"stack":null,"depth":0,"refund":0,"contractAddress":"0x0000000000000000000000000000000000000000","callerAddress":"0x0000000000000000000000000000000000000000","opName":"STOP"}`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -103,5 +116,163 @@ func TestStructLogMarshalingOmitEmpty(t *testing.T) {
 				t.Fatalf("mismatched results\n\thave: %v\n\twant: %v", have, want)
 			}
 		})
+	}
+}
+
+// TestFormatLogsLegacyJSON checks that our legacy structLog JSON encoding
+// matches the expected Ethereum-style shape: omitting empty error, 0x-prefixed
+// and padded memory/storage, and hex-encoded return value.
+func TestFormatLogsLegacyJSON(t *testing.T) {
+	// Build a single StructLog with:
+	// - a small memory slice so we exercise padding
+	// - a storage entry
+	// - an error
+	addr := common.HexToAddress("0x0102030405060708090a0b0c0d0e0f1011121314")
+	key := common.HexToHash("0x01")
+	val := common.HexToHash("0x02")
+
+	log := StructLog{
+		Pc:              1,
+		Op:              vm.SSTORE,
+		Gas:             10,
+		GasCost:         5,
+		Memory:          []byte{0xaa, 0xbb},
+		MemorySize:      2,
+		Depth:           1,
+		RefundCounter:   0,
+		Err:             vm.ErrExecutionReverted,
+		Storage:         map[common.Hash]common.Hash{key: val},
+		ContractAddress: addr,
+		CallerAddress:   addr,
+	}
+
+	formatted := formatLogs([]StructLog{log})
+	if len(formatted) != 1 {
+		t.Fatalf("expected 1 formatted log, got %d", len(formatted))
+	}
+
+	fl := formatted[0]
+
+	// Error must be a non-nil pointer with the right value.
+	if fl.Error == nil || *fl.Error != "execution reverted" {
+		t.Fatalf("unexpected error field: %#v", fl.Error)
+	}
+
+	// Memory must be present, with a single, 32-byte padded word encoded as 0x + 64 hex chars.
+	if fl.Memory == nil {
+		t.Fatalf("expected memory to be set")
+	}
+	if len(*fl.Memory) != 1 {
+		t.Fatalf("expected 1 memory word, got %d", len(*fl.Memory))
+	}
+	memWord := (*fl.Memory)[0]
+	if len(memWord) != 2+64 { // 0x + 64 hex chars
+		t.Fatalf("unexpected memory word length: got %d, value %q", len(memWord), memWord)
+	}
+	if memWord[:2] != "0x" {
+		t.Fatalf("memory word missing 0x prefix: %q", memWord)
+	}
+
+	// Storage keys and values must be 0x-prefixed hex.
+	if fl.Storage == nil {
+		t.Fatalf("expected storage to be set")
+	}
+	st := *fl.Storage
+	gotVal, ok := st[key.Hex()]
+	if !ok {
+		t.Fatalf("expected storage key %s to be present", key.Hex())
+	}
+	if gotVal != val.Hex() {
+		t.Fatalf("unexpected storage value: have %s, want %s", gotVal, val.Hex())
+	}
+}
+
+// TestStructLogLegacyJSONSpecFormatting mirrors the go-ethereum test to ensure
+// our legacy-ish JSON formatting matches the spec expectations for error,
+// memory padding and storage encoding.
+func TestStructLogLegacyJSONSpecFormatting(t *testing.T) {
+	tests := []struct {
+		name string
+		log  *StructLog
+		want string
+	}{
+		{
+			name: "omits empty error and pads memory/storage",
+			log: &StructLog{
+				Pc:         7,
+				Op:         vm.SSTORE,
+				Gas:        100,
+				GasCost:    20,
+				Memory:     []byte{0xaa, 0xbb},
+				Storage:    map[common.Hash]common.Hash{common.BigToHash(big.NewInt(1)): common.BigToHash(big.NewInt(2))},
+				Depth:      1,
+				ReturnData: []byte{0x12, 0x34},
+			},
+			want: `{"pc":7,"op":"SSTORE","gas":100,"gasCost":20,"depth":1,"returnData":"0x1234","memory":["0xaabb000000000000000000000000000000000000000000000000000000000000"],"storage":{"0x0000000000000000000000000000000000000000000000000000000000000001":"0x0000000000000000000000000000000000000000000000000000000000000002"}}`,
+		},
+		{
+			name: "includes error only when present",
+			log: &StructLog{
+				Pc:      1,
+				Op:      vm.STOP,
+				Gas:     2,
+				GasCost: 3,
+				Depth:   1,
+				Err:     errors.New("boom"),
+			},
+			want: `{"pc":1,"op":"STOP","gas":2,"gasCost":3,"depth":1,"error":"boom"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			have := string(tt.log.toLegacyJSON())
+			if have != tt.want {
+				t.Fatalf("mismatched results\n\thave: %v\n\twant: %v", have, tt.want)
+			}
+		})
+	}
+}
+
+// TestExecutionResultReturnValueEncoding ensures that ExecutionResult encodes
+// returnValue as hexutil.Bytes and omits it (empty bytes) on hard failure.
+func TestExecutionResultReturnValueEncoding(t *testing.T) {
+	// Successful execution: return data should be preserved and hex-encoded.
+	{
+		logger := &StructLogger{}
+		logger.output = []byte{0x01, 0x02}
+		logger.usedGas = 21
+
+		got, err := logger.GetResult()
+		if err != nil {
+			t.Fatalf("GetResult (success) returned error: %v", err)
+		}
+		var res ExecutionResult
+		if err := json.Unmarshal(got, &res); err != nil {
+			t.Fatalf("unmarshal result (success): %v", err)
+		}
+		if string(res.ReturnValue) != string(hexutil.Bytes{0x01, 0x02}) {
+			t.Fatalf("unexpected return value (success): %v", res.ReturnValue)
+		}
+	}
+
+	// Hard failure (non-revert): return data should be empty.
+	{
+		logger := &StructLogger{}
+		logger.output = []byte{0x01, 0x02}
+		logger.usedGas = 21
+		logger.err = vm.ErrOutOfGas
+
+		got, err := logger.GetResult()
+		if err != nil {
+			t.Fatalf("GetResult (failure) returned error: %v", err)
+		}
+		var res ExecutionResult
+		if err := json.Unmarshal(got, &res); err != nil {
+			t.Fatalf("unmarshal result (failure): %v", err)
+		}
+		if len(res.ReturnValue) != 0 {
+			t.Fatalf("expected empty return value on hard failure, got %v", res.ReturnValue)
+		}
 	}
 }


### PR DESCRIPTION
This PR makes error field truly optional in tracer logger. `StructLogRes.Error` was a string. Even when there was no error, JSON had "error": "". After changes, It’s a *string with `omitempty`, and we only set it when there is a real error message. Many tracers/INDEXERS/specs expect the field to be absent when no error occurs, not present with "". This fixes schema/decoder issues and false “error” detections. 
Current memory was chunked into 32‑byte slices and encoded with ```fmt.Sprintf("%x", slice)```. A partial word (e.g. 2 bytes) gave "0xaabb" instead of a 32‑byte (64‑hex‑char) word. After changes each memory chunk is:
- Cut into up to 32 bytes,
- Zero‑padded to 32 bytes,
- Hex‑encoded via `hexutil.Bytes(word).String()` → 0x + 64 hex chars.
Tools that assume 32‑byte, zero‑padded, 0x‑prefixed words (as in Geth) no longer break or misinterpret short words at the end of memory.

Also, the PR helps the storage and return data hex encoding is now consistent. In current code:
Storage keys/values were `fmt.Sprintf("%x", hash)` → no 0x prefix, inconsistent with most Ethereum JSON APIs.
`ExecutionResult.ReturnValue` was a plain hex string and manually blanked out on failure.
But the PR changes it to:
- Storage uses `hash.Hex()` for both key and value → consistent 0x‑prefixed hex.
- ReturnValue is `hexutil.Bytes`, and we zero the underlying bytes on hard failure.

So, now debuggers and explorers that expect standard 0x‑prefixed hex (like the Execution APIs / Geth) can work with your traces without custom handling.

The PR fixes **debug_traceTransaction** style output’s JSON shape and hex formats now match what existing Ethereum tooling already knows how to parse.

Note: the same changes on Ethereum can be found on [PR#34093](https://github.com/ethereum/go-ethereum/pull/34093/changes)