### PR TITLE
fix(unit_test): fix the TestBloomEpochConfigured, the smallest epoch should be choosen

### DIFF
--- a/internal/params/config_test.go
+++ b/internal/params/config_test.go
@@ -65,15 +65,34 @@ func TestMainnetTBDFeaturesInactiveBeforeActivation(t *testing.T) {
 	require.False(t, rules.IsCXReceiptStateRollback)
 }
 
+func requireBloomFeaturesActiveAtBloom(
+	t *testing.T,
+	name string,
+	cfg *ChainConfig,
+	featureEpochs []*big.Int,
+) {
+	t.Helper()
+
+	maxFeatureEpoch := maxEpoch(featureEpochs)
+
+	require.Truef(
+		t,
+		cfg.isBloomFeatureActive(maxFeatureEpoch, cfg.BloomEpoch),
+		"%s bloom features must be active at BloomEpoch=%s; max feature epoch=%s",
+		name,
+		cfg.BloomEpoch,
+		maxFeatureEpoch,
+	)
+}
+
 func TestBloomEpochConfigured(t *testing.T) {
 	require.Equal(t, big.NewInt(7414), TestnetChainConfig.BloomEpoch)
 	require.Equal(t, big.NewInt(53508), PartnerChainConfig.BloomEpoch)
 	require.Equal(t, big.NewInt(5), LocalnetChainConfig.BloomEpoch)
 
-	require.True(t, TestnetChainConfig.BloomEpoch.Cmp(maxEpoch(testnetBloomFeatureEpochs())) >= 0)
-	require.True(t, PartnerChainConfig.BloomEpoch.Cmp(maxEpoch(devnetBloomFeatureEpochs())) >= 0)
-	require.True(t, LocalnetChainConfig.BloomEpoch.Cmp(maxEpoch(localnetBloomFeatureEpochs())) >= 0)
-
+	requireBloomFeaturesActiveAtBloom(t, "testnet", TestnetChainConfig, testnetBloomFeatureEpochs())
+	requireBloomFeaturesActiveAtBloom(t, "partner", PartnerChainConfig, devnetBloomFeatureEpochs())
+	requireBloomFeaturesActiveAtBloom(t, "localnet", LocalnetChainConfig, localnetBloomFeatureEpochs())
 	for _, epoch := range localnetBloomFeatureEpochs() {
 		require.Equal(t, big.NewInt(5), epoch)
 	}


### PR DESCRIPTION
## Issue

The current test still assumes the old invariant:

```go
BloomEpoch >= max(bloom feature epochs)
```

That was valid when `BloomEpoch` was `7420`, but this PR intentionally changes the testnet `BloomEpoch` to `7414` while several bloom-related feature epochs (e.g. `LeaderRotationV2Epoch`, `EIP2537PrecompileEpoch`, `BLSProofBindEpoch`) remain at `7420`.

As a result, the assertion now evaluates to:

```text
7414 >= 7420 // false
```

and fails, even though the configuration is intentional.

The test should verify the actual behavior implemented by the code—that bloom-bundled features are active at `BloomEpoch`—rather than requiring `BloomEpoch` to be numerically greater than or equal to every individual feature epoch. The latter assumption is no longer valid after introducing an earlier `BloomEpoch`.


## Test

### Unit Test Coverage

Before:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

After:

```
<!-- copy/paste 'go test -cover' result in the directory you made change -->
```

### Test/Run Logs

<!-- links to the test/run log, or copy&paste part of the log if it is too long -->
<!-- or you may just create a [gist](https://gist.github.com/) and link the gist here -->

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **YES|NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

3. **Describe how the plan was tested.**

4. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

5. **What are the planned flag epoch numbers and their ETAs on Pangaea?**

6. **What are the planned flag epoch numbers and their ETAs on mainnet?**

    Note that this must be enough to cover baking period on Pangaea.

7. **What should node operators know about this planned change?**

8. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 11.)

    **YES|NO**

9. **Does the existing `node.sh` continue to work with this change?**

10. **What should node operators know about this change?**

11. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

## TODO
