### PR TITLE
Update epoch values for Bloom release activation

### DIFF
--- a/core/beacon_slash_validate_test.go
+++ b/core/beacon_slash_validate_test.go
@@ -54,7 +54,7 @@ func TestCheckBeaconSlashEvidenceUniqueness_SkippedBeforeFork(t *testing.T) {
 	records, _ := reporterVariantSlashRecords(t)
 	cfg := params.MainnetChainConfig
 
-	err := checkBeaconSlashEvidenceUniqueness(cfg, big.NewInt(1_000_000), records)
+	err := checkBeaconSlashEvidenceUniqueness(cfg, big.NewInt(2958), records)
 	require.NoError(t, err)
 }
 
@@ -100,7 +100,7 @@ func TestCheckBeaconHeaderSlashEvidence_SkippedBeforeFork(t *testing.T) {
 	records, _ := reporterVariantSlashRecords(t)
 	cfg := params.MainnetChainConfig
 
-	err := checkBeaconHeaderSlashEvidence(cfg, nil, nil, big.NewInt(1_000_000), records)
+	err := checkBeaconHeaderSlashEvidence(cfg, nil, nil, big.NewInt(2958), records)
 	require.NoError(t, err)
 }
 

--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -42,13 +42,10 @@ var (
 		EIP155Epoch:                           big.NewInt(28),
 		S3Epoch:                               big.NewInt(28),
 		CrossTxEpoch:                          big.NewInt(28),
-		CXMerkleProofReplayFixEpoch:           EpochTBD,
-		CXReceiptStateRollbackEpoch:           EpochTBD,
 		MinCommissionPromoPeriod:              big.NewInt(100),
 		ReceiptLogEpoch:                       big.NewInt(101),
 		PreStakingEpoch:                       big.NewInt(185),
 		CrossLinkEpoch:                        big.NewInt(186),
-		RejectShard0CrossLinkEpoch:            EpochTBD, // mainnet activation TBD (consensus hardfork)
 		StakingEpoch:                          big.NewInt(186),
 		QuickUnlockEpoch:                      big.NewInt(191),
 		FiveSecondsEpoch:                      big.NewInt(230),
@@ -80,13 +77,22 @@ var (
 		LeaderRotationInternalValidatorsEpoch: big.NewInt(2152), // 2024-10-31 13:02 UTC
 		LeaderRotationExternalValidatorsEpoch: big.NewInt(2152), // 2024-10-31 13:02 UTC
 		HIP32Epoch:                            big.NewInt(2152), // 2024-10-31 13:02 UTC
+		CXMerkleProofReplayFixEpoch:           big.NewInt(2959), // Bloom release
+		RejectShard0CrossLinkEpoch:            big.NewInt(2959), // Bloom release
+		DuplicateCrossLinkEpoch:               big.NewInt(2959), // Bloom release
+		ValidatorWrapperAddressBindEpoch:      big.NewInt(2959), // Bloom release
+		SlashExternalStakeDenomFixEpoch:       big.NewInt(2959), // Bloom release
+		RejectDuplicateSlashEvidenceEpoch:     big.NewInt(2959), // Bloom release
+		SlashGroupOrderFixEpoch:               big.NewInt(2959), // Bloom release
+		CXReceiptStateRollbackEpoch:           big.NewInt(2959), // Bloom release
+		ShardStateValidationEpoch:             big.NewInt(2959), // Bloom release
+		SlashBallotSignerFixEpoch:             big.NewInt(2959), // Bloom release
+		VerifyBeaconHeaderSlashEpoch:          big.NewInt(2959), // Bloom release
 		AllowlistEpoch:                        EpochTBD,
 		LeaderRotationV2Epoch:                 EpochTBD,
 		DevnetExternalEpoch:                   EpochTBD,
 		TestnetExternalEpoch:                  EpochTBD,
 		TimestampValidationEpoch:              EpochTBD,
-		DuplicateCrossLinkEpoch:               EpochTBD,
-		ShardStateValidationEpoch:             EpochTBD,
 		IsOneSecondEpoch:                      EpochTBD,
 		EIP2537PrecompileEpoch:                EpochTBD,
 		EIP1153TransientStorageEpoch:          EpochTBD,
@@ -97,13 +103,7 @@ var (
 		EIP6780Epoch:                          EpochTBD,
 		PragueEpoch:                           EpochTBD,
 		EIP8024Epoch:                          EpochTBD,
-		ValidatorWrapperAddressBindEpoch:      EpochTBD,
-		SlashExternalStakeDenomFixEpoch:       EpochTBD,
-		RejectDuplicateSlashEvidenceEpoch:     EpochTBD,
-		SlashGroupOrderFixEpoch:               EpochTBD,
 		BLSProofBindEpoch:                     EpochTBD,
-		SlashBallotSignerFixEpoch:             EpochTBD,
-		VerifyBeaconHeaderSlashEpoch:          EpochTBD,
 	}
 
 	// TestnetChainConfig contains the chain parameters to run a node on the harmony test network.

--- a/internal/params/config_test.go
+++ b/internal/params/config_test.go
@@ -16,9 +16,8 @@ func TestIsOneEpochBeforeHIP30(t *testing.T) {
 	require.False(t, c.IsOneEpochBeforeHIP30(big.NewInt(3)))
 }
 
-func TestMainnetTBDFeaturesInactiveBeforeActivation(t *testing.T) {
-	// Representative mainnet epoch well below every EpochTBD placeholder (10_000_000).
-	epoch := big.NewInt(3000)
+func TestMainnetFeaturesInactiveBeforeBloomActivation(t *testing.T) {
+	epoch := big.NewInt(2958)
 	cfg := MainnetChainConfig
 
 	checks := []struct {
@@ -63,4 +62,35 @@ func TestMainnetTBDFeaturesInactiveBeforeActivation(t *testing.T) {
 	require.False(t, rules.Is7939CLZ)
 	require.False(t, rules.IsEIP5656Mcopy)
 	require.False(t, rules.IsCXReceiptStateRollback)
+}
+
+func TestMainnetBloomFeaturesActiveAtActivation(t *testing.T) {
+	epoch := big.NewInt(2959)
+	cfg := MainnetChainConfig
+
+	checks := []struct {
+		name string
+		got  bool
+	}{
+		{"CXMerkleProofReplayFix", cfg.IsCXMerkleProofReplayFixEpoch(epoch)},
+		{"CXReceiptStateRollback", cfg.IsCXReceiptStateRollback(epoch)},
+		{"RejectShard0CrossLink", cfg.IsRejectShard0CrossLink(epoch)},
+		{"DuplicateCrossLink", cfg.IsDuplicateCrossLinkRejection(epoch)},
+		{"ShardStateValidation", cfg.IsShardStateValidation(epoch)},
+		{"ValidatorWrapperAddressBind", cfg.IsValidatorWrapperAddressBind(epoch)},
+		{"SlashExternalStakeDenomFix", cfg.IsSlashExternalStakeDenomFix(epoch)},
+		{"RejectDuplicateSlashEvidence", cfg.IsRejectDuplicateSlashEvidence(epoch)},
+		{"SlashGroupOrderFix", cfg.IsSlashGroupOrderFix(epoch)},
+		{"SlashBallotSignerFix", cfg.IsSlashBallotSignerFix(epoch)},
+		{"VerifyBeaconHeaderSlash", cfg.IsVerifyBeaconHeaderSlash(epoch)},
+	}
+
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			require.True(t, check.got, "Bloom feature should be active at activation epoch")
+		})
+	}
+
+	rules := cfg.Rules(epoch)
+	require.True(t, rules.IsCXReceiptStateRollback)
 }


### PR DESCRIPTION
This pull request updates the mainnet chain configuration in `internal/params/config.go` to schedule several protocol upgrades (hardforks) for activation at epoch 2959, which is labeled as the "Bloom release." Previously, these upgrades were marked as "TBD" (to be determined). This change ensures that all the related protocol features are enabled simultaneously at the specified epoch.

Mainnet protocol upgrade scheduling:

* Set the activation epoch for multiple protocol features to `2959` (the Bloom release), including `CXMerkleProofReplayFixEpoch`, `RejectShard0CrossLinkEpoch`, `DuplicateCrossLinkEpoch`, `ValidatorWrapperAddressBindEpoch`, `SlashExternalStakeDenomFixEpoch`, `RejectDuplicateSlashEvidenceEpoch`, `SlashGroupOrderFixEpoch`, `CXReceiptStateRollbackEpoch`, `ShardStateValidationEpoch`, `SlashBallotSignerFixEpoch`, and `VerifyBeaconHeaderSlashEpoch`.
* Removed the "TBD" (to be determined) status for these protocol features in the configuration, replacing them with the scheduled epoch [[1]](diffhunk://#diff-059a645c15f37b27def02577139d5b663f6d5accc121a58c6401fceae3241062L45-L51) [[2]](diffhunk://#diff-059a645c15f37b27def02577139d5b663f6d5accc121a58c6401fceae3241062L100-L106).

These changes coordinate the activation of several protocol improvements and fixes to occur together at epoch 2959.