### PR TITLE
Handle stale snapshots by returning ErrSnapshotStale

### DIFF
--- a/core/state/snapshot/difflayer.go
+++ b/core/state/snapshot/difflayer.go
@@ -295,6 +295,10 @@ func (dl *diffLayer) AccountRLP(hash common.Hash) ([]byte, error) {
 	// Check the bloom filter first whether there's even a point in reaching into
 	// all the maps in all the layers below
 	dl.lock.RLock()
+	if dl.Stale() {
+		dl.lock.RUnlock()
+		return nil, ErrSnapshotStale
+	}
 	hit := dl.diffed.Contains(accountBloomHasher(hash))
 	if !hit {
 		hit = dl.diffed.Contains(destructBloomHasher(hash))
@@ -361,6 +365,10 @@ func (dl *diffLayer) Storage(accountHash, storageHash common.Hash) ([]byte, erro
 	// Check the bloom filter first whether there's even a point in reaching into
 	// all the maps in all the layers below
 	dl.lock.RLock()
+	if dl.Stale() {
+		dl.lock.RUnlock()
+		return nil, ErrSnapshotStale
+	}
 	hit := dl.diffed.Contains(storageBloomHasher{accountHash, storageHash})
 	if !hit {
 		hit = dl.diffed.Contains(destructBloomHasher(accountHash))


### PR DESCRIPTION
This pull request adds additional stale state checks to the diff layer's account and storage retrieval methods, improving the robustness of snapshot state management. Now, before attempting to access account or storage data, the code verifies if the diff layer is stale and returns an appropriate error if so.

Improvements to snapshot diff layer safety:

* Added a check for `Stale()` in the `AccountRLP` method of `diffLayer` to prevent access and return `ErrSnapshotStale` if the layer is stale.
* Added a similar `Stale()` check in the `Storage` method of `diffLayer` to ensure safe handling of stale state.