### PR TITLE
core: Beacon cross-link validation hardening

### DIFF
--- a/core/blockchain_impl.go
+++ b/core/blockchain_impl.go
@@ -403,6 +403,17 @@ func VerifyBlockCrossLinks(blockchain BlockChain, block *types.Block) error {
 	}
 
 	for _, crossLink := range crossLinks {
+		// CrossLinks on beacon headers must reference only non-beacon shards when the
+		// RejectShard0CrossLink fork is enabled for the block epoch.
+		if blockchain.Config().IsRejectShard0CrossLink(block.Epoch()) &&
+			crossLink.ShardID() == shard.BeaconChainShardID {
+			return errors.Errorf(
+				"[CrossLinkVerification] invalid crosslink shard: %d block: %d on beacon block %d",
+				crossLink.ShardID(),
+				crossLink.BlockNum(),
+				block.NumberU64(),
+			)
+		}
 		// ReadCrossLink beacon chain usage.
 		cl, err := blockchain.ReadCrossLink(crossLink.ShardID(), crossLink.BlockNum())
 		if err == nil && cl != nil {

--- a/internal/chain/reward.go
+++ b/internal/chain/reward.go
@@ -347,7 +347,18 @@ func distributeRewardAfterAggregateEpoch(bc engine.ChainReader, state *state.DB,
 			if err := rlp.DecodeBytes(cxLinks, &crossLinks); err != nil {
 				return numeric.ZeroDec(), network.EmptyPayout, err
 			}
-			allCrossLinks = append(allCrossLinks, crossLinks...)
+			// Defensive filter follows the RejectShard0CrossLink fork activation.
+			for _, cl := range crossLinks {
+				if bc.Config().IsRejectShard0CrossLink(curHeader.Epoch()) &&
+					cl.ShardID() == shard.BeaconChainShardID {
+					utils.Logger().Warn().
+						Uint64("beacon-block-number", curHeader.Number().Uint64()).
+						Uint64("crosslink-block-number", cl.BlockNum()).
+						Msg("ignoring shard-0 crosslink in beacon header CrossLinks")
+					continue
+				}
+				allCrossLinks = append(allCrossLinks, cl)
+			}
 		}
 	}
 
@@ -439,6 +450,14 @@ func distributeRewardBeforeAggregateEpoch(bc engine.ChainReader, state *state.DB
 		startTime = time.Now()
 		for i := range crossLinks {
 			cxLink := crossLinks[i]
+			if bc.Config().IsRejectShard0CrossLink(header.Epoch()) &&
+				cxLink.ShardID() == shard.BeaconChainShardID {
+				utils.Logger().Warn().
+					Uint64("beacon-block-number", header.Number().Uint64()).
+					Uint64("crosslink-block-number", cxLink.BlockNum()).
+					Msg("ignoring shard-0 crosslink in beacon header CrossLinks")
+				continue
+			}
 			payables, _, err := processOneCrossLink(bc, state, cxLink, defaultReward, i)
 
 			if err != nil {

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -46,6 +46,7 @@ var (
 		ReceiptLogEpoch:                       big.NewInt(101),
 		PreStakingEpoch:                       big.NewInt(185),
 		CrossLinkEpoch:                        big.NewInt(186),
+		RejectShard0CrossLinkEpoch:            EpochTBD, // mainnet activation TBD (consensus hardfork)
 		StakingEpoch:                          big.NewInt(186),
 		QuickUnlockEpoch:                      big.NewInt(191),
 		FiveSecondsEpoch:                      big.NewInt(230),
@@ -107,6 +108,7 @@ var (
 		ReceiptLogEpoch:                       big.NewInt(0),
 		PreStakingEpoch:                       big.NewInt(1),
 		CrossLinkEpoch:                        big.NewInt(2),
+		RejectShard0CrossLinkEpoch:            big.NewInt(0),
 		StakingEpoch:                          big.NewInt(2),
 		QuickUnlockEpoch:                      big.NewInt(0),
 		FiveSecondsEpoch:                      big.NewInt(0),
@@ -168,6 +170,7 @@ var (
 		ReceiptLogEpoch:                       big.NewInt(0),
 		PreStakingEpoch:                       big.NewInt(1),
 		CrossLinkEpoch:                        big.NewInt(2),
+		RejectShard0CrossLinkEpoch:            big.NewInt(0),
 		StakingEpoch:                          big.NewInt(2),
 		QuickUnlockEpoch:                      big.NewInt(0),
 		FiveSecondsEpoch:                      big.NewInt(0),
@@ -229,6 +232,7 @@ var (
 		ReceiptLogEpoch:                       big.NewInt(0),
 		PreStakingEpoch:                       big.NewInt(1),
 		CrossLinkEpoch:                        big.NewInt(2),
+		RejectShard0CrossLinkEpoch:            big.NewInt(0),
 		StakingEpoch:                          big.NewInt(2),
 		QuickUnlockEpoch:                      big.NewInt(0),
 		FiveSecondsEpoch:                      big.NewInt(0),
@@ -291,6 +295,7 @@ var (
 		ReceiptLogEpoch:                       big.NewInt(0),
 		PreStakingEpoch:                       big.NewInt(1),
 		CrossLinkEpoch:                        big.NewInt(2),
+		RejectShard0CrossLinkEpoch:            big.NewInt(0),
 		StakingEpoch:                          big.NewInt(2),
 		QuickUnlockEpoch:                      big.NewInt(0),
 		FiveSecondsEpoch:                      big.NewInt(0),
@@ -351,6 +356,7 @@ var (
 		ReceiptLogEpoch:                       big.NewInt(0),
 		PreStakingEpoch:                       big.NewInt(0),
 		CrossLinkEpoch:                        big.NewInt(2),
+		RejectShard0CrossLinkEpoch:            big.NewInt(0),
 		StakingEpoch:                          big.NewInt(2),
 		QuickUnlockEpoch:                      big.NewInt(0),
 		FiveSecondsEpoch:                      big.NewInt(0),
@@ -409,6 +415,7 @@ var (
 		big.NewInt(0),                      // EthCompatibleEpoch
 		big.NewInt(0),                      // CrossTxEpoch
 		big.NewInt(0),                      // CrossLinkEpoch
+		big.NewInt(0),                      // RejectShard0CrossLinkEpoch
 		big.NewInt(1),                      // AggregatedRewardEpoch
 		big.NewInt(1),                      // StakingEpoch
 		big.NewInt(0),                      // PreStakingEpoch
@@ -472,6 +479,7 @@ var (
 		big.NewInt(0),        // EthCompatibleEpoch
 		big.NewInt(0),        // CrossTxEpoch
 		big.NewInt(0),        // CrossLinkEpoch
+		big.NewInt(0),        // RejectShard0CrossLinkEpoch
 		big.NewInt(1),        // AggregatedRewardEpoch
 		big.NewInt(1),        // StakingEpoch
 		big.NewInt(0),        // PreStakingEpoch
@@ -578,6 +586,10 @@ type ChainConfig struct {
 	// CrossLinkEpoch is the epoch where beaconchain starts containing
 	// cross-shard links.
 	CrossLinkEpoch *big.Int `json:"cross-link-epoch,omitempty"`
+
+	// RejectShard0CrossLinkEpoch is the epoch where beacon headers start rejecting
+	// shard-0 cross-links in Header.CrossLinks.
+	RejectShard0CrossLinkEpoch *big.Int `json:"reject-shard0-cross-link-epoch,omitempty"`
 
 	// AggregatedRewardEpoch is the epoch when block rewards are distributed every 64 blocks
 	AggregatedRewardEpoch *big.Int `json:"aggregated-reward-epoch,omitempty"`
@@ -935,6 +947,12 @@ func (c *ChainConfig) IsQuickUnlock(epoch *big.Int) bool {
 // IsCrossLink returns whether epoch is either equal to the CrossLink fork epoch or greater.
 func (c *ChainConfig) IsCrossLink(epoch *big.Int) bool {
 	return isForked(c.CrossLinkEpoch, epoch)
+}
+
+// IsRejectShard0CrossLink determines whether shard-0 cross-links in beacon
+// header CrossLinks are rejected by consensus.
+func (c *ChainConfig) IsRejectShard0CrossLink(epoch *big.Int) bool {
+	return isForked(c.RejectShard0CrossLinkEpoch, epoch)
 }
 
 // IsS3 returns whether epoch is either equal to the S3 fork epoch or greater.


### PR DESCRIPTION
This change improves beacon cross-link handling by tightening validation rules and aligning behavior with intended shard separation. It introduces an activation gate in chain configuration so the new behavior can be enabled in a coordinated way across networks without changing pre-activation behavior.

As part of this, cross-link processing in reward-related paths is made more defensive and consistent with the same activation logic. This keeps accounting behavior stable before activation while ensuring post-activation processing follows stricter expectations for cross-link inputs.