### PR TITLE
Fix slash verification to use double-sign key intersection only

### DIFF
--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -101,6 +101,7 @@ var (
 		RejectDuplicateSlashEvidenceEpoch:     EpochTBD,
 		SlashGroupOrderFixEpoch:               EpochTBD,
 		BLSProofBindEpoch:                     EpochTBD,
+		SlashBallotSignerFixEpoch:             EpochTBD,
 	}
 
 	// TestnetChainConfig contains the chain parameters to run a node on the harmony test network.
@@ -170,6 +171,7 @@ var (
 		RejectDuplicateSlashEvidenceEpoch:     EpochTBD,
 		SlashGroupOrderFixEpoch:               EpochTBD,
 		BLSProofBindEpoch:                     EpochTBD,
+		SlashBallotSignerFixEpoch:             EpochTBD,
 	}
 	// PangaeaChainConfig contains the chain parameters for the Pangaea network.
 	// All features except for CrossLink are enabled at launch.
@@ -238,6 +240,7 @@ var (
 		RejectDuplicateSlashEvidenceEpoch:     EpochTBD,
 		SlashGroupOrderFixEpoch:               EpochTBD,
 		BLSProofBindEpoch:                     EpochTBD,
+		SlashBallotSignerFixEpoch:             EpochTBD,
 	}
 
 	// PartnerChainConfig contains the chain parameters for the Partner network.
@@ -308,6 +311,7 @@ var (
 		RejectDuplicateSlashEvidenceEpoch:     EpochTBD,
 		SlashGroupOrderFixEpoch:               EpochTBD,
 		BLSProofBindEpoch:                     EpochTBD,
+		SlashBallotSignerFixEpoch:             EpochTBD,
 	}
 
 	// StressnetChainConfig contains the chain parameters for the Stress test network.
@@ -377,6 +381,7 @@ var (
 		RejectDuplicateSlashEvidenceEpoch:     EpochTBD,
 		SlashGroupOrderFixEpoch:               EpochTBD,
 		BLSProofBindEpoch:                     EpochTBD,
+		SlashBallotSignerFixEpoch:             EpochTBD,
 	}
 
 	// LocalnetChainConfig contains the chain parameters to run for local development.
@@ -445,6 +450,7 @@ var (
 		RejectDuplicateSlashEvidenceEpoch:     big.NewInt(0),
 		SlashGroupOrderFixEpoch:               big.NewInt(2),
 		BLSProofBindEpoch:                     EpochTBD,
+		SlashBallotSignerFixEpoch:             big.NewInt(2),
 	}
 
 	// AllProtocolChanges ...
@@ -516,6 +522,7 @@ var (
 		big.NewInt(0),                      // RejectDuplicateSlashEvidenceEpoch
 		big.NewInt(1),                      // SlashGroupOrderFixEpoch
 		big.NewInt(0),                      // BLSProofBindEpoch
+		big.NewInt(1),                      // SlashBallotSignerFixEpoch
 	}
 
 	// TestChainConfig ...
@@ -587,6 +594,7 @@ var (
 		big.NewInt(0),        // RejectDuplicateSlashEvidenceEpoch
 		big.NewInt(1),        // SlashGroupOrderFixEpoch
 		EpochTBD,             // BLSProofBindEpoch
+		big.NewInt(1),        // SlashBallotSignerFixEpoch
 	}
 
 	// TestRules ...
@@ -831,6 +839,11 @@ type ChainConfig struct {
 	// signatures to the validator address and rejects duplicate BLS keys among
 	// validators created earlier in the same block.
 	BLSProofBindEpoch *big.Int `json:"bls-proof-bind-epoch,omitempty"`
+	// SlashBallotSignerFixEpoch is the first epoch where slash verification requires
+	// ballot signer keys to match the double-sign intersection and verifies
+	// signatures against that intersection only. Until set to a concrete epoch on
+	// a network, EpochTBD leaves the rule inactive there.
+	SlashBallotSignerFixEpoch *big.Int `json:"slash-ballot-signer-fix-epoch,omitempty"`
 }
 
 // String implements the fmt.Stringer interface.
@@ -913,6 +926,8 @@ func (c *ChainConfig) mustValid() {
 	// slash groups are only applied in the staking era
 	require(c.SlashGroupOrderFixEpoch == nil || c.SlashGroupOrderFixEpoch.Cmp(c.StakingEpoch) >= 0,
 		"must satisfy: SlashGroupOrderFixEpoch >= StakingEpoch")
+	require(c.SlashBallotSignerFixEpoch == nil || c.SlashBallotSignerFixEpoch.Cmp(c.StakingEpoch) >= 0,
+		"must satisfy: SlashBallotSignerFixEpoch >= StakingEpoch")
 }
 
 // IsEIP155 returns whether epoch is either equal to the EIP155 fork epoch or greater.
