### PR TITLE
testnet: move Bloom hardfork activation to epoch 7414

### DIFF
--- a/internal/params/config.go
+++ b/internal/params/config.go
@@ -178,7 +178,7 @@ var (
 		RejectShard0CrossLinkEpoch:            big.NewInt(7385),
 		CXMerkleProofReplayFixEpoch:           big.NewInt(7385),
 		BLSProofBindEpoch:                     big.NewInt(7420),
-		BloomEpoch:                            big.NewInt(7420),
+		BloomEpoch:                            big.NewInt(7414),
 	}
 	// PangaeaChainConfig contains the chain parameters for the Pangaea network.
 	// All features except for CrossLink are enabled at launch.


### PR DESCRIPTION
This PR moves `BloomEpoch` on testnet from 7420 to 7414.

