### PR TITLE
Activation epochs for devnet

### DIFF
--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -264,14 +264,14 @@ var (
 		IsOneSecondEpoch:                      big.NewInt(17436),
 		EIP2537PrecompileEpoch:                EpochTBD,
 		EIP1153TransientStorageEpoch:          big.NewInt(35626),
-		EIP7939CLZEpoch:                       EpochTBD,
-		EIP5656McopyEpoch:                     EpochTBD,
-		EIP3855Epoch:                          EpochTBD,
-		EIP3860Epoch:                          EpochTBD,
-		EIP6780Epoch:                          EpochTBD,
 		TimestampValidationEpoch:              big.NewInt(47190),
+		EIP7939CLZEpoch:                       big.NewInt(49685),
+		EIP5656McopyEpoch:                     big.NewInt(49685),
+		EIP3855Epoch:                          big.NewInt(49685),
+		EIP3860Epoch:                          big.NewInt(49685),
+		EIP8024Epoch:                          big.NewInt(49685),
+		EIP6780Epoch:                          EpochTBD, //????
 		PragueEpoch:                           EpochTBD,
-		EIP8024Epoch:                          EpochTBD,
 	}
 
 	// StressnetChainConfig contains the chain parameters for the Stress test network.


### PR DESCRIPTION
This pull request updates the activation epochs for several Ethereum protocol upgrades (EIPs) in the `internal/params/config.go` configuration file. The main change is that multiple EIPs now have a specific activation epoch set, rather than being marked as "to be determined." Additionally, a new EIP (EIP-8024) is added with an activation epoch.

Protocol upgrade activation updates:

* Set the activation epoch for `EIP7939CLZEpoch`, `EIP5656McopyEpoch`, `EIP3855Epoch`, `EIP3860Epoch`, and the newly added `EIP8024Epoch` to `49685` instead of `EpochTBD`. (`[internal/params/config.goL267-L274](diffhunk://#diff-059a645c15f37b27def02577139d5b663f6d5accc121a58c6401fceae3241062L267-L274)`)
* Left `EIP6780Epoch` as `EpochTBD` with a comment, and removed/reordered some EIP fields for clarity. (`[internal/params/config.goL267-L274](diffhunk://#diff-059a645c15f37b27def02577139d5b663f6d5accc121a58c6401fceae3241062L267-L274)`)…P3860, and EIP8024
