### PR TITLE
test: run Go checks natively and build localnet image on demand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SHELL := bash
 EPOCH_TO_WAIT ?=5
 EXTRA_NODES_FILE ?="./test/configs/local-extra-nodes.txt"
 
-.PHONY: all help libs exe race trace-pointer debug debug-ext debug-kill test test-go test-api test-api-attach linux_static deb_init deb_build deb debpub_dev debpub_prod rpm_init rpm_build rpm rpmpub_dev rpmpub_prod clean distclean docker go-vet go-test docker build_localnet_validator protofiles travis_go_checker travis_rpc_checker travis_rosetta_checker debug-start-log debug-stop-log debug-restart-log debug-delete-log
+.PHONY: all help libs exe race trace-pointer debug debug-ext debug-kill test test-all test-go test-integration test-rpc test-rpc-attach test-rosetta test-rosetta-attach test-pyhmy test-api test-api-attach linux_static deb_init deb_build deb debpub_dev debpub_prod rpm_init rpm_build rpm rpmpub_dev rpmpub_prod clean distclean docker go-vet go-test docker build_localnet_validator protofiles travis_go_checker travis_rpc_checker travis_rosetta_checker debug-start-log debug-stop-log debug-restart-log debug-delete-log
 
 all: libs
 	bash ./scripts/go_executable_build.sh -S
@@ -26,9 +26,12 @@ help:
 	@echo "debug-ext - start a localnet with 2 shards and external (s0 rpc endpoint = localhost:9598; s1 rpc endpoint = localhost:9596)"
 	@echo "clean - remove node files & logs created by localnet"
 	@echo "distclean - remove node files & logs created by localnet, and all libs"
-	@echo "test - run the entire test suite (go test & Node API test)"
+	@echo "test - run native Go checks and unit tests"
+	@echo "test-all - run native Go checks and all localnet integration suites"
 	@echo "test-go - run the go test (with go lint, fmt, imports, mod, and generate checks)"
+	@echo "test-integration - run RPC, Rosetta, and pyhmy localnet tests"
 	@echo "test-rpc - run the rpc tests"
+	@echo "test-pyhmy - run the pyhmy tests"
 	@echo "test-rpc-attach - attach onto the rpc testing docker container for inspection"
 	@echo "test-rosetta - run the rosetta tests"
 	@echo "test-rosetta-attach - attach onto the rosetta testing docker container for inspection"
@@ -141,14 +144,22 @@ distclean: clean
 go-get:
 	go get -v ./...
 
-test:
+test: test-go
+
+test-all:
 	bash ./test/all.sh
 
 test-go:
 	bash ./test/go.sh
 
+test-integration:
+	bash ./test/localnet.sh rpc rosetta pyhmy
+
 test-rpc:
 	bash ./test/rpc.sh run
+
+test-pyhmy:
+	bash ./test/localnet.sh pyhmy
 
 test-rpc-attach:
 	bash ./test/rpc.sh attach

--- a/test/all.sh
+++ b/test/all.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 bash "$DIR/kill_node.sh"
-docker pull harmonyone/localnet-test
-docker run -it \
-  -p 9500:9500 -p 9501:9501 -p 9599:9599 -p 9598:9598 -p 9799:9799 -p 9798:9798 -p 9899:9899 -p 9898:9898 \
-  -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test
+
+bash "$DIR/go.sh"
+bash "$DIR/localnet.sh" rpc rosetta pyhmy

