### PR TITLE
feat(github_ci): speed up test runs with one binary build

### DIFF
--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - &setup-go
         name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 #v6.5.0
         with:
           go-version: '1.24.2'
           cache-dependency-path: go/src/github.com/harmony-one/harmony/go.sum

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -68,10 +68,20 @@ jobs:
         run: make BLS_SWAP_G=1 -j4
         working-directory: go/src/github.com/harmony-one/bls
 
-      - &build-harmony
-        name: Build harmony
+      - name: Build harmony
         run: make
         working-directory: go/src/github.com/harmony-one/harmony
+
+      - name: Upload harmony binaries artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+        with:
+          name: harmony-binaries
+          path: |
+            go/src/github.com/harmony-one/harmony/bin/harmony
+            go/src/github.com/harmony-one/harmony/bin/bootnode
+          retention-days: 1
+          if-no-files-found: error
+          compression-level: 6
 
   go-checker:
     name: Run unit tests
@@ -84,7 +94,6 @@ jobs:
       - *setup-go
       - *build-mcl
       - *build-bls
-      - *build-harmony
 
       - name: Install tools
         run: |
@@ -100,6 +109,7 @@ jobs:
 
   rpc-checker:
     name: Run RPC integration tests
+    needs: build
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
@@ -109,7 +119,24 @@ jobs:
       - *setup-go
       - *build-mcl
       - *build-bls
-      - *build-harmony
+
+      - &download-harmony-binaries
+        name: Download and extract harmony binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
+        with:
+          name: harmony-binaries
+          path: go/src/github.com/harmony-one/harmony/bin
+
+      - &prepare-harmony-binaries
+        name: Prepare harmony binaries
+        run: |
+          set -euo pipefail
+
+          chmod +x go/src/github.com/harmony-one/harmony/bin/harmony
+          chmod +x go/src/github.com/harmony-one/harmony/bin/bootnode
+
+          test -x go/src/github.com/harmony-one/harmony/bin/harmony
+          test -x go/src/github.com/harmony-one/harmony/bin/bootnode
 
       - &checkout-harmony-test
         name: Checkout harmony-test
@@ -133,6 +160,7 @@ jobs:
 
   pyhmy-checker:
     name: Run pyhmy tests
+    needs: build
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
@@ -142,7 +170,8 @@ jobs:
       - *setup-go
       - *build-mcl
       - *build-bls
-      - *build-harmony
+      - *download-harmony-binaries
+      - *prepare-harmony-binaries
       - *checkout-harmony-test
 
       - name: Run pyhmy checker

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -154,7 +154,6 @@ jobs:
           TRAVIS_PULL_REQUEST_SLUG: ${{ github.event.pull_request.head.repo.full_name }}
           TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }}
           TRAVIS_BRANCH: ${{ github.ref_name }}
-          HARMONY_PREBUILT_STATIC: 'true'
 
   pyhmy-checker:
     name: Run pyhmy tests (${{ matrix.arch }})

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -58,16 +58,6 @@ jobs:
           go-version: '1.24.2'
           cache-dependency-path: go/src/github.com/harmony-one/harmony/go.sum
 
-      - &build-mcl
-        name: Build mcl
-        run: make -j4
-        working-directory: go/src/github.com/harmony-one/mcl
-
-      - &build-bls
-        name: Build bls
-        run: make BLS_SWAP_G=1 -j4
-        working-directory: go/src/github.com/harmony-one/bls
-
       - name: Build harmony
         run: make
         working-directory: go/src/github.com/harmony-one/harmony
@@ -85,6 +75,7 @@ jobs:
 
   go-checker:
     name: Run unit tests
+    needs: build
     runs-on: ubuntu-24.04
     timeout-minutes: 25
     steps:
@@ -92,9 +83,12 @@ jobs:
       - *checkout-mcl
       - *checkout-bls
       - *setup-go
-      - *build-mcl
-      - *build-bls
-
+      - name: Build mcl
+        run: make -j4
+        working-directory: go/src/github.com/harmony-one/mcl
+      - name: Build bls
+        run: make BLS_SWAP_G=1 -j4
+        working-directory: go/src/github.com/harmony-one/bls
       - name: Install tools
         run: |
           go install golang.org/x/tools/cmd/goimports@v0.30.0
@@ -114,12 +108,6 @@ jobs:
     timeout-minutes: 25
     steps:
       - *checkout-harmony
-      - *checkout-mcl
-      - *checkout-bls
-      - *setup-go
-      - *build-mcl
-      - *build-bls
-
       - &download-harmony-binaries
         name: Download and extract harmony binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
@@ -150,7 +138,6 @@ jobs:
 
       - name: Run RPC checker
         run: |
-          make go-get
           bash ./scripts/travis_rpc_checker.sh
         working-directory: go/src/github.com/harmony-one/harmony
         env: &travis-pr-env