@@ -1202,6 +1217,12 @@ func (c *ChainConfig) IsValidatorWrapperAddressBind(epoch *big.Int) bool {
 // IsBLSProofBind requires BLS proof-of-possession to be bound to validator address.
 func (c *ChainConfig) IsBLSProofBind(epoch *big.Int) bool {
 	return isForked(c.BLSProofBindEpoch, epoch)
+}
+
+// IsSlashBallotSignerFix returns whether slash verification uses stricter ballot
+// signer key rules during double-sign evidence checks.
+func (c *ChainConfig) IsSlashBallotSignerFix(epoch *big.Int) bool {
+	return isForked(c.SlashBallotSignerFixEpoch, epoch)
 }
 
 func (c *ChainConfig) IsHIP32(epoch *big.Int) bool {

--- a/staking/slash/double-sign.go
+++ b/staking/slash/double-sign.go
@@ -94,6 +94,7 @@ var (
 	errSlashEpochHeightMismatch = errors.New("slash evidence epoch does not match block height epoch")
 	// ErrSlashEpochHeightMismatch is returned when slash evidence epoch disagrees with its block height.
 	ErrSlashEpochHeightMismatch = errSlashEpochHeightMismatch
+	errSlashExtraBallotKeys     = errors.New("slash ballot signer keys do not match double-sign intersection")
 )
 
 // MarshalJSON ..
@@ -239,6 +240,7 @@ func Verify(
 		)
 	}
 
+	useSlashBallotSignerFix := chain.Config().IsSlashBallotSignerFix(candidate.Evidence.Epoch)
 	for _, ballot := range [...]Vote{
 		candidate.Evidence.FirstVote,
 		candidate.Evidence.SecondVote,
@@ -251,7 +253,15 @@ func Verify(
 			return err
 		}
 
-		for _, pubKey := range ballot.SignerPubKeys {
+		verifyKeys := ballot.SignerPubKeys
+		if useSlashBallotSignerFix {
+			if len(ballot.SignerPubKeys) != len(doubleSignKeys) {
+				return errSlashExtraBallotKeys
+			}
+			verifyKeys = doubleSignKeys
+		}
+
+		for _, pubKey := range verifyKeys {
 			publicKeyObj, err := bls.BytesToBLSPublicKey(pubKey[:])
 
 			if err != nil {

--- a/staking/slash/double-sign_test.go
+++ b/staking/slash/double-sign_test.go
@@ -80,6 +80,96 @@ var (
 	reporterAddr = makeTestAddress("reporter")
 )
 
+func TestVerifyRejectsExtraBallotSignerKeys(t *testing.T) {
+	record := extraBallotSignerSlashRecord(t)
+	sdb := defaultTestStateDB()
+	chain := defaultFakeBlockChain()
+
+	err := Verify(chain, sdb, &record)
+	if err == nil {
+		t.Fatal("expected slash with mismatched ballot signer keys to be rejected")
+	}
+	if !strings.Contains(err.Error(), errSlashExtraBallotKeys.Error()) &&
+		!strings.Contains(err.Error(), errFailVerifySlash.Error()) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestVerifyExtraBallotSignerKeysBackwardCompat(t *testing.T) {
+	record := extraBallotSignerSlashRecord(t)
+	sdb := defaultTestStateDB()
+	chain := defaultFakeBlockChain()
+	chain.config.SlashBallotSignerFixEpoch = params.EpochTBD
+
+	if err := Verify(chain, sdb, &record); err != nil {
+		t.Fatalf("legacy slash verify should accept aggregated-key proof before fork: %v", err)
+	}
+}
+
+func extraBallotSignerSlashRecord(t *testing.T) Record {
+	t.Helper()
+
+	attacker1 := genKeyPair()
+	attacker2 := genKeyPair()
+	extra1 := subtractBLSPublicKeys(t, attacker1.pub, offKey.pub)
+	extra2 := subtractBLSPublicKeys(t, attacker2.pub, offKey.pub)
+
+	firstVote := makeExtraBallotVote(t, attacker1, offPub, extra1, doubleSignBlock1)
+	secondVote := makeExtraBallotVote(t, attacker2, offPub, extra2, doubleSignBlock2)
+
+	return Record{
+		Evidence: Evidence{
+			ConflictingVotes: ConflictingVotes{
+				FirstVote:  firstVote,
+				SecondVote: secondVote,
+			},
+			Moment: Moment{
+				Epoch:   big.NewInt(doubleSignEpoch),
+				ShardID: doubleSignShardID,
+				Height:  doubleSignBlockNumber,
+				ViewID:  doubleSignViewID,
+			},
+			Offender: offAddr,
+		},
+		Reporter: reporterAddr,
+	}
+}
+
+func makeExtraBallotVote(
+	t *testing.T,
+	attacker blsKeyPair,
+	victimPub bls.SerializedPublicKey,
+	extraPub bls.SerializedPublicKey,
+	block *types.Block,
+) Vote {
+	t.Helper()
+
+	msg := consensus_sig.ConstructCommitPayload(
+		params.LocalnetChainConfig,
+		block.Epoch(),
+		block.Hash(),
+		block.Number().Uint64(),
+		block.Header().ViewID().Uint64(),
+	)
+	return Vote{
+		SignerPubKeys:   []bls.SerializedPublicKey{victimPub, extraPub},
+		BlockHeaderHash: block.Hash(),
+		Signature:       attacker.pri.SignHash(msg).Serialize(),
+	}
+}
+
+func subtractBLSPublicKeys(t *testing.T, minuendPub, subtrahendPub *bls_core.PublicKey) bls.SerializedPublicKey {
+	t.Helper()
+
+	diffPub := &bls_core.PublicKey{}
+	diffPub.Add(minuendPub)
+	diffPub.Sub(subtrahendPub)
+
+	var serialized bls.SerializedPublicKey
+	copy(serialized[:], diffPub.Serialize())
+	return serialized
+}
+
 func TestVerify(t *testing.T) {
 	tests := []struct {
 		r      Record


### PR DESCRIPTION
This change tightens how double-sign slash evidence is validated once `SlashBallotSignerFixEpoch` is reached. Slash verification already identifies the accused validator from the BLS keys shared by both conflicting votes. After the fork, it also requires each ballot’s signer list to match that shared set exactly, and it verifies signatures against those keys rather than any additional signer entries in the ballot.
