### PR TITLE
staking: bind BLS proof-of-possession to validator address

### DIFF
--- a/core/staking_verifier.go
+++ b/core/staking_verifier.go
@@ -46,6 +46,7 @@ func checkValidatorWrapperAddressBinding(
 func checkDuplicateFields(
 	addrs []common.Address, state vm.StateDB,
 	validator common.Address, identity string, blsKeys []bls.SerializedPublicKey,
+	checkSameBlock bool,
 ) error {
 	checkIdentity := identity != ""
 	checkBlsKeys := len(blsKeys) != 0
@@ -55,22 +56,47 @@ func checkDuplicateFields(
 		blsKeyMap[key] = struct{}{}
 	}
 
+	checked := map[common.Address]struct{}{}
+	checkAddr := func(addr common.Address) error {
+		if bytes.Equal(validator.Bytes(), addr.Bytes()) {
+			return nil
+		}
+		wrapper, err := state.ValidatorWrapper(addr, true, false)
+		if err != nil {
+			return err
+		}
+
+		if checkIdentity && wrapper.Identity == identity {
+			return errors.Wrapf(errDupIdentity, "duplicate identity %s", identity)
+		}
+		if checkBlsKeys {
+			for _, existingKey := range wrapper.SlotPubKeys {
+				if _, ok := blsKeyMap[existingKey]; ok {
+					return errors.Wrapf(errDupBlsKey, "duplicate bls key %x", existingKey)
+				}
+			}
+		}
+		return nil
+	}
+
 	for _, addr := range addrs {
-		if !bytes.Equal(validator.Bytes(), addr.Bytes()) {
-			wrapper, err := state.ValidatorWrapper(addr, true, false)
+		checked[addr] = struct{}{}
+		if err := checkAddr(addr); err != nil {
+			return err
+		}
+	}
 
-			if err != nil {
-				return err
-			}
-
-			if checkIdentity && wrapper.Identity == identity {
-				return errors.Wrapf(errDupIdentity, "duplicate identity %s", identity)
-			}
-			if checkBlsKeys {
-				for _, existingKey := range wrapper.SlotPubKeys {
-					if _, ok := blsKeyMap[existingKey]; ok {
-						return errors.Wrapf(errDupBlsKey, "duplicate bls key %x", existingKey)
-					}
+	if checkSameBlock {
+		if lister, ok := state.(interface {
+			CachedValidatorAddresses() []common.Address
+		}); ok {
+			for _, addr := range lister.CachedValidatorAddresses() {
+				if _, ok := checked[addr]; ok {
+					continue
+				}
+				checked[addr] = struct{}{}
+				if err := checkAddr(addr); err != nil {
+					return err
 				}
 			}
 		}
@@ -112,17 +138,20 @@ func VerifyAndCreateValidatorFromMsg(
 	if err != nil {
 		return nil, err
 	}
+	bindBLSProof := chainContext.Config().IsBLSProofBind(epoch)
 	if err := checkDuplicateFields(
 		addrs, stateDB,
 		msg.ValidatorAddress,
 		msg.Identity,
-		msg.SlotPubKeys); err != nil {
+		msg.SlotPubKeys,
+		bindBLSProof,
+	); err != nil {
 		return nil, err
 	}
 	if !CanTransfer(stateDB, msg.ValidatorAddress, msg.Amount) {
 		return nil, errInsufficientBalanceForStake
 	}
-	v, err := staking.CreateValidatorFromNewMsg(msg, blockNum, epoch)
+	v, err := staking.CreateValidatorFromNewMsg(msg, blockNum, epoch, bindBLSProof)
 	if err != nil {
 		return nil, err
 	}
@@ -168,11 +197,14 @@ func VerifyAndEditValidatorFromMsg(
 	if err != nil {
 		return nil, err
 	}
+	bindBLSProof := chainContext.Config().IsBLSProofBind(epoch)
 	if err := checkDuplicateFields(
 		addrs, stateDB,
 		msg.ValidatorAddress,
 		msg.Identity,
-		newBlsKeys); err != nil {
+		newBlsKeys,
+		bindBLSProof,
+	); err != nil {
 		return nil, err
 	}
 	// request a copy, but delegations are not being changed so do not deep copy them
@@ -180,7 +212,7 @@ func VerifyAndEditValidatorFromMsg(
 	if err != nil {
 		return nil, err
 	}
-	if err := staking.UpdateValidatorFromEditMsg(&wrapper.Validator, msg, epoch); err != nil {
+	if err := staking.UpdateValidatorFromEditMsg(&wrapper.Validator, msg, epoch, bindBLSProof); err != nil {
 		return nil, err
 	}
 	newRate := wrapper.Validator.Rate

--- a/core/staking_verifier_test.go
+++ b/core/staking_verifier_test.go
@@ -195,7 +195,7 @@ func TestCheckDuplicateFields(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = checkDuplicateFields(addrs, test.sdb, test.validator, test.identity, test.pubs)
+		err = checkDuplicateFields(addrs, test.sdb, test.validator, test.identity, test.pubs, false)
 
 		if assErr := assertError(err, test.expErr); assErr != nil {
 			t.Errorf("Test %v: %v", i, assErr)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1284,6 +1284,19 @@ func (db *DB) SetValidatorWrapperAddressBind(enabled bool) {
 	db.validatorWrapperAddressBind = enabled
 }
 
+// CachedValidatorAddresses returns validator addresses loaded or updated in the
+// current state transition. Used to detect duplicate BLS keys among validators
+// created earlier in the same block.
+func (db *DB) CachedValidatorAddresses() []common.Address {
+	addrs := make([]common.Address, 0, len(db.stateValidators))
+	for addr := range db.stateValidators {
+		if db.IsValidator(addr) {
+			addrs = append(addrs, addr)
+		}
+	}
+	return addrs
+}
+
 // ValidatorWrapper retrieves the existing validator in the cache, if sendOriginal
 // else it will return a copy of the wrapper - which needs to be explicitly committed
 // with UpdateValidatorWrapper.

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -99,6 +99,7 @@ var (
 		SlashExternalStakeDenomFixEpoch:       EpochTBD,
 		RejectDuplicateSlashEvidenceEpoch:     EpochTBD,
 		SlashGroupOrderFixEpoch:               EpochTBD,
+		BLSProofBindEpoch:                     EpochTBD,
 	}
 
 	// TestnetChainConfig contains the chain parameters to run a node on the harmony test network.
@@ -166,6 +167,7 @@ var (
 		SlashExternalStakeDenomFixEpoch:       EpochTBD,
 		RejectDuplicateSlashEvidenceEpoch:     EpochTBD,
 		SlashGroupOrderFixEpoch:               EpochTBD,
+		BLSProofBindEpoch:                     EpochTBD,
 	}
 	// PangaeaChainConfig contains the chain parameters for the Pangaea network.
 	// All features except for CrossLink are enabled at launch.
@@ -232,6 +234,7 @@ var (
 		SlashExternalStakeDenomFixEpoch:       EpochTBD,
 		RejectDuplicateSlashEvidenceEpoch:     EpochTBD,
 		SlashGroupOrderFixEpoch:               EpochTBD,
+		BLSProofBindEpoch:                     EpochTBD,
 	}
 
 	// PartnerChainConfig contains the chain parameters for the Partner network.
@@ -300,6 +303,7 @@ var (
 		SlashExternalStakeDenomFixEpoch:       EpochTBD,
 		RejectDuplicateSlashEvidenceEpoch:     EpochTBD,
 		SlashGroupOrderFixEpoch:               EpochTBD,
+		BLSProofBindEpoch:                     EpochTBD,
 	}
 
 	// StressnetChainConfig contains the chain parameters for the Stress test network.
@@ -367,6 +371,7 @@ var (
 		SlashExternalStakeDenomFixEpoch:       EpochTBD,
 		RejectDuplicateSlashEvidenceEpoch:     EpochTBD,
 		SlashGroupOrderFixEpoch:               EpochTBD,
+		BLSProofBindEpoch:                     EpochTBD,
 	}
 
 	// LocalnetChainConfig contains the chain parameters to run for local development.
@@ -433,6 +438,7 @@ var (
 		SlashExternalStakeDenomFixEpoch:       EpochTBD,
 		RejectDuplicateSlashEvidenceEpoch:     big.NewInt(0),
 		SlashGroupOrderFixEpoch:               big.NewInt(2),
+		BLSProofBindEpoch:                     EpochTBD,
 	}
 
 	// AllProtocolChanges ...
@@ -502,6 +508,7 @@ var (
 		big.NewInt(0),                      // SlashExternalStakeDenomFixEpoch
 		big.NewInt(0),                      // RejectDuplicateSlashEvidenceEpoch
 		big.NewInt(1),                      // SlashGroupOrderFixEpoch
+		big.NewInt(0),                      // BLSProofBindEpoch
 	}
 
 	// TestChainConfig ...
@@ -571,6 +578,7 @@ var (
 		big.NewInt(0),        // SlashExternalStakeDenomFixEpoch
 		big.NewInt(0),        // RejectDuplicateSlashEvidenceEpoch
 		big.NewInt(1),        // SlashGroupOrderFixEpoch
+		EpochTBD,             // BLSProofBindEpoch
 	}
 
 	// TestRules ...
@@ -807,6 +815,10 @@ type ChainConfig struct {
 	// SlashGroupOrderFixEpoch is the first epoch to apply slash groups in a
 	// canonical lexicographic order during beacon-chain finalization.
 	SlashGroupOrderFixEpoch *big.Int `json:"slash-group-order-fix-epoch,omitempty"`
+	// BLSProofBindEpoch is the first epoch that binds BLS proof-of-possession
+	// signatures to the validator address and rejects duplicate BLS keys among
+	// validators created earlier in the same block.
+	BLSProofBindEpoch *big.Int `json:"bls-proof-bind-epoch,omitempty"`
 }
 
 // String implements the fmt.Stringer interface.
@@ -1167,6 +1179,11 @@ func (c *ChainConfig) IsSlashGroupOrderFix(epoch *big.Int) bool {
 // IsValidatorWrapperAddressBind requires wrapper.Address to match the loading account.
 func (c *ChainConfig) IsValidatorWrapperAddressBind(epoch *big.Int) bool {
 	return isForked(c.ValidatorWrapperAddressBindEpoch, epoch)
+}
+
+// IsBLSProofBind requires BLS proof-of-possession to be bound to validator address.
+func (c *ChainConfig) IsBLSProofBind(epoch *big.Int) bool {
+	return isForked(c.BLSProofBindEpoch, epoch)
 }
 
 func (c *ChainConfig) IsHIP32(epoch *big.Int) bool {

--- a/staking/types/validator.go
+++ b/staking/types/validator.go
@@ -492,15 +492,33 @@ func (d Description) EnsureLength() (Description, error) {
 	return d, nil
 }
 
+// BLSProofMessageHash returns the message hash used for BLS proof-of-possession.
+// When bindToAddress is true, the validator address is prepended so the PoP
+// cannot be replayed for a different validator account.
+func BLSProofMessageHash(validatorAddr common.Address, bindToAddress bool) []byte {
+	if bindToAddress {
+		messageBytes := make([]byte, common.AddressLength+len(BLSVerificationStr))
+		copy(messageBytes, validatorAddr.Bytes())
+		copy(messageBytes[common.AddressLength:], BLSVerificationStr)
+		return hash.Keccak256(messageBytes)
+	}
+	return hash.Keccak256([]byte(BLSVerificationStr))
+}
+
 // VerifyBLSKeys checks if the public BLS key at index i of pubKeys matches the
 // BLS key signature at index i of pubKeysSigs.
-func VerifyBLSKeys(pubKeys []bls.SerializedPublicKey, pubKeySigs []bls.SerializedSignature) error {
+func VerifyBLSKeys(
+	pubKeys []bls.SerializedPublicKey,
+	pubKeySigs []bls.SerializedSignature,
+	validatorAddr common.Address,
+	bindToAddress bool,
+) error {
 	if len(pubKeys) != len(pubKeySigs) {
 		return errBLSKeysNotMatchSigs
 	}
 
 	for i := 0; i < len(pubKeys); i++ {
-		if err := VerifyBLSKey(&pubKeys[i], &pubKeySigs[i]); err != nil {
+		if err := VerifyBLSKey(&pubKeys[i], &pubKeySigs[i], validatorAddr, bindToAddress); err != nil {
 			return err
 		}
 	}
@@ -509,7 +527,12 @@ func VerifyBLSKeys(pubKeys []bls.SerializedPublicKey, pubKeySigs []bls.Serialize
 }
 
 // VerifyBLSKey checks if the public BLS key matches the BLS signature
-func VerifyBLSKey(pubKey *bls.SerializedPublicKey, pubKeySig *bls.SerializedSignature) error {
+func VerifyBLSKey(
+	pubKey *bls.SerializedPublicKey,
+	pubKeySig *bls.SerializedSignature,
+	validatorAddr common.Address,
+	bindToAddress bool,
+) error {
 	if len(pubKeySig) == 0 {
 		return errBLSKeysNotMatchSigs
 	}
@@ -524,9 +547,8 @@ func VerifyBLSKey(pubKey *bls.SerializedPublicKey, pubKeySig *bls.SerializedSign
 		return err
 	}
 
-	messageBytes := []byte(BLSVerificationStr)
-	msgHash := hash.Keccak256(messageBytes)
-	if !msgSig.VerifyHash(blsPubKey, msgHash[:]) {
+	msgHash := BLSProofMessageHash(validatorAddr, bindToAddress)
+	if !msgSig.VerifyHash(blsPubKey, msgHash) {
 		return errBLSKeysNotMatchSigs
 	}
 
@@ -580,7 +602,7 @@ func matchesHarmonyBLSKey(
 
 // CreateValidatorFromNewMsg creates validator from NewValidator message
 func CreateValidatorFromNewMsg(
-	val *CreateValidator, blockNum, epoch *big.Int,
+	val *CreateValidator, blockNum, epoch *big.Int, bindBLSProof bool,
 ) (*Validator, error) {
 	desc, err := val.Description.EnsureLength()
 	if err != nil {
@@ -596,7 +618,7 @@ func CreateValidatorFromNewMsg(
 		return nil, err
 	}
 
-	if err = VerifyBLSKeys(pubKeys, val.SlotKeySigs); err != nil {
+	if err = VerifyBLSKeys(pubKeys, val.SlotKeySigs, val.ValidatorAddress, bindBLSProof); err != nil {
 		return nil, err
 	}
 
@@ -615,7 +637,9 @@ func CreateValidatorFromNewMsg(
 }
 
 // UpdateValidatorFromEditMsg updates validator from EditValidator message
-func UpdateValidatorFromEditMsg(validator *Validator, edit *EditValidator, epoch *big.Int) error {
+func UpdateValidatorFromEditMsg(
+	validator *Validator, edit *EditValidator, epoch *big.Int, bindBLSProof bool,
+) error {
 	if validator.Address != edit.ValidatorAddress {
 		return errAddressNotMatch
 	}
@@ -671,7 +695,9 @@ func UpdateValidatorFromEditMsg(validator *Validator, edit *EditValidator, epoch
 			); err != nil {
 				return err
 			}
-			if err := VerifyBLSKey(edit.SlotKeyToAdd, edit.SlotKeyToAddSig); err != nil {
+			if err := VerifyBLSKey(
+				edit.SlotKeyToAdd, edit.SlotKeyToAddSig, validator.Address, bindBLSProof,
+			); err != nil {
 				return err
 			}
 			validator.SlotPubKeys = append(validator.SlotPubKeys, *edit.SlotKeyToAdd)

--- a/staking/types/validator_test.go
+++ b/staking/types/validator_test.go
@@ -447,7 +447,7 @@ func TestVerifyBLSKeys(t *testing.T) {
 		pubs := getPubsFromPairs(pairs, test.pubIndexes)
 		sigs := getSigsFromPairs(pairs, test.sigIndexes)
 
-		err := VerifyBLSKeys(pubs, sigs)
+		err := VerifyBLSKeys(pubs, sigs, validatorAddr, false)
 		if assErr := assertError(err, test.expErr); assErr != nil {
 			t.Errorf("Test %v: %v", i, assErr)
 		}
@@ -506,7 +506,7 @@ func TestCreateValidatorFromNewMsg(t *testing.T) {
 		cv := makeCreateValidator()
 		test.editCreateValidator(&cv)
 
-		v, err := CreateValidatorFromNewMsg(&cv, common.Big1, common.Big1)
+		v, err := CreateValidatorFromNewMsg(&cv, common.Big1, common.Big1, false)
 		if assErr := assertError(err, test.expErr); assErr != nil {
 			t.Errorf("Test %v: %v", i, assErr)
 		}
@@ -673,7 +673,7 @@ func TestUpdateValidatorFromEditMsg(t *testing.T) {
 	for i, test := range tests {
 		val := makeValidValidator()
 
-		err := UpdateValidatorFromEditMsg(&val, &test.editValidator, common.Big0)
+		err := UpdateValidatorFromEditMsg(&val, &test.editValidator, common.Big0, false)
 		if assErr := assertError(err, test.expErr); assErr != nil {
 			t.Errorf("Test %v: %v", i, assErr)
 		}


### PR DESCRIPTION
This PR tightens `CreateValidator` and `EditValidator` staking validation around BLS slot keys. Today, proof-of-possession (PoP) is verified against a fixed message, and duplicate BLS-key checks only look at the committed validator list from parent state. That leaves room for inconsistent validation when multiple staking transactions in the same block register overlapping keys.