@@ -165,18 +152,12 @@ jobs:
     timeout-minutes: 25
     steps:
       - *checkout-harmony
-      - *checkout-mcl
-      - *checkout-bls
-      - *setup-go
-      - *build-mcl
-      - *build-bls
       - *download-harmony-binaries
       - *prepare-harmony-binaries
       - *checkout-harmony-test
 
       - name: Run pyhmy checker
         run: |
-          make go-get
           bash ./scripts/travis_pyhmy_checker.sh
         working-directory: go/src/github.com/harmony-one/harmony
         env: *travis-pr-env

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -83,11 +83,13 @@ jobs:
           compression-level: 6
 
   go-checker:
-    name: Run unit tests (${{ matrix.arch }})
+    name: Run unit tests
     needs: build
-    runs-on: ${{ matrix.os }}
+    # TODO:@mur-me for now only amd64, in the future
+    # frozen621/harmony-proto:latest shouldn't be used and
+    # build-docker-proto-image.yaml should cover it
+    runs-on: ubuntu-24.04
     timeout-minutes: 25
-    strategy: *arch-matrix
     steps:
       - *checkout-harmony
       - *checkout-mcl
@@ -158,9 +160,16 @@ jobs:
   pyhmy-checker:
     name: Run pyhmy tests (${{ matrix.arch }})
     needs: build
+    # TODO:@mur-me for now only amd64, in the future
+    # we need to rewrite https://github.com/harmony-one/go-sdk/blob/master/.github/workflows/hmybuild.yml to cover arm64
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
-    strategy: *arch-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            arch: amd64
     steps:
       - *checkout-harmony
       - *checkout-bls

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -59,7 +59,7 @@ jobs:
           cache-dependency-path: go/src/github.com/harmony-one/harmony/go.sum
 
       - name: Build harmony
-        run: make
+        run: make linux_static
         working-directory: go/src/github.com/harmony-one/harmony
 
       - name: Upload harmony binaries artifact

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -19,9 +19,18 @@ concurrency:
 
 jobs:
   build:
-    name: Build harmony/bootnode binary
-    runs-on: ubuntu-24.04
+    name: Build harmony/bootnode binary (${{ matrix.arch }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 25
+    strategy: &arch-matrix
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+
     steps:
       - &checkout-harmony
         name: Checkout harmony
@@ -65,7 +74,7 @@ jobs:
       - name: Upload harmony binaries artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
-          name: harmony-binaries
+          name: harmony-binaries-${{ matrix.arch }}
           path: |
             go/src/github.com/harmony-one/harmony/bin/harmony
             go/src/github.com/harmony-one/harmony/bin/bootnode
@@ -74,10 +83,11 @@ jobs:
           compression-level: 6
 
   go-checker:
-    name: Run unit tests
+    name: Run unit tests (${{ matrix.arch }})
     needs: build
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 25
+    strategy: *arch-matrix
     steps:
       - *checkout-harmony
       - *checkout-mcl
@@ -94,7 +104,6 @@ jobs:
           go install golang.org/x/tools/cmd/goimports@v0.30.0
           go install github.com/fjl/gencodec@v0.1.1
         working-directory: go/src/github.com/harmony-one/harmony
-
       - name: Run go checker
         run: |
           make go-get
@@ -102,17 +111,18 @@ jobs:
         working-directory: go/src/github.com/harmony-one/harmony
 
   rpc-checker:
-    name: Run RPC integration tests
+    name: Run RPC integration tests (${{ matrix.arch }})
     needs: build
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 25
+    strategy: *arch-matrix
     steps:
       - *checkout-harmony
       - &download-harmony-binaries
         name: Download and extract harmony binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
         with:
-          name: harmony-binaries
+          name: harmony-binaries-${{ matrix.arch }}
           path: go/src/github.com/harmony-one/harmony/bin
 
       - &prepare-harmony-binaries
@@ -144,12 +154,14 @@ jobs:
           TRAVIS_PULL_REQUEST_SLUG: ${{ github.event.pull_request.head.repo.full_name }}
           TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }}
           TRAVIS_BRANCH: ${{ github.ref_name }}
+          HARMONY_PREBUILT_STATIC: 'true'
 
   pyhmy-checker:
-    name: Run pyhmy tests
+    name: Run pyhmy tests (${{ matrix.arch }})
     needs: build
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 25
+    strategy: *arch-matrix
     steps:
       - *checkout-harmony
       - *checkout-bls

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -152,6 +152,7 @@ jobs:
     timeout-minutes: 25
     steps:
       - *checkout-harmony
+      - *checkout-bls
       - *download-harmony-binaries
       - *prepare-harmony-binaries
       - *checkout-harmony-test

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -110,7 +110,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go with go.mod
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 #v6.5.0
         with:
           go-version-file: harmony/go.mod
           # Release artifacts should not restore mutable CI/PR caches.

