### PR TITLE
Perf: skip re-encoding unchanged validator wrappers on Finalise

### DIFF
--- a/core/state/journal.go
+++ b/core/state/journal.go
@@ -158,6 +158,7 @@ func (v validatorWrapperChange) dirtied() *common.Address {
 // revert undoes the changes introduced by this journal entry.
 func (v validatorWrapperChange) revert(s *DB) {
 	s.stateValidators[*(v.address)] = v.prev
+	s.MarkValidatorWrapperDirty(*(v.address))
 }
 
 func (ch createObjectChange) revert(s *DB) {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -93,6 +93,7 @@ type DB struct {
 	stateObjectsDirty    map[common.Address]struct{} // State objects modified in the current execution
 	stateObjectsDestruct map[common.Address]struct{} // State objects destructed in the block
 	stateValidators      map[common.Address]*stk.ValidatorWrapper
+	stateValidatorsDirty map[common.Address]struct{} // Cached wrappers that need a write on Finalise
 
 	// DB error.
 	// State objects are used by the consensus core and VM which are
@@ -163,6 +164,7 @@ func New(root common.Hash, db Database, snaps *snapshot.Tree) (*DB, error) {
 		stateObjectsDirty:    make(map[common.Address]struct{}),
 		stateObjectsDestruct: make(map[common.Address]struct{}),
 		stateValidators:      make(map[common.Address]*stk.ValidatorWrapper),
+		stateValidatorsDirty: make(map[common.Address]struct{}),
 		logs:                 make(map[common.Hash][]*types2.Log),
 		preimages:            make(map[common.Hash][]byte),
 		journal:              newJournal(),
@@ -224,6 +226,7 @@ func (db *DB) Reset(root common.Hash) error {
 	db.stateObjectsPending = make(map[common.Address]struct{})
 	db.stateObjectsDirty = make(map[common.Address]struct{})
 	db.stateValidators = make(map[common.Address]*stk.ValidatorWrapper)
+	db.stateValidatorsDirty = make(map[common.Address]struct{})
 	db.thash = common.Hash{}
 	db.bhash = common.Hash{}
 	db.ethTxHash = common.Hash{}
@@ -781,6 +784,7 @@ func (db *DB) Copy() *DB {
 		stateObjectsDirty:    make(map[common.Address]struct{}, len(db.journal.dirties)),
 		stateObjectsDestruct: make(map[common.Address]struct{}, len(db.stateObjectsDestruct)),
 		stateValidators:      make(map[common.Address]*stk.ValidatorWrapper),
+		stateValidatorsDirty: make(map[common.Address]struct{}, len(db.stateValidatorsDirty)),
 		refund:               db.refund,
 		logs:                 make(map[common.Hash][]*types2.Log, len(db.logs)),
 		logSize:              db.logSize,
@@ -824,9 +828,16 @@ func (db *DB) Copy() *DB {
 	for addr := range db.stateObjectsDestruct {
 		state.stateObjectsDestruct[addr] = struct{}{}
 	}
+	// Deep-copy all cached validator wrappers and preserve dirty flags.
 	for addr, wrapper := range db.stateValidators {
+		if wrapper == nil {
+			continue
+		}
 		copied := staketest.CopyValidatorWrapper(*wrapper)
 		state.stateValidators[addr] = &copied
+	}
+	for addr := range db.stateValidatorsDirty {
+		state.stateValidatorsDirty[addr] = struct{}{}
 	}
 	for hash, logs := range db.logs {
 		cpy := make([]*types2.Log, len(logs))
@@ -912,16 +923,22 @@ func (db *DB) GetRefund() uint64 {
 // the journal as well as the refunds. Finalise, however, will not push any updates
 // into the tries just yet. Only IntermediateRoot or Commit will do that.
 func (db *DB) Finalise(deleteEmptyObjects bool) {
-	// Commit validator changes in cache to stateObjects
-	// TODO: remove validator cache after commit
-	for addr, wrapper := range db.stateValidators {
+	// Persist dirty validator wrappers into account code.
+	remainingDirty := make(map[common.Address]struct{})
+	for addr := range db.stateValidatorsDirty {
+		wrapper, ok := db.stateValidators[addr]
+		if !ok || wrapper == nil {
+			continue
+		}
 		if err := db.UpdateValidatorWrapper(addr, wrapper); err != nil {
 			utils.Logger().Warn().Err(err).
 				Str("name", wrapper.Name).
 				Str("addr", addr.String()).
 				Msg("Unable to update the validator wrapper on the finalize")
+			remainingDirty[addr] = struct{}{}
 		}
 	}
+	db.stateValidatorsDirty = remainingDirty
 	addressesToPrefetch := make([][]byte, 0, len(db.journal.dirties))
 	for addr := range db.journal.dirties {
 		obj, exist := db.stateObjects[addr]
@@ -1297,6 +1314,14 @@ func (db *DB) CachedValidatorAddresses() []common.Address {
 	return addrs
 }
 
+// MarkValidatorWrapperDirty marks the cached validator wrapper for write on Finalise.
+func (db *DB) MarkValidatorWrapperDirty(addr common.Address) {
+	if db.stateValidatorsDirty == nil {
+		db.stateValidatorsDirty = make(map[common.Address]struct{})
+	}
+	db.stateValidatorsDirty[addr] = struct{}{}
+}
+
 // ValidatorWrapper retrieves the existing validator in the cache, if sendOriginal
 // else it will return a copy of the wrapper - which needs to be explicitly committed
 // with UpdateValidatorWrapper.
@@ -1376,6 +1401,7 @@ func (db *DB) UpdateValidatorWrapper(
 	db.SetCode(addr, by, true)
 	// update cache
 	db.stateValidators[addr] = val
+	db.MarkValidatorWrapperDirty(addr)
 	return nil
 }
 
@@ -1468,6 +1494,7 @@ func (db *DB) AddReward(
 		return nil
 	}
 
+	db.MarkValidatorWrapperDirty(snapshot.Address)
 	rewardPool := big.NewInt(0).Set(reward)
 	curValidator.BlockReward.Add(curValidator.BlockReward, reward)
 	// Payout commission

--- a/core/state/validator_dirty_test.go
+++ b/core/state/validator_dirty_test.go
@@ -1,0 +1,180 @@
+package state
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/harmony-one/harmony/core/rawdb"
+	"github.com/harmony-one/harmony/numeric"
+	staketest "github.com/harmony-one/harmony/staking/types/test"
+)
+
+func TestFinaliseWritesOnlyDirtyValidators(t *testing.T) {
+	db, _ := New(common.Hash{}, NewDatabase(rawdb.NewMemoryDatabase()), nil)
+
+	cleanAddr := common.BytesToAddress([]byte("validator-clean"))
+	dirtyAddr := common.BytesToAddress([]byte("validator-dirty"))
+
+	clean := staketest.GetDefaultValidatorWrapper()
+	clean.Address = cleanAddr
+	clean.Delegations[0].DelegatorAddress = cleanAddr
+	dirty := staketest.GetDefaultValidatorWrapper()
+	dirty.Address = dirtyAddr
+	dirty.Delegations[0].DelegatorAddress = dirtyAddr
+
+	if err := db.UpdateValidatorWrapper(cleanAddr, &clean); err != nil {
+		t.Fatalf("UpdateValidatorWrapper clean: %v", err)
+	}
+	if err := db.UpdateValidatorWrapper(dirtyAddr, &dirty); err != nil {
+		t.Fatalf("UpdateValidatorWrapper dirty: %v", err)
+	}
+	db.Finalise(false)
+
+	cleanCodeBefore := append([]byte(nil), db.GetCode(cleanAddr)...)
+	dirtyCodeBefore := append([]byte(nil), db.GetCode(dirtyAddr)...)
+	if len(cleanCodeBefore) == 0 || len(dirtyCodeBefore) == 0 {
+		t.Fatal("expected validator code to be present after finalize")
+	}
+
+	if _, err := db.ValidatorWrapper(cleanAddr, true, false); err != nil {
+		t.Fatalf("load clean: %v", err)
+	}
+	dirtyWrapper, err := db.ValidatorWrapper(dirtyAddr, true, false)
+	if err != nil {
+		t.Fatalf("load dirty: %v", err)
+	}
+	if _, ok := db.stateValidatorsDirty[cleanAddr]; ok {
+		t.Fatal("read-only load marked clean validator dirty")
+	}
+	if _, ok := db.stateValidatorsDirty[dirtyAddr]; ok {
+		t.Fatal("read-only load marked dirty validator dirty")
+	}
+
+	dirtyWrapper.BlockReward = big.NewInt(12345)
+	db.MarkValidatorWrapperDirty(dirtyAddr)
+
+	db.Finalise(false)
+
+	if !bytes.Equal(db.GetCode(cleanAddr), cleanCodeBefore) {
+		t.Fatal("clean validator was re-encoded on finalize")
+	}
+	if bytes.Equal(db.GetCode(dirtyAddr), dirtyCodeBefore) {
+		t.Fatal("dirty validator was not written on finalize")
+	}
+	if _, ok := db.stateValidatorsDirty[dirtyAddr]; ok {
+		t.Fatal("successful finalize left validator dirty")
+	}
+
+	got, err := db.ValidatorWrapper(dirtyAddr, true, false)
+	if err != nil {
+		t.Fatalf("reload dirty: %v", err)
+	}
+	if got.BlockReward.Cmp(big.NewInt(12345)) != 0 {
+		t.Fatalf("dirty BlockReward = %v, want 12345", got.BlockReward)
+	}
+}
+
+func TestAddRewardMarksValidatorDirty(t *testing.T) {
+	db, _ := New(common.Hash{}, NewDatabase(rawdb.NewMemoryDatabase()), nil)
+
+	addr := common.BytesToAddress([]byte("validator-reward"))
+	wrapper := staketest.GetDefaultValidatorWrapper()
+	wrapper.Address = addr
+	wrapper.Delegations[0].DelegatorAddress = addr
+	if err := db.UpdateValidatorWrapper(addr, &wrapper); err != nil {
+		t.Fatalf("UpdateValidatorWrapper: %v", err)
+	}
+	db.Finalise(false)
+
+	snapshot := staketest.GetDefaultValidatorWrapper()
+	snapshot.Address = addr
+	snapshot.Delegations[0].DelegatorAddress = addr
+	shares := map[common.Address]numeric.Dec{
+		addr: numeric.NewDec(1),
+	}
+	if err := db.AddReward(&snapshot, big.NewInt(1000), shares); err != nil {
+		t.Fatalf("AddReward: %v", err)
+	}
+	if _, ok := db.stateValidatorsDirty[addr]; !ok {
+		t.Fatal("AddReward did not mark validator dirty")
+	}
+}
+
+func TestCopyPreservesValidatorCacheAndDirtyFlags(t *testing.T) {
+	db, _ := New(common.Hash{}, NewDatabase(rawdb.NewMemoryDatabase()), nil)
+
+	cleanAddr := common.BytesToAddress([]byte("copy-clean"))
+	dirtyAddr := common.BytesToAddress([]byte("copy-dirty"))
+
+	clean := staketest.GetDefaultValidatorWrapper()
+	clean.Address = cleanAddr
+	clean.Delegations[0].DelegatorAddress = cleanAddr
+	dirty := staketest.GetDefaultValidatorWrapper()
+	dirty.Address = dirtyAddr
+	dirty.Delegations[0].DelegatorAddress = dirtyAddr
+
+	if err := db.UpdateValidatorWrapper(cleanAddr, &clean); err != nil {
+		t.Fatalf("UpdateValidatorWrapper clean: %v", err)
+	}
+	if err := db.UpdateValidatorWrapper(dirtyAddr, &dirty); err != nil {
+		t.Fatalf("UpdateValidatorWrapper dirty: %v", err)
+	}
+	db.Finalise(false)
+
+	if _, err := db.ValidatorWrapper(cleanAddr, true, false); err != nil {
+		t.Fatalf("load clean: %v", err)
+	}
+	dirtyWrapper, err := db.ValidatorWrapper(dirtyAddr, true, false)
+	if err != nil {
+		t.Fatalf("load dirty: %v", err)
+	}
+	dirtyWrapper.BlockReward = big.NewInt(7)
+	db.MarkValidatorWrapperDirty(dirtyAddr)
+
+	copied := db.Copy()
+	if _, ok := copied.stateValidators[cleanAddr]; !ok {
+		t.Fatal("copy missing clean validator wrapper")
+	}
+	if _, ok := copied.stateValidators[dirtyAddr]; !ok {
+		t.Fatal("copy missing dirty validator wrapper")
+	}
+	if _, ok := copied.stateValidatorsDirty[dirtyAddr]; !ok {
+		t.Fatal("copy missing dirty flag")
+	}
+	if _, ok := copied.stateValidatorsDirty[cleanAddr]; ok {
+		t.Fatal("copy marked clean validator dirty")
+	}
+	if copied.stateValidators[dirtyAddr].BlockReward.Cmp(big.NewInt(7)) != 0 {
+		t.Fatal("copy did not preserve dirty wrapper mutation")
+	}
+	if copied.stateValidators[dirtyAddr] == db.stateValidators[dirtyAddr] {
+		t.Fatal("copy shared wrapper pointer with original")
+	}
+}
+
+func TestCachedValidatorAddressesSurvivesFinaliseAndCopy(t *testing.T) {
+	db, _ := New(common.Hash{}, NewDatabase(rawdb.NewMemoryDatabase()), nil)
+
+	addr := common.BytesToAddress([]byte("cached-validator"))
+	wrapper := staketest.GetDefaultValidatorWrapper()
+	wrapper.Address = addr
+	wrapper.Delegations[0].DelegatorAddress = addr
+	db.SetValidatorFlag(addr)
+	if err := db.UpdateValidatorWrapper(addr, &wrapper); err != nil {
+		t.Fatalf("UpdateValidatorWrapper: %v", err)
+	}
+	db.Finalise(false)
+
+	addrs := db.CachedValidatorAddresses()
+	if len(addrs) != 1 || addrs[0] != addr {
+		t.Fatalf("CachedValidatorAddresses after Finalise = %v, want [%s]", addrs, addr.Hex())
+	}
+
+	copied := db.Copy()
+	copiedAddrs := copied.CachedValidatorAddresses()
+	if len(copiedAddrs) != 1 || copiedAddrs[0] != addr {
+		t.Fatalf("CachedValidatorAddresses on Copy = %v, want [%s]", copiedAddrs, addr.Hex())
+	}
+}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -554,6 +554,7 @@ func MayShardReduction(bc ChainContext, statedb *state.DB, header *block.Header)
 			// once epoch X begins, they can terminate servers from shards 2 and 3.
 			if curShard >= uint64(nextNumShards) || curShard != nextShard {
 				validator.Status = effective.Inactive
+				statedb.MarkValidatorWrapperDirty(address)
 				break
 			}
 		}

--- a/internal/chain/engine.go
+++ b/internal/chain/engine.go
@@ -428,14 +428,22 @@ func payoutUndelegations(
 				"[Finalize] failed to get validator from state to finalize",
 			)
 		}
+		wrapperDirty := false
 		for i := range wrapper.Delegations {
 			delegation := &wrapper.Delegations[i]
+			before := len(delegation.Undelegations)
 			totalWithdraw := delegation.RemoveUnlockedUndelegations(
 				header.Epoch(), wrapper.LastEpochInCommittee, lockPeriod, noEarlyUnlock, isMaxRate,
 			)
+			if len(delegation.Undelegations) != before {
+				wrapperDirty = true
+			}
 			if totalWithdraw.Sign() != 0 {
 				state.AddBalance(delegation.DelegatorAddress, totalWithdraw)
 			}
+		}
+		if wrapperDirty {
+			state.MarkValidatorWrapperDirty(validator)
 		}
 		countTrack[validator] = len(wrapper.Delegations)
 	}
@@ -484,6 +492,7 @@ func setElectionEpochAndMinFee(chain engine.ChainReader, header *block.Header, s
 		}
 		// Set last epoch in committee
 		wrapper.LastEpochInCommittee = newShardState.Epoch
+		state.MarkValidatorWrapperDirty(addr)
 		if minRateNotZero {
 			// Set first election epoch (applies only if previously unset)
 			state.SetValidatorFirstElectionEpoch(addr, newShardState.Epoch)

--- a/staking/availability/interface.go
+++ b/staking/availability/interface.go
@@ -27,4 +27,5 @@ type RoundHeader interface {
 type ValidatorState interface {
 	ValidatorWrapper(common.Address, bool, bool) (*staking.ValidatorWrapper, error)
 	UpdateValidatorWrapper(common.Address, *staking.ValidatorWrapper) error
+	MarkValidatorWrapperDirty(common.Address)
 }

--- a/staking/availability/measure.go
+++ b/staking/availability/measure.go
@@ -119,6 +119,7 @@ func bumpCount(
 					wrapper.Counters.NumBlocksSigned, common.Big1,
 				)
 			}
+			state.MarkValidatorWrapperDirty(addr)
 		}
 	}
 
@@ -216,6 +217,7 @@ func ComputeAndMutateEPOSStatus(
 	switch computed.IsBelowThreshold {
 	case missedTooManyBlocks:
 		wrapper.Status = effective.Inactive
+		state.MarkValidatorWrapperDirty(addr)
 		utils.Logger().Info().
 			Str("threshold", measure.String()).
 			Interface("computed", computed).
@@ -260,6 +262,7 @@ func UpdateMinimumCommissionFee(
 				Str("firstElectionEpoch", firstElectionEpoch.String()).
 				Msg("updating min commission rate")
 			wrapper.Rate.SetBytes(minRate.Bytes())
+			state.MarkValidatorWrapperDirty(addr)
 			return true, nil
 		}
 	}
@@ -268,6 +271,7 @@ func UpdateMinimumCommissionFee(
 
 type stateValidatorWrapper interface {
 	ValidatorWrapper(addr common.Address, sendOriginal bool, copyDelegations bool) (*staking.ValidatorWrapper, error)
+	MarkValidatorWrapperDirty(addr common.Address)
 }
 
 // UpdateMaxCommissionFee makes sure the max-rate is at least higher than the rate + max-rate-change.
@@ -295,6 +299,7 @@ func UpdateMaxCommissionFee(IsTopMaxRate bool, state stateValidatorWrapper, addr
 			Str("new max-rate", newRate.String()).
 			Msg("updating max commission rate")
 		wrapper.MaxRate.SetBytes(newRate.Bytes())
+		state.MarkValidatorWrapperDirty(addr)
 	}
 
 	return nil

--- a/staking/availability/measure_test.go
+++ b/staking/availability/measure_test.go
@@ -660,6 +660,8 @@ func (state testStateDB) UpdateValidatorWrapper(addr common.Address, wrapper *st
 	return nil
 }
 
+func (state testStateDB) MarkValidatorWrapperDirty(addr common.Address) {}
+
 func (state testStateDB) GetCode(addr common.Address, isValidatorCode bool) []byte {
 	wrapper, ok := state[addr]
 	if !ok {
@@ -793,6 +795,8 @@ type stateValidatorWrapperImpl struct {
 func (a stateValidatorWrapperImpl) ValidatorWrapper(addr common.Address, sendOriginal bool, copyDelegations bool) (*staking.ValidatorWrapper, error) {
 	return a.v, a.err
 }
+
+func (a stateValidatorWrapperImpl) MarkValidatorWrapperDirty(addr common.Address) {}
 
 func TestUpdateMaxCommissionFee(t *testing.T) {
 	t.Run("0.6 + 0.6 = 1 (100%)", func(t *testing.T) {

--- a/staking/slash/double-sign.go
+++ b/staking/slash/double-sign.go
@@ -403,6 +403,7 @@ func delegatorSlashApplyDebt(
 	slashTrack *Application,
 	useSlashExternalStakeDenomFix bool,
 ) error {
+	state.MarkValidatorWrapperDirty(current.Address)
 	slashIndexPairs, totalStake := makeSlashList(snapshot, current)
 	validatorDelegation := &current.Delegations[0]
 	selfStakeForExternalDenom := validatorDelegation.Amount


### PR DESCRIPTION
During block processing, validator wrappers are often loaded into the state cache for reading (rewards, snapshots, checks) and only some of them are actually changed. Today, `Finalise` re-encodes **every** cached validator with `SanityCheck` + full RLP, including validators that were only read. That is expensive when many validators and delegations are in cache.

This PR tracks which validator wrappers were mutated and writes only those on `Finalise`. Staking rules, unlock logic, election behavior, and on-disk RLP layout are unchanged. 

## What changed

Validator wrappers that change in place (rewards, signing counters, undelegation unlocks, commission updates, slash, and so on) are marked dirty. `UpdateValidatorWrapper` also marks dirty. On `Finalise`, only dirty wrappers are encoded and written into account code. Successful writes clear the dirty flag; failed writes stay dirty so a later finalize can retry.

`DB.Copy` still deep-copies the full validator cache and the dirty set, so same-block checks that rely on `CachedValidatorAddresses` keep working. Unit tests cover dirty finalize, `AddReward` dirty marking, copy behavior, and cached address visibility after finalize/copy.

## Compatibility

No hardfork is required. This is a node performance change only.