### PR TITLE
Add CXReceiptStateRollbackEpoch for cross-shard receipt handling

### DIFF
--- a/core/vm/contracts_write_test.go
+++ b/core/vm/contracts_write_test.go
@@ -263,6 +263,67 @@ func TestCrossShardXferPrecompile(t *testing.T) {
 	}
 }
 
+func TestCrossShardXferReceiptRevertedWithCreate(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	stateCache := state.NewDatabase(db)
+	statedb, err := state.New(common.Hash{}, stateCache, nil)
+	require.NoError(t, err)
+
+	var env = NewEVM(BlockContext{
+		EpochNumber: big.NewInt(1),
+		NumShards:   2,
+		Transfer: func(db StateDB, sender, recipient common.Address, amount *big.Int, txType types.TransactionType) {
+		},
+		CanTransfer: func(_ StateDB, _ common.Address, _ *big.Int) bool {
+			return true
+		},
+		IsValidator: func(_ StateDB, _ common.Address) bool {
+			return false
+		},
+	}, TxContext{}, statedb, params.AllProtocolChanges, Config{})
+
+	ret, _, _, err := env.Create(
+		AccountRef(common.HexToAddress("0x1337")),
+		crossShardXferThenRevertInitCode(CrossShardXferPrecompileTests[0].input, CrossShardXferPrecompileTests[0].value),
+		10_000_000,
+		CrossShardXferPrecompileTests[0].value,
+	)
+
+	require.ErrorIs(t, err, ErrExecutionReverted)
+	require.Empty(t, ret)
+	require.Nil(t, env.CXReceipt, "reverted constructor must not leak cross-shard receipt")
+}
+
+func crossShardXferThenRevertInitCode(input []byte, value *big.Int) []byte {
+	code := make([]byte, 0, 128)
+	for offset := 0; offset < len(input); offset += 32 {
+		chunk := make([]byte, 32)
+		copy(chunk, input[offset:])
+		code = append(code, byte(PUSH32))
+		code = append(code, chunk...)
+		code = append(code, byte(PUSH1), byte(offset), byte(MSTORE))
+	}
+	valueBytes := value.Bytes()
+	code = append(code,
+		byte(PUSH1), 0x00, // out size
+		byte(PUSH1), 0x00, // out offset
+		byte(PUSH1), byte(len(input)), // input size
+		byte(PUSH1), 0x00, // input offset
+		byte(PUSH1)+byte(len(valueBytes))-1,
+	)
+	code = append(code, valueBytes...)
+	code = append(code,
+		byte(PUSH1), 0xf9, // cross-shard precompile
+		byte(PUSH2), 0x27, 0x10, // gas
+		byte(CALL),
+		byte(POP),
+		byte(PUSH1), 0x00,
+		byte(PUSH1), 0x00,
+		byte(REVERT),
+	)
+	return code
+}
+
 var CrossShardXferPrecompileTests = []writeCapablePrecompileTest{
 	{
 		input:    []byte{40, 72, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 107, 199, 94, 45, 99, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 165, 36, 21, 19, 218, 159, 68, 99, 241, 212, 135, 75, 84, 141, 251, 172, 41, 217, 31, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -283,6 +283,23 @@ func (evm *EVM) SetTxContext(txCtx TxContext) {
 	evm.TxContext = txCtx
 }
 
+func (evm *EVM) snapshotCXReceipt() *types.CXReceipt {
+	if !evm.chainRules.IsCXReceiptStateRollback {
+		return nil
+	}
+	if evm.CXReceipt == nil {
+		return nil
+	}
+	return evm.CXReceipt.Copy()
+}
+
+func (evm *EVM) restoreCXReceipt(receipt *types.CXReceipt) {
+	if !evm.chainRules.IsCXReceiptStateRollback {
+		return
+	}
+	evm.CXReceipt = receipt
+}
+
 // Call executes the contract associated with the addr with the given input as
 // parameters. It also handles any necessary value transfer required and takes
 // the necessary steps to create accounts and reverses the state in case of an
@@ -297,6 +314,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 		return nil, gas, ErrInsufficientBalance
 	}
 	snapshot := evm.StateDB.Snapshot()
+	cxReceiptSnapshot := evm.snapshotCXReceipt()
 	p, isPrecompile := evm.precompile(addr)
 
 	if !evm.StateDB.Exist(addr) {
@@ -368,6 +386,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	// when we're in homestead this also counts for code storage gas errors.
 	if err != nil {
 		evm.StateDB.RevertToSnapshot(snapshot)
+		evm.restoreCXReceipt(cxReceiptSnapshot)
 		if err != ErrExecutionReverted {
 			gas = 0
 		}
@@ -405,6 +424,7 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 		return nil, gas, ErrInsufficientBalance
 	}
 	var snapshot = evm.StateDB.Snapshot()
+	cxReceiptSnapshot := evm.snapshotCXReceipt()
 
 	// Invoke tracer hooks that signal entering/exiting a call frame
 	if evm.Config.Debug && evm.Config.Tracer != nil {
@@ -446,6 +466,7 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 	}
 	if err != nil {
 		evm.StateDB.RevertToSnapshot(snapshot)
+		evm.restoreCXReceipt(cxReceiptSnapshot)
 		if err != ErrExecutionReverted {
 			gas = 0
 		}
@@ -464,6 +485,7 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 		return nil, gas, ErrDepth
 	}
 	var snapshot = evm.StateDB.Snapshot()
+	cxReceiptSnapshot := evm.snapshotCXReceipt()
 
 	// Invoke tracer hooks that signal entering/exiting a call frame
 	if evm.Config.Debug && evm.Config.Tracer != nil {
@@ -491,6 +513,7 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 	}
 	if err != nil {
 		evm.StateDB.RevertToSnapshot(snapshot)
+		evm.restoreCXReceipt(cxReceiptSnapshot)
 		if err != ErrExecutionReverted {
 			gas = 0
 		}
@@ -513,6 +536,7 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	// then certain tests start failing; stRevertTest/RevertPrecompiledTouchExactOOG.json.
 	// We could change this, but for now it's left for legacy reasons
 	var snapshot = evm.StateDB.Snapshot()
+	cxReceiptSnapshot := evm.snapshotCXReceipt()
 
 	// We do an AddBalance of zero here, just in order to trigger a touch.
 	// This doesn't matter on Mainnet, where all empties are gone at the time of Byzantium,
@@ -552,6 +576,7 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	}
 	if err != nil {
 		evm.StateDB.RevertToSnapshot(snapshot)
+		evm.restoreCXReceipt(cxReceiptSnapshot)
 		if err != ErrExecutionReverted {
 			gas = 0
 		}
@@ -598,6 +623,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	}
 	// Create a new account on the state
 	snapshot := evm.StateDB.Snapshot()
+	cxReceiptSnapshot := evm.snapshotCXReceipt()
 	evm.StateDB.CreateAccount(address)
 	if evm.chainRules.IsEIP158 {
 		evm.StateDB.SetNonce(address, 1)
@@ -651,6 +677,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	// when we're in homestead this also counts for code storage gas errors.
 	if maxCodeSizeExceeded || (err != nil && (evm.chainRules.IsS3 || err != ErrCodeStoreOutOfGas)) {
 		evm.StateDB.RevertToSnapshot(snapshot)
+		evm.restoreCXReceipt(cxReceiptSnapshot)
 		if err != ErrExecutionReverted {
 			contract.UseGas(contract.Gas)
 		}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -91,7 +91,7 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 		}
 		// Automatically enable EIP-6780 if the chain rule is active
 		if evm.chainRules.IsEIP6780 {
-			copy := *cfg.JumpTable
+			copy := copyJumpTable(cfg.JumpTable)
 			if err := EnableEIP(6780, &copy); err != nil {
 				log.Error("EIP-6780 activation failed", "error", err)
 			} else {
@@ -111,7 +111,7 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 			cfg.ExtraEips = append(cfg.ExtraEips, 8024)
 		}
 		for i, eip := range cfg.ExtraEips {
-			copy := *cfg.JumpTable
+			copy := copyJumpTable(cfg.JumpTable)
 			if err := EnableEIP(eip, &copy); err != nil {
 				// Disable it, so caller can check if it's activated or not
 				cfg.ExtraEips = append(cfg.ExtraEips[:i], cfg.ExtraEips[i+1:]...)

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -62,6 +62,18 @@ var (
 // JumpTable contains the EVM opcodes supported at a given fork.
 type JumpTable [256]*operation
 
+func copyJumpTable(jt *JumpTable) JumpTable {
+	var cpy JumpTable
+	for i, op := range jt {
+		if op == nil {
+			continue
+		}
+		opCopy := *op
+		cpy[i] = &opCopy
+	}
+	return cpy
+}
+
 func validate(jt JumpTable) JumpTable {
 	for i, op := range jt {
 		if op == nil {

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -43,6 +43,7 @@ var (
 		S3Epoch:                               big.NewInt(28),
 		CrossTxEpoch:                          big.NewInt(28),
 		CXMerkleProofReplayFixEpoch:           EpochTBD,
+		CXReceiptStateRollbackEpoch:           EpochTBD,
 		MinCommissionPromoPeriod:              big.NewInt(100),
 		ReceiptLogEpoch:                       big.NewInt(101),
 		PreStakingEpoch:                       big.NewInt(185),
@@ -111,6 +112,7 @@ var (
 		S3Epoch:                               big.NewInt(0),
 		CrossTxEpoch:                          big.NewInt(0),
 		CXMerkleProofReplayFixEpoch:           big.NewInt(0),
+		CXReceiptStateRollbackEpoch:           EpochTBD,
 		MinCommissionPromoPeriod:              big.NewInt(2),
 		ReceiptLogEpoch:                       big.NewInt(0),
 		PreStakingEpoch:                       big.NewInt(1),
@@ -179,6 +181,7 @@ var (
 		S3Epoch:                               big.NewInt(0),
 		CrossTxEpoch:                          big.NewInt(0),
 		CXMerkleProofReplayFixEpoch:           big.NewInt(0),
+		CXReceiptStateRollbackEpoch:           EpochTBD,
 		MinCommissionPromoPeriod:              big.NewInt(10),
 		ReceiptLogEpoch:                       big.NewInt(0),
 		PreStakingEpoch:                       big.NewInt(1),
@@ -247,6 +250,7 @@ var (
 		S3Epoch:                               big.NewInt(0),
 		CrossTxEpoch:                          big.NewInt(0),
 		CXMerkleProofReplayFixEpoch:           big.NewInt(0),
+		CXReceiptStateRollbackEpoch:           EpochTBD,
 		MinCommissionPromoPeriod:              big.NewInt(10),
 		ReceiptLogEpoch:                       big.NewInt(0),
 		PreStakingEpoch:                       big.NewInt(1),
@@ -316,6 +320,7 @@ var (
 		S3Epoch:                               big.NewInt(0),
 		CrossTxEpoch:                          big.NewInt(0),
 		CXMerkleProofReplayFixEpoch:           big.NewInt(0),
+		CXReceiptStateRollbackEpoch:           EpochTBD,
 		MinCommissionPromoPeriod:              big.NewInt(10),
 		ReceiptLogEpoch:                       big.NewInt(0),
 		PreStakingEpoch:                       big.NewInt(1),
@@ -383,6 +388,7 @@ var (
 		S3Epoch:                               big.NewInt(0),
 		CrossTxEpoch:                          big.NewInt(0),
 		CXMerkleProofReplayFixEpoch:           big.NewInt(0),
+		CXReceiptStateRollbackEpoch:           big.NewInt(0),
 		MinCommissionPromoPeriod:              big.NewInt(10),
 		ReceiptLogEpoch:                       big.NewInt(0),
 		PreStakingEpoch:                       big.NewInt(0),
@@ -451,6 +457,7 @@ var (
 		big.NewInt(0),                      // EthCompatibleEpoch
 		big.NewInt(0),                      // CrossTxEpoch
 		big.NewInt(0),                      // CXMerkleProofReplayFixEpoch
+		big.NewInt(0),                      // CXReceiptStateRollbackEpoch
 		big.NewInt(0),                      // CrossLinkEpoch
 		big.NewInt(0),                      // RejectShard0CrossLinkEpoch
 		big.NewInt(1),                      // AggregatedRewardEpoch
@@ -521,6 +528,7 @@ var (
 		big.NewInt(0),        // EthCompatibleEpoch
 		big.NewInt(0),        // CrossTxEpoch
 		big.NewInt(0),        // CXMerkleProofReplayFixEpoch
+		big.NewInt(0),        // CXReceiptStateRollbackEpoch
 		big.NewInt(0),        // CrossLinkEpoch
 		big.NewInt(0),        // RejectShard0CrossLinkEpoch
 		big.NewInt(1),        // AggregatedRewardEpoch
@@ -634,6 +642,10 @@ type ChainConfig struct {
 	// CXMerkleProofReplayFixEpoch is the epoch where CX receipt replay checks
 	// bind merkle proof identity to authenticated source headers.
 	CXMerkleProofReplayFixEpoch *big.Int `json:"cx-merkle-proof-replay-fix-epoch,omitempty"`
+
+	// CXReceiptStateRollbackEpoch is the epoch where EVM frame reverts also
+	// roll back cross-shard receipts created by the cross-shard precompile.
+	CXReceiptStateRollbackEpoch *big.Int `json:"cx-receipt-state-rollback-epoch,omitempty"`
 
 	// CrossLinkEpoch is the epoch where beaconchain starts containing
 	// cross-shard links.
@@ -931,6 +943,12 @@ func (c *ChainConfig) HasCrossTxFields(epoch *big.Int) bool {
 // IsCXMerkleProofReplayFixEpoch determines whether replay-fix checks are enabled.
 func (c *ChainConfig) IsCXMerkleProofReplayFixEpoch(epoch *big.Int) bool {
 	return isForked(c.CXMerkleProofReplayFixEpoch, epoch)
+}
+
+// IsCXReceiptStateRollback returns whether EVM frame reverts also roll back
+// cross-shard receipts created by the cross-shard precompile.
+func (c *ChainConfig) IsCXReceiptStateRollback(epoch *big.Int) bool {
+	return isForked(c.CXReceiptStateRollbackEpoch, epoch)
 }
 
 // IsEthCompatible determines whether it is ethereum compatible epoch
@@ -1283,16 +1301,17 @@ type Rules struct {
 	IsEIP2537Precompile,
 	// eip-155 chain id fix
 	IsChainIdFix bool
-	IsValidatorCodeFix     bool
-	IsYoloV2               bool
-	Is1153TransientStorage bool
-	Is7939CLZ              bool
-	IsEIP5656Mcopy         bool
-	IsEIP3855              bool
-	IsEIP6780              bool
-	Is3860                 bool
-	IsPrague               bool // EIP-2935: Serve historical block hashes from state
-	Is8024                 bool
+	IsValidatorCodeFix       bool
+	IsYoloV2                 bool
+	Is1153TransientStorage   bool
+	Is7939CLZ                bool
+	IsEIP5656Mcopy           bool
+	IsEIP3855                bool
+	IsEIP6780                bool
+	Is3860                   bool
+	IsPrague                 bool // EIP-2935: Serve historical block hashes from state
+	Is8024                   bool
+	IsCXReceiptStateRollback bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -1332,5 +1351,6 @@ func (c *ChainConfig) Rules(epoch *big.Int) Rules {
 		Is3860:                     c.IsEIP3860(epoch),
 		IsPrague:                   c.IsPrague(epoch),
 		Is8024:                     c.IsEIP8024(epoch),
+		IsCXReceiptStateRollback:   c.IsCXReceiptStateRollback(epoch),
 	}
 }


### PR DESCRIPTION
* Added a new test (`TestCrossShardXferReceiptRevertedWithCreate`) to ensure that when a contract creation triggers a cross-shard transfer and then reverts. This test constructs a contract that calls the cross-shard precompile and then reverts.


* Introduced the `CXReceiptStateRollbackEpoch` field in `ChainConfig`, updated all relevant network configurations, and added the `IsCXReceiptStateRollback` method and rule to control this behavior based on the current epoch. [[1]](diffhunk://#diff-059a645c15f37b27def02577139d5b663f6d5accc121a58c6401fceae3241062R46) [[2]](diffhunk://#diff-059a645c15f37b27def02577139d5b663f6d5accc121a58c6401fceae3241062R115) [[3]](diffhunk://#diff-059a645c15f37b27def02577139d5b663f6d5accc121a58c6401fceae3241062R184) [[4]](diffhunk://#diff-059a645c15f37b27def02577139d5b663f6d5accc121a58c6401fceae3241062R253) [[5]](diffhunk://#diff-059a645c15f37b27def02577139d5b663f6d5accc121a58c6401fceae3241062R323) [[6]](diffhunk://#diff-059a645c15f37b27def02577139d5b663f6d5accc121a58c6401fceae3241062R391) [[7]](diffhunk://#diff-059a645c15f37b27def02577139d5b663f6d5accc121a58c6401fceae3241062R460) [[8]](diffhunk://#diff-059a645c15f37b27def02577139d5b663f6d5accc121a58c6401fceae3241062R531) [[9]](diffhunk://#diff-059a645c15f37b27def02577139d5b663f6d5accc121a58c6401fceae3241062R646-R649) [[10]](diffhunk://#diff-059a645c15f37b27def02577139d5b663f6d5accc121a58c6401fceae3241062R948-R953) [[11]](diffhunk://#diff-059a645c15f37b27def02577139d5b663f6d5accc121a58c6401fceae3241062R1314) [[12]](diffhunk://#diff-059a645c15f37b27def02577139d5b663f6d5accc121a58c6401fceae3241062R1354)



