### PR TITLE
Await until next second for block timestamp validation

### DIFF
--- a/api/service/ntp/service.go
+++ b/api/service/ntp/service.go
@@ -2,6 +2,9 @@ package ntptime
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
+	"strings"
 	"sync"
 	"time"
 
@@ -39,38 +42,58 @@ func (ntpInner) Query(addr string) (*ntp.Response, error) {
 type ntpTimeImpl struct {
 	mu     sync.RWMutex
 	offset time.Duration // difference between NTP time and local clock
-	addr   string
+	addr   string        // active server chosen at startup
 	inner  inner
 }
 
-// TryNew creates an ntpTimeImpl, retrying up to tries times on failure.
-func TryNew(addr string, tries uint) (*ntpTimeImpl, error) {
-	return tryNew(addr, tries, ntpInner{})
+// TryNew creates an ntpTimeImpl from a comma-separated list of NTP server
+// addresses, retrying up to tries times on failure.
+func TryNew(ntpServers string, tries uint) (*ntpTimeImpl, error) {
+	return tryNew(ntpServers, tries, ntpInner{})
 }
 
-func tryNew(addr string, tries uint, inner inner) (*ntpTimeImpl, error) {
+func tryNew(ntpServers string, tries uint, inner inner) (*ntpTimeImpl, error) {
 	if tries == 0 {
-		return newNTPTime(addr, inner)
+		return newNTPTime(ntpServers, inner)
 	}
-	rs, err := newNTPTime(addr, inner)
+	rs, err := newNTPTime(ntpServers, inner)
 	if err != nil {
-		return tryNew(addr, tries-1, inner)
+		return tryNew(ntpServers, tries-1, inner)
 	}
 	return rs, nil
 }
 
-func newNTPTime(addr string, inner inner) (*ntpTimeImpl, error) {
-	a := &ntpTimeImpl{
-		mu:    sync.RWMutex{},
-		addr:  addr,
-		inner: inner,
+func newNTPTime(ntpServers string, inner inner) (*ntpTimeImpl, error) {
+	addrs := parseServers(ntpServers)
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("no NTP servers provided")
 	}
-	tm, err := inner.Query(addr)
-	if err != nil {
-		return nil, err
+	// Shuffle so every node doesn't hammer the same server.
+	rand.Shuffle(len(addrs), func(i, j int) { addrs[i], addrs[j] = addrs[j], addrs[i] })
+	for _, addr := range addrs {
+		tm, err := inner.Query(addr)
+		if err != nil {
+			continue
+		}
+		return &ntpTimeImpl{
+			addr:   addr,
+			inner:  inner,
+			offset: tm.ClockOffset,
+		}, nil
 	}
-	a.offset = tm.ClockOffset
-	return a, nil
+	return nil, fmt.Errorf("all NTP servers unreachable")
+}
+
+// parseServers splits a comma-separated server list and trims whitespace.
+func parseServers(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // Run periodically refreshes the NTP clock offset every duration.

--- a/cmd/config/default.go
+++ b/cmd/config/default.go
@@ -144,7 +144,7 @@ var defaultConfig = harmonyconfig.HarmonyConfig{
 }
 
 var defaultSysConfig = harmonyconfig.SysConfig{
-	NtpServer: "1.pool.ntp.org,0.beevik-ntp.pool.ntp.org",
+	NtpServer: "time.cloudflare.com,0.pool.ntp.org,1.pool.ntp.org,2.pool.ntp.org,3.pool.ntp.org",
 }
 
 var defaultDevnetConfig = harmonyconfig.DevnetConfig{

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -682,7 +682,7 @@ func setupChain(hc harmonyconfig.HarmonyConfig, nodeConfig *nodeconfig.ConfigTyp
 		chainDBFactory = &shardchain.LDBFactory{RootDir: nodeConfig.DBDir}
 	}
 
-	engine := chain.NewEngine()
+	engine := chain.NewEngineWithTime(registry.Now)
 	registry.SetEngine(engine)
 
 	chainConfig := nodeConfig.GetNetworkType().ChainConfig()

--- a/cmd/harmony/main.go
+++ b/cmd/harmony/main.go
@@ -257,6 +257,7 @@ func setupNodeAndRun(hc harmonyconfig.HarmonyConfig) {
 		impl, err := ntptime.TryNew(nodeConfig.NtpServer, 3)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error initializing NTP time provider: %v\n", err)
+			os.Exit(1)
 		} else {
 			go impl.Run(context.Background(), time.Minute)
 			ntpService = impl

--- a/consensus/consensus_block_proposing.go
+++ b/consensus/consensus_block_proposing.go
@@ -15,10 +15,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Constants of proposing a new block
 const (
 	IncomingReceiptsLimit = 2000 // 2000 * (numShards - 1)
-	SleepPeriod           = 1 * time.Millisecond
 )
 
 // ProposeNewBlock proposes a new block...

--- a/consensus/consensus_block_proposing.go
+++ b/consensus/consensus_block_proposing.go
@@ -18,11 +18,11 @@ import (
 // Constants of proposing a new block
 const (
 	IncomingReceiptsLimit = 2000 // 2000 * (numShards - 1)
-	SleepPeriod           = 20 * time.Millisecond
+	SleepPeriod           = 1 * time.Millisecond
 )
 
 // ProposeNewBlock proposes a new block...
-func (consensus *Consensus) ProposeNewBlock(commitSigs chan []byte) (*types.Block, error) {
+func (consensus *Consensus) ProposeNewBlock(now time.Time, commitSigs chan []byte) (*types.Block, error) {
 	var (
 		currentHeader = consensus.Blockchain().CurrentHeader()
 		nowEpoch      = currentHeader.Epoch()
@@ -32,18 +32,7 @@ func (consensus *Consensus) ProposeNewBlock(commitSigs chan []byte) (*types.Bloc
 	utils.AnalysisStart("ProposeNewBlock", nowEpoch, blockNow)
 	defer utils.AnalysisEnd("ProposeNewBlock", nowEpoch, blockNow)
 
-	// Update worker's current header and
-	// state data in preparation to propose/process new transactions.
-	// After NTPEpoch, use the NTP-corrected clock stored in the registry
-	// so that the block timestamp reflects true wall-clock time even when
-	// the local system clock drifts.
-	var blockTime time.Time
-	if consensus.Blockchain().Config().IsNTP(nowEpoch) {
-		blockTime = consensus.registry.Now()
-	} else {
-		blockTime = time.Now()
-	}
-	env, err := worker.UpdateCurrent(blockTime)
+	env, err := worker.UpdateCurrent(now)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to update worker")
 	}

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -691,7 +691,6 @@ func (consensus *Consensus) GetLogger() *zerolog.Logger {
 // getLogger returns logger for consensus contexts added
 func (consensus *Consensus) getLogger() *zerolog.Logger {
 	logger := utils.Logger().With().
-		Time(zerolog.TimestampFieldName, consensus.registry.Now()).
 		Uint32("shardID", consensus.ShardID).
 		Uint64("myBlock", consensus.current.getBlockNum()).
 		Uint64("myViewID", consensus.current.getCurBlockViewID()).

--- a/consensus/consensus_service.go
+++ b/consensus/consensus_service.go
@@ -691,6 +691,7 @@ func (consensus *Consensus) GetLogger() *zerolog.Logger {
 // getLogger returns logger for consensus contexts added
 func (consensus *Consensus) getLogger() *zerolog.Logger {
 	logger := utils.Logger().With().
+		Time(zerolog.TimestampFieldName, consensus.registry.Now()).
 		Uint32("shardID", consensus.ShardID).
 		Uint64("myBlock", consensus.current.getBlockNum()).
 		Uint64("myViewID", consensus.current.getCurBlockViewID()).

--- a/consensus/consensus_v2.go
+++ b/consensus/consensus_v2.go
@@ -437,7 +437,7 @@ func (consensus *Consensus) tick() {
 				continue
 			}
 		}
-		if !v.Expired(time.Now()) {
+		if !v.Expired(consensus.registry.Now()) {
 			continue
 		}
 		if k != timeoutViewChange {
@@ -469,7 +469,7 @@ func (consensus *Consensus) BlockChannel(newBlock *types.Block) {
 		consensus.mutex.Lock()
 		defer consensus.mutex.Unlock()
 		// Update time due for next block
-		consensus.NextBlockDue = time.Now().Add(consensus.BlockPeriod)
+		consensus.NextBlockDue = consensus.registry.Now().Add(consensus.BlockPeriod)
 
 		startTime = time.Now()
 		consensus.msgSender.Reset(newBlock.NumberU64())

--- a/consensus/proposer.go
+++ b/consensus/proposer.go
@@ -42,22 +42,10 @@ func (p *Proposer) WaitForConsensusReadyV2(stopChan chan struct{}, stoppedChan c
 				for retryCount := 0; retryCount < 3 && consensus.IsLeader(); retryCount++ {
 					var (
 						currentHeader = p.consensus.Blockchain().CurrentHeader()
-						nowEpoch      = currentHeader.Epoch()
 						parentTime    = currentHeader.Time().Int64()
+						now           = consensus.registry.Now()
+						timestamp     = now.Unix()
 					)
-
-					// Update worker's current header and
-					// state data in preparation to propose/process new transactions.
-					// After NTPEpoch, use the NTP-corrected clock stored in the registry
-					// so that the block timestamp reflects true wall-clock time even when
-					// the local system clock drifts.
-					var now time.Time
-					if consensus.Blockchain().Config().IsNTP(nowEpoch) {
-						now = consensus.registry.Now()
-					} else {
-						now = time.Now()
-					}
-					timestamp := now.Unix()
 					if timestamp <= parentTime {
 						// Current time is within the same second as the parent block.
 						// Sleep until the next second so the child timestamp is strictly

--- a/consensus/proposer.go
+++ b/consensus/proposer.go
@@ -40,7 +40,31 @@ func (p *Proposer) WaitForConsensusReadyV2(stopChan chan struct{}, stoppedChan c
 				return
 			case proposal := <-consensus.GetReadySignal():
 				for retryCount := 0; retryCount < 3 && consensus.IsLeader(); retryCount++ {
-					time.Sleep(SleepPeriod)
+					var (
+						currentHeader = p.consensus.Blockchain().CurrentHeader()
+						nowEpoch      = currentHeader.Epoch()
+						parentTime    = currentHeader.Time().Int64()
+					)
+
+					// Update worker's current header and
+					// state data in preparation to propose/process new transactions.
+					// After NTPEpoch, use the NTP-corrected clock stored in the registry
+					// so that the block timestamp reflects true wall-clock time even when
+					// the local system clock drifts.
+					var now time.Time
+					if consensus.Blockchain().Config().IsNTP(nowEpoch) {
+						now = consensus.registry.Now()
+					} else {
+						now = time.Now()
+					}
+					timestamp := now.Unix()
+					if timestamp <= parentTime {
+						// Current time is within the same second as the parent block.
+						// Sleep until the next second so the child timestamp is strictly
+						// greater, satisfying the engine.go validation check.
+						time.Sleep(time.Until(time.Unix(parentTime+1, 0)))
+						continue
+					}
 					consensus.GetLogger().Info().
 						Uint64("blockNum", proposal.blockNum).
 						Bool("asyncProposal", proposal.Type == AsyncProposal).
@@ -76,7 +100,7 @@ func (p *Proposer) WaitForConsensusReadyV2(stopChan chan struct{}, stoppedChan c
 							}
 						}
 					}()
-					newBlock, err := consensus.ProposeNewBlock(newCommitSigsChan)
+					newBlock, err := consensus.ProposeNewBlock(now, newCommitSigsChan)
 					if err == nil {
 						consensus.GetLogger().Info().
 							Uint64("blockNum", newBlock.NumberU64()).

--- a/consensus/proposer.go
+++ b/consensus/proposer.go
@@ -46,12 +46,41 @@ func (p *Proposer) WaitForConsensusReadyV2(stopChan chan struct{}, stoppedChan c
 						now           = consensus.registry.Now()
 						timestamp     = now.Unix()
 					)
+					// Block timestamps are validated at second precision and must strictly increase.
+					// We decide whether we can propose using consensus.registry.Now(), which is the
+					// NTP-adjusted consensus clock. Do not use time.Until(target) here: time.Until()
+					// is based on raw local time.Now(), and local time can be a few milliseconds
+					// ahead/behind registry.Now().
+					//
+					// Near the next-second boundary this matters:
+					//   registry.Now() may still be 24.999s while time.Now() is already 25.004s.
+					// If we sleep using local time, the sleep duration can be <= 0 even though the
+					// consensus clock still has not crossed parentTime+1. That can burn all retries,
+					// skip proposal setup, and leave finalCommit with no receiver for commitSigAndBitmap.
+					//
+					// Therefore compute the delay using the same clock used for the timestamp check,
+					// then re-read registry.Now() after sleeping before deciding whether to continue.
 					if timestamp <= parentTime {
-						// Current time is within the same second as the parent block.
-						// Sleep until the next second so the child timestamp is strictly
-						// greater, satisfying the engine.go validation check.
-						time.Sleep(time.Until(time.Unix(parentTime+1, 0)))
-						continue
+						target := time.Unix(parentTime+1, 0)
+
+						if delay := target.Sub(consensus.registry.Now()); delay > 0 {
+							time.Sleep(delay)
+						}
+
+						now = consensus.registry.Now()
+						timestamp = now.Unix()
+
+						if timestamp <= parentTime {
+							consensus.GetLogger().Warn().
+								Int64("parentTimeUnix", parentTime).
+								Time("registryNow", now).
+								Time("targetTime", target).
+								Int64("registryTimestampUnix", timestamp).
+								Int("retryCount", retryCount).
+								Msg("[timestamp-guard] registry clock still not past parent timestamp after sleep")
+
+							continue
+						}
 					}
 					consensus.GetLogger().Info().
 						Uint64("blockNum", proposal.blockNum).

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -86,13 +86,13 @@ func (pm *State) fallbackNextViewID() (uint64, time.Duration) {
 // The view change duration is a fixed duration now to avoid stuck into offline nodes during
 // the view change.
 // viewID is only used as the fallback mechansim to determine the nextViewID
-func (pm *State) getNextViewID(curHeader *block.Header) (uint64, time.Duration) {
+func (pm *State) getNextViewID(curHeader *block.Header, now time.Time) (uint64, time.Duration) {
 	if curHeader == nil {
 		return pm.fallbackNextViewID()
 	}
 	blockTimestamp := curHeader.Time().Int64()
 	stuckBlockViewID := curHeader.ViewID().Uint64() + 1
-	curTimestamp := time.Now().Unix()
+	curTimestamp := now.Unix()
 
 	// timestamp messed up in current validator node
 	if curTimestamp <= blockTimestamp {
@@ -226,7 +226,7 @@ func (consensus *Consensus) startViewChange() {
 	consensus.consensusTimeout[timeoutBootstrap].Stop()
 	consensus.current.SetMode(ViewChanging)
 	curHeader := consensus.Blockchain().CurrentHeader()
-	nextViewID, duration := consensus.current.getNextViewID(curHeader)
+	nextViewID, duration := consensus.current.getNextViewID(curHeader, consensus.registry.Now())
 	consensus.setViewChangingID(nextViewID)
 	epoch := curHeader.Epoch()
 	ss, err := consensus.Blockchain().ReadShardState(epoch)

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -40,13 +40,17 @@ const (
 	vrfBeta          = 32 // 32 bytes randomness
 	vrfProof         = 96 // 96 bytes proof (bls sig)
 	// Maximum allowed future skew for block timestamps.
-	allowedFutureBlockTime = 15 * time.Second
+	allowedFutureBlockTime = 1 * time.Second
 )
 
 type engineImpl struct {
 	// Caching field
 	epochCtxCache    *lru.Cache // epochCtxKey -> epochCtx
 	verifiedSigCache *lru.Cache // verifiedSigKey -> struct{}{}
+
+	// now returns the current time. Defaults to time.Now; can be overridden
+	// with an NTP-corrected source via SetNow.
+	now func() time.Time
 }
 
 // NewEngine creates Engine with some cache
@@ -56,6 +60,19 @@ func NewEngine() *engineImpl {
 	return &engineImpl{
 		epochCtxCache:    epochCtxCache,
 		verifiedSigCache: sigCache,
+		now:              time.Now,
+	}
+}
+
+// NewEngineWithTime creates Engine with a custom clock.
+// Use registry.Now for NTP-corrected time.
+func NewEngineWithTime(now func() time.Time) *engineImpl {
+	sigCache, _ := lru.New(verifiedSigCache)
+	epochCtxCache, _ := lru.New(epochCtxCache)
+	return &engineImpl{
+		epochCtxCache:    epochCtxCache,
+		verifiedSigCache: sigCache,
+		now:              now,
 	}
 }
 
@@ -73,7 +90,8 @@ func (e *engineImpl) VerifyHeader(chain engine.ChainReader, header *block.Header
 			return errors.New("timestamp older than parent")
 		}
 		// Reject blocks that are too far in the future relative to local wall clock.
-		limit := big.NewInt(time.Now().Add(allowedFutureBlockTime).Unix())
+		// Use the NTP-corrected clock if one was injected via SetNow.
+		limit := big.NewInt(e.now().Add(allowedFutureBlockTime).Unix())
 		if header.Time().Cmp(limit) > 0 {
 			return engine.ErrFutureBlock
 		}


### PR DESCRIPTION
This pull request makes several improvements to the block proposing logic in the consensus mechanism, primarily focusing on more precise block timestamp handling and improved sleep timing. The changes ensure that block timestamps are strictly increasing and reflect accurate wall-clock time, especially when using NTP, and refactor the code to pass the current time explicitly.

**Block timestamp handling and accuracy:**

* The logic for determining the block timestamp is moved from `ProposeNewBlock` to the proposer loop (`WaitForConsensusReadyV2`), ensuring that the block timestamp is always strictly greater than the parent block's timestamp. The code now explicitly sleeps until the next second if necessary.
* The `now` time value is passed explicitly to `ProposeNewBlock`, rather than being determined inside the method, improving testability and clarity. [[1]](diffhunk://#diff-2668cc7eabbb47387732df8057e06ea5364a7216a77b5b02864364d65827133fL21-R25) [[2]](diffhunk://#diff-2668cc7eabbb47387732df8057e06ea5364a7216a77b5b02864364d65827133fL35-R35) [[3]](diffhunk://#diff-bbc0fda6ab77138378c2a3470d12c91cb080269ae82b349e2cae87dd8d8858fdL79-R103)
* fix ntp servers parsing
* add random pick of ntp server to get time 
* lower future block tolerance to the 1s, we are not Ethereum with 12s block finality 
* exit if no ntp servers provided
* update ntp list to the broader set of servers, remove example server from the beevik library
* block proposal readiness is checked with consensus.registry.Now() guaranteeing that blocks will have only increasing timestamps