### PR TITLE
Fix EIPs activations

### DIFF
--- a/core/vm/eips_harmony_test.go
+++ b/core/vm/eips_harmony_test.go
@@ -4,7 +4,9 @@ import (
 	"math/big"
 	"testing"
 
+	ethparams "github.com/ethereum/go-ethereum/params"
 	"github.com/harmony-one/harmony/internal/params"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
 
@@ -54,5 +56,115 @@ func TestOpChainID(t *testing.T) {
 		}
 		rs := stack.pop()
 		require.Equal(t, rs.Uint64(), uint64(ethCompatibleChainID))
+	})
+}
+
+func TestAutoEIPActivationRespectsEpochBoundaries(t *testing.T) {
+	baseCfg := &params.ChainConfig{
+		ChainID:                               big.NewInt(1),
+		EthCompatibleChainID:                  big.NewInt(1),
+		EthCompatibleShard0ChainID:            big.NewInt(1),
+		EIP155Epoch:                           big.NewInt(0),
+		S3Epoch:                               big.NewInt(0),
+		CrossTxEpoch:                          big.NewInt(0),
+		MinCommissionPromoPeriod:              big.NewInt(10),
+		ReceiptLogEpoch:                       big.NewInt(0),
+		PreStakingEpoch:                       big.NewInt(0),
+		CrossLinkEpoch:                        big.NewInt(0),
+		StakingEpoch:                          big.NewInt(1),
+		QuickUnlockEpoch:                      big.NewInt(0),
+		FiveSecondsEpoch:                      big.NewInt(0),
+		RedelegationEpoch:                     big.NewInt(0),
+		IstanbulEpoch:                         big.NewInt(0),
+		TwoSecondsEpoch:                       big.NewInt(0),
+		EthCompatibleEpoch:                    big.NewInt(0),
+		SixtyPercentEpoch:                     big.NewInt(0),
+		NoEarlyUnlockEpoch:                    big.NewInt(0),
+		VRFEpoch:                              big.NewInt(0),
+		MinDelegation100Epoch:                 big.NewInt(0),
+		MinCommissionRateEpoch:                big.NewInt(0),
+		EPoSBound35Epoch:                      big.NewInt(0),
+		AggregatedRewardEpoch:                 big.NewInt(1),
+		PrevVRFEpoch:                          big.NewInt(0),
+		DataCopyFixEpoch:                      big.NewInt(0),
+		SHA3Epoch:                             big.NewInt(0),
+		HIP6And8Epoch:                         big.NewInt(0),
+		StakingPrecompileEpoch:                big.NewInt(0),
+		EIP2537PrecompileEpoch:                big.NewInt(0),
+		EIP3855Epoch:                          big.NewInt(100),
+		ChainIdFixEpoch:                       big.NewInt(0),
+		SlotsLimitedEpoch:                     big.NewInt(0),
+		CrossShardXferPrecompileEpoch:         big.NewInt(1),
+		AllowlistEpoch:                        big.NewInt(0),
+		LeaderRotationInternalValidatorsEpoch: big.NewInt(0),
+		LeaderRotationExternalValidatorsEpoch: big.NewInt(0),
+		LeaderRotationV2Epoch:                 big.NewInt(0),
+		FeeCollectEpoch:                       big.NewInt(1),
+		ValidatorCodeFixEpoch:                 big.NewInt(0),
+		HIP30Epoch:                            big.NewInt(2),
+		DevnetExternalEpoch:                   big.NewInt(0),
+		TestnetExternalEpoch:                  big.NewInt(0),
+		BlockGas30MEpoch:                      big.NewInt(0),
+		MaxRateEpoch:                          big.NewInt(2),
+		TopMaxRateEpoch:                       big.NewInt(0),
+		HIP32Epoch:                            big.NewInt(0),
+		IsOneSecondEpoch:                      big.NewInt(0),
+		EIP1153TransientStorageEpoch:          big.NewInt(0),
+		EIP7939CLZEpoch:                       big.NewInt(0),
+		EIP5656McopyEpoch:                     big.NewInt(0),
+		EIP3860Epoch:                          big.NewInt(100),
+		EIP6780Epoch:                          big.NewInt(100),
+		NTPEpoch:                              big.NewInt(0),
+		TimestampValidationEpoch:              big.NewInt(0),
+		PragueEpoch:                           big.NewInt(0),
+		EIP8024Epoch:                          big.NewInt(100),
+	}
+
+	t.Run("before-activation-keeps-legacy-behavior", func(t *testing.T) {
+		evm := NewEVM(
+			BlockContext{EpochNumber: big.NewInt(99)},
+			TxContext{},
+			nil,
+			baseCfg,
+			Config{},
+		)
+		jt := evm.interpreter.cfg.JumpTable
+
+		require.Equal(t, minStack(0, 0), jt[PUSH0].minStack)
+		require.Equal(t, maxStack(0, 0), jt[PUSH0].maxStack)
+		require.Equal(t, minStack(0, 0), jt[DUPN].minStack)
+		require.Equal(t, minStack(0, 0), jt[SWAPN].minStack)
+		require.Equal(t, minStack(0, 0), jt[EXCHANGE].minStack)
+
+		stack := newstack()
+		stack.push(uint256.NewInt(ethparams.MaxInitCodeSize + 1))
+		stack.push(uint256.NewInt(0))
+		stack.push(uint256.NewInt(0))
+		_, err := jt[CREATE].dynamicGas(evm, nil, stack, NewMemory(), 0)
+		require.NoError(t, err)
+	})
+
+	t.Run("at-activation-enables-new-behavior", func(t *testing.T) {
+		evm := NewEVM(
+			BlockContext{EpochNumber: big.NewInt(100)},
+			TxContext{},
+			nil,
+			baseCfg,
+			Config{},
+		)
+		jt := evm.interpreter.cfg.JumpTable
+
+		require.Equal(t, minStack(0, 1), jt[PUSH0].minStack)
+		require.Equal(t, maxStack(0, 1), jt[PUSH0].maxStack)
+		require.Equal(t, minStack(1, 0), jt[DUPN].minStack)
+		require.Equal(t, minStack(2, 0), jt[SWAPN].minStack)
+		require.Equal(t, minStack(2, 0), jt[EXCHANGE].minStack)
+
+		stack := newstack()
+		stack.push(uint256.NewInt(ethparams.MaxInitCodeSize + 1))
+		stack.push(uint256.NewInt(0))
+		stack.push(uint256.NewInt(0))
+		_, err := jt[CREATE].dynamicGas(evm, nil, stack, NewMemory(), 0)
+		require.ErrorIs(t, err, ErrGasUintOverflow)
 	})
 }

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -98,6 +98,14 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 				cfg.JumpTable = &copy
 			}
 		}
