### PR TITLE
streamsync: speed up stream rediscovery and recover faster from local outages

### DIFF
--- a/api/service/synchronize/stagedstreamsync/const.go
+++ b/api/service/synchronize/stagedstreamsync/const.go
@@ -52,8 +52,7 @@ const (
 
 	// StreamDiscoveryWatchdogTimeout is the maximum time to wait for enough stream
 	// connections before resetting stream manager runtime state and retrying.
-	// Keep it longer than streammanager.MaxRemovalCooldownDuration so punished nodes
-	// are not unblocked immediately by watchdog recovery.
+	// Intended to stay above streammanager.MaxRemovalCooldownDuration.
 	StreamDiscoveryWatchdogTimeout time.Duration = 30 * time.Minute
 
 	// pivot block distance ranges
@@ -98,7 +97,7 @@ type (
 		Concurrency          int // Number of concurrent sync requests
 		MinStreams           int // Minimum number of streams to do sync
 		InitStreams          int // Number of streams requirement for initial bootstrap
-		MaxAdvertiseWaitTime int // max minutes between advertisements (wired to advertiseLoop)
+		MaxAdvertiseWaitTime int // max minutes between advertisements in normal mode
 		// stream manager config
 		SmSoftLowCap int
 		SmHardLowCap int

--- a/api/service/synchronize/stagedstreamsync/const.go
+++ b/api/service/synchronize/stagedstreamsync/const.go
@@ -52,9 +52,9 @@ const (
 
 	// StreamDiscoveryWatchdogTimeout is the maximum time to wait for enough stream
 	// connections before resetting stream manager runtime state and retrying.
-	// Keep it longer than stream removal cooldown windows so punished nodes are not
-	// unblocked immediately by watchdog recovery.
-	StreamDiscoveryWatchdogTimeout time.Duration = 75 * time.Minute
+	// Keep it longer than streammanager.MaxRemovalCooldownDuration so punished nodes
+	// are not unblocked immediately by watchdog recovery.
+	StreamDiscoveryWatchdogTimeout time.Duration = 30 * time.Minute
 
 	// pivot block distance ranges
 	MinPivotDistanceToHead uint64 = 1024
@@ -98,7 +98,7 @@ type (
 		Concurrency          int // Number of concurrent sync requests
 		MinStreams           int // Minimum number of streams to do sync
 		InitStreams          int // Number of streams requirement for initial bootstrap
-		MaxAdvertiseWaitTime int // maximum time duration between protocol advertisements
+		MaxAdvertiseWaitTime int // max minutes between advertisements (wired to advertiseLoop)
 		// stream manager config
 		SmSoftLowCap int
 		SmHardLowCap int

--- a/cmd/config/config_migrations_test.go
+++ b/cmd/config/config_migrations_test.go
@@ -389,6 +389,13 @@ func Test_migrateConf(t *testing.T) {
 				hc := defConf
 				hc.Sync.Client = true
 				hc.Sync.Enabled = true
+				// Fixture predates the mainnet peer-floor reduction; migration keeps
+				// explicit Sync values from the old config file.
+				hc.Sync.Concurrency = 6
+				hc.Sync.MinPeers = 6
+				hc.Sync.InitStreams = 8
+				hc.Sync.DiscSoftLowCap = 8
+				hc.Sync.DiscHardLowCap = 6
 				return hc
 			}(),
 			wantErr: false,

--- a/cmd/config/config_migrations_test.go
+++ b/cmd/config/config_migrations_test.go
@@ -389,8 +389,7 @@ func Test_migrateConf(t *testing.T) {
 				hc := defConf
 				hc.Sync.Client = true
 				hc.Sync.Enabled = true
-				// Fixture predates the mainnet peer-floor reduction; migration keeps
-				// explicit Sync values from the old config file.
+				// Fixture Sync peer settings are preserved by migration.
 				hc.Sync.Concurrency = 6
 				hc.Sync.MinPeers = 6
 				hc.Sync.InitStreams = 8

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -140,6 +140,13 @@ Version = "1.0.4"
 		t.Errorf("Expected config version: 1.0.4, not %v", config.Version)
 	}
 	config.Version = defConf.Version // Shortcut for testing, value checked above
+	// Fixture Sync peer settings are preserved by migration; MaxAdvertiseWaitTime
+	// uses the current default when absent from the fixture.
+	defConf.Sync.Concurrency = 6
+	defConf.Sync.MinPeers = 6
+	defConf.Sync.InitStreams = 8
+	defConf.Sync.DiscSoftLowCap = 8
+	defConf.Sync.DiscHardLowCap = 6
 	require.Equal(t, config, defConf)
 }
 

--- a/cmd/config/default.go
+++ b/cmd/config/default.go
@@ -212,7 +212,7 @@ var (
 		Concurrency:          4,
 		MinPeers:             4,
 		InitStreams:          5,
-		MaxAdvertiseWaitTime: 15, // minutes; caps advertiseLoop sleep in normal mode
+		MaxAdvertiseWaitTime: 15, // minutes
 		DiscSoftLowCap:       5,
 		DiscHardLowCap:       3,
 		DiscHighCap:          128,

--- a/cmd/config/default.go
+++ b/cmd/config/default.go
@@ -209,12 +209,12 @@ var (
 		SyncMode:             0,
 		Client:               false,
 		StagedSyncCfg:        defaultStagedSyncConfig,
-		Concurrency:          6,
-		MinPeers:             6,
-		InitStreams:          8,
-		MaxAdvertiseWaitTime: 60, //minutes
-		DiscSoftLowCap:       8,
-		DiscHardLowCap:       6,
+		Concurrency:          4,
+		MinPeers:             4,
+		InitStreams:          5,
+		MaxAdvertiseWaitTime: 15, // minutes; caps advertiseLoop sleep in normal mode
+		DiscSoftLowCap:       5,
+		DiscHardLowCap:       3,
 		DiscHighCap:          128,
 		DiscBatch:            8,
 		TrustedNodes:         []string{},

--- a/cmd/config/flags.go
+++ b/cmd/config/flags.go
@@ -1982,7 +1982,7 @@ var (
 	}
 	syncMaxAdvertiseWaitTimeFlag = cli.IntFlag{
 		Name:   "sync.max-advertise-wait-time",
-		Usage:  "The max time duration between two advertises for each p2p peer to tell other nodes what protocols it supports",
+		Usage:  "Max minutes between sync protocol advertisements in normal mode (caps advertise sleep)",
 		Hidden: true,
 	}
 	syncDiscSoftLowFlag = cli.IntFlag{

--- a/cmd/config/flags.go
+++ b/cmd/config/flags.go
@@ -1982,7 +1982,7 @@ var (
 	}
 	syncMaxAdvertiseWaitTimeFlag = cli.IntFlag{
 		Name:   "sync.max-advertise-wait-time",
-		Usage:  "Max minutes between sync protocol advertisements in normal mode (caps advertise sleep)",
+		Usage:  "Max minutes between sync protocol advertisements in normal mode",
 		Hidden: true,
 	}
 	syncDiscSoftLowFlag = cli.IntFlag{

--- a/internal/configs/harmony/harmony.go
+++ b/internal/configs/harmony/harmony.go
@@ -372,7 +372,7 @@ type SyncConfig struct {
 	Concurrency          int              // concurrency used for stream sync protocol
 	MinPeers             int              // minimum streams to start a sync task.
 	InitStreams          int              // minimum streams in bootstrap to start sync loop.
-	MaxAdvertiseWaitTime int              // max minutes between advertisements (normal mode advertiseLoop cap)
+	MaxAdvertiseWaitTime int              // max minutes between advertisements in normal mode
 	DiscSoftLowCap       int              // when number of streams is below this value, spin discover during check
 	DiscHardLowCap       int              // when removing stream, num is below this value, spin discovery immediately
 	DiscHighCap          int              // upper limit of streams in one sync protocol

--- a/internal/configs/harmony/harmony.go
+++ b/internal/configs/harmony/harmony.go
@@ -372,7 +372,7 @@ type SyncConfig struct {
 	Concurrency          int              // concurrency used for stream sync protocol
 	MinPeers             int              // minimum streams to start a sync task.
 	InitStreams          int              // minimum streams in bootstrap to start sync loop.
-	MaxAdvertiseWaitTime int              // maximum time duration between advertisements
+	MaxAdvertiseWaitTime int              // max minutes between advertisements (normal mode advertiseLoop cap)
 	DiscSoftLowCap       int              // when number of streams is below this value, spin discover during check
 	DiscHardLowCap       int              // when removing stream, num is below this value, spin discovery immediately
 	DiscHighCap          int              // upper limit of streams in one sync protocol

--- a/p2p/stream/common/streammanager/config.go
+++ b/p2p/stream/common/streammanager/config.go
@@ -19,27 +19,21 @@ const (
 	// RemovalCooldownDuration defines the cooldown period before a removed stream can reconnect.
 	RemovalCooldownDuration = 5 * time.Minute
 	// MaxRemovalCooldownDuration is the upper bound for removal cooldowns.
-	// Keep it shorter than stagedstreamsync.StreamDiscoveryWatchdogTimeout so watchdog
-	// recovery can clear blocked peers after cooldowns would have expired anyway.
+	// Intended to stay below stagedstreamsync.StreamDiscoveryWatchdogTimeout.
 	MaxRemovalCooldownDuration = 15 * time.Minute
 
-	// Mass-disconnect / local-outage detection:
-	// Many streams dying in a short window usually means the local uplink failed, not that
-	// every remote peer is bad. Skip critical cooldowns and allow quick reconnect.
+	// Mass-disconnect / local-outage detection parameters.
 	massDisconnectWindow   = 45 * time.Second
 	massDisconnectMinCount = 3
-	// localOutageDuration is how long after a mass disconnect we keep treating
-	// connection-loss removals as local-outage (soft reconnect).
+	// localOutageDuration is how long connection-loss removals use soft reconnect.
 	localOutageDuration = 2 * time.Minute
-	// localOutageDiscHoldoff delays DHT rediscovery briefly after mass disconnect so we
-	// do not hammer discovery while the local network is still down.
+	// localOutageDiscHoldoff is the delay before rediscovery after a mass disconnect.
 	localOutageDiscHoldoff = 30 * time.Second
-	// localOutageMinInterval rate-limits how often a new local-outage window may start,
-	// so sybil flaps cannot repeatedly wipe critical cooldowns.
+	// localOutageMinInterval is the minimum time between local-outage windows.
 	localOutageMinInterval = 10 * time.Minute
 
-	// streamRegistrationWait is how long to wait for async handleStream registrations
-	// after trusted peer NewStream succeeds, before deciding whether to skip DHT.
+	// streamRegistrationWait is the max wait for async stream registration after
+	// trusted peer NewStream succeeds.
 	streamRegistrationWait = 5 * time.Second
 	// streamRegistrationPoll is the polling interval while waiting for registrations.
 	streamRegistrationPoll = 50 * time.Millisecond

--- a/p2p/stream/common/streammanager/config.go
+++ b/p2p/stream/common/streammanager/config.go
@@ -16,9 +16,33 @@ const (
 	connectTimeout = 60 * time.Second
 	// MaxReservedStreams is the maximum number of reserved streams
 	MaxReservedStreams = 100
-	// RemovalCooldownDuration defines the cooldown period (in minutes) before a removed stream can reconnect.
-	RemovalCooldownDuration    = 5 * time.Minute
-	MaxRemovalCooldownDuration = 60 * time.Minute
+	// RemovalCooldownDuration defines the cooldown period before a removed stream can reconnect.
+	RemovalCooldownDuration = 5 * time.Minute
+	// MaxRemovalCooldownDuration is the upper bound for removal cooldowns.
+	// Keep it shorter than stagedstreamsync.StreamDiscoveryWatchdogTimeout so watchdog
+	// recovery can clear blocked peers after cooldowns would have expired anyway.
+	MaxRemovalCooldownDuration = 15 * time.Minute
+
+	// Mass-disconnect / local-outage detection:
+	// Many streams dying in a short window usually means the local uplink failed, not that
+	// every remote peer is bad. Skip critical cooldowns and allow quick reconnect.
+	massDisconnectWindow   = 45 * time.Second
+	massDisconnectMinCount = 3
+	// localOutageDuration is how long after a mass disconnect we keep treating
+	// connection-loss removals as local-outage (soft reconnect).
+	localOutageDuration = 2 * time.Minute
+	// localOutageDiscHoldoff delays DHT rediscovery briefly after mass disconnect so we
+	// do not hammer discovery while the local network is still down.
+	localOutageDiscHoldoff = 30 * time.Second
+	// localOutageMinInterval rate-limits how often a new local-outage window may start,
+	// so sybil flaps cannot repeatedly wipe critical cooldowns.
+	localOutageMinInterval = 10 * time.Minute
+
+	// streamRegistrationWait is how long to wait for async handleStream registrations
+	// after trusted peer NewStream succeeds, before deciding whether to skip DHT.
+	streamRegistrationWait = 5 * time.Second
+	// streamRegistrationPoll is the polling interval while waiting for registrations.
+	streamRegistrationPoll = 50 * time.Millisecond
 
 	// setupConcurrency limits concurrent stream setup goroutines
 	setupConcurrency = 16

--- a/p2p/stream/common/streammanager/mass_disconnect.go
+++ b/p2p/stream/common/streammanager/mass_disconnect.go
@@ -1,0 +1,141 @@
+package streammanager
+
+import (
+	"strings"
+	"time"
+)
+
+// disconnectTracker detects mass stream removals that likely indicate a local
+// network outage rather than many independent remote-peer failures.
+type disconnectTracker struct {
+	removalTimes     []time.Time
+	localOutageUntil time.Time
+	lastOutageStart  time.Time
+}
+
+// observeRemoval records a connection-loss stream removal and returns whether this
+// removal falls inside a local-outage window. Punitive (bad-data / protocol) removals
+// must not call this with connectionLoss=false counting — callers should only invoke
+// when isConnectionLossReason(reason) is true.
+//
+// activeBefore is the number of streams (main+reserved) before this removal.
+func (dt *disconnectTracker) observeRemoval(now time.Time, activeBefore int) (inLocalOutage bool, justEntered bool) {
+	if !dt.localOutageUntil.IsZero() && now.Before(dt.localOutageUntil) {
+		dt.record(now)
+		return true, false
+	}
+
+	dt.prune(now)
+	dt.record(now)
+
+	threshold := massDisconnectThreshold(activeBefore + len(dt.removalTimes) - 1)
+	// activeBefore + already-counted prior removals in the window approximates the
+	// stream population at the start of the disconnect wave.
+	if len(dt.removalTimes) < threshold {
+		return false, false
+	}
+
+	// Rate-limit entering a new local-outage window.
+	if !dt.lastOutageStart.IsZero() && now.Sub(dt.lastOutageStart) < localOutageMinInterval {
+		return false, false
+	}
+
+	dt.localOutageUntil = now.Add(localOutageDuration)
+	dt.lastOutageStart = now
+	return true, true
+}
+
+func (dt *disconnectTracker) inLocalOutage(now time.Time) bool {
+	return !dt.localOutageUntil.IsZero() && now.Before(dt.localOutageUntil)
+}
+
+func (dt *disconnectTracker) record(now time.Time) {
+	dt.removalTimes = append(dt.removalTimes, now)
+}
+
+func (dt *disconnectTracker) prune(now time.Time) {
+	cutoff := now.Add(-massDisconnectWindow)
+	i := 0
+	for i < len(dt.removalTimes) && dt.removalTimes[i].Before(cutoff) {
+		i++
+	}
+	if i > 0 {
+		dt.removalTimes = append([]time.Time(nil), dt.removalTimes[i:]...)
+	}
+}
+
+// massDisconnectThreshold returns how many removals in the window count as a mass event.
+// Small stream sets use a lower floor so losing all/most peers still qualifies.
+func massDisconnectThreshold(approxActiveAtWaveStart int) int {
+	if approxActiveAtWaveStart <= 0 {
+		return massDisconnectMinCount
+	}
+	if approxActiveAtWaveStart < massDisconnectMinCount {
+		return approxActiveAtWaveStart
+	}
+	half := (approxActiveAtWaveStart + 1) / 2
+	if half < massDisconnectMinCount {
+		return massDisconnectMinCount
+	}
+	return half
+}
+
+// isPunitiveRemovalReason reports removals caused by bad/invalid peer behavior or
+// protocol faults. These must keep hard cooldowns even during a local outage.
+func isPunitiveRemovalReason(reason string) bool {
+	r := strings.ToLower(reason)
+	punitiveHints := []string{
+		"too many failures",
+		"nil block",
+		"invalid block",
+		"invalid stream",
+		"protocol error",
+		"critical protocol",
+		"zero hashes",
+		"all zero hashes",
+		"empty blockbytes",
+		"not valid",
+		"unexpected blockbytes",
+		"unmatched number",
+		"unverifiable",
+		"zero bytes block",
+		"expected more hashes",
+	}
+	for _, hint := range punitiveHints {
+		if strings.Contains(r, hint) {
+			return true
+		}
+	}
+	return false
+}
+
+// isConnectionLossReason reports removals that look like transport / local-network
+// failures rather than malicious or buggy peer data. Only these may receive soft
+// reconnect treatment under local-outage mode.
+func isConnectionLossReason(reason string) bool {
+	if reason == "" {
+		return false
+	}
+	r := strings.ToLower(reason)
+	if isPunitiveRemovalReason(r) {
+		return false
+	}
+	connectionHints := []string{
+		"read msg failed",
+		"remote closed",
+		"progress timeout",
+		"too many recoverable errors",
+		"stream error",
+		"connection reset",
+		"broken pipe",
+		"local network",
+		"network error",
+		"disconnect",
+	}
+	for _, hint := range connectionHints {
+		if strings.Contains(r, hint) {
+			return true
+		}
+	}
+	return false
+}

--- a/p2p/stream/common/streammanager/mass_disconnect.go
+++ b/p2p/stream/common/streammanager/mass_disconnect.go
@@ -5,20 +5,17 @@ import (
 	"time"
 )
 
-// disconnectTracker detects mass stream removals that likely indicate a local
-// network outage rather than many independent remote-peer failures.
+// disconnectTracker tracks clustered stream removals and local-outage windows.
 type disconnectTracker struct {
 	removalTimes     []time.Time
 	localOutageUntil time.Time
 	lastOutageStart  time.Time
 }
 
-// observeRemoval records a connection-loss stream removal and returns whether this
-// removal falls inside a local-outage window. Punitive (bad-data / protocol) removals
-// must not call this with connectionLoss=false counting — callers should only invoke
-// when isConnectionLossReason(reason) is true.
+// observeRemoval records a connection-loss removal and reports whether the removal
+// is inside a local-outage window. Call only for connection-loss removals.
 //
-// activeBefore is the number of streams (main+reserved) before this removal.
+// activeBefore is the number of streams (main+reserved) at the start of this removal.
 func (dt *disconnectTracker) observeRemoval(now time.Time, activeBefore int) (inLocalOutage bool, justEntered bool) {
 	if !dt.localOutageUntil.IsZero() && now.Before(dt.localOutageUntil) {
 		dt.record(now)
@@ -29,13 +26,12 @@ func (dt *disconnectTracker) observeRemoval(now time.Time, activeBefore int) (in
 	dt.record(now)
 
 	threshold := massDisconnectThreshold(activeBefore + len(dt.removalTimes) - 1)
-	// activeBefore + already-counted prior removals in the window approximates the
-	// stream population at the start of the disconnect wave.
+	// activeBefore plus prior removals in the window approximates stream count at
+	// the start of the disconnect wave.
 	if len(dt.removalTimes) < threshold {
 		return false, false
 	}
 
-	// Rate-limit entering a new local-outage window.
 	if !dt.lastOutageStart.IsZero() && now.Sub(dt.lastOutageStart) < localOutageMinInterval {
 		return false, false
 	}
@@ -64,8 +60,8 @@ func (dt *disconnectTracker) prune(now time.Time) {
 	}
 }
 
-// massDisconnectThreshold returns how many removals in the window count as a mass event.
-// Small stream sets use a lower floor so losing all/most peers still qualifies.
+// massDisconnectThreshold is the number of removals in the window that opens a
+// local-outage window. Smaller stream sets use a lower floor.
 func massDisconnectThreshold(approxActiveAtWaveStart int) int {
 	if approxActiveAtWaveStart <= 0 {
 		return massDisconnectMinCount
@@ -80,8 +76,7 @@ func massDisconnectThreshold(approxActiveAtWaveStart int) int {
 	return half
 }
 
-// isPunitiveRemovalReason reports removals caused by bad/invalid peer behavior or
-// protocol faults. These must keep hard cooldowns even during a local outage.
+// isPunitiveRemovalReason reports removals for invalid peer data or protocol faults.
 func isPunitiveRemovalReason(reason string) bool {
 	r := strings.ToLower(reason)
 	punitiveHints := []string{
@@ -109,9 +104,8 @@ func isPunitiveRemovalReason(reason string) bool {
 	return false
 }
 
-// isConnectionLossReason reports removals that look like transport / local-network
-// failures rather than malicious or buggy peer data. Only these may receive soft
-// reconnect treatment under local-outage mode.
+// isConnectionLossReason reports removals for transport or local-network failures.
+// These use soft reconnect while a local-outage window is active.
 func isConnectionLossReason(reason string) bool {
 	if reason == "" {
 		return false

--- a/p2p/stream/common/streammanager/mass_disconnect_test.go
+++ b/p2p/stream/common/streammanager/mass_disconnect_test.go
@@ -130,7 +130,7 @@ func TestDisconnectTracker_SmallSetLosingAllPeers(t *testing.T) {
 
 func TestHandleRemoveStream_MassDisconnectSkipsCriticalCooldownForConnectionLoss(t *testing.T) {
 	sm := newTestStreamManager()
-	sm.pf = newTestPeerFinder(nil, emptyDelayFunc) // prevent bootstrap discovery from inflating stream count
+	sm.pf = newTestPeerFinder(nil, emptyDelayFunc)
 	sm.config.HardLoCap = 2
 	sm.config.SoftLoCap = 2
 	sm.Start()
@@ -138,7 +138,6 @@ func TestHandleRemoveStream_MassDisconnectSkipsCriticalCooldownForConnectionLoss
 
 	const lossReason = "force close: remote closed stream"
 
-	// Seed 4 streams so threshold is 3.
 	for i := 1; i <= 4; i++ {
 		if err := sm.NewStream(newTestStream(makeStreamID(i), testProtoID)); err != nil {
 			t.Fatalf("add stream %d: %v", i, err)
@@ -203,7 +202,7 @@ func TestHandleRemoveStream_PunitiveKeepsCriticalCooldownDuringOutage(t *testing
 		}
 	}
 
-	// Trigger local outage via connection-loss removals.
+	// Trigger local outage with connection-loss removals.
 	for i := 1; i <= 3; i++ {
 		if err := sm.RemoveStream(makeStreamID(i), lossReason, true); err != nil {
 			t.Fatalf("loss remove %d: %v", i, err)
@@ -213,7 +212,6 @@ func TestHandleRemoveStream_PunitiveKeepsCriticalCooldownDuringOutage(t *testing
 		t.Fatal("expected local outage")
 	}
 
-	// Bad-data peer removed during outage must keep critical cooldown.
 	if err := sm.RemoveStream(makeStreamID(4), badReason, true); err != nil {
 		t.Fatalf("punitive remove: %v", err)
 	}

--- a/p2p/stream/common/streammanager/mass_disconnect_test.go
+++ b/p2p/stream/common/streammanager/mass_disconnect_test.go
@@ -1,0 +1,260 @@
+package streammanager
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMassDisconnectThreshold(t *testing.T) {
+	tests := []struct {
+		active int
+		want   int
+	}{
+		{0, massDisconnectMinCount},
+		{1, 1},
+		{2, 2},
+		{3, massDisconnectMinCount},
+		{4, massDisconnectMinCount},
+		{8, 4},
+		{10, 5},
+	}
+	for _, tt := range tests {
+		if got := massDisconnectThreshold(tt.active); got != tt.want {
+			t.Fatalf("active=%d: got %d want %d", tt.active, got, tt.want)
+		}
+	}
+}
+
+func TestIsConnectionLossReason(t *testing.T) {
+	loss := []string{
+		"force close: remote closed stream",
+		"force close: read msg failed",
+		"force close: progress timeout",
+		"force close: connection reset",
+		"force close: broken pipe",
+	}
+	for _, r := range loss {
+		if !isConnectionLossReason(r) {
+			t.Fatalf("expected connection-loss: %q", r)
+		}
+	}
+	punitive := []string{
+		"force close: too many failures",
+		"force close: nil block hashes",
+		"force close: identifySyncedStreams: critical protocol error",
+		"force close: invalid block is received from stream",
+		"force close: downloadRawBlocks received blockBytes are not valid",
+		"reset", // bare / ambiguous reasons are not treated as connection-loss
+	}
+	for _, r := range punitive {
+		if isConnectionLossReason(r) {
+			t.Fatalf("expected punitive/non-loss: %q", r)
+		}
+	}
+}
+
+func TestDisconnectTracker_MassDetectsLocalOutage(t *testing.T) {
+	var dt disconnectTracker
+	now := time.Now()
+
+	// 8 streams: threshold = 4
+	for i := 0; i < 3; i++ {
+		in, entered := dt.observeRemoval(now.Add(time.Duration(i)*time.Second), 8-i)
+		if in || entered {
+			t.Fatalf("removal %d should not trigger local outage yet", i+1)
+		}
+	}
+	in, entered := dt.observeRemoval(now.Add(4*time.Second), 5)
+	if !in || !entered {
+		t.Fatalf("4th removal should enter local outage, in=%v entered=%v", in, entered)
+	}
+	if !dt.inLocalOutage(now.Add(5 * time.Second)) {
+		t.Fatal("expected active local outage")
+	}
+
+	// Subsequent removal while in outage stays in outage without re-entering.
+	in, entered = dt.observeRemoval(now.Add(6*time.Second), 4)
+	if !in || entered {
+		t.Fatalf("while in outage: in=%v entered=%v", in, entered)
+	}
+}
+
+func TestDisconnectTracker_RateLimitsOutageEntry(t *testing.T) {
+	var dt disconnectTracker
+	now := time.Now()
+
+	// Enter outage.
+	for i := 0; i < 4; i++ {
+		dt.observeRemoval(now.Add(time.Duration(i)*time.Second), 8-i)
+	}
+	if !dt.inLocalOutage(now.Add(4 * time.Second)) {
+		t.Fatal("expected first outage")
+	}
+
+	// Expire outage window but stay inside min interval.
+	dt.localOutageUntil = now
+	dt.removalTimes = nil
+	later := now.Add(localOutageDuration + time.Minute) // still < 10m from lastOutageStart
+	for i := 0; i < 4; i++ {
+		in, entered := dt.observeRemoval(later.Add(time.Duration(i)*time.Second), 8-i)
+		if in || entered {
+			t.Fatalf("rate-limited re-entry should not start outage at removal %d", i+1)
+		}
+	}
+
+	// After min interval, a new wave may enter outage again.
+	dt.removalTimes = nil
+	reopen := now.Add(localOutageMinInterval + time.Second)
+	for i := 0; i < 3; i++ {
+		dt.observeRemoval(reopen.Add(time.Duration(i)*time.Second), 8-i)
+	}
+	in, entered := dt.observeRemoval(reopen.Add(4*time.Second), 5)
+	if !in || !entered {
+		t.Fatalf("after min interval should allow new outage, in=%v entered=%v", in, entered)
+	}
+}
+
+func TestDisconnectTracker_SmallSetLosingAllPeers(t *testing.T) {
+	var dt disconnectTracker
+	now := time.Now()
+
+	in, entered := dt.observeRemoval(now, 2)
+	if in || entered {
+		t.Fatal("first of two should not trigger yet")
+	}
+	in, entered = dt.observeRemoval(now.Add(time.Second), 1)
+	if !in || !entered {
+		t.Fatalf("losing both peers should trigger local outage, in=%v entered=%v", in, entered)
+	}
+}
+
+func TestHandleRemoveStream_MassDisconnectSkipsCriticalCooldownForConnectionLoss(t *testing.T) {
+	sm := newTestStreamManager()
+	sm.pf = newTestPeerFinder(nil, emptyDelayFunc) // prevent bootstrap discovery from inflating stream count
+	sm.config.HardLoCap = 2
+	sm.config.SoftLoCap = 2
+	sm.Start()
+	defer sm.Close()
+
+	const lossReason = "force close: remote closed stream"
+
+	// Seed 4 streams so threshold is 3.
+	for i := 1; i <= 4; i++ {
+		if err := sm.NewStream(newTestStream(makeStreamID(i), testProtoID)); err != nil {
+			t.Fatalf("add stream %d: %v", i, err)
+		}
+	}
+
+	if err := sm.RemoveStream(makeStreamID(1), lossReason, true); err != nil {
+		t.Fatalf("remove 1: %v", err)
+	}
+	info, ok := sm.removedStreams.Get(makeStreamID(1))
+	if !ok {
+		t.Fatal("expected removal info for stream 1")
+	}
+	if info.HasExpired() {
+		t.Fatal("first critical connection-loss should still have cooldown before mass detect")
+	}
+
+	if err := sm.RemoveStream(makeStreamID(2), lossReason, true); err != nil {
+		t.Fatalf("remove 2: %v", err)
+	}
+	if err := sm.RemoveStream(makeStreamID(3), lossReason, true); err != nil {
+		t.Fatalf("remove 3: %v", err)
+	}
+
+	info3, ok := sm.removedStreams.Get(makeStreamID(3))
+	if !ok {
+		t.Fatal("expected removal info for stream 3")
+	}
+	if !info3.HasExpired() {
+		t.Fatal("mass-disconnect connection-loss should allow immediate reconnect")
+	}
+	if !sm.disconnectTracker.inLocalOutage(time.Now()) {
+		t.Fatal("expected local outage after mass disconnect")
+	}
+
+	if err := sm.RemoveStream(makeStreamID(4), lossReason, true); err != nil {
+		t.Fatalf("remove 4: %v", err)
+	}
+	info4, ok := sm.removedStreams.Get(makeStreamID(4))
+	if !ok {
+		t.Fatal("expected removal info for stream 4")
+	}
+	if !info4.HasExpired() {
+		t.Fatal("connection-loss during local outage should allow immediate reconnect")
+	}
+}
+
+func TestHandleRemoveStream_PunitiveKeepsCriticalCooldownDuringOutage(t *testing.T) {
+	sm := newTestStreamManager()
+	sm.pf = newTestPeerFinder(nil, emptyDelayFunc)
+	sm.config.HardLoCap = 2
+	sm.config.SoftLoCap = 2
+	sm.Start()
+	defer sm.Close()
+
+	const lossReason = "force close: remote closed stream"
+	const badReason = "force close: identifySyncedStreams: critical protocol error"
+
+	for i := 1; i <= 5; i++ {
+		if err := sm.NewStream(newTestStream(makeStreamID(i), testProtoID)); err != nil {
+			t.Fatalf("add stream %d: %v", i, err)
+		}
+	}
+
+	// Trigger local outage via connection-loss removals.
+	for i := 1; i <= 3; i++ {
+		if err := sm.RemoveStream(makeStreamID(i), lossReason, true); err != nil {
+			t.Fatalf("loss remove %d: %v", i, err)
+		}
+	}
+	if !sm.disconnectTracker.inLocalOutage(time.Now()) {
+		t.Fatal("expected local outage")
+	}
+
+	// Bad-data peer removed during outage must keep critical cooldown.
+	if err := sm.RemoveStream(makeStreamID(4), badReason, true); err != nil {
+		t.Fatalf("punitive remove: %v", err)
+	}
+	info, ok := sm.removedStreams.Get(makeStreamID(4))
+	if !ok {
+		t.Fatal("expected removal info for punitive peer")
+	}
+	if info.HasExpired() {
+		t.Fatal("punitive removal during local outage must keep critical cooldown")
+	}
+}
+
+func TestHandleRemoveStream_PunitiveDoesNotTriggerMassDisconnect(t *testing.T) {
+	sm := newTestStreamManager()
+	sm.pf = newTestPeerFinder(nil, emptyDelayFunc)
+	sm.config.HardLoCap = 2
+	sm.config.SoftLoCap = 2
+	sm.Start()
+	defer sm.Close()
+
+	const badReason = "force close: nil block hashes"
+	for i := 1; i <= 4; i++ {
+		if err := sm.NewStream(newTestStream(makeStreamID(i), testProtoID)); err != nil {
+			t.Fatalf("add stream %d: %v", i, err)
+		}
+	}
+	for i := 1; i <= 4; i++ {
+		if err := sm.RemoveStream(makeStreamID(i), badReason, true); err != nil {
+			t.Fatalf("remove %d: %v", i, err)
+		}
+	}
+	if sm.disconnectTracker.inLocalOutage(time.Now()) {
+		t.Fatal("punitive removals must not open a local-outage window")
+	}
+	for i := 1; i <= 4; i++ {
+		info, ok := sm.removedStreams.Get(makeStreamID(i))
+		if !ok {
+			t.Fatalf("missing removal info %d", i)
+		}
+		if info.HasExpired() {
+			t.Fatalf("punitive peer %d should still be on critical cooldown", i)
+		}
+	}
+}

--- a/p2p/stream/common/streammanager/streammanager.go
+++ b/p2p/stream/common/streammanager/streammanager.go
@@ -88,7 +88,7 @@ type streamManager struct {
 	numTrustedStreamsMain     int64 // Count of trusted streams in main list
 	numTrustedStreamsReserved int64 // Count of trusted streams in reserved list
 
-	// disconnectTracker detects mass removals that indicate a local network outage.
+	// disconnectTracker tracks clustered stream removals and local-outage windows.
 	disconnectTracker disconnectTracker
 
 	// callback for when enough streams are found
@@ -157,9 +157,8 @@ func (rm *RemovalInfo) ResetCount() {
 	rm.count = 0
 }
 
-// MarkRemovedForLocalOutage records a removal caused by a likely local network outage.
-// Peers may reconnect immediately; the removal count is reset so soft escalation does not
-// carry over from the outage wave.
+// MarkRemovedForLocalOutage records a connection-loss removal during a local-outage
+// window. The peer may reconnect immediately and the removal count is reset.
 func (rm *RemovalInfo) MarkRemovedForLocalOutage() {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
@@ -611,7 +610,6 @@ func (sm *streamManager) addStreamFromReserved(count int) (int, error) {
 }
 
 func (sm *streamManager) handleRemoveStream(id sttypes.StreamID, reason string, criticalErr bool) error {
-	// Resolve which set contains the stream before counting toward mass-disconnect.
 	st, inMain := sm.streams.get(id)
 	inReserved := false
 	if !inMain {
@@ -624,8 +622,8 @@ func (sm *streamManager) handleRemoveStream(id sttypes.StreamID, reason string, 
 	now := time.Now()
 	connectionLoss := isConnectionLossReason(reason)
 	_, isTrusted := sm.trustedStreams.Get(id)
-	// Trusted streams stay protected on critical errors unless we are in a local
-	// outage and this removal is a connection-loss (so dead trusted links can drop).
+	// Trusted streams with critical errors stay registered unless the removal is a
+	// connection loss during an active local-outage window.
 	if isTrusted && criticalErr && !(sm.disconnectTracker.inLocalOutage(now) && connectionLoss) {
 		streamCriticalErrorCounterVec.With(prometheus.Labels{"topic": string(sm.myProtoID)}).Inc()
 		sm.logger.Info().
@@ -646,7 +644,6 @@ func (sm *streamManager) handleRemoveStream(id sttypes.StreamID, reason string, 
 	activeBefore := sm.streams.size() + sm.reservedStreams.size()
 	inLocalOutage := sm.disconnectTracker.inLocalOutage(now)
 	justEntered := false
-	// Only connection-loss removals feed mass-disconnect detection.
 	if connectionLoss {
 		inLocalOutage, justEntered = sm.disconnectTracker.observeRemoval(now, activeBefore)
 		if justEntered {
@@ -654,8 +651,7 @@ func (sm *streamManager) handleRemoveStream(id sttypes.StreamID, reason string, 
 		}
 	}
 
-	// Soft reconnect only for connection-loss removals inside a local-outage window.
-	// Bad-data / protocol removals keep full critical/soft cooldowns.
+	// Soft reconnect applies to connection-loss removals during a local-outage window.
 	softReconnect := inLocalOutage && connectionLoss
 	effectiveCritical := criticalErr && !softReconnect
 	if effectiveCritical {
@@ -732,13 +728,10 @@ func (sm *streamManager) onLocalOutageDetected(activeBefore int, reason string) 
 		Dur("discHoldoff", localOutageDiscHoldoff).
 		Dur("minInterval", localOutageMinInterval).
 		Str("lastReason", reason).
-		Msg("[StreamManager] mass disconnect detected; treating connection-loss removals as local network outage")
+		Msg("[StreamManager] mass disconnect detected; local-outage window started")
 
-	// Peers are not at fault for connection loss; clear connect-failure cooldown so
-	// reconnect can succeed once the local network recovers.
 	sm.coolDownCache.Reset()
 
-	// Brief holdoff so we do not immediately spam DHT while the uplink may still be down.
 	sm.coolDown.Set()
 	go func() {
 		timer := time.NewTimer(localOutageDiscHoldoff)
@@ -784,8 +777,7 @@ func (sm *streamManager) handleResetForWatchdog() error {
 	mainStreams := sm.streams.size()
 	reservedStreams := sm.reservedStreams.size()
 
-	// Keep active connections intact. Clear cooldown/blocking state so peer
-	// discovery can retry candidates again.
+	// Preserve active connections. Clear cooldown and discovery-blocking state.
 	sm.removedStreams.Clear()
 	sm.coolDownCache.Reset()
 	sm.coolDown.UnSet()
@@ -1111,8 +1103,6 @@ func (sm *streamManager) discoverAndSetupStream(discCtx context.Context) (int, e
 				Msg("[discoverAndSetupStream] processing trusted peers for bootstrap stream setup")
 
 			streamsBefore := sm.streams.size()
-			// Setup trusted streams - this function handles batching and waiting for NewStream.
-			// Registration still happens asynchronously in handleStream.
 			successCount := sm.setupTrustedStreams(discCtx, trustedPeers, trustedMinPeers)
 			connectedTrustedStreams = successCount
 
@@ -1136,9 +1126,7 @@ func (sm *streamManager) discoverAndSetupStream(discCtx context.Context) (int, e
 		}
 	}
 
-	// Only skip DHT after streams are actually registered. Counting initiated
-	// NewStream successes can race ahead of handleStream registration and leave
-	// the node below HardLoCap with discovery stopped.
+	// Skip DHT when enough compatible streams are already registered.
 	if sm.hardHaveEnoughStream() {
 		return sm.streams.size(), nil
 	}
@@ -1183,10 +1171,8 @@ func (sm *streamManager) discoverAndSetupStream(discCtx context.Context) (int, e
 	return connectedTrustedStreams + connecting, nil
 }
 
-// waitForStreamRegistrations polls until at least target compatible streams are
-// registered, HardLoCap is met, or the wait budget/context expires. setupStreamWithPeer
-// launches handleStream asynchronously, so NewStream success alone is not enough to
-// decide whether DHT discovery can be skipped.
+// waitForStreamRegistrations waits until target compatible streams are registered,
+// HardLoCap is met, or the wait budget/context expires.
 func (sm *streamManager) waitForStreamRegistrations(ctx context.Context, target int) {
 	if target <= 0 || sm.hardHaveEnoughStream() {
 		return

--- a/p2p/stream/common/streammanager/streammanager.go
+++ b/p2p/stream/common/streammanager/streammanager.go
@@ -88,6 +88,9 @@ type streamManager struct {
 	numTrustedStreamsMain     int64 // Count of trusted streams in main list
 	numTrustedStreamsReserved int64 // Count of trusted streams in reserved list
 
+	// disconnectTracker detects mass removals that indicate a local network outage.
+	disconnectTracker disconnectTracker
+
 	// callback for when enough streams are found
 	enoughStreamsCallback func()
 }
@@ -135,7 +138,7 @@ func (rm *RemovalInfo) HasExpired() bool {
 	rm.mu.RLock()
 	defer rm.mu.RUnlock()
 
-	return time.Now().After(rm.expireAt)
+	return !time.Now().Before(rm.expireAt)
 }
 
 // BumpCount increases the removal count.
@@ -151,6 +154,19 @@ func (rm *RemovalInfo) ResetCount() {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
 
+	rm.count = 0
+}
+
+// MarkRemovedForLocalOutage records a removal caused by a likely local network outage.
+// Peers may reconnect immediately; the removal count is reset so soft escalation does not
+// carry over from the outage wave.
+func (rm *RemovalInfo) MarkRemovedForLocalOutage() {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+
+	now := time.Now()
+	rm.removedAt = now
+	rm.expireAt = now
 	rm.count = 0
 }
 
@@ -595,104 +611,71 @@ func (sm *streamManager) addStreamFromReserved(count int) (int, error) {
 }
 
 func (sm *streamManager) handleRemoveStream(id sttypes.StreamID, reason string, criticalErr bool) error {
-	// Check which set contains the stream - only delete from the one that has it
+	// Resolve which set contains the stream before counting toward mass-disconnect.
 	st, inMain := sm.streams.get(id)
+	inReserved := false
 	if !inMain {
-		// Try reserved streams
-		st, inReserved := sm.reservedStreams.get(id)
+		st, inReserved = sm.reservedStreams.get(id)
 		if !inReserved {
 			return ErrStreamAlreadyRemoved
 		}
-		// Stream is in reserved list
-		if criticalErr {
-			streamCriticalErrorCounterVec.With(prometheus.Labels{"topic": string(sm.myProtoID)}).Inc()
-		}
+	}
 
-		// Check if this is a trusted stream and handle accordingly
-		_, isTrusted := sm.trustedStreams.Get(id)
-		if isTrusted {
-			if criticalErr {
-				// Trusted streams with critical errors are not removed (protected)
-				sm.logger.Info().
-					Str("protocolID", string(sm.myProtoID)).
-					Uint32("shardID", uint32(sm.myProtoSpec.ShardID)).
-					Int("NumStreams", sm.streams.size()).
-					Int("NumTrustedStreamsMain", int(atomic.LoadInt64(&sm.numTrustedStreamsMain))).
-					Int("NumTrustedStreamsReserved", int(atomic.LoadInt64(&sm.numTrustedStreamsReserved))).
-					Interface("StreamID", id).
-					Bool("trusted", true).
-					Str("reason", reason).
-					Bool("criticalErr", criticalErr).
-					Msg("[StreamManager] trusted peer got critical error but not removed")
-				return nil
-			}
-			// Trusted stream with non-critical error: remove from trustedStreams map and update counters
-			sm.trustedStreams.Delete(id)
-			atomic.AddInt64(&sm.numTrustedStreamsReserved, -1)
-		}
-
-		sm.reservedStreams.deleteStream(st)
+	now := time.Now()
+	connectionLoss := isConnectionLossReason(reason)
+	_, isTrusted := sm.trustedStreams.Get(id)
+	// Trusted streams stay protected on critical errors unless we are in a local
+	// outage and this removal is a connection-loss (so dead trusted links can drop).
+	if isTrusted && criticalErr && !(sm.disconnectTracker.inLocalOutage(now) && connectionLoss) {
+		streamCriticalErrorCounterVec.With(prometheus.Labels{"topic": string(sm.myProtoID)}).Inc()
 		sm.logger.Info().
 			Str("protocolID", string(sm.myProtoID)).
 			Uint32("shardID", uint32(sm.myProtoSpec.ShardID)).
 			Int("NumStreams", sm.streams.size()).
-			Int("NumReservedStreams", sm.reservedStreams.size()).
 			Int("NumTrustedStreamsMain", int(atomic.LoadInt64(&sm.numTrustedStreamsMain))).
 			Int("NumTrustedStreamsReserved", int(atomic.LoadInt64(&sm.numTrustedStreamsReserved))).
 			Interface("StreamID", id).
+			Bool("trusted", true).
+			Bool("reserved", !inMain).
 			Str("reason", reason).
 			Bool("criticalErr", criticalErr).
-			Bool("trusted", isTrusted).
-			Msg("[StreamManager] removed stream from reserved streams list")
-
-		info, exist := sm.removedStreams.Get(id)
-		if !exist {
-			info = &RemovalInfo{count: 0}
-			sm.removedStreams.Set(id, info)
-		}
-		info.MarkAsRemoved(criticalErr)
-
-		sm.removeStreamFeed.Send(EvtStreamRemoved{id})
-		removedStreamsCounterVec.With(prometheus.Labels{"topic": string(sm.myProtoID)}).Inc()
-		streamRemovalReasonCounterVec.With(prometheus.Labels{"reason": reason, "critical": strconv.FormatBool(criticalErr)}).Inc()
-		numStreamsGaugeVec.With(prometheus.Labels{"topic": string(sm.myProtoID)}).Set(float64(sm.streams.size()))
-		numReservedStreamsGaugeVec.With(prometheus.Labels{"topic": string(sm.myProtoID)}).Set(float64(sm.reservedStreams.size()))
-		numTrustedPeerStreamsGaugeVec.With(prometheus.Labels{"topic": string(sm.myProtoID)}).Set(float64(atomic.LoadInt64(&sm.numTrustedStreamsMain)))
-		numReservedTrustedPeerStreamsGaugeVec.With(prometheus.Labels{"topic": string(sm.myProtoID)}).Set(float64(atomic.LoadInt64(&sm.numTrustedStreamsReserved)))
-
-		sm.tryToReplaceRemovedStream()
+			Msg("[StreamManager] trusted peer got critical error but not removed")
 		return nil
 	}
 
-	// Stream is in main list
-	if criticalErr {
+	activeBefore := sm.streams.size() + sm.reservedStreams.size()
+	inLocalOutage := sm.disconnectTracker.inLocalOutage(now)
+	justEntered := false
+	// Only connection-loss removals feed mass-disconnect detection.
+	if connectionLoss {
+		inLocalOutage, justEntered = sm.disconnectTracker.observeRemoval(now, activeBefore)
+		if justEntered {
+			sm.onLocalOutageDetected(activeBefore, reason)
+		}
+	}
+
+	// Soft reconnect only for connection-loss removals inside a local-outage window.
+	// Bad-data / protocol removals keep full critical/soft cooldowns.
+	softReconnect := inLocalOutage && connectionLoss
+	effectiveCritical := criticalErr && !softReconnect
+	if effectiveCritical {
 		streamCriticalErrorCounterVec.With(prometheus.Labels{"topic": string(sm.myProtoID)}).Inc()
 	}
 
-	// Check if this is a trusted stream and handle accordingly
-	_, isTrusted := sm.trustedStreams.Get(id)
 	if isTrusted {
-		if criticalErr {
-			// Trusted streams with critical errors are not removed (protected)
-			sm.logger.Info().
-				Str("protocolID", string(sm.myProtoID)).
-				Uint32("shardID", uint32(sm.myProtoSpec.ShardID)).
-				Int("NumStreams", sm.streams.size()).
-				Int("NumTrustedStreamsMain", int(atomic.LoadInt64(&sm.numTrustedStreamsMain))).
-				Int("NumTrustedStreamsReserved", int(atomic.LoadInt64(&sm.numTrustedStreamsReserved))).
-				Interface("StreamID", id).
-				Bool("trusted", true).
-				Str("reason", reason).
-				Bool("criticalErr", criticalErr).
-				Msg("[StreamManager] trusted peer got critical error but not removed")
-			return nil
-		}
-		// Trusted stream with non-critical error: remove from trustedStreams map and update counters
 		sm.trustedStreams.Delete(id)
-		atomic.AddInt64(&sm.numTrustedStreamsMain, -1)
+		if inMain {
+			atomic.AddInt64(&sm.numTrustedStreamsMain, -1)
+		} else {
+			atomic.AddInt64(&sm.numTrustedStreamsReserved, -1)
+		}
 	}
 
-	sm.streams.deleteStream(st)
+	if inMain {
+		sm.streams.deleteStream(st)
+	} else {
+		sm.reservedStreams.deleteStream(st)
+	}
 
 	sm.logger.Info().
 		Str("protocolID", string(sm.myProtoID)).
@@ -704,29 +687,74 @@ func (sm *streamManager) handleRemoveStream(id sttypes.StreamID, reason string, 
 		Interface("StreamID", id).
 		Str("reason", reason).
 		Bool("criticalErr", criticalErr).
+		Bool("effectiveCritical", effectiveCritical).
+		Bool("connectionLoss", connectionLoss).
+		Bool("softReconnect", softReconnect).
+		Bool("localOutage", inLocalOutage).
 		Bool("trusted", isTrusted).
-		Msg("[StreamManager] removed stream from main streams list")
+		Bool("reserved", !inMain).
+		Msg("[StreamManager] removed stream")
 
+	sm.recordStreamRemoval(id, effectiveCritical, softReconnect, reason)
+	sm.tryToReplaceRemovedStream()
+	return nil
+}
+
+func (sm *streamManager) recordStreamRemoval(id sttypes.StreamID, effectiveCritical, softReconnect bool, reason string) {
 	info, exist := sm.removedStreams.Get(id)
 	if !exist {
 		info = &RemovalInfo{count: 0}
 		sm.removedStreams.Set(id, info)
 	}
-	info.MarkAsRemoved(criticalErr)
+	if softReconnect {
+		info.MarkRemovedForLocalOutage()
+	} else {
+		info.MarkAsRemoved(effectiveCritical)
+	}
 
-	// try to replace removed streams from reserved list
 	sm.removeStreamFeed.Send(EvtStreamRemoved{id})
-
 	removedStreamsCounterVec.With(prometheus.Labels{"topic": string(sm.myProtoID)}).Inc()
-	streamRemovalReasonCounterVec.With(prometheus.Labels{"reason": reason, "critical": strconv.FormatBool(criticalErr)}).Inc()
+	streamRemovalReasonCounterVec.With(prometheus.Labels{
+		"reason":   reason,
+		"critical": strconv.FormatBool(effectiveCritical),
+	}).Inc()
 	numStreamsGaugeVec.With(prometheus.Labels{"topic": string(sm.myProtoID)}).Set(float64(sm.streams.size()))
 	numReservedStreamsGaugeVec.With(prometheus.Labels{"topic": string(sm.myProtoID)}).Set(float64(sm.reservedStreams.size()))
 	numTrustedPeerStreamsGaugeVec.With(prometheus.Labels{"topic": string(sm.myProtoID)}).Set(float64(atomic.LoadInt64(&sm.numTrustedStreamsMain)))
 	numReservedTrustedPeerStreamsGaugeVec.With(prometheus.Labels{"topic": string(sm.myProtoID)}).Set(float64(atomic.LoadInt64(&sm.numTrustedStreamsReserved)))
+}
 
-	sm.tryToReplaceRemovedStream()
+func (sm *streamManager) onLocalOutageDetected(activeBefore int, reason string) {
+	sm.logger.Warn().
+		Int("activeBefore", activeBefore).
+		Int("removalsInWindow", len(sm.disconnectTracker.removalTimes)).
+		Dur("outageDuration", localOutageDuration).
+		Dur("discHoldoff", localOutageDiscHoldoff).
+		Dur("minInterval", localOutageMinInterval).
+		Str("lastReason", reason).
+		Msg("[StreamManager] mass disconnect detected; treating connection-loss removals as local network outage")
 
-	return nil
+	// Peers are not at fault for connection loss; clear connect-failure cooldown so
+	// reconnect can succeed once the local network recovers.
+	sm.coolDownCache.Reset()
+
+	// Brief holdoff so we do not immediately spam DHT while the uplink may still be down.
+	sm.coolDown.Set()
+	go func() {
+		timer := time.NewTimer(localOutageDiscHoldoff)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			sm.coolDown.UnSet()
+			select {
+			case sm.discCh <- discTask{}:
+			default:
+			}
+			sm.logger.Info().Msg("[StreamManager] local outage discovery holdoff ended; rediscovery triggered")
+		case <-sm.ctx.Done():
+			sm.coolDown.UnSet()
+		}
+	}()
 }
 
 func (sm *streamManager) tryToReplaceRemovedStream() error {
@@ -1082,23 +1110,37 @@ func (sm *streamManager) discoverAndSetupStream(discCtx context.Context) (int, e
 				Int("NumTrustedStreamsReserved", int(atomic.LoadInt64(&sm.numTrustedStreamsReserved))).
 				Msg("[discoverAndSetupStream] processing trusted peers for bootstrap stream setup")
 
-			// Setup trusted streams - this function handles batching and waiting
+			streamsBefore := sm.streams.size()
+			// Setup trusted streams - this function handles batching and waiting for NewStream.
+			// Registration still happens asynchronously in handleStream.
 			successCount := sm.setupTrustedStreams(discCtx, trustedPeers, trustedMinPeers)
 			connectedTrustedStreams = successCount
+
+			if successCount > 0 {
+				expected := streamsBefore + successCount
+				if expected > sm.config.HardLoCap {
+					expected = sm.config.HardLoCap
+				}
+				sm.waitForStreamRegistrations(discCtx, expected)
+			}
 
 			sm.logger.Info().
 				Str("protocolID", string(sm.myProtoID)).
 				Uint32("shardID", uint32(sm.myProtoSpec.ShardID)).
 				Int("successCount", successCount).
 				Int("trustedMinPeers", trustedMinPeers).
+				Int("registeredStreams", sm.streams.size()).
 				Int("NumTrustedStreamsMain", int(atomic.LoadInt64(&sm.numTrustedStreamsMain))).
 				Int("NumTrustedStreamsReserved", int(atomic.LoadInt64(&sm.numTrustedStreamsReserved))).
-				Msg("[discoverAndSetupStream] completed trusted peer stream setup, proceeding to discover other peers")
+				Msg("[discoverAndSetupStream] completed trusted peer stream setup")
 		}
 	}
 
-	if sm.streams.size()+connectedTrustedStreams >= sm.config.HardLoCap {
-		return connectedTrustedStreams, nil
+	// Only skip DHT after streams are actually registered. Counting initiated
+	// NewStream successes can race ahead of handleStream registration and leave
+	// the node below HardLoCap with discovery stopped.
+	if sm.hardHaveEnoughStream() {
+		return sm.streams.size(), nil
 	}
 
 	peers, err := sm.discover(discCtx)
@@ -1139,6 +1181,42 @@ func (sm *streamManager) discoverAndSetupStream(discCtx context.Context) (int, e
 	}
 
 	return connectedTrustedStreams + connecting, nil
+}
+
+// waitForStreamRegistrations polls until at least target compatible streams are
+// registered, HardLoCap is met, or the wait budget/context expires. setupStreamWithPeer
+// launches handleStream asynchronously, so NewStream success alone is not enough to
+// decide whether DHT discovery can be skipped.
+func (sm *streamManager) waitForStreamRegistrations(ctx context.Context, target int) {
+	if target <= 0 || sm.hardHaveEnoughStream() {
+		return
+	}
+	if sm.streams.numStreamsWithMinProtoSpec(sm.myProtoSpec) >= target {
+		return
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, streamRegistrationWait)
+	defer cancel()
+	ticker := time.NewTicker(streamRegistrationPoll)
+	defer ticker.Stop()
+
+	for {
+		if sm.hardHaveEnoughStream() {
+			return
+		}
+		if sm.streams.numStreamsWithMinProtoSpec(sm.myProtoSpec) >= target {
+			return
+		}
+		select {
+		case <-waitCtx.Done():
+			sm.logger.Debug().
+				Int("target", target).
+				Int("registered", sm.streams.numStreamsWithMinProtoSpec(sm.myProtoSpec)).
+				Msg("[StreamManager] timed out waiting for stream registrations; continuing with DHT if needed")
+			return
+		case <-ticker.C:
+		}
+	}
 }
 
 func (sm *streamManager) discover(ctx context.Context) (<-chan libp2p_peer.AddrInfo, error) {

--- a/p2p/stream/common/streammanager/streammanager_test.go
+++ b/p2p/stream/common/streammanager/streammanager_test.go
@@ -316,7 +316,7 @@ func TestDiscoverSkipsDHTOnlyAfterRegisteredHardLoCap(t *testing.T) {
 	sm := newTestStreamManager()
 	sm.config.HardLoCap = 2
 	sm.config.DiscBatch = 4
-	// Empty peer finder: if DHT runs, connecting stays 0.
+	// Empty peer finder: connecting stays 0 when DHT runs.
 	sm.pf = newTestPeerFinder(nil, emptyDelayFunc)
 
 	discovered, err := sm.discoverAndSetupStream(context.Background())

--- a/p2p/stream/common/streammanager/streammanager_test.go
+++ b/p2p/stream/common/streammanager/streammanager_test.go
@@ -1,6 +1,7 @@
 package streammanager
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -281,6 +282,63 @@ func TestStreamSet_numStreamsWithMinProtoID(t *testing.T) {
 	num := ss.numStreamsWithMinProtoSpec(minSpec)
 	if num != numPid2 {
 		t.Errorf("unexpected result: %v/%v", num, numPid2)
+	}
+}
+
+func TestWaitForStreamRegistrations(t *testing.T) {
+	sm := newTestStreamManager()
+	sm.config.HardLoCap = 3
+
+	done := make(chan struct{})
+	go func() {
+		sm.waitForStreamRegistrations(context.Background(), 2)
+		close(done)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	select {
+	case <-done:
+		t.Fatal("wait returned before streams were registered")
+	default:
+	}
+
+	sm.streams.addStream(newTestStream(makeStreamID(1), testProtoID))
+	sm.streams.addStream(newTestStream(makeStreamID(2), testProtoID))
+
+	select {
+	case <-done:
+	case <-time.After(defTestWait):
+		t.Fatal("timed out waiting for registration wait to complete")
+	}
+}
+
+func TestDiscoverSkipsDHTOnlyAfterRegisteredHardLoCap(t *testing.T) {
+	sm := newTestStreamManager()
+	sm.config.HardLoCap = 2
+	sm.config.DiscBatch = 4
+	// Empty peer finder: if DHT runs, connecting stays 0.
+	sm.pf = newTestPeerFinder(nil, emptyDelayFunc)
+
+	discovered, err := sm.discoverAndSetupStream(context.Background())
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if discovered != 0 {
+		t.Fatalf("expected DHT path with no peers below HardLoCap, got discovered=%d", discovered)
+	}
+	if sm.hardHaveEnoughStream() {
+		t.Fatal("expected HardLoCap unmet before registrations")
+	}
+
+	sm.streams.addStream(newTestStream(makeStreamID(101), testProtoID))
+	sm.streams.addStream(newTestStream(makeStreamID(102), testProtoID))
+
+	discovered, err = sm.discoverAndSetupStream(context.Background())
+	if err != nil {
+		t.Fatalf("discover after hard cap: %v", err)
+	}
+	if discovered != sm.streams.size() {
+		t.Fatalf("expected skip to return registered stream count %d, got %d", sm.streams.size(), discovered)
 	}
 }
 

--- a/p2p/stream/protocols/sync/const.go
+++ b/p2p/stream/protocols/sync/const.go
@@ -96,8 +96,10 @@ const (
 	MaxBackoffStartup           = 15 * time.Second  // 15 seconds max backoff
 
 	// Advertisement loop timing constants
-	MinSleepTimeNormal  = 30 * time.Second // Minimum sleep time in normal mode
-	MaxSleepTimeNormal  = 60 * time.Minute // Maximum sleep time in normal mode
+	MinSleepTimeNormal = 30 * time.Second // Minimum sleep time in normal mode
+	// MaxSleepTimeNormal is the fallback max advertise sleep when MaxAdvertiseWaitTime
+	// is unset/zero. Prefer config Sync.MaxAdvertiseWaitTime (minutes) as the source of truth.
+	MaxSleepTimeNormal  = 15 * time.Minute
 	MinSleepTimeStartup = 10 * time.Second // Minimum sleep time in startup mode
 	MaxSleepTimeStartup = 2 * time.Minute  // Maximum sleep time in startup mode
 
@@ -111,10 +113,10 @@ const (
 	// DHT Request Limits - How many peers to request from DHT
 	// These should be higher than target limits because DHT may return invalid peers
 	// Based on stream sync configuration and realistic peer discovery ratios:
-	// - Mainnet: Request 20, expect ~8 valid (40% success rate)
+	// - Mainnet: Request 20, expect ~5 valid (matches InitStreams)
 	// - Testnet: Request 8, expect ~2 valid (25% success rate)
 	// - Devnet: Request 12, expect ~4 valid (33% success rate)
-	DHTRequestLimitMainnet   = 20 // Request 20, expect ~8 valid
+	DHTRequestLimitMainnet   = 20 // Request 20, expect ~5 valid
 	DHTRequestLimitTestnet   = 10 // Request 10, expect ~3 valid
 	DHTRequestLimitPangaea   = 10 // Request 10, expect ~3 valid
 	DHTRequestLimitPartner   = 10 // Request 10, expect ~3 valid
@@ -125,12 +127,12 @@ const (
 	// Target Valid Peer Counts - How many valid peers we want to find
 	// These are the actual peer counts we aim for after filtering
 	// Based on stream sync configuration requirements:
-	// - Mainnet: InitStreams=8, DiscSoftLowCap=8, DiscHardLowCap=6
+	// - Mainnet: InitStreams=5, DiscSoftLowCap=5, DiscHardLowCap=3
 	// - Testnet: InitStreams=3, DiscSoftLowCap=3, DiscHardLowCap=3
 	// - Localnet: InitStreams=4, DiscSoftLowCap=4, DiscHardLowCap=4
 	// - Partner: InitStreams=3, DiscSoftLowCap=3, DiscHardLowCap=3
 	// - Else: InitStreams=4, DiscSoftLowCap=4, DiscHardLowCap=4
-	TargetValidPeersMainnet   = 8 // Target 8 valid peers (matches InitStreams)
+	TargetValidPeersMainnet   = 5 // Target 5 valid peers (matches InitStreams)
 	TargetValidPeersTestnet   = 3 // Target 3 valid peers (matches InitStreams)
 	TargetValidPeersPangaea   = 3 // Target 3 valid peers (testnet-like)
 	TargetValidPeersPartner   = 3 // Target 3 valid peers (matches InitStreams)

--- a/p2p/stream/protocols/sync/const.go
+++ b/p2p/stream/protocols/sync/const.go
@@ -97,8 +97,7 @@ const (
 
 	// Advertisement loop timing constants
 	MinSleepTimeNormal = 30 * time.Second // Minimum sleep time in normal mode
-	// MaxSleepTimeNormal is the fallback max advertise sleep when MaxAdvertiseWaitTime
-	// is unset/zero. Prefer config Sync.MaxAdvertiseWaitTime (minutes) as the source of truth.
+	// MaxSleepTimeNormal is used when Sync.MaxAdvertiseWaitTime is unset or non-positive.
 	MaxSleepTimeNormal  = 15 * time.Minute
 	MinSleepTimeStartup = 10 * time.Second // Minimum sleep time in startup mode
 	MaxSleepTimeStartup = 2 * time.Minute  // Maximum sleep time in startup mode

--- a/p2p/stream/protocols/sync/protocol.go
+++ b/p2p/stream/protocols/sync/protocol.go
@@ -80,7 +80,7 @@ type (
 		Explorer   bool
 		EpochChain bool
 
-		MaxAdvertiseWaitTime int // max minutes between advertisements (wired to advertiseLoop)
+		MaxAdvertiseWaitTime int // max minutes between advertisements in normal mode
 		// stream manager config
 		SmSoftLowCap int
 		SmHardLowCap int
@@ -306,8 +306,7 @@ func (p *Protocol) advertiseLoop() {
 }
 
 // maxAdvertiseSleep returns the normal-mode max sleep between advertise cycles.
-// Sync.MaxAdvertiseWaitTime (minutes) is the configured source of truth; MaxSleepTimeNormal
-// is only the fallback when the config value is unset or non-positive.
+// Uses Sync.MaxAdvertiseWaitTime when set; otherwise MaxSleepTimeNormal.
 func (p *Protocol) maxAdvertiseSleep() time.Duration {
 	if p.config.MaxAdvertiseWaitTime > 0 {
 		return time.Duration(p.config.MaxAdvertiseWaitTime) * time.Minute

--- a/p2p/stream/protocols/sync/protocol.go
+++ b/p2p/stream/protocols/sync/protocol.go
@@ -80,7 +80,7 @@ type (
 		Explorer   bool
 		EpochChain bool
 
-		MaxAdvertiseWaitTime int
+		MaxAdvertiseWaitTime int // max minutes between advertisements (wired to advertiseLoop)
 		// stream manager config
 		SmSoftLowCap int
 		SmHardLowCap int
@@ -268,7 +268,7 @@ func (p *Protocol) advertiseLoop() {
 			maxSleepTime = MaxSleepTimeStartup
 		} else {
 			minSleepTime = MinSleepTimeNormal
-			maxSleepTime = MaxSleepTimeNormal
+			maxSleepTime = p.maxAdvertiseSleep()
 		}
 
 		sleep := p.advertise()
@@ -303,6 +303,16 @@ func (p *Protocol) advertiseLoop() {
 			return
 		}
 	}
+}
+
+// maxAdvertiseSleep returns the normal-mode max sleep between advertise cycles.
+// Sync.MaxAdvertiseWaitTime (minutes) is the configured source of truth; MaxSleepTimeNormal
+// is only the fallback when the config value is unset or non-positive.
+func (p *Protocol) maxAdvertiseSleep() time.Duration {
+	if p.config.MaxAdvertiseWaitTime > 0 {
+		return time.Duration(p.config.MaxAdvertiseWaitTime) * time.Minute
+	}
+	return MaxSleepTimeNormal
 }
 
 // isValidPeer checks if a discovered peer is valid for our use case

--- a/p2p/stream/protocols/sync/protocol_test.go
+++ b/p2p/stream/protocols/sync/protocol_test.go
@@ -16,6 +16,21 @@ import (
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 )
 
+func TestProtocol_MaxAdvertiseSleep(t *testing.T) {
+	p := &Protocol{
+		config: Config{},
+	}
+	if got := p.maxAdvertiseSleep(); got != MaxSleepTimeNormal {
+		t.Fatalf("fallback sleep: got %v want %v", got, MaxSleepTimeNormal)
+	}
+
+	p.config.MaxAdvertiseWaitTime = 7
+	want := 7 * time.Minute
+	if got := p.maxAdvertiseSleep(); got != want {
+		t.Fatalf("configured sleep: got %v want %v", got, want)
+	}
+}
+
 func TestProtocol_Match(t *testing.T) {
 	tests := []struct {
 		targetID protocol.ID


### PR DESCRIPTION
This PR Improves stream sync recovery when peers drop or the node briefly loses network, so sync can restart without long stalls or a process restart.

## What changed
- **Lower mainnet peer floors** so sync can start with fewer streams (`MinPeers=4`, boot `InitStreams=5`, hard/soft discovery caps aligned).
- **Shorter recovery timers**: discovery watchdog `30m` (was `75m`), max removal cooldown `15m` (was `60m`).
- **Advertise timing**: use `MaxAdvertiseWaitTime` (mainnet `15m`) as the real cap between advertise cycles.
- **Fix DHT skip race**: wait for trusted streams to actually register before skipping DHT discovery.
- **Mass-disconnect detection**: if many streams die quickly, treat it as a local network outage, allow fast reconnect for connection-loss failures, then rediscover after a short holdoff.
- **Keep punishing bad peers**: protocol/bad-data removals still get full critical cooldowns, even during a local outage; local-outage mode is also rate-limited (once per 10m).

## How this helps
- **Faster recovery** after brief internet drops or peer flaps, without waiting over an hour for watchdog/cooldowns.
- **Better discovery** by not skipping DHT too early and by advertising more often when needed.
- **Safer stream failure handling** by distinguishing connection-loss from malicious/buggy peer behavior.