--- a/test/build_linux_binaries.sh
+++ b/test/build_linux_binaries.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GO_BUILDER_IMAGE=${GO_BUILDER_IMAGE:-golang:1.24.2@sha256:30baaea08c5d1e858329c50f29fe381e9b7d7bced11a0f5f1f69a1504cdfbf5e}
+LOCALNET_ARCH=${LOCALNET_ARCH:-$(docker info --format '{{.Architecture}}')}
+BUILD_STAMP="$ROOT/bin/.localnet-build"
+
+case "$LOCALNET_ARCH" in
+  arm64|aarch64)
+    LOCALNET_ARCH=arm64
+    FILE_ARCH='ARM aarch64'
+    ;;
+  amd64|x86_64)
+    LOCALNET_ARCH=amd64
+    FILE_ARCH='x86-64'
+    ;;
+  *)
+    echo "Unsupported localnet architecture: $LOCALNET_ARCH" >&2
+    exit 2
+    ;;
+esac
+
+hash_stream() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | cut -d' ' -f1
+  else
+    shasum -a 256 | cut -d' ' -f1
+  fi
+}
+
+source_id=$({
+  git -C "$ROOT" rev-parse HEAD
+  git -C "$ROOT" diff --binary HEAD -- . ':(exclude)bin'
+  while IFS= read -r -d '' path; do
+    printf '%s\0' "$path"
+    git -C "$ROOT" hash-object "$path"
+  done < <(git -C "$ROOT" ls-files --others --exclude-standard -z)
+} | hash_stream)
+expected_stamp="$source_id $LOCALNET_ARCH $GO_BUILDER_IMAGE"
+
+binaries_match_arch() {
+  local binary description
+  for binary in harmony bootnode; do
+    [[ -x "$ROOT/bin/$binary" ]] || return 1
+    description=$(file "$ROOT/bin/$binary")
+    [[ "$description" == *"ELF 64-bit"* && "$description" == *"$FILE_ARCH"* ]] || return 1
+  done
+}
+
+has_current_binaries() {
+  binaries_match_arch || return 1
+  [[ -f "$BUILD_STAMP" ]] || return 1
+  [[ $(<"$BUILD_STAMP") == "$expected_stamp" ]]
+}
+
+if has_current_binaries; then
+  echo "[harmony] using existing Linux $LOCALNET_ARCH binaries"
+  exit 0
+fi
+
+git_common_dir=$(git -C "$ROOT" rev-parse --path-format=absolute --git-common-dir)
+mkdir -p "$ROOT/bin"
+
+mounts=(
+  -v "$ROOT:$ROOT"
+  -v harmony-go-mod-cache:/go/pkg/mod
+  -v harmony-go-build-cache:/root/.cache/go-build
+)
+if [[ "$git_common_dir" != "$ROOT"/* ]]; then
+  mounts+=(-v "$git_common_dir:$git_common_dir:ro")
+fi
+
+echo "[harmony] building Linux $LOCALNET_ARCH binaries with $GO_BUILDER_IMAGE"
+docker run --rm \
+  --platform "linux/$LOCALNET_ARCH" \
+  "${mounts[@]}" \
+  -w "$ROOT" \
+  -e "GOFLAGS=-buildvcs=false -mod=mod" \
+  "$GO_BUILDER_IMAGE" \
+  bash ./scripts/go_executable_build.sh -s
+
+if ! binaries_match_arch; then
+  echo "Linux $LOCALNET_ARCH harmony/bootnode build did not produce compatible binaries" >&2
+  exit 1
+fi
+
+printf '%s\n' "$expected_stamp" > "$BUILD_STAMP"

--- a/test/copy_harmony_worktree.sh
+++ b/test/copy_harmony_worktree.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE=${1:?source worktree is required}
+DESTINATION=${2:?destination is required}
+
+SOURCE=$(cd "$SOURCE" && pwd)
+mkdir -p "$DESTINATION"
+DESTINATION=$(cd "$DESTINATION" && pwd)
+
+(
+  cd "$SOURCE"
+  git ls-files -co --exclude-standard -z |
+    while IFS= read -r -d '' path; do
+      if [[ -e "$path" || -L "$path" ]]; then
+        printf '%s\0' "$path"
+      fi
+    done |
+    tar --null -T - -cf -
+) | tar -xf - -C "$DESTINATION"

--- a/test/go.sh
+++ b/test/go.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-docker pull harmonyone/localnet-test
-docker run -it \
-  -p 9500:9500 -p 9501:9501 -p 9599:9599 -p 9598:9598 -p 9799:9799 -p 9798:9798 -p 9899:9899 -p 9898:9898 \
-  -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test -g
+
+cd "$DIR/.."
+exec bash ./scripts/travis_go_checker.sh

--- a/test/localnet.Dockerfile
+++ b/test/localnet.Dockerfile
@@ -1,0 +1,126 @@
+FROM golang:1.24.2@sha256:30baaea08c5d1e858329c50f29fe381e9b7d7bced11a0f5f1f69a1504cdfbf5e
+
+ARG MAIN_REPO_BRANCH=dev
+ARG MAIN_REPO_ORG=harmony-one
+ARG APT_SNAPSHOT=20260729T000000Z
+ARG PYHMY_REF=5aeb8601fa174c734f9091619520cf3160b04a16
+ARG MESH_CLI_REF=bbbd759336a0912853d8b10e84a3731c7a0b99d3
+ARG HMY_VERSION=v2026.0.0
+ARG HMY_AMD64_SHA256=489682b069817dce437ac1cbff6b9b564f167019e026c71dfe413405034f9ccd
+ARG HMY_ARM64_SHA256=dd3aff0fd8971adc0e4ed11fc41791e86767b2a71d13f4a0b12c68f6a904b662
+
+ENV BRANCH=${MAIN_REPO_BRANCH}
+ENV MAIN_REPO=${MAIN_REPO_ORG}
+ENV HMY_VERSION=${HMY_VERSION}
+ENV DEBIAN_FRONTEND=noninteractive
+
+SHELL ["/bin/bash", "-c"]
+WORKDIR "$GOPATH/src/github.com/harmony-one"
+
+RUN set -euo pipefail && \
+    rm -f /etc/apt/sources.list.d/debian.sources && \
+    printf '%s\n' \
+      "deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/${APT_SNAPSHOT} bookworm main" \
+      "deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/${APT_SNAPSHOT} bookworm-updates main" \
+      "deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/${APT_SNAPSHOT} bookworm-security main" \
+      > /etc/apt/sources.list && \
+    apt-get update > /dev/null && \
+    apt-get install -y --no-install-recommends \
+      jq=1.6-2.1+deb12u2 \
+      python3-pip=23.0.1+dfsg-1 \
+      unzip=6.0-28 \
+      > /dev/null && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN set -euo pipefail && \
+    git init -q pyhmy && \
+    git -C pyhmy remote add origin https://github.com/harmony-one/pyhmy.git && \
+    git -C pyhmy fetch -q --depth=1 origin "$PYHMY_REF" && \
+    git -C pyhmy checkout -q --detach FETCH_HEAD && \
+    git config --global --add safe.directory "$GOPATH/src/github.com/harmony-one/harmony" && \
+    git config --global --add safe.directory "$GOPATH/src/github.com/harmony-one/pyhmy"
+
+WORKDIR "$GOPATH/src/github.com/coinbase/mesh-cli"
+RUN set -euo pipefail && \
+    case "$(dpkg --print-architecture)" in \
+      amd64) HMY_ASSET=hmy-amd64; HMY_SHA256="$HMY_AMD64_SHA256" ;; \
+      arm64) HMY_ASSET=hmy-arm64; HMY_SHA256="$HMY_ARM64_SHA256" ;; \
+      *) echo "Unsupported architecture: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSL -o /go/bin/hmy \
+      "https://github.com/harmony-one/go-sdk/releases/download/${HMY_VERSION}/${HMY_ASSET}" && \
+    printf '%s  %s\n' "$HMY_SHA256" /go/bin/hmy | sha256sum -c - && \
+    chmod +x /go/bin/hmy && \
+    git init -q . && \
+    git remote add origin https://github.com/coinbase/mesh-cli.git && \
+    git fetch -q --depth=1 origin "$MESH_CLI_REF" && \
+    git checkout -q --detach FETCH_HEAD && \
+    make install > /dev/null
+
+WORKDIR "$GOPATH/src/github.com/harmony-one/harmony-test/localnet"
+COPY scripts/ scripts/
+COPY rpc_tests/ rpc_tests/
+COPY configs/ configs/
+COPY requirements.txt requirements.txt
+
+RUN printf '%s\n' \
+      'annotated-types==0.8.0' \
+      'attrs==26.1.0' \
+      'bitarray==3.9.2' \
+      'certifi==2026.7.22' \
+      'charset-normalizer==3.4.9' \
+      'ckzg==2.1.8' \
+      'cytoolz==1.0.1' \
+      'eth-account==0.13.7' \
+      'eth-hash==0.8.0' \
+      'eth-keyfile==0.8.1' \
+      'eth-keys==0.7.0' \
+      'eth-rlp==2.2.0' \
+      'eth-typing==6.0.0' \
+      'eth-utils==5.3.0' \
+      'eth_abi==6.0.0b1' \
+      'execnet==2.1.2' \
+      'flaky==3.7.0' \
+      'hexbytes==1.3.0' \
+      'idna==3.18' \
+      'iniconfig==2.3.0' \
+      'packaging==26.2' \
+      'parsimonious==0.10.0' \
+      'pexpect==4.9.0' \
+      'pluggy==1.6.0' \
+      'ptyprocess==0.7.0' \
+      'py==1.11.0' \
+      'pycryptodome==3.23.0' \
+      'pydantic==2.13.4' \
+      'pydantic_core==2.46.4' \
+      'pytest==6.2.5' \
+      'pytest-forked==1.6.0' \
+      'pytest-ordering==0.6' \
+      'pytest-xdist==1.33.0' \
+      'regex==2026.7.19' \
+      'requests==2.33.0' \
+      'rlp==4.1.0' \
+      'setuptools==80.9.0' \
+      'six==1.17.0' \
+      'toml==0.10.2' \
+      'toolz==1.1.0' \
+      'typing-inspection==0.4.2' \
+      'typing_extensions==4.16.0' \
+      'urllib3==2.7.0' \
+      'wheel==0.45.1' \
+      > /tmp/constraints.txt && \
+    sed -i '/^pyhmy==/d' requirements.txt && \
+    python3 -m pip install -c /tmp/constraints.txt \
+      setuptools==80.9.0 wheel==0.45.1 \
+      --break-system-packages --no-cache-dir > /dev/null && \
+    python3 -m pip install -c /tmp/constraints.txt -r requirements.txt \
+      --break-system-packages --no-cache-dir > /dev/null && \
+    rm requirements.txt && \
+    chmod +x scripts/run.sh
+
+WORKDIR "$GOPATH/src/github.com/harmony-one/pyhmy"
+RUN python3 -m pip install -c /tmp/constraints.txt \
+      --no-build-isolation --break-system-packages --no-cache-dir . > /dev/null
+
+WORKDIR "$GOPATH/src/github.com/harmony-one/harmony"
+ENTRYPOINT ["/go/src/github.com/harmony-one/harmony-test/localnet/scripts/run.sh"]

--- a/test/localnet.sh
+++ b/test/localnet.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HARMONY_TEST_REPOSITORY=${HARMONY_TEST_REPOSITORY:-https://github.com/harmony-one/harmony-test.git}
+HARMONY_TEST_REF=${HARMONY_TEST_REF:-6afe7cdc1ecdb920d1c9a19d1b1ca912d3a590ab}
+HARMONY_BINARY_BUILDER=${HARMONY_BINARY_BUILDER:-$ROOT/test/build_linux_binaries.sh}
+MAIN_REPO_ORG=${MAIN_REPO_ORG:-harmony-one}
+MAIN_REPO_BRANCH=${MAIN_REPO_BRANCH:-$(git -C "$ROOT" branch --show-current)}
+KEEP=false
+MODES=()
+TEMP_TEST_DIR=
+TEMP_RUN_DIR=
+REMOVE_IMAGE=false
+IMAGE_BUILT=false
+IMAGE_EXPLICIT=false
+if [[ -n ${LOCALNET_IMAGE:-} ]]; then
+  IMAGE_EXPLICIT=true
+fi
+
+usage() {
+  cat <<'EOF'
+Usage: test/localnet.sh [--keep] MODE [MODE...]
+
+Modes:
+  rpc      Run RPC integration tests
+  pyhmy    Run pyhmy tests
+  rosetta  Run Rosetta tests
+
+Environment:
+  HARMONY_TEST_REF         harmony-test branch, tag, or commit (default: pinned commit)
+  HARMONY_TEST_DIR         existing harmony-test checkout; skips the temporary fetch
+  HARMONY_TEST_REPOSITORY  repository used when HARMONY_TEST_DIR is unset
+  HARMONY_BINARY_BUILDER   prepares compatible Linux harmony/bootnode binaries
+  HARMONY_RUN_ROOT         existing disposable Harmony tree; skips temporary copy
+  LOCALNET_ARCH            Docker architecture (default: Docker daemon architecture)
+  LOCALNET_IMAGE           image tag to retain; unset uses a temporary local tag
+EOF
+}
+
+cleanup() {
+  if [[ "$REMOVE_IMAGE" == true && "$IMAGE_BUILT" == true && "$KEEP" != true ]]; then
+    docker image rm -f "$LOCALNET_IMAGE" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$TEMP_TEST_DIR" ]]; then
+    rm -rf "$TEMP_TEST_DIR"
+  fi
+  if [[ -n "$TEMP_RUN_DIR" ]]; then
+    rm -rf "$TEMP_RUN_DIR"
+  fi
+}
+trap cleanup EXIT
+
+while (($#)); do
+  case "$1" in
+    --keep) KEEP=true ;;
+    rpc|pyhmy|rosetta) MODES+=("$1") ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown localnet test mode: $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+if ((${#MODES[@]} == 0)); then
+  usage >&2
+  exit 2
+fi
+if [[ "$KEEP" == true && ${#MODES[@]} -ne 1 ]]; then
+  echo "--keep requires exactly one test mode" >&2
+  exit 2
+fi
+
+LOCALNET_ARCH=${LOCALNET_ARCH:-$(docker info --format '{{.Architecture}}')}
+case "$LOCALNET_ARCH" in
+  arm64|aarch64) LOCALNET_ARCH=arm64 ;;
+  amd64|x86_64) LOCALNET_ARCH=amd64 ;;
+  *) echo "Unsupported Docker architecture: $LOCALNET_ARCH" >&2; exit 2 ;;
+esac
+export LOCALNET_ARCH
+
+"$HARMONY_BINARY_BUILDER"
+
+if [[ -n ${HARMONY_TEST_DIR:-} ]]; then
+  TEST_DIR=$(cd "$HARMONY_TEST_DIR" && pwd)
+  echo "[harmony-test] using local checkout: $TEST_DIR"
+else
+  TEMP_TEST_DIR=$(mktemp -d)
+  TEST_DIR="$TEMP_TEST_DIR/harmony-test"
+  git init -q "$TEST_DIR"
+  git -C "$TEST_DIR" remote add origin "$HARMONY_TEST_REPOSITORY"
+  git -C "$TEST_DIR" fetch --depth=1 origin "$HARMONY_TEST_REF"
+  git -C "$TEST_DIR" checkout -q --detach FETCH_HEAD
+  echo "[harmony-test] using ref '$HARMONY_TEST_REF' at $(git -C "$TEST_DIR" rev-parse HEAD)"
+fi
+
+if [[ ! -f "$TEST_DIR/localnet/Dockerfile" ]]; then
+  echo "Missing harmony-test localnet Dockerfile: $TEST_DIR/localnet/Dockerfile" >&2
+  exit 1
+fi
+
+if [[ -z ${LOCALNET_IMAGE:-} && "$KEEP" == true ]]; then
+  LOCALNET_IMAGE=harmony-localnet-test:keep
+elif [[ -z ${LOCALNET_IMAGE:-} ]]; then
+  resolved_ref=$(git -C "$TEST_DIR" rev-parse --short=12 HEAD 2>/dev/null || echo local)
+  LOCALNET_IMAGE="harmony-localnet-test:${resolved_ref}-$$"
+  REMOVE_IMAGE=true
+fi
+
+if [[ "$KEEP" == true ]]; then
+  docker rm -f harmony-localnet-test >/dev/null 2>&1 || true
+  if [[ "$IMAGE_EXPLICIT" != true ]]; then
+    docker image rm -f "$LOCALNET_IMAGE" >/dev/null 2>&1 || true
+  fi
+fi
+
+docker build --pull \
+  --platform "linux/$LOCALNET_ARCH" \
+  -f "$ROOT/test/localnet.Dockerfile" \
+  --build-arg "MAIN_REPO_BRANCH=$MAIN_REPO_BRANCH" \
+  --build-arg "MAIN_REPO_ORG=$MAIN_REPO_ORG" \
+  --progress plain \
+  -t "$LOCALNET_IMAGE" \
+  "$TEST_DIR/localnet"
+IMAGE_BUILT=true
+
+if [[ -n ${HARMONY_RUN_ROOT:-} ]]; then
+  RUN_ROOT=$(cd "$HARMONY_RUN_ROOT" && pwd)
+else
+  TEMP_RUN_DIR=$(mktemp -d)
+  RUN_ROOT="$TEMP_RUN_DIR/harmony"
+  "$ROOT/test/copy_harmony_worktree.sh" "$ROOT" "$RUN_ROOT"
+  mkdir -p "$RUN_ROOT/bin"
+  cp "$ROOT/bin/harmony" "$ROOT/bin/bootnode" "$RUN_ROOT/bin/"
+fi
+
+PORTS=(
+  -p 9500:9500 -p 9501:9501
+  -p 9599:9599 -p 9598:9598
+  -p 9799:9799 -p 9798:9798
+  -p 9899:9899 -p 9898:9898
+)
+
+for mode in "${MODES[@]}"; do
+  case "$mode" in
+    rpc) flags=(-B -n) ;;
+    pyhmy) flags=(-B -p) ;;
+    rosetta) flags=(-B -r) ;;
+  esac
+
+  run_args=(run)
+  if [[ "$KEEP" == true ]]; then
+    run_args+=(--name harmony-localnet-test)
+    flags+=(-k)
+  else
+    run_args+=(--rm)
+  fi
+
+  docker "${run_args[@]}" \
+    --platform "linux/$LOCALNET_ARCH" \
+    -e HARMONY_PREBUILT_STATIC=true \
+    "${PORTS[@]}" \
+    -v "$RUN_ROOT:/go/src/github.com/harmony-one/harmony" \
+    "$LOCALNET_IMAGE" "${flags[@]}"
+done

--- a/test/localnet_runner_test.sh
+++ b/test/localnet_runner_test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local needle=$1 file=$2
+  grep -F -- "$needle" "$file" >/dev/null || fail "expected '$needle' in $file"
+}
+
+assert_not_contains() {
+  local needle=$1 file=$2
+  if grep -F -- "$needle" "$file" >/dev/null; then
+    fail "did not expect '$needle' in $file"
+  fi
+}
+
+[[ -x "$ROOT/test/localnet.sh" ]] || fail "test/localnet.sh must be executable"
+[[ -x "$ROOT/test/copy_harmony_worktree.sh" ]] || fail "copy helper must be executable"
+[[ -f "$ROOT/test/localnet.Dockerfile" ]] || fail "pinned localnet Dockerfile must exist"
+assert_not_contains "docker pull" "$ROOT/test/all.sh"
+assert_not_contains "docker pull" "$ROOT/test/go.sh"
+assert_not_contains "docker pull" "$ROOT/test/rpc.sh"
+assert_not_contains "docker pull" "$ROOT/test/rosetta.sh"
+assert_not_contains "docker" "$ROOT/test/go.sh"
+assert_contains 'localnet.sh" rpc rosetta pyhmy' "$ROOT/test/all.sh"
+assert_contains '6afe7cdc1ecdb920d1c9a19d1b1ca912d3a590ab' "$ROOT/test/localnet.sh"
+assert_contains 'test: test-go' "$ROOT/Makefile"
+assert_contains 'test-integration:' "$ROOT/Makefile"
+assert_contains 'test-all:' "$ROOT/Makefile"
+
+bash "$ROOT/test/rpc.sh" >/dev/null || fail "rpc.sh without arguments must show usage"
+bash "$ROOT/test/rosetta.sh" >/dev/null || fail "rosetta.sh without arguments must show usage"
+
+mkdir -p "$TMPDIR_TEST/source"
+git -C "$TMPDIR_TEST/source" init -q
+git -C "$TMPDIR_TEST/source" config user.email test@example.com
+git -C "$TMPDIR_TEST/source" config user.name test
+printf 'keep\n' > "$TMPDIR_TEST/source/keep"
+printf 'delete\n' > "$TMPDIR_TEST/source/deleted"
+git -C "$TMPDIR_TEST/source" add keep deleted
+git -C "$TMPDIR_TEST/source" commit -qm fixture
+rm "$TMPDIR_TEST/source/deleted"
+printf 'untracked\n' > "$TMPDIR_TEST/source/untracked"
+"$ROOT/test/copy_harmony_worktree.sh" "$TMPDIR_TEST/source" "$TMPDIR_TEST/copied"
+[[ -f "$TMPDIR_TEST/copied/keep" ]] || fail "tracked files must be copied"
+[[ -f "$TMPDIR_TEST/copied/untracked" ]] || fail "untracked files must be copied"
+[[ ! -e "$TMPDIR_TEST/copied/deleted" ]] || fail "tracked deletions must be preserved"
+
+mkdir -p "$TMPDIR_TEST/bin" "$TMPDIR_TEST/harmony-test/localnet" "$TMPDIR_TEST/run-root"
+: > "$TMPDIR_TEST/harmony-test/localnet/Dockerfile"
+cat > "$TMPDIR_TEST/bin/docker" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$DOCKER_LOG"
+if [[ ${DOCKER_FAIL_RUN:-} == 1 && ${1:-} == run ]]; then
+  exit 42
+fi
+STUB
+chmod +x "$TMPDIR_TEST/bin/docker"
+
+cat > "$TMPDIR_TEST/bin/build-linux-binaries" <<'STUB'
+#!/usr/bin/env bash
+printf 'built\n' >> "$BUILDER_LOG"
+STUB
+chmod +x "$TMPDIR_TEST/bin/build-linux-binaries"
+
+DOCKER_LOG="$TMPDIR_TEST/docker.log" \
+BUILDER_LOG="$TMPDIR_TEST/builder.log" \
+HARMONY_TEST_DIR="$TMPDIR_TEST/harmony-test" \
+HARMONY_BINARY_BUILDER="$TMPDIR_TEST/bin/build-linux-binaries" \
+HARMONY_RUN_ROOT="$TMPDIR_TEST/run-root" \
+LOCALNET_ARCH=arm64 \
+LOCALNET_IMAGE="harmony-localnet-test:test" \
+PATH="$TMPDIR_TEST/bin:$PATH" \
+  "$ROOT/test/localnet.sh" rpc rosetta pyhmy
+
+[[ $(grep -c '^built$' "$TMPDIR_TEST/builder.log") -eq 1 ]] || fail "Linux binaries must be prepared once"
+[[ $(grep -c '^build ' "$TMPDIR_TEST/docker.log") -eq 1 ]] || fail "image must be built exactly once"
+[[ $(grep -c '^run ' "$TMPDIR_TEST/docker.log") -eq 3 ]] || fail "integration suites must use isolated runs"
+assert_contains "build --pull" "$TMPDIR_TEST/docker.log"
+assert_contains "--platform linux/arm64" "$TMPDIR_TEST/docker.log"
+assert_contains "-f $ROOT/test/localnet.Dockerfile" "$TMPDIR_TEST/docker.log"
+assert_contains "-t harmony-localnet-test:test" "$TMPDIR_TEST/docker.log"
+assert_contains "harmony-localnet-test:test -B -n" "$TMPDIR_TEST/docker.log"
+assert_contains "harmony-localnet-test:test -B -p" "$TMPDIR_TEST/docker.log"
+assert_contains "harmony-localnet-test:test -B -r" "$TMPDIR_TEST/docker.log"
+assert_not_contains "pull harmonyone/localnet-test" "$TMPDIR_TEST/docker.log"
+assert_contains 'GOFLAGS=-buildvcs=false -mod=mod' "$ROOT/test/build_linux_binaries.sh"
+assert_contains 'FROM golang:1.24.2@sha256:' "$ROOT/test/localnet.Dockerfile"
+assert_contains 'PYHMY_REF=5aeb8601fa174c734f9091619520cf3160b04a16' "$ROOT/test/localnet.Dockerfile"
+assert_contains 'MESH_CLI_REF=bbbd759336a0912853d8b10e84a3731c7a0b99d3' "$ROOT/test/localnet.Dockerfile"
+assert_contains 'setuptools==80.9.0' "$ROOT/test/localnet.Dockerfile"
+assert_contains '--no-build-isolation' "$ROOT/test/localnet.Dockerfile"
+
+: > "$TMPDIR_TEST/docker.log"
+DOCKER_LOG="$TMPDIR_TEST/docker.log" \
+BUILDER_LOG="$TMPDIR_TEST/builder.log" \
+HARMONY_TEST_DIR="$TMPDIR_TEST/harmony-test" \
+HARMONY_BINARY_BUILDER="$TMPDIR_TEST/bin/build-linux-binaries" \
+HARMONY_RUN_ROOT="$TMPDIR_TEST/run-root" \
+LOCALNET_ARCH=arm64 \
+PATH="$TMPDIR_TEST/bin:$PATH" \
+  "$ROOT/test/localnet.sh" rpc
+assert_contains "image rm -f harmony-localnet-test:" "$TMPDIR_TEST/docker.log"
+
+: > "$TMPDIR_TEST/docker.log"
+DOCKER_LOG="$TMPDIR_TEST/docker.log" \
+BUILDER_LOG="$TMPDIR_TEST/builder.log" \
+HARMONY_TEST_DIR="$TMPDIR_TEST/harmony-test" \
+HARMONY_BINARY_BUILDER="$TMPDIR_TEST/bin/build-linux-binaries" \
+HARMONY_RUN_ROOT="$TMPDIR_TEST/run-root" \
+LOCALNET_ARCH=arm64 \
+PATH="$TMPDIR_TEST/bin:$PATH" \
+  "$ROOT/test/localnet.sh" --keep rpc
+assert_contains "-t harmony-localnet-test:keep" "$TMPDIR_TEST/docker.log"
+assert_contains "--name harmony-localnet-test" "$TMPDIR_TEST/docker.log"
+assert_contains "image rm -f harmony-localnet-test:keep" "$TMPDIR_TEST/docker.log"
+
+: > "$TMPDIR_TEST/docker.log"
+if DOCKER_FAIL_RUN=1 \
+  DOCKER_LOG="$TMPDIR_TEST/docker.log" \
+  BUILDER_LOG="$TMPDIR_TEST/builder.log" \
+  HARMONY_TEST_DIR="$TMPDIR_TEST/harmony-test" \
+  HARMONY_BINARY_BUILDER="$TMPDIR_TEST/bin/build-linux-binaries" \
+  HARMONY_RUN_ROOT="$TMPDIR_TEST/run-root" \
+  LOCALNET_ARCH=arm64 \
+  PATH="$TMPDIR_TEST/bin:$PATH" \
+    "$ROOT/test/localnet.sh" rpc >/dev/null 2>&1; then
+  fail "docker run failures must propagate"
+fi
+assert_contains "image rm -f harmony-localnet-test:" "$TMPDIR_TEST/docker.log"
+
+if HARMONY_TEST_DIR="$TMPDIR_TEST/harmony-test" PATH="$TMPDIR_TEST/bin:$PATH" \
+  "$ROOT/test/localnet.sh" unsupported >/dev/null 2>&1; then
+  fail "unknown mode must fail"
+fi
+
+echo "localnet runner tests passed"

--- a/test/rosetta.sh
+++ b/test/rosetta.sh
@@ -1,16 +1,14 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-bash "$DIR/kill_node.sh"
 
 docker_name="harmony-localnet-test"
 
-case ${1} in
+case ${1:-} in
 run)
-    docker pull harmonyone/localnet-test
-    docker rm "$docker_name"
-    docker run -it --name "$docker_name" \
-      -p 9500:9500 -p 9501:9501 -p 9599:9599 -p 9598:9598 -p 9799:9799 -p 9798:9798 -p 9899:9899 -p 9898:9898 \
-      -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test -r -k
+    bash "$DIR/kill_node.sh"
+    exec bash "$DIR/localnet.sh" --keep rosetta
     ;;
 attach)
     docker exec -it "$docker_name" /bin/bash

--- a/test/rpc.sh
+++ b/test/rpc.sh
@@ -1,16 +1,14 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-bash "$DIR/kill_node.sh"
 
 docker_name="harmony-localnet-test"
 
-case ${1} in
+case ${1:-} in
 run)
-    docker pull harmonyone/localnet-test
-    docker rm "$docker_name"
-    docker run -it --name "$docker_name" \
-      -p 9500:9500 -p 9501:9501 -p 9599:9599 -p 9598:9598 -p 9799:9799 -p 9798:9798 -p 9899:9899 -p 9898:9898 \
-      -v "$DIR/../:/go/src/github.com/harmony-one/harmony" harmonyone/localnet-test -n -k
+    bash "$DIR/kill_node.sh"
+    exec bash "$DIR/localnet.sh" --keep rpc
     ;;
 attach)
     docker exec -it "$docker_name" /bin/bash


### PR DESCRIPTION
## Why

`make test` currently runs inside `harmonyone/localnet-test`, an old published image with Go 1.16. The current repository requires Go 1.24, so the default test command fails before tests start. The same path also assumes a normal checkout and breaks with linked worktrees.

This PR separates two jobs that were bundled together:

```text
make test
  -> run the existing Go checker natively

make test-integration
  -> build a local pinned image
  -> run rpc, rosetta, and pyhmy
  -> remove the container, image, and temporary source copy
```

Docker remains in use for the multi-process localnet. The default Go test path no longer depends on Docker or Docker Hub.

## Expected impact

This is a correctness and reproducibility change for local/manual test entry points. It is not a GitHub Actions speed optimization.

The CI workflow already builds Harmony binaries once per architecture and runs unit, RPC, and pyhmy jobs in parallel. This PR does not change `.github/workflows/ci-pr.yaml` or the CI checker scripts, so those job times should remain roughly the same.

## What changed

- `make test` runs `scripts/travis_go_checker.sh` on the host.
- `make test-integration` and the per-suite targets use `test/localnet.sh`.
- The runner builds Linux `harmony` and `bootnode` binaries for the Docker daemon architecture.
- The image and external test inputs are pinned instead of using `harmonyone/localnet-test:latest`.
- Integration tests run against a disposable copy of the checkout. This works with linked worktrees and prevents localnet scripts from writing into the active checkout.

## Why the diff is 577 lines

Most of the diff is the self-contained integration environment and its tests. Existing entry points change by only 34 additions and 25 deletions.

| File | Purpose |
| --- | --- |
| `test/localnet.sh` | Build, run, and clean up one or more localnet suites |
| `test/localnet.Dockerfile` | Pin the localnet toolchain and dependencies |
| `test/build_linux_binaries.sh` | Produce compatible Linux binaries and reuse them only when the source stamp matches |
| `test/copy_harmony_worktree.sh` | Create the disposable runtime source tree, including local modifications and deletions |
| `test/localnet_runner_test.sh` | Cover cleanup, failures, worktrees, tracked deletions, and image ownership |

Suggested review order: `Makefile` and `test/go.sh`, then `test/localnet.sh`, its two helpers, the Dockerfile, and finally the runner test.

## Targets after this change

| Command | Runs |
| --- | --- |
| `make test` | Native Go checks |
| `make test-all` | Native Go checks followed by all localnet suites |
| `make test-integration` | RPC, Rosetta, and pyhmy localnet suites |
| `make test-rpc` | RPC only |
| `make test-rosetta` | Rosetta only |
| `make test-pyhmy` | pyhmy only |

## Verification

- `make test`
- `bash -n` and ShellCheck for changed scripts
- `bash test/localnet_runner_test.sh`
- real ARM64 localnet image build and Linux binary startup
- CI unit tests on amd64 and arm64
- CI RPC tests on amd64 and arm64
- CI pyhmy tests on amd64 and arm64

All current GitHub checks pass.

## Out of scope

This PR does not change production code, CI scheduling, localnet topology, or RPC/pyhmy/Rosetta assertions. It only changes how local/manual test environments are prepared and selected.