--- a/scripts/travis_pyhmy_checker.sh
+++ b/scripts/travis_pyhmy_checker.sh
@@ -48,4 +48,4 @@ cd localnet
 docker build --build-arg MAIN_REPO_BRANCH="${MAIN_REPO_BRANCH}" --progress plain \
     --build-arg MAIN_REPO_ORG="${MAIN_REPO_ORG}" -t harmonyone/localnet-test .
 # WARN: this is the place where LOCAL repository is provided to the harmony-tests repo
-docker run -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test -p
+docker run -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test -B -p

--- a/scripts/travis_pyhmy_checker.sh
+++ b/scripts/travis_pyhmy_checker.sh
@@ -48,4 +48,4 @@ cd localnet
 docker build --build-arg MAIN_REPO_BRANCH="${MAIN_REPO_BRANCH}" --progress plain \
     --build-arg MAIN_REPO_ORG="${MAIN_REPO_ORG}" -t harmonyone/localnet-test .
 # WARN: this is the place where LOCAL repository is provided to the harmony-tests repo
-docker run -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test -B -p
+docker run -e HARMONY_PREBUILT_STATIC=true -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test -B -p

--- a/scripts/travis_rosetta_checker.sh
+++ b/scripts/travis_rosetta_checker.sh
@@ -48,4 +48,4 @@ cd localnet
 docker build --build-arg MAIN_REPO_BRANCH="${MAIN_REPO_BRANCH}" --progress plain \
     --build-arg MAIN_REPO_ORG="${MAIN_REPO_ORG}" -t harmonyone/localnet-test .
 # WARN: this is the place where LOCAL repository is provided to the harmony-tests repo
-docker run -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test -r
+docker run -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test -B -r

--- a/scripts/travis_rpc_checker.sh
+++ b/scripts/travis_rpc_checker.sh
@@ -48,4 +48,4 @@ cd localnet
 docker build --build-arg MAIN_REPO_BRANCH="${MAIN_REPO_BRANCH}" --progress plain \
     --build-arg MAIN_REPO_ORG="${MAIN_REPO_ORG}" -t harmonyone/localnet-test .
 # WARN: this is the place where LOCAL repository is provided to the harmony-tests repo
-docker run -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test -n
+docker run -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test -B -n


### PR DESCRIPTION
## Issue
### What was done

* Reworked CI so Harmony binaries are built once in the `build` job and reused by integration test jobs.
* Built static `harmony` and `bootnode` binaries with `make linux_static`.
* Uploaded only required binaries as a short-lived GitHub Actions artifact:
  * `harmony`
  * `bootnode`
* Updated `rpc-checker` and `pyhmy-checker` to download and reuse the prebuilt binaries.
* Removed duplicate Harmony binary builds from checker jobs.
* Restored executable permissions after artifact download.
* Updated localnet test execution to use prebuilt binaries with `-B`.
* Started to build arm binary as well
* Run RPC tests against arm binary. 
* upgrade setup go step to the `6.5.0` version

**Note: pyhmy and unit tests will be covered separate, there are dependencies on the proto image and arm pyhmy cli**

### Why this is better

* Avoids rebuilding the same binaries multiple times.
* Makes RPC and pyhmy tests run against the exact binary produced by the build job.
* Reduces CI time and wasted runner CPU.
* Makes the CI flow easier to debug and reason about.

### Conntected PRs

* https://github.com/harmony-one/harmony-test/pull/47 - stop to build the harmony, remove build dependencies
* https://github.com/harmony-one/pyhmy/pull/52 -  added a env variable and folders check to the code to understand that we are running against static binaries

## Test

### Tests performed

* Verified `harmony` and `bootnode` are built and uploaded as artifacts.
* Verified checker jobs download the binaries into the expected `bin/` path.
* Verified binaries are executable after download.
* Verified mounted binaries are visible inside the localnet container.
* Verified RPC and pyhmy flows run with the prebuilt binary mode.

### Test/Run Logs

https://github.com/harmony-one/harmony/actions/runs/28190779640


## Diagram 
```mermaid
flowchart LR
    subgraph BEFORE["Before"]
        A1["Build job builds harmony"]
        A2["RPC job builds harmony again"]
        A3["pyhmy job builds harmony again"]
        A4["localnet Dockerfile may build harmony again"]
        A5["run.sh may build again"]
        A6["Slow, duplicated, unclear tested binary"]
        A1 --> A2 --> A3 --> A4 --> A5 --> A6
    end

    subgraph NOW["Now"]
        B1["Build job builds static harmony + bootnode once"]
        B2["Upload harmony-binaries artifact"]
        B3["RPC downloads artifact"]
        B4["pyhmy downloads artifact"]
        B5["localnet runs with -B"]
        B6["Tests use same prebuilt binaries"]
        B1 --> B2
        B2 --> B3 --> B5 --> B6
        B2 --> B4 --> B5
    end

    BEFORE --> NOW
```


## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