+		// Automatically enable EIP-3855 if the epoch is reached
+		if evm.chainRules.IsEIP3855 {
+			cfg.ExtraEips = append(cfg.ExtraEips, 3855)
+		}
+		// Automatically enable EIP-3860 if the epoch is reached
+		if evm.chainRules.Is3860 {
+			cfg.ExtraEips = append(cfg.ExtraEips, 3860)
+		}
 		// Automatically enable EIP-8024 if the epoch is reached
 		if evm.chainRules.Is8024 {
 			cfg.ExtraEips = append(cfg.ExtraEips, 8024)

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -1165,6 +1165,7 @@ type Rules struct {
 	Is1153TransientStorage bool
 	Is7939CLZ              bool
 	IsEIP5656Mcopy         bool
+	IsEIP3855              bool
 	IsEIP6780              bool
 	Is3860                 bool
 	IsPrague               bool // EIP-2935: Serve historical block hashes from state
@@ -1203,6 +1204,7 @@ func (c *ChainConfig) Rules(epoch *big.Int) Rules {
 		Is1153TransientStorage:     c.IsEIP1153TransientStorage(epoch),
 		Is7939CLZ:                  c.IsEIP7939CLZ(epoch),
 		IsEIP5656Mcopy:             c.IsEIP5656Mcopy(epoch),
+		IsEIP3855:                  c.IsEIP3855(epoch),
 		IsEIP6780:                  c.IsEIP6780(epoch),
 		Is3860:                     c.IsEIP3860(epoch),
 		IsPrague:                   c.IsPrague(epoch),


### PR DESCRIPTION
Ensures interpreter jump tables honor chain epoch flags for opcodes gated by EIP-3855 (PUSH0), EIP-3860 (create initcode metering), and EIP-8024 (DUPN/SWAPN/EXCHANGE), matching logic already used in state transition / tx pool for 3860. Adds IsEIP3855 to params.Rules and wires it from ChainConfig, since the interpreter consulted rules but that flag did not exist. Adds TestInterpreterAutoActivatesEpochEIPs so enabled vs disabled epoch configs produce the expected ExtraEips entries.