### PR TITLE
consensus: fix cascading block-time skew with stall-safe timestamp caps

### DIFF
--- a/consensus/proposer.go
+++ b/consensus/proposer.go
@@ -7,6 +7,71 @@ import (
 	"github.com/harmony-one/harmony/node/harmony/worker"
 )
 
+const (
+	// maxProposerForwardStep mirrors internal/chain.maxBlockTimeStep (12s).
+	// When local wall is only moderately ahead of parent.Time, clamp the
+	// proposed unix time to parent+maxProposerForwardStep so the header stays
+	// inside the engine's per-block step bound relative to that parent.
+	// When wall is far ahead of parent (see stallRecoveryThreshold), do not
+	// clamp so the proposed time can follow local wall (matches engine's
+	// max(parent+step, localWall) step ceiling).
+	maxProposerForwardStep int64 = 12
+	// stallRecoveryThreshold separates the two clamp behaviors above, in
+	// seconds of (localWall - parent.Time). Large gaps often mean no block was
+	// committed for a while (parent time is stale vs this leader's clock), not
+	// only sub-second skew. The threshold is chosen above typical skew but
+	// below multi-minute scales; it is a heuristic, not consensus state.
+	stallRecoveryThreshold int64 = 30
+	// maxProposerCatchupWait caps sleeping until parent.Time+1 when the leader
+	// wall is behind the parent header time. Without a cap, a far-future
+	// parent would block this goroutine for a long time. 17s covers waiting
+	// out a parent timestamp that is still valid under allowedFutureBlockTime
+	// (15s) plus typical inter-second boundary (+1s), on the same machine.
+	maxProposerCatchupWait = 17 * time.Second
+)
+
+// proposalTiming describes the next wait/propose action from the leader's
+// local wall time and parent header unix time only (no chain or peer state).
+// Exactly one mode applies: ready (propose), sleep then retry, or giveUp.
+type proposalTiming struct {
+	// ready: when true, the leader should propose with timestamp = proposeAt.
+	ready     bool
+	proposeAt time.Time
+	// sleep: when non-zero, the leader should sleep for this duration and retry.
+	sleep time.Duration
+	// giveUp: when true, the leader should break out of the retry loop because
+	// the parent timestamp is too far in the future to wait out.
+	giveUp bool
+}
+
+// computeProposalTiming is the pure decision function used by
+// WaitForConsensusReadyV2. Extracted so the timing logic can be unit-tested
+// without spinning up the full consensus stack.
+//
+// Semantics (wall := now.Unix(), parent := parentTime):
+//   - wall <= parent: sleep until parent+1, capped by maxProposerCatchupWait;
+//     if the sleep would exceed the cap, giveUp for this attempt.
+//   - wall > parent+maxProposerForwardStep && wall-parent <= stallRecoveryThreshold:
+//     clamp to parent+maxProposerForwardStep (skew clamp band).
+//   - wall > parent+stallRecoveryThreshold: no clamp; propose at wall.
+//   - else wall > parent && wall <= parent+maxProposerForwardStep: propose at wall.
+func computeProposalTiming(now time.Time, parentTime int64) proposalTiming {
+	timestamp := now.Unix()
+	if timestamp > parentTime+maxProposerForwardStep &&
+		timestamp-parentTime <= stallRecoveryThreshold {
+		timestamp = parentTime + maxProposerForwardStep
+		now = time.Unix(timestamp, 0)
+	}
+	if timestamp <= parentTime {
+		waitFor := time.Unix(parentTime+1, 0).Sub(now)
+		if waitFor > maxProposerCatchupWait {
+			return proposalTiming{giveUp: true}
+		}
+		return proposalTiming{sleep: waitFor}
+	}
+	return proposalTiming{ready: true, proposeAt: now}
+}
+
 type Proposer struct {
 	consensus *Consensus
 }
@@ -40,19 +105,21 @@ func (p *Proposer) WaitForConsensusReadyV2(stopChan chan struct{}, stoppedChan c
 				return
 			case proposal := <-consensus.GetReadySignal():
 				for retryCount := 0; retryCount < 3 && consensus.IsLeader(); retryCount++ {
-					var (
-						currentHeader = p.consensus.Blockchain().CurrentHeader()
-						now           = time.Now()
-						timestamp     = now.Unix()
-						parentTime    = currentHeader.Time().Int64()
-					)
-					if timestamp <= parentTime {
-						// Current time is within the same second as the parent block.
-						// Sleep until the next second so the child timestamp is strictly
-						// greater, satisfying the engine.go validation check.
-						time.Sleep(time.Until(time.Unix(parentTime+1, 0)))
+					currentHeader := p.consensus.Blockchain().CurrentHeader()
+					parentTime := currentHeader.Time().Int64()
+					timing := computeProposalTiming(time.Now(), parentTime)
+					if timing.giveUp {
+						consensus.GetLogger().Warn().
+							Int64("parentTime", parentTime).
+							Int64("now", time.Now().Unix()).
+							Msg("[Proposer] parent timestamp too far ahead, giving up this round")
+						break
+					}
+					if !timing.ready {
+						time.Sleep(timing.sleep)
 						continue
 					}
+					now := timing.proposeAt
 					consensus.GetLogger().Info().
 						Uint64("blockNum", proposal.blockNum).
 						Bool("asyncProposal", proposal.Type == AsyncProposal).

--- a/consensus/proposer.go
+++ b/consensus/proposer.go
@@ -12,16 +12,10 @@ const (
 	// When local wall is only moderately ahead of parent.Time, clamp the
 	// proposed unix time to parent+maxProposerForwardStep so the header stays
 	// inside the engine's per-block step bound relative to that parent.
-	// When wall is far ahead of parent (see stallRecoveryThreshold), do not
+	// When wall is far ahead of parent (above skew-clamp threshold), do not
 	// clamp so the proposed time can follow local wall (matches engine's
 	// max(parent+step, localWall) step ceiling).
 	maxProposerForwardStep int64 = 12
-	// stallRecoveryThreshold separates the two clamp behaviors above, in
-	// seconds of (localWall - parent.Time). Large gaps often mean no block was
-	// committed for a while (parent time is stale vs this leader's clock), not
-	// only sub-second skew. The threshold is chosen above typical skew but
-	// below multi-minute scales; it is a heuristic, not consensus state.
-	stallRecoveryThreshold int64 = 30
 	// maxProposerCatchupWait caps sleeping until parent.Time+1 when the leader
 	// wall is behind the parent header time. Without a cap, a far-future
 	// parent would block this goroutine for a long time. 17s covers waiting
@@ -48,17 +42,23 @@ type proposalTiming struct {
 // WaitForConsensusReadyV2. Extracted so the timing logic can be unit-tested
 // without spinning up the full consensus stack.
 //
-// Semantics (wall := now.Unix(), parent := parentTime):
+// When timestampValidation is false (before TimestampValidationEpoch), only the
+// legacy sleep-until-parent+1 behavior applies.
+//
+// When timestampValidation is true (wall := now.Unix(), parent := parentTime):
 //   - wall <= parent: sleep until parent+1, capped by maxProposerCatchupWait;
 //     if the sleep would exceed the cap, giveUp for this attempt.
-//   - wall > parent+maxProposerForwardStep && wall-parent <= stallRecoveryThreshold:
+//   - wall > parent+maxProposerForwardStep && wall-parent <= skewClampThreshold:
 //     clamp to parent+maxProposerForwardStep (skew clamp band).
-//   - wall > parent+stallRecoveryThreshold: no clamp; propose at wall.
+//   - wall > parent+skewClampThreshold: no clamp; propose at wall (stall recovery).
 //   - else wall > parent && wall <= parent+maxProposerForwardStep: propose at wall.
-func computeProposalTiming(now time.Time, parentTime int64) proposalTiming {
+func computeProposalTiming(now time.Time, parentTime int64, skewClampThreshold int64, timestampValidation bool) proposalTiming {
+	if !timestampValidation {
+		return computeLegacyProposalTiming(now, parentTime)
+	}
 	timestamp := now.Unix()
 	if timestamp > parentTime+maxProposerForwardStep &&
-		timestamp-parentTime <= stallRecoveryThreshold {
+		timestamp-parentTime <= skewClampThreshold {
 		timestamp = parentTime + maxProposerForwardStep
 		now = time.Unix(timestamp, 0)
 	}
@@ -68,6 +68,16 @@ func computeProposalTiming(now time.Time, parentTime int64) proposalTiming {
 			return proposalTiming{giveUp: true}
 		}
 		return proposalTiming{sleep: waitFor}
+	}
+	return proposalTiming{ready: true, proposeAt: now}
+}
+
+// computeLegacyProposalTiming is the pre-TimestampValidationEpoch leader behavior:
+// sleep until parent+1 when wall is not past parent, otherwise propose at wall.
+func computeLegacyProposalTiming(now time.Time, parentTime int64) proposalTiming {
+	timestamp := now.Unix()
+	if timestamp <= parentTime {
+		return proposalTiming{sleep: time.Unix(parentTime+1, 0).Sub(now)}
 	}
 	return proposalTiming{ready: true, proposeAt: now}
 }
@@ -107,7 +117,11 @@ func (p *Proposer) WaitForConsensusReadyV2(stopChan chan struct{}, stoppedChan c
 				for retryCount := 0; retryCount < 3 && consensus.IsLeader(); retryCount++ {
 					currentHeader := p.consensus.Blockchain().CurrentHeader()
 					parentTime := currentHeader.Time().Int64()
-					timing := computeProposalTiming(time.Now(), parentTime)
+					chainConfig := p.consensus.Blockchain().Config()
+					epoch := currentHeader.Epoch()
+					timestampValidation := chainConfig != nil && chainConfig.IsTimestampValidation(epoch)
+					skewClamp := int64(viewChangeSlot)
+					timing := computeProposalTiming(time.Now(), parentTime, skewClamp, timestampValidation)
 					if timing.giveUp {
 						consensus.GetLogger().Warn().
 							Int64("parentTime", parentTime).

--- a/consensus/proposer_test.go
+++ b/consensus/proposer_test.go
@@ -1,0 +1,288 @@
+package consensus
+
+import (
+	"testing"
+	"time"
+)
+
+// allowSlack absorbs sub-second drift between the test's "now" and the
+// computed time. The proposer logic operates on whole-second Unix timestamps,
+// so off-by-one-second comparisons are expected at boundaries; we tolerate up
+// to 1.5 s of slack on sleep durations.
+const proposerTestSleepSlack = 1500 * time.Millisecond
+
+// fixedNow returns a time.Time at the given Unix second so tests are
+// deterministic and not subject to whatever the runtime clock happens to be.
+func fixedNow(unixSec int64) time.Time {
+	return time.Unix(unixSec, 0)
+}
+
+func TestComputeProposalTiming_ReadyCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		parentTime  int64
+		wallOffset  int64 // wall = parent + wallOffset
+		wantTimestamp int64 // expected proposeAt.Unix()
+	}{
+		{"one_second_after_parent", 1000, 1, 1001},
+		{"two_second_after_parent_normal", 1000, 2, 1002},
+		{"five_second_after_parent", 1000, 5, 1005},
+		{"at_step_boundary_no_clamp", 1000, maxProposerForwardStep, 1000 + maxProposerForwardStep},
+		// > step but <= threshold → clamp to parent+step
+		{"just_past_step_clamps", 1000, maxProposerForwardStep + 1, 1000 + maxProposerForwardStep},
+		{"plus_15s_skew_clamps", 1000, 17, 1000 + maxProposerForwardStep},
+		{"at_stall_threshold_clamps", 1000, stallRecoveryThreshold, 1000 + maxProposerForwardStep},
+		// > threshold → stall recovery, NO clamp, propose at wall
+		{"just_past_threshold_no_clamp", 1000, stallRecoveryThreshold + 1, 1000 + stallRecoveryThreshold + 1},
+		{"short_stall_propose_at_wall", 1000, 60, 1060},
+		{"five_minute_stall_propose_at_wall", 1000, 300, 1300},
+		{"one_hour_stall_propose_at_wall", 1000, 3600, 4600},
+		{"one_day_stall_propose_at_wall", 1000, 86400, 87400},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			now := fixedNow(tc.parentTime + tc.wallOffset)
+			d := computeProposalTiming(now, tc.parentTime)
+			if !d.ready {
+				t.Fatalf("expected ready, got %+v", d)
+			}
+			if d.giveUp {
+				t.Fatalf("expected !giveUp, got %+v", d)
+			}
+			if d.sleep != 0 {
+				t.Fatalf("expected zero sleep, got %v", d.sleep)
+			}
+			if got := d.proposeAt.Unix(); got != tc.wantTimestamp {
+				t.Fatalf("proposeAt = %d, want %d", got, tc.wantTimestamp)
+			}
+		})
+	}
+}
+
+func TestComputeProposalTiming_SleepCases(t *testing.T) {
+	tests := []struct {
+		name           string
+		parentTime     int64
+		wallOffset     int64 // negative or zero
+		wantSleepLower time.Duration
+		wantSleepUpper time.Duration
+	}{
+		{
+			name:           "wall_equals_parent_sleep_1s",
+			parentTime:     1000,
+			wallOffset:     0,
+			wantSleepLower: 1 * time.Second,
+			wantSleepUpper: 1 * time.Second,
+		},
+		{
+			name:           "wall_one_before_parent_sleep_2s",
+			parentTime:     1000,
+			wallOffset:     -1,
+			wantSleepLower: 2 * time.Second,
+			wantSleepUpper: 2 * time.Second,
+		},
+		{
+			name:           "wall_five_before_parent_sleep_6s",
+			parentTime:     1000,
+			wallOffset:     -5,
+			wantSleepLower: 6 * time.Second,
+			wantSleepUpper: 6 * time.Second,
+		},
+		{
+			name:           "wall_ten_before_parent_sleep_11s",
+			parentTime:     1000,
+			wallOffset:     -10,
+			wantSleepLower: 11 * time.Second,
+			wantSleepUpper: 11 * time.Second,
+		},
+		{
+			name:           "at_catchup_cap_boundary",
+			parentTime:     1000,
+			wallOffset:     -(int64(maxProposerCatchupWait.Seconds()) - 1),
+			wantSleepLower: maxProposerCatchupWait,
+			wantSleepUpper: maxProposerCatchupWait,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			now := fixedNow(tc.parentTime + tc.wallOffset)
+			d := computeProposalTiming(now, tc.parentTime)
+			if d.ready {
+				t.Fatalf("expected !ready, got %+v", d)
+			}
+			if d.giveUp {
+				t.Fatalf("expected !giveUp, got %+v", d)
+			}
+			if d.sleep < tc.wantSleepLower-proposerTestSleepSlack ||
+				d.sleep > tc.wantSleepUpper+proposerTestSleepSlack {
+				t.Fatalf("sleep = %v, want in [%v, %v]",
+					d.sleep, tc.wantSleepLower, tc.wantSleepUpper)
+			}
+		})
+	}
+}
+
+func TestComputeProposalTiming_GiveUpCases(t *testing.T) {
+	tests := []struct {
+		name       string
+		parentTime int64
+		wallOffset int64 // must yield wait > maxProposerCatchupWait
+	}{
+		{
+			name:       "wait_one_past_cap_gives_up",
+			parentTime: 1000,
+			wallOffset: -(int64(maxProposerCatchupWait.Seconds()) + 1),
+		},
+		{
+			name:       "wait_thirty_seconds_gives_up",
+			parentTime: 1000,
+			wallOffset: -30,
+		},
+		{
+			name:       "wait_one_minute_gives_up",
+			parentTime: 1000,
+			wallOffset: -60,
+		},
+		{
+			name:       "wait_one_hour_gives_up",
+			parentTime: 1000,
+			wallOffset: -3600,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			now := fixedNow(tc.parentTime + tc.wallOffset)
+			d := computeProposalTiming(now, tc.parentTime)
+			if !d.giveUp {
+				t.Fatalf("expected giveUp, got %+v", d)
+			}
+			if d.ready {
+				t.Fatalf("expected !ready, got %+v", d)
+			}
+			if d.sleep != 0 {
+				t.Fatalf("expected zero sleep on give-up, got %v", d.sleep)
+			}
+		})
+	}
+}
+
+// TestComputeProposalTiming_ClampVsStallBoundary pins down the exact
+// transition between "clamp to parent+step" and "propose at wall".
+func TestComputeProposalTiming_ClampVsStallBoundary(t *testing.T) {
+	parentTime := int64(1000)
+	step := maxProposerForwardStep
+	threshold := stallRecoveryThreshold
+
+	// At threshold (inclusive): clamp.
+	at := computeProposalTiming(fixedNow(parentTime+threshold), parentTime)
+	if !at.ready || at.proposeAt.Unix() != parentTime+step {
+		t.Fatalf("at threshold: expected clamp to parent+step (%d), got %+v",
+			parentTime+step, at)
+	}
+
+	// One past threshold: no clamp, propose at wall.
+	past := computeProposalTiming(fixedNow(parentTime+threshold+1), parentTime)
+	if !past.ready || past.proposeAt.Unix() != parentTime+threshold+1 {
+		t.Fatalf("past threshold: expected no clamp (propose at %d), got %+v",
+			parentTime+threshold+1, past)
+	}
+}
+
+// TestComputeProposalTiming_AdversarialSkewedLeaderClamps verifies a +15s
+// clock-skewed leader's proposed timestamp gets clamped to parent+step so
+// honest validators (with synced clocks) will accept the block.
+func TestComputeProposalTiming_AdversarialSkewedLeaderClamps(t *testing.T) {
+	parentTime := int64(1000)
+	// Simulate a leader 15s ahead of real time, with parent freshly produced.
+	skewedNow := fixedNow(parentTime + 15)
+
+	d := computeProposalTiming(skewedNow, parentTime)
+	if !d.ready {
+		t.Fatalf("expected ready, got %+v", d)
+	}
+	if d.proposeAt.Unix() != parentTime+maxProposerForwardStep {
+		t.Fatalf("expected clamp to parent+step (%d), got %d",
+			parentTime+maxProposerForwardStep, d.proposeAt.Unix())
+	}
+}
+
+// TestComputeProposalTiming_FastStallRecovery verifies that a long stall
+// produces a block at wall clock (single-block recovery), not a clamped
+// block that would take many rounds to catch up.
+func TestComputeProposalTiming_FastStallRecovery(t *testing.T) {
+	parentTime := int64(1000)
+	// 5-minute stall.
+	wall := parentTime + 300
+	d := computeProposalTiming(fixedNow(wall), parentTime)
+	if !d.ready {
+		t.Fatalf("expected ready, got %+v", d)
+	}
+	if d.proposeAt.Unix() != wall {
+		t.Fatalf("expected propose at wall (%d) for stall recovery, got %d",
+			wall, d.proposeAt.Unix())
+	}
+}
+
+// TestComputeProposalTiming_CascadingAftermath verifies that when parent is
+// slightly in the future of wall (after a cascading-skew round), the proposer
+// sleeps the right amount and the wait is within the catch-up cap.
+func TestComputeProposalTiming_CascadingAftermath(t *testing.T) {
+	parentTime := int64(1000)
+	// Honest leader's wall is BlockPeriod (2s) after the prior tick, but parent
+	// was produced by a +10s-skewed leader.
+	wall := parentTime - 8 // need to wait 9s for wall to exceed parent
+	d := computeProposalTiming(fixedNow(wall), parentTime)
+	if d.ready || d.giveUp {
+		t.Fatalf("expected sleep path, got %+v", d)
+	}
+	expected := time.Duration(parentTime+1-wall) * time.Second
+	if d.sleep != expected {
+		t.Fatalf("expected sleep %v, got %v", expected, d.sleep)
+	}
+	if d.sleep > maxProposerCatchupWait {
+		t.Fatalf("sleep %v exceeds catchup cap %v", d.sleep, maxProposerCatchupWait)
+	}
+}
+
+// TestComputeProposalTiming_HonestRecoveryAfterClampedLeader verifies the
+// honest path after a clamped leader produced parent+step: the next leader's
+// wall should already be at or past parent, so no sleep needed.
+func TestComputeProposalTiming_HonestRecoveryAfterClampedLeader(t *testing.T) {
+	// Previous (skewed) leader was clamped to parentPrev+step.
+	parentPrev := int64(1000)
+	parentTime := parentPrev + maxProposerForwardStep // = 1012
+	// Honest next leader's wall = parentPrev + 2 (BlockPeriod). That is BEHIND
+	// the clamped parent.Time. So proposer must sleep.
+	wall := parentPrev + 2 // = 1002
+	d := computeProposalTiming(fixedNow(wall), parentTime)
+	if d.ready || d.giveUp {
+		t.Fatalf("expected sleep, got %+v", d)
+	}
+	expected := time.Duration(parentTime+1-wall) * time.Second // 11s
+	if d.sleep != expected {
+		t.Fatalf("expected %v sleep, got %v", expected, d.sleep)
+	}
+	// 11s must be within catch-up cap (17s).
+	if d.sleep > maxProposerCatchupWait {
+		t.Fatalf("legitimate cascading aftermath sleep %v exceeds cap %v",
+			d.sleep, maxProposerCatchupWait)
+	}
+}
+
+// TestComputeProposalTiming_ConstantsAlignWithEngine pins down the relation
+// between the proposer constants and the engine's maxBlockTimeStep. If these
+// drift apart we get cross-version validation mismatches.
+func TestComputeProposalTiming_ConstantsAlignWithEngine(t *testing.T) {
+	if maxProposerForwardStep <= 0 {
+		t.Fatalf("maxProposerForwardStep must be positive, got %d", maxProposerForwardStep)
+	}
+	if stallRecoveryThreshold <= maxProposerForwardStep {
+		t.Fatalf("stallRecoveryThreshold (%d) must exceed maxProposerForwardStep (%d)",
+			stallRecoveryThreshold, maxProposerForwardStep)
+	}
+	if maxProposerCatchupWait < time.Duration(maxProposerForwardStep)*time.Second {
+		t.Fatalf("maxProposerCatchupWait (%v) must be >= maxProposerForwardStep seconds (%ds) "+
+			"to handle worst-case cascading-skew aftermath",
+			maxProposerCatchupWait, maxProposerForwardStep)
+	}
+}

--- a/consensus/proposer_test.go
+++ b/consensus/proposer_test.go
@@ -18,6 +18,7 @@ func fixedNow(unixSec int64) time.Time {
 }
 
 func TestComputeProposalTiming_ReadyCases(t *testing.T) {
+	skewClamp := int64(viewChangeSlot)
 	tests := []struct {
 		name          string
 		parentTime    int64
@@ -31,9 +32,9 @@ func TestComputeProposalTiming_ReadyCases(t *testing.T) {
 		// > step but <= threshold → clamp to parent+step
 		{"just_past_step_clamps", 1000, maxProposerForwardStep + 1, 1000 + maxProposerForwardStep},
 		{"plus_15s_skew_clamps", 1000, 17, 1000 + maxProposerForwardStep},
-		{"at_stall_threshold_clamps", 1000, stallRecoveryThreshold, 1000 + maxProposerForwardStep},
+		{"at_stall_threshold_clamps", 1000, skewClamp, 1000 + maxProposerForwardStep},
 		// > threshold → stall recovery, NO clamp, propose at wall
-		{"just_past_threshold_no_clamp", 1000, stallRecoveryThreshold + 1, 1000 + stallRecoveryThreshold + 1},
+		{"just_past_threshold_no_clamp", 1000, skewClamp + 1, 1000 + skewClamp + 1},
 		{"short_stall_propose_at_wall", 1000, 60, 1060},
 		{"five_minute_stall_propose_at_wall", 1000, 300, 1300},
 		{"one_hour_stall_propose_at_wall", 1000, 3600, 4600},
@@ -42,7 +43,7 @@ func TestComputeProposalTiming_ReadyCases(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			now := fixedNow(tc.parentTime + tc.wallOffset)
-			d := computeProposalTiming(now, tc.parentTime)
+			d := computeProposalTiming(now, tc.parentTime, skewClamp, true)
 			if !d.ready {
 				t.Fatalf("expected ready, got %+v", d)
 			}
@@ -60,6 +61,7 @@ func TestComputeProposalTiming_ReadyCases(t *testing.T) {
 }
 
 func TestComputeProposalTiming_SleepCases(t *testing.T) {
+	skewClamp := int64(viewChangeSlot)
 	tests := []struct {
 		name           string
 		parentTime     int64
@@ -106,7 +108,7 @@ func TestComputeProposalTiming_SleepCases(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			now := fixedNow(tc.parentTime + tc.wallOffset)
-			d := computeProposalTiming(now, tc.parentTime)
+			d := computeProposalTiming(now, tc.parentTime, skewClamp, true)
 			if d.ready {
 				t.Fatalf("expected !ready, got %+v", d)
 			}
@@ -123,6 +125,7 @@ func TestComputeProposalTiming_SleepCases(t *testing.T) {
 }
 
 func TestComputeProposalTiming_GiveUpCases(t *testing.T) {
+	skewClamp := int64(viewChangeSlot)
 	tests := []struct {
 		name       string
 		parentTime int64
@@ -152,7 +155,7 @@ func TestComputeProposalTiming_GiveUpCases(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			now := fixedNow(tc.parentTime + tc.wallOffset)
-			d := computeProposalTiming(now, tc.parentTime)
+			d := computeProposalTiming(now, tc.parentTime, skewClamp, true)
 			if !d.giveUp {
 				t.Fatalf("expected giveUp, got %+v", d)
 			}
@@ -171,17 +174,17 @@ func TestComputeProposalTiming_GiveUpCases(t *testing.T) {
 func TestComputeProposalTiming_ClampVsStallBoundary(t *testing.T) {
 	parentTime := int64(1000)
 	step := maxProposerForwardStep
-	threshold := stallRecoveryThreshold
+	threshold := int64(viewChangeSlot)
 
 	// At threshold (inclusive): clamp.
-	at := computeProposalTiming(fixedNow(parentTime+threshold), parentTime)
+	at := computeProposalTiming(fixedNow(parentTime+threshold), parentTime, threshold, true)
 	if !at.ready || at.proposeAt.Unix() != parentTime+step {
 		t.Fatalf("at threshold: expected clamp to parent+step (%d), got %+v",
 			parentTime+step, at)
 	}
 
 	// One past threshold: no clamp, propose at wall.
-	past := computeProposalTiming(fixedNow(parentTime+threshold+1), parentTime)
+	past := computeProposalTiming(fixedNow(parentTime+threshold+1), parentTime, threshold, true)
 	if !past.ready || past.proposeAt.Unix() != parentTime+threshold+1 {
 		t.Fatalf("past threshold: expected no clamp (propose at %d), got %+v",
 			parentTime+threshold+1, past)
@@ -193,10 +196,9 @@ func TestComputeProposalTiming_ClampVsStallBoundary(t *testing.T) {
 // honest validators (with synced clocks) will accept the block.
 func TestComputeProposalTiming_AdversarialSkewedLeaderClamps(t *testing.T) {
 	parentTime := int64(1000)
-	// Simulate a leader 15s ahead of real time, with parent freshly produced.
 	skewedNow := fixedNow(parentTime + 15)
 
-	d := computeProposalTiming(skewedNow, parentTime)
+	d := computeProposalTiming(skewedNow, parentTime, int64(viewChangeSlot), true)
 	if !d.ready {
 		t.Fatalf("expected ready, got %+v", d)
 	}
@@ -211,9 +213,8 @@ func TestComputeProposalTiming_AdversarialSkewedLeaderClamps(t *testing.T) {
 // block that would take many rounds to catch up.
 func TestComputeProposalTiming_FastStallRecovery(t *testing.T) {
 	parentTime := int64(1000)
-	// 5-minute stall.
 	wall := parentTime + 300
-	d := computeProposalTiming(fixedNow(wall), parentTime)
+	d := computeProposalTiming(fixedNow(wall), parentTime, int64(viewChangeSlot), true)
 	if !d.ready {
 		t.Fatalf("expected ready, got %+v", d)
 	}
@@ -223,15 +224,51 @@ func TestComputeProposalTiming_FastStallRecovery(t *testing.T) {
 	}
 }
 
+// TestComputeProposalTiming_SkewClampBand verifies +42s skew clamps with
+// viewChangeSlot threshold instead of using stall recovery.
+func TestComputeProposalTiming_SkewClampBand(t *testing.T) {
+	parentTime := int64(1000)
+	threshold := int64(viewChangeSlot)
+
+	d := computeProposalTiming(fixedNow(parentTime+42), parentTime, threshold, true)
+	if !d.ready || d.proposeAt.Unix() != parentTime+maxProposerForwardStep {
+		t.Fatalf("+42s: expected clamp to %d, got %+v",
+			parentTime+maxProposerForwardStep, d)
+	}
+
+	d = computeProposalTiming(fixedNow(parentTime+46), parentTime, threshold, true)
+	if !d.ready || d.proposeAt.Unix() != parentTime+46 {
+		t.Fatalf("+46s: expected wall, got %+v", d)
+	}
+}
+
+// TestComputeProposalTiming_LegacyBeforeFork matches pre-fork leader behavior.
+func TestComputeProposalTiming_LegacyBeforeFork(t *testing.T) {
+	parentTime := int64(1000)
+
+	// No clamp even with large positive skew.
+	d := computeProposalTiming(fixedNow(parentTime+42), parentTime, 0, false)
+	if !d.ready || d.proposeAt.Unix() != parentTime+42 {
+		t.Fatalf("legacy +42s: expected wall, got %+v", d)
+	}
+
+	// Sleep without give-up cap when far behind parent.
+	d = computeProposalTiming(fixedNow(parentTime-60), parentTime, 0, false)
+	if d.ready || d.giveUp {
+		t.Fatalf("legacy -60s: expected sleep, got %+v", d)
+	}
+	if d.sleep != 61*time.Second {
+		t.Fatalf("legacy sleep = %v, want 61s", d.sleep)
+	}
+}
+
 // TestComputeProposalTiming_CascadingAftermath verifies that when parent is
 // slightly in the future of wall (after a cascading-skew round), the proposer
 // sleeps the right amount and the wait is within the catch-up cap.
 func TestComputeProposalTiming_CascadingAftermath(t *testing.T) {
 	parentTime := int64(1000)
-	// Honest leader's wall is BlockPeriod (2s) after the prior tick, but parent
-	// was produced by a +10s-skewed leader.
-	wall := parentTime - 8 // need to wait 9s for wall to exceed parent
-	d := computeProposalTiming(fixedNow(wall), parentTime)
+	wall := parentTime - 8
+	d := computeProposalTiming(fixedNow(wall), parentTime, int64(viewChangeSlot), true)
 	if d.ready || d.giveUp {
 		t.Fatalf("expected sleep path, got %+v", d)
 	}
@@ -248,21 +285,17 @@ func TestComputeProposalTiming_CascadingAftermath(t *testing.T) {
 // honest path after a clamped leader produced parent+step: the next leader's
 // wall should already be at or past parent, so no sleep needed.
 func TestComputeProposalTiming_HonestRecoveryAfterClampedLeader(t *testing.T) {
-	// Previous (skewed) leader was clamped to parentPrev+step.
 	parentPrev := int64(1000)
-	parentTime := parentPrev + maxProposerForwardStep // = 1012
-	// Honest next leader's wall = parentPrev + 2 (BlockPeriod). That is BEHIND
-	// the clamped parent.Time. So proposer must sleep.
-	wall := parentPrev + 2 // = 1002
-	d := computeProposalTiming(fixedNow(wall), parentTime)
+	parentTime := parentPrev + maxProposerForwardStep
+	wall := parentPrev + 2
+	d := computeProposalTiming(fixedNow(wall), parentTime, int64(viewChangeSlot), true)
 	if d.ready || d.giveUp {
 		t.Fatalf("expected sleep, got %+v", d)
 	}
-	expected := time.Duration(parentTime+1-wall) * time.Second // 11s
+	expected := time.Duration(parentTime+1-wall) * time.Second
 	if d.sleep != expected {
 		t.Fatalf("expected %v sleep, got %v", expected, d.sleep)
 	}
-	// 11s must be within catch-up cap (17s).
 	if d.sleep > maxProposerCatchupWait {
 		t.Fatalf("legitimate cascading aftermath sleep %v exceeds cap %v",
 			d.sleep, maxProposerCatchupWait)
@@ -276,9 +309,9 @@ func TestComputeProposalTiming_ConstantsAlignWithEngine(t *testing.T) {
 	if maxProposerForwardStep <= 0 {
 		t.Fatalf("maxProposerForwardStep must be positive, got %d", maxProposerForwardStep)
 	}
-	if stallRecoveryThreshold <= maxProposerForwardStep {
-		t.Fatalf("stallRecoveryThreshold (%d) must exceed maxProposerForwardStep (%d)",
-			stallRecoveryThreshold, maxProposerForwardStep)
+	if int64(viewChangeSlot) <= maxProposerForwardStep {
+		t.Fatalf("viewChangeSlot (%d) must exceed maxProposerForwardStep (%d)",
+			viewChangeSlot, maxProposerForwardStep)
 	}
 	if maxProposerCatchupWait < time.Duration(maxProposerForwardStep)*time.Second {
 		t.Fatalf("maxProposerCatchupWait (%v) must be >= maxProposerForwardStep seconds (%ds) "+

--- a/consensus/proposer_test.go
+++ b/consensus/proposer_test.go
@@ -19,9 +19,9 @@ func fixedNow(unixSec int64) time.Time {
 
 func TestComputeProposalTiming_ReadyCases(t *testing.T) {
 	tests := []struct {
-		name        string
-		parentTime  int64
-		wallOffset  int64 // wall = parent + wallOffset
+		name          string
+		parentTime    int64
+		wallOffset    int64 // wall = parent + wallOffset
 		wantTimestamp int64 // expected proposeAt.Unix()
 	}{
 		{"one_second_after_parent", 1000, 1, 1001},

--- a/consensus/view_change.go
+++ b/consensus/view_change.go
@@ -13,6 +13,7 @@ import (
 	"github.com/harmony-one/harmony/crypto/bls"
 	"github.com/harmony-one/harmony/internal/chain"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
+	"github.com/harmony-one/harmony/internal/params"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p"
 	"github.com/harmony-one/harmony/shard"
@@ -76,6 +77,27 @@ func (pm *State) fallbackNextViewID() (uint64, time.Duration) {
 	return pm.GetViewChangingID() + 1, time.Duration(diff * diff * int64(viewChangeDuration))
 }
 
+// effectiveViewChangeTimestamp returns the wall time used to advance view ID.
+// When timestamp validation is active and local wall is behind block time (e.g.
+// after a skewed leader committed a far-future header), use block time so all
+// validators stay on the deterministic path instead of fallbackNextViewID.
+func effectiveViewChangeTimestamp(curTimestamp, blockTimestamp int64, timestampValidation bool) int64 {
+	if timestampValidation && curTimestamp <= blockTimestamp {
+		return blockTimestamp
+	}
+	return curTimestamp
+}
+
+// viewChangeTimestampDiff returns the slot-based diff for getNextViewID. The
+// second return is false when legacy rules require fallbackNextViewID.
+func viewChangeTimestampDiff(curTimestamp, blockTimestamp int64, timestampValidation bool) (uint64, bool) {
+	if !timestampValidation && curTimestamp <= blockTimestamp {
+		return 0, false
+	}
+	effective := effectiveViewChangeTimestamp(curTimestamp, blockTimestamp, timestampValidation)
+	return uint64((effective-blockTimestamp)/viewChangeSlot + 1), true
+}
+
 // getNextViewID return the next view ID based on the timestamp
 // The next view ID is calculated based on the difference of validator's timestamp
 // and the block's timestamp. So that it can be deterministic to return the next view ID
@@ -86,30 +108,29 @@ func (pm *State) fallbackNextViewID() (uint64, time.Duration) {
 // The view change duration is a fixed duration now to avoid stuck into offline nodes during
 // the view change.
 // viewID is only used as the fallback mechansim to determine the nextViewID
-func (pm *State) getNextViewID(curHeader *block.Header) (uint64, time.Duration) {
+func (pm *State) getNextViewID(curHeader *block.Header, chainConfig *params.ChainConfig) (uint64, time.Duration) {
 	if curHeader == nil {
 		return pm.fallbackNextViewID()
 	}
 	blockTimestamp := curHeader.Time().Int64()
 	stuckBlockViewID := curHeader.ViewID().Uint64() + 1
 	curTimestamp := time.Now().Unix()
+	timestampValidation := chainConfig != nil && chainConfig.IsTimestampValidation(curHeader.Epoch())
 
-	// timestamp messed up in current validator node
-	if curTimestamp <= blockTimestamp {
+	diff, ok := viewChangeTimestampDiff(curTimestamp, blockTimestamp, timestampValidation)
+	if !ok {
 		pm.getLogger().Error().
 			Int64("curTimestamp", curTimestamp).
 			Int64("blockTimestamp", blockTimestamp).
 			Msg("[getNextViewID] timestamp of block too high")
 		return pm.fallbackNextViewID()
 	}
-	// diff only increases, since view change timeout is shorter than
-	// view change slot now, we want to make sure diff is always greater than 0
-	diff := uint64((curTimestamp-blockTimestamp)/viewChangeSlot + 1)
 	nextViewID := diff + stuckBlockViewID
 
 	pm.getLogger().Info().
 		Int64("curTimestamp", curTimestamp).
 		Int64("blockTimestamp", blockTimestamp).
+		Bool("timestampValidation", timestampValidation).
 		Uint64("nextViewID", nextViewID).
 		Uint64("stuckBlockViewID", stuckBlockViewID).
 		Msg("[getNextViewID]")
@@ -226,7 +247,7 @@ func (consensus *Consensus) startViewChange() {
 	consensus.consensusTimeout[timeoutBootstrap].Stop()
 	consensus.current.SetMode(ViewChanging)
 	curHeader := consensus.Blockchain().CurrentHeader()
-	nextViewID, duration := consensus.current.getNextViewID(curHeader)
+	nextViewID, duration := consensus.current.getNextViewID(curHeader, consensus.Blockchain().Config())
 	consensus.setViewChangingID(nextViewID)
 	epoch := curHeader.Epoch()
 	ss, err := consensus.Blockchain().ReadShardState(epoch)

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -41,6 +41,10 @@ const (
 	vrfProof         = 96 // 96 bytes proof (bls sig)
 	// Maximum allowed future skew for block timestamps.
 	allowedFutureBlockTime = 15 * time.Second
+	// Maximum amount a block timestamp may advance past its parent (per block).
+	// Caps cascading chain-time drift when leaders skew ahead of peers.
+	// Set above 2× the largest consensus BlockPeriod used in this repo (5s).
+	maxBlockTimeStep = 12 * time.Second
 )
 
 type engineImpl struct {
@@ -75,6 +79,27 @@ func (e *engineImpl) VerifyHeader(chain engine.ChainReader, header *block.Header
 		// Reject blocks that are too far in the future relative to local wall clock.
 		limit := big.NewInt(time.Now().Add(allowedFutureBlockTime).Unix())
 		if header.Time().Cmp(limit) > 0 {
+			return engine.ErrFutureBlock
+		}
+		// Bound per-block forward progression: a single block may not jump more
+		// than maxBlockTimeStep past its parent, relative to this node's local
+		// wall clock at verification time. This limits how far chain time can
+		// ratchet per block when parents were produced with skewed clocks.
+		//
+		// If local wall time already exceeds parent+maxBlockTimeStep, use that
+		// wall time as the step ceiling instead (same clock source as the
+		// allowed-future check above). That way a long header-time gap (e.g.
+		// no blocks for a while) does not force recovery only maxBlockTimeStep
+		// seconds per block.
+		stepLimit := new(big.Int).Add(
+			parentHeader.Time(),
+			big.NewInt(int64(maxBlockTimeStep.Seconds())),
+		)
+		walltime := big.NewInt(time.Now().Unix())
+		if walltime.Cmp(stepLimit) > 0 {
+			stepLimit = walltime
+		}
+		if header.Time().Cmp(stepLimit) > 0 {
 			return engine.ErrFutureBlock
 		}
 	}

--- a/internal/chain/engine_test.go
+++ b/internal/chain/engine_test.go
@@ -542,9 +542,9 @@ func TestVerifyHeaderTimestamp_WallClockFutureLimit(t *testing.T) {
 	skewSec := int64(allowedFutureBlockTime.Seconds())
 
 	tests := []struct {
-		name         string
+		name          string
 		offsetFromNow int64
-		wantErr      error
+		wantErr       error
 	}{
 		// Inside the wall-clock window AND inside the step window (parent==now):
 		{"at_skew_boundary_within_step", skewSec - int64(maxBlockTimeStep.Seconds()), nil},
@@ -675,10 +675,10 @@ func TestVerifyHeaderTimestamp_ParentAheadOfWall(t *testing.T) {
 	now := time.Now().Unix()
 
 	tests := []struct {
-		name      string
+		name        string
 		parentAhead int64 // parent.Time = now + parentAhead
-		headerTime int64 // header.Time absolute (computed lazily below)
-		wantErr   error
+		headerTime  int64 // header.Time absolute (computed lazily below)
+		wantErr     error
 	}{
 		// parent = now+5: step arm allows parent+12 = now+17; wall arm allows now+15.
 		// header at now+15 should be rejected by step arm? No — step is parent+12=now+17 ≥ now+15 ✓.
@@ -691,9 +691,9 @@ func TestVerifyHeaderTimestamp_ParentAheadOfWall(t *testing.T) {
 	}
 
 	// fill in headerTime values that depend on `now`
-	tests[0].headerTime = now + 15            // wall+15 exactly
-	tests[1].headerTime = now + 16            // one past wall+15
-	tests[2].headerTime = now + 5 + 13        // parent+13 also > wall+15 but also fails step
+	tests[0].headerTime = now + 15     // wall+15 exactly
+	tests[1].headerTime = now + 16     // one past wall+15
+	tests[2].headerTime = now + 5 + 13 // parent+13 also > wall+15 but also fails step
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/chain/engine_test.go
+++ b/internal/chain/engine_test.go
@@ -469,3 +469,284 @@ func TestVerifyHeaderTimestampValidationBackwardCompatibleBeforeFork(t *testing.
 		t.Fatalf("expected future timestamp allowed pre-fork, got %v", err)
 	}
 }
+
+// setupTimestampValidationChain returns a chain wired with the timestamp
+// validation fork active, the parent header committed at parentTime, and a
+// helper to build child headers parented to it.
+func setupTimestampValidationChain(t *testing.T, parentTime int64) (
+	*fakeBlockChain, *engineImpl, func(ts int64) *block.Header,
+) {
+	t.Helper()
+	chain := makeFakeBlockChain()
+	eng := NewEngine()
+
+	// Force fork active for any epoch >= 0.
+	chain.config.TimestampValidationEpoch = big.NewInt(0)
+
+	parent := blockfactory.NewTestHeader()
+	parent.SetNumber(big.NewInt(doubleSignBlockNumber))
+	parent.SetEpoch(big.NewInt(currentEpoch))
+	parent.SetTime(big.NewInt(parentTime))
+	chain.currentBlock = *types.NewBlockWithHeader(parent)
+	parent = chain.CurrentHeader()
+
+	mkChild := func(ts int64) *block.Header {
+		h := blockfactory.NewTestHeader()
+		h.SetParentHash(parent.Hash())
+		h.SetNumber(new(big.Int).Add(parent.Number(), big.NewInt(1)))
+		h.SetEpoch(parent.Epoch())
+		h.SetTime(big.NewInt(ts))
+		return h
+	}
+	return chain, eng, mkChild
+}
+
+// TestVerifyHeaderTimestamp_Monotonic covers the strict-monotonic rule
+// (header.Time MUST be > parent.Time) at the boundary.
+func TestVerifyHeaderTimestamp_Monotonic(t *testing.T) {
+	now := time.Now().Unix()
+	chain, eng, mkChild := setupTimestampValidationChain(t, now)
+
+	tests := []struct {
+		name        string
+		headerTime  int64
+		expectError bool
+	}{
+		{"equal_to_parent_rejected", now, true},
+		{"one_below_parent_rejected", now - 1, true},
+		{"far_below_parent_rejected", now - 1000, true},
+		{"one_above_parent_accepted", now + 1, false},
+		{"small_step_accepted", now + 2, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := eng.VerifyHeader(chain, mkChild(tc.headerTime), false)
+			if tc.expectError && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.expectError && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+// TestVerifyHeaderTimestamp_WallClockFutureLimit covers the
+// allowedFutureBlockTime ceiling (header.Time MUST be <= now + 15s).
+func TestVerifyHeaderTimestamp_WallClockFutureLimit(t *testing.T) {
+	// Parent right at wall clock so the wall-clock arm is the binding constraint
+	// rather than the step arm. (parent + maxStep would otherwise be tighter.)
+	now := time.Now().Unix()
+	chain, eng, mkChild := setupTimestampValidationChain(t, now)
+
+	skewSec := int64(allowedFutureBlockTime.Seconds())
+
+	tests := []struct {
+		name         string
+		offsetFromNow int64
+		wantErr      error
+	}{
+		// Inside the wall-clock window AND inside the step window (parent==now):
+		{"at_skew_boundary_within_step", skewSec - int64(maxBlockTimeStep.Seconds()), nil},
+		// Beyond wall-clock window must be ErrFutureBlock.
+		{"one_past_skew_rejected", skewSec + 1, engine.ErrFutureBlock},
+		{"far_past_skew_rejected", skewSec + 60, engine.ErrFutureBlock},
+		{"way_in_future_rejected", 3600, engine.ErrFutureBlock},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := eng.VerifyHeader(chain, mkChild(now+tc.offsetFromNow), false)
+			if tc.wantErr == nil && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if tc.wantErr != nil && err != tc.wantErr {
+				t.Fatalf("expected %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// TestVerifyHeaderTimestamp_StepLimitNormalOp exercises the per-block
+// forward-step bound when parent is roughly aligned with wall clock.
+// In this regime, parent+maxStep is the binding constraint.
+func TestVerifyHeaderTimestamp_StepLimitNormalOp(t *testing.T) {
+	now := time.Now().Unix()
+	// Parent slightly behind wall (typical BlockPeriod gap).
+	parentTime := now - 2
+	chain, eng, mkChild := setupTimestampValidationChain(t, parentTime)
+
+	step := int64(maxBlockTimeStep.Seconds())
+
+	tests := []struct {
+		name       string
+		headerTime int64
+		wantErr    error
+	}{
+		{"one_above_parent", parentTime + 1, nil},
+		{"five_above_parent", parentTime + 5, nil},
+		{"at_step_boundary_accepted", parentTime + step, nil},
+		{"one_past_step_rejected", parentTime + step + 1, engine.ErrFutureBlock},
+		{"well_past_step_rejected", parentTime + step + 5, engine.ErrFutureBlock},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := eng.VerifyHeader(chain, mkChild(tc.headerTime), false)
+			if tc.wantErr == nil && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if tc.wantErr != nil && err != tc.wantErr {
+				t.Fatalf("expected %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// TestVerifyHeaderTimestamp_StallRecovery exercises the wall-aware relaxation
+// of the step limit. When parent is far behind wall (a real network stall),
+// the validator should accept blocks up to current wall clock so chain time
+// catches up in a single block instead of crawling at maxStep/block.
+func TestVerifyHeaderTimestamp_StallRecovery(t *testing.T) {
+	now := time.Now().Unix()
+
+	tests := []struct {
+		name       string
+		stallSec   int64 // how far parent is behind wall
+		headerTime func(parent, wall int64) int64
+		wantErr    error
+	}{
+		{
+			name:       "short_view_change_block_at_wall",
+			stallSec:   30,
+			headerTime: func(_, wall int64) int64 { return wall },
+			wantErr:    nil,
+		},
+		{
+			name:       "five_minute_stall_block_at_wall",
+			stallSec:   300,
+			headerTime: func(_, wall int64) int64 { return wall },
+			wantErr:    nil,
+		},
+		{
+			name:       "one_hour_stall_block_at_wall",
+			stallSec:   3600,
+			headerTime: func(_, wall int64) int64 { return wall },
+			wantErr:    nil,
+		},
+		{
+			name:       "stall_block_below_wall_still_above_parent_step",
+			stallSec:   300,
+			headerTime: func(parent, _ int64) int64 { return parent + 50 },
+			wantErr:    nil,
+		},
+		{
+			name:       "stall_block_at_parent_plus_step",
+			stallSec:   300,
+			headerTime: func(parent, _ int64) int64 { return parent + int64(maxBlockTimeStep.Seconds()) },
+			wantErr:    nil,
+		},
+		{
+			name:       "stall_block_beyond_wall_rejected",
+			stallSec:   300,
+			headerTime: func(_, wall int64) int64 { return wall + int64(allowedFutureBlockTime.Seconds()) + 5 },
+			wantErr:    engine.ErrFutureBlock,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parentTime := now - tc.stallSec
+			chain, eng, mkChild := setupTimestampValidationChain(t, parentTime)
+			err := eng.VerifyHeader(chain, mkChild(tc.headerTime(parentTime, now)), false)
+			if tc.wantErr == nil && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if tc.wantErr != nil && err != tc.wantErr {
+				t.Fatalf("expected %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// TestVerifyHeaderTimestamp_ParentAheadOfWall covers the case where parent is
+// already slightly in the future (e.g., from a previous +skew leader). The
+// max(parent+maxStep, wall) arm yields parent+maxStep, but the wall+15s arm
+// is the actual binding constraint when parent is enough into the future.
+func TestVerifyHeaderTimestamp_ParentAheadOfWall(t *testing.T) {
+	now := time.Now().Unix()
+
+	tests := []struct {
+		name      string
+		parentAhead int64 // parent.Time = now + parentAhead
+		headerTime int64 // header.Time absolute (computed lazily below)
+		wantErr   error
+	}{
+		// parent = now+5: step arm allows parent+12 = now+17; wall arm allows now+15.
+		// header at now+15 should be rejected by step arm? No — step is parent+12=now+17 ≥ now+15 ✓.
+		// And wall arm allows ≤ now+15 ✓. So accepted.
+		{"parent_ahead_within_both_arms", 5, 0 /* set below */, nil},
+		// parent+12 = now+17 > now+15 (wall+15). Reject under wall+15 ceiling.
+		{"parent_ahead_violates_wall_ceiling", 5, 0, engine.ErrFutureBlock},
+		// header at parent+13 violates step arm too.
+		{"parent_ahead_violates_step_arm", 5, 0, engine.ErrFutureBlock},
+	}
+
+	// fill in headerTime values that depend on `now`
+	tests[0].headerTime = now + 15            // wall+15 exactly
+	tests[1].headerTime = now + 16            // one past wall+15
+	tests[2].headerTime = now + 5 + 13        // parent+13 also > wall+15 but also fails step
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parentTime := now + tc.parentAhead
+			chain, eng, mkChild := setupTimestampValidationChain(t, parentTime)
+			err := eng.VerifyHeader(chain, mkChild(tc.headerTime), false)
+			if tc.wantErr == nil && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if tc.wantErr != nil && err != tc.wantErr {
+				t.Fatalf("expected %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// TestVerifyHeaderTimestamp_CascadingSkewBound is the security test: a
+// hypothetical +15s-skewed leader cannot push chain time more than
+// maxBlockTimeStep ahead of parent. The validator (with synced clock) MUST
+// reject the abusive block.
+func TestVerifyHeaderTimestamp_CascadingSkewBound(t *testing.T) {
+	now := time.Now().Unix()
+	parentTime := now - 2 // typical block period gap, parent slightly behind real time
+	chain, eng, mkChild := setupTimestampValidationChain(t, parentTime)
+
+	step := int64(maxBlockTimeStep.Seconds())
+
+	// Honest leader at parent + step is the maximum chain-time advancement.
+	if err := eng.VerifyHeader(chain, mkChild(parentTime+step), false); err != nil {
+		t.Fatalf("expected boundary accept, got %v", err)
+	}
+	// Adversarial leader trying to push chain time +15s above real wall must be
+	// rejected (parent + step is the binding constraint, not wall + 15s).
+	skewedHeader := mkChild(now + int64(allowedFutureBlockTime.Seconds()))
+	if err := eng.VerifyHeader(chain, skewedHeader, false); err != engine.ErrFutureBlock {
+		t.Fatalf("expected ErrFutureBlock for cascading-skew push, got %v", err)
+	}
+}
+
+// TestVerifyHeaderTimestamp_UnknownAncestor verifies the existing precedence
+// of the ErrUnknownAncestor check vs. the new timestamp checks.
+func TestVerifyHeaderTimestamp_UnknownAncestor(t *testing.T) {
+	chain := makeFakeBlockChain()
+	eng := NewEngine()
+	chain.config.TimestampValidationEpoch = big.NewInt(0)
+
+	orphan := blockfactory.NewTestHeader()
+	orphan.SetParentHash(common.HexToHash("0xdead"))
+	orphan.SetNumber(big.NewInt(doubleSignBlockNumber + 1))
+	orphan.SetEpoch(big.NewInt(currentEpoch))
+	orphan.SetTime(big.NewInt(time.Now().Unix()))
+
+	if err := eng.VerifyHeader(chain, orphan, false); err != engine.ErrUnknownAncestor {
+		t.Fatalf("expected ErrUnknownAncestor, got %v", err)
+	}
+}


### PR DESCRIPTION

Harmony already requires each block timestamp to be after its parent’s, and not more than about 15 seconds ahead of the validator’s own clock. That catches obviously bad headers, but it does not stop chain time from jumping forward several seconds in one block when a leader’s clock is fast. The next leader must still pick a time after that parent, so block time can ratchet ahead of real wall time. Peers with slightly slow clocks may reject blocks or wait a long time before they can vote or propose, which hurts liveness and makes view changes messy. If a block with a very high timestamp is already on chain and a node’s clock is still behind that time, view-change logic used to take a non-deterministic fallback path so nodes could disagree on the next leader.

There is no shared network clock. Each node only sees its own `time.Now()` when validating or proposing. This PR keeps using wall clock (same as today’s 15-second rule) but aligns what the leader writes with what other nodes will accept, and limits how far one block can push time past its parent in the common case.

On header verification, when `TimestampValidationEpoch` is active, a block may not advance more than 12 seconds past its parent’s timestamp unless the node’s local time has already moved much further ahead (for example after a long period with no blocks). In that stall case the limit can follow local time so recovery does not take many blocks of tiny steps.

The leader uses matching rules before it proposes. If its clock is only moderately ahead of the parent, it clamps the timestamp so peers are likely to accept the block. If the gap is very large and looks like a real stall rather than mild skew (beyond the 45-second view-change slot band), it may propose at full local time so the chain can catch up in one block. If the leader’s clock is behind the parent time, it still waits until it can use a later second, but it will not sleep without limit; after 17 seconds it gives up that round instead of hanging the proposer.

View change is updated so that when timestamp validation is on, a block time in the future of local wall clock no longer triggers the old fallback for computing the next view ID. Nodes stay on the same deterministic timing path instead of diverging.

Before `TimestampValidationEpoch`, only the older leader behavior remains (sleep until parent+1, no clamp or give-up cap). Engine timestamp checks were already gated on that epoch; proposer and view-change behavior now follow the same gate.

**Notes**
- Constants (12s step, 30s stall heuristic, 17s sleep cap) are paired between engine and proposer; changing one side should be reflected on the other and in tests.
- If mainnet rollout needs a **separate fork flag** instead of piggybacking on `TimestampValidationEpoch`, that can be a follow-up; this PR implements the behavioral fix behind the existing timestamp-validation gate.
