### PR TITLE
[refactor] - fix the proto.Docker and github CI, enable zizmor linter

### DIFF
--- a/.github/workflows/build-docker-proto-image.yaml
+++ b/.github/workflows/build-docker-proto-image.yaml
@@ -3,33 +3,59 @@ name: Build and Push harmony proto Docker Image
 on:
   workflow_dispatch:
 
+permissions: {}
 jobs:
   build_and_push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout harmony core code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
         with:
           path: harmony
           ref: ${{ github.ref }}
-          fetch-depth: 0
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Get image version
+        id: image-version
+        run: |
+          set -euo pipefail
+
+          SHORT_SHA="$(git -C harmony rev-parse --short=12 HEAD)"
+          FULL_SHA="$(git -C harmony rev-parse HEAD)"
+
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "full_sha=${FULL_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 #v4.2.0
+        with:
+          platforms: arm64
+          cache-image: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 #v4.1.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee #v4.2.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a #v7.3.0
         with:
           context: ./harmony/api/service/synchronize/legacysync/downloader
           file: ./harmony/api/service/synchronize/legacysync/downloader/Proto.Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
+            harmonyone/harmony-proto:${{ steps.image-version.outputs.short_sha }}
             harmonyone/harmony-proto:latest
+          labels: |
+            org.opencontainers.image.revision=${{ steps.image-version.outputs.full_sha }}
+            org.opencontainers.image.version=${{ steps.image-version.outputs.short_sha }}

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,35 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+    paths:
+      - '.github/workflows/**/*.yml'
+      - '.github/workflows/**/*.yaml'
+
+  pull_request:
+    branches: ["**"]
+    paths:
+      - '.github/workflows/**/*.yml'
+      - '.github/workflows/**/*.yaml'
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          inputs: ./.github/
+          advanced-security: false

--- a/api/service/synchronize/legacysync/downloader/Proto.Dockerfile
+++ b/api/service/synchronize/legacysync/downloader/Proto.Dockerfile
@@ -1,9 +1,12 @@
 FROM golang:1.24.2-bullseye
 
-RUN apt update
-RUN apt install -y protobuf-compiler
-RUN protoc --version
-RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30.0
-RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3
+# hadolint ignore=DL3008
+RUN apt-get update > /dev/null 2>&1 && \
+    apt-get install -y protobuf-compiler --no-install-recommends && \
+    protoc --version && \
+    go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30.0 && \
+    go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3 && \
+    apt-get clean > /dev/null 2>&1 && \
+    rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["protoc", "-I=/tmp", "--go_out=/tmp", "--go-grpc_out=/tmp"]


### PR DESCRIPTION
## Issue

What was done:
* fix the all static lint issues on the build-docker-proto-image workflow
* add versioning via short sha for the image instead of just latest
* additionally add even full sha as a label for the image
* fix all hadolint issues on the proto.Docker file
* add [zizmor](https://zizmor.sh/) to lint our github actions

## Test

My test docker image - https://hub.docker.com/r/murme123/harmony-proto/tags
I've already tried to run it in our tests, **note: this change will be the second pr, when I'll create proto image in the harmonyone dockerhub:**  - https://github.com/mur-me/harmony/actions/runs/28533403471

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
