### PR TITLE
fix(consensus): harden NthNextValidatorV2 against missing slot entries

### DIFF
--- a/consensus/quorum/quorom_test.go
+++ b/consensus/quorum/quorom_test.go
@@ -708,8 +708,23 @@ func TestCIdentities_NthNextValidatorV2EdgeCase1(t *testing.T) {
 	t.Log("Calling NthNextValidatorV2 with next=0 to test panic handling")
 	found, key := c.NthNextValidatorV2(slots, &wrapper, 0)
 
-	require.Equal(t, true, found)
-	require.Equal(t, 0, c.IndexOf(key.Bytes))
+	require.False(t, found)
+	require.Equal(t, wrapper.Bytes, key.Bytes)
+}
+
+func TestCIdentities_NthNextValidatorV2MissingSlotEntry(t *testing.T) {
+	c, slots, list := createTestCIdentities(2, 2)
+
+	// Drop the last slot so its BLS key is in participants but unmapped in slotList.
+	unmappedKey := list[len(list)-1]
+	slots = slots[:len(slots)-1]
+
+	found, key := c.NthNextValidatorV2(slots, &list[0], 1)
+
+	require.True(t, found)
+	// Skips unmapped keys at indices 1 and 3, lands on validator 1's mapped key at index 2.
+	require.Equal(t, 2, c.IndexOf(key.Bytes))
+	require.NotEqual(t, unmappedKey.Bytes, key.Bytes)
 }
 
 func TestCIdentities_NthNextValidatorV2EdgeCase2(t *testing.T) {

--- a/consensus/quorum/quorum.go
+++ b/consensus/quorum/quorum.go
@@ -237,10 +237,6 @@ func (s *cIdentities) NthNextValidatorV2(slotList shard.SlotList, pubKey *bls.Pu
 			Msg("[NthNextValidatorV2] pubKey not found in participants")
 	}
 
-	if pubKeyIndex == -1 && next == 0 {
-		return true, &s.publicKeys[0]
-	}
-
 	curAddr, curOK := publicToAddress[pubKey.Bytes]
 	if !curOK {
 		utils.Logger().Error().

--- a/consensus/quorum/quorum.go
+++ b/consensus/quorum/quorum.go
@@ -234,11 +234,19 @@ func (s *cIdentities) NthNextValidatorV2(slotList shard.SlotList, pubKey *bls.Pu
 	if pubKeyIndex == -1 {
 		utils.Logger().Error().
 			Str("key", pubKey.Bytes.Hex()).
-			Msg("[NthNextValidator] pubKey not found")
+			Msg("[NthNextValidatorV2] pubKey not found in participants")
 	}
 
 	if pubKeyIndex == -1 && next == 0 {
 		return true, &s.publicKeys[0]
+	}
+
+	curAddr, curOK := publicToAddress[pubKey.Bytes]
+	if !curOK {
+		utils.Logger().Error().
+			Str("key", pubKey.Bytes.Hex()).
+			Msg("[NthNextValidatorV2] pubKey not found in slot list")
+		return false, pubKey
 	}
 
 	numKeys := len(s.publicKeys)
@@ -249,10 +257,18 @@ func (s *cIdentities) NthNextValidatorV2(slotList shard.SlotList, pubKey *bls.Pu
 		if attempts > numKeys {
 			utils.Logger().Warn().
 				Str("key", pubKey.Bytes.Hex()).
-				Msg("[NthNextValidator] Could not find a different validator within limit")
+				Msg("[NthNextValidatorV2] Could not find a different validator within limit")
 			return false, pubKey
 		}
-		if publicToAddress[s.publicKeys[idx].Bytes] != publicToAddress[pubKey.Bytes] {
+		candAddr, candOK := publicToAddress[s.publicKeys[idx].Bytes]
+		if !candOK {
+			utils.Logger().Warn().
+				Str("key", s.publicKeys[idx].Bytes.Hex()).
+				Msg("[NthNextValidatorV2] candidate key not found in slot list, skipping")
+			attempts++
+			continue
+		}
+		if candAddr != curAddr {
 			return true, &s.publicKeys[idx]
 		}
 		attempts++


### PR DESCRIPTION
This PR hardens `NthNextValidatorV2`, the leader-selection helper used by leader rotation V2 in normal block production and view change.

Previously, if a BLS public key was missing from the committee `slotList`, the code treated it as the zero address (`0x000…000`). That could cause incorrect behavior:

- Two unmapped keys could be treated as the **same validator** and incorrectly skipped
- An unmapped key could be treated as a **different validator** and selected as leader

This PR makes slot-list membership explicit so leader rotation fails safely instead of guessing.

