### PR TITLE
[fix] - switch unit tests to the new proto image, enable unit tests on the arm64

### DIFF
--- a/.github/workflows/build-docker-proto-image.yaml
+++ b/.github/workflows/build-docker-proto-image.yaml
@@ -38,10 +38,10 @@ jobs:
           cache-image: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 #v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c #v4.2.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee #v4.2.0
+        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 #v4.3.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -83,13 +83,11 @@ jobs:
           compression-level: 6
 
   go-checker:
-    name: Run unit tests
+    name: Run unit tests (${{ matrix.arch }})
     needs: build
-    # TODO:@mur-me for now only amd64, in the future
-    # frozen621/harmony-proto:latest shouldn't be used and
-    # build-docker-proto-image.yaml should cover it
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 25
+    strategy: *arch-matrix
     steps:
       - *checkout-harmony
       - *checkout-mcl

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -202,10 +202,10 @@ jobs:
           cache-image: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 #v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c #v4.2.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee #v4.2.0
+        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 #v4.3.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/api/proto/message/gen.sh
+++ b/api/proto/message/gen.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run --platform linux/amd64 -v ${PWD}:/tmp ${PROTOC_IMAGE}  /tmp/harmonymessage.proto
+docker run -v ${PWD}:/tmp ${PROTOC_IMAGE}  /tmp/harmonymessage.proto

--- a/api/service/synchronize/legacysync/downloader/proto/gen.sh
+++ b/api/service/synchronize/legacysync/downloader/proto/gen.sh
@@ -6,4 +6,4 @@
 #SRC_DIR=$(dirname $0)
 #protoc -I ${SRC_DIR}/proto/ ${SRC_DIR}/proto/downloader.proto --go_out=${SRC_DIR}/proto --go-grpc_out=${SRC_DIR}/proto
 
-docker run --platform linux/amd64 -v ${PWD}:/tmp ${PROTOC_IMAGE}  /tmp/downloader.proto
+docker run -v ${PWD}:/tmp ${PROTOC_IMAGE}  /tmp/downloader.proto

--- a/p2p/stream/protocols/sync/message/gen.sh
+++ b/p2p/stream/protocols/sync/message/gen.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run --platform linux/amd64 -v ${PWD}:/tmp ${PROTOC_IMAGE} /tmp/msg.proto
+docker run -v ${PWD}:/tmp ${PROTOC_IMAGE} /tmp/msg.proto

--- a/scripts/gogenerate.sh
+++ b/scripts/gogenerate.sh
@@ -6,4 +6,4 @@ case "${0}" in
 *) progdir=.;;
 esac
 git grep -l '^//go:generate ' -- '*.go' | \
-	PROTOC_IMAGE="frozen621/harmony-proto:latest" "${progdir}/xargs_by_dir.sh" go generate -v -x
+	PROTOC_IMAGE="harmonyone/harmony-proto:51f7fa3c1588" "${progdir}/xargs_by_dir.sh" go generate -v -x


### PR DESCRIPTION
## Issue

What was  done: 
* turned on unit tests on the ARM architecture:
  * created a new proto image https://hub.docker.com/r/harmonyone/harmony-proto/tags on the dev branch
  * started to use in the code as `harmonyone/harmony-proto:51f7fa3c1588` which is multiarch build for amd64/arm64
  * removed everything connected with hardcoded `--platform linux/amd64`, platform must resolve automatically
  * enabled the same matrix as usual - arm64 and amd64
* upgraded docker actions to use the latest releases

## Test

Github actions run: https://github.com/harmony-one/harmony/pull/5073/checks

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
