### PR TITLE
refactor: move `SafeMap` to `common/types`

### DIFF
--- a/api/service/synchronize/stagedstreamsync/stage_blockhashes.go
+++ b/api/service/synchronize/stagedstreamsync/stage_blockhashes.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	types "github.com/harmony-one/harmony/common/types"
 	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/internal/utils"
 	sttypes "github.com/harmony-one/harmony/p2p/stream/types"
@@ -228,7 +229,7 @@ func (bh *StageBlockHashes) runBlockHashWorkerLoop(ctx context.Context,
 		}
 
 		// Map to store block hashes fetched from peers
-		peerHashes := sttypes.NewSafeMap[sttypes.StreamID, []common.Hash]()
+		peerHashes := types.NewSafeMap[sttypes.StreamID, []common.Hash]()
 		var wg sync.WaitGroup
 
 		if bh.configs.protocol.NumStreams() < bh.configs.concurrency {
@@ -376,7 +377,7 @@ func (bh *StageBlockHashes) checkFinalHashes(batch []uint64, hashes map[uint64]c
 // calculateFinalBlockHashes Calculates the most frequent block hashes for a given batch and removes streams with invalid hashes.
 // note: final hashes could be zero hashes
 func (bh *StageBlockHashes) calculateFinalBlockHashes(
-	peerHashes *sttypes.SafeMap[sttypes.StreamID, []common.Hash],
+	peerHashes *types.SafeMap[sttypes.StreamID, []common.Hash],
 	batch []uint64,
 ) (map[uint64]common.Hash, map[sttypes.StreamID]struct{}, error) {
 

--- a/api/service/synchronize/stagedstreamsync/stage_bodies.go
+++ b/api/service/synchronize/stagedstreamsync/stage_bodies.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	ctypes "github.com/harmony-one/harmony/common/types"
 	"github.com/harmony-one/harmony/core"
 	"github.com/harmony-one/harmony/core/types"
 	"github.com/harmony-one/harmony/internal/utils"
@@ -191,7 +192,7 @@ func (b *StageBodies) Exec(ctx context.Context, firstCycle bool, invalidBlockRev
 // Failed streams are only punished when synced streams exist; otherwise the
 // stream pool is preserved to avoid cascading removal during systemic issues.
 func (b *StageBodies) identifySyncedStreams(ctx context.Context, s *StageState, targetHeight uint64, excludeIDs []sttypes.StreamID) (streams []sttypes.StreamID, err error) {
-	results := sttypes.NewSafeMap[sttypes.StreamID, error]()
+	results := ctypes.NewSafeMap[sttypes.StreamID, error]()
 	var (
 		wg          sync.WaitGroup
 		syncedCount int32

--- a/common/types/safe_map.go
+++ b/common/types/safe_map.go
@@ -1,4 +1,4 @@
-package sttypes
+package types
 
 import (
 	"sync"

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -16,6 +16,7 @@ import (
 	"github.com/harmony-one/abool"
 	prom "github.com/harmony-one/harmony/api/service/prometheus"
 	"github.com/harmony-one/harmony/common/clock"
+	ctypes "github.com/harmony-one/harmony/common/types"
 	bls "github.com/harmony-one/harmony/crypto/bls/core"
 	nodeconfig "github.com/harmony-one/harmony/internal/configs/node"
 	"github.com/harmony-one/harmony/internal/utils"
@@ -465,7 +466,7 @@ func NewHost(cfg HostConfig) (Host, error) {
 		joined:                  map[string]*libp2p_pubsub.Topic{},
 		self:                    *self,
 		trustedNodes:            cfg.TrustedNodes,
-		trustedPeerIDs:          sttypes.NewSafeMap[libp2p_peer.ID, struct{}](),
+		trustedPeerIDs:          ctypes.NewSafeMap[libp2p_peer.ID, struct{}](),
 		trustedMinPeers:         cfg.TrustedMinPeers,
 		trustedBootstrapEnabled: cfg.TrustedBootstrapEnabled,
 		dnsStaticNodes:          cfg.DNSStaticNodes,
@@ -580,7 +581,7 @@ type HostV2 struct {
 	streamProtos            []sttypes.Protocol
 	self                    Peer
 	trustedNodes            []string
-	trustedPeerIDs          *sttypes.SafeMap[libp2p_peer.ID, struct{}] // Thread-safe map of trusted peer IDs
+	trustedPeerIDs          *ctypes.SafeMap[libp2p_peer.ID, struct{}] // Thread-safe map of trusted peer IDs
 	trustedMinPeers         int
 	trustedBootstrapEnabled bool
 	dnsStaticNodes          []string

--- a/p2p/stream/common/requestmanager/interface_test.go
+++ b/p2p/stream/common/requestmanager/interface_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/rlp"
+	types "github.com/harmony-one/harmony/common/types"
 	"github.com/harmony-one/harmony/p2p/stream/common/streammanager"
 	sttypes "github.com/harmony-one/harmony/p2p/stream/types"
 )
@@ -156,8 +157,8 @@ func makeDummyTestStreams(indexes []int) []sttypes.Stream {
 	return sts
 }
 
-func makeDummyStreamSets(indexes []int) *sttypes.SafeMap[sttypes.StreamID, *stream] {
-	m := sttypes.NewSafeMap[sttypes.StreamID, *stream]()
+func makeDummyStreamSets(indexes []int) *types.SafeMap[sttypes.StreamID, *stream] {
+	m := types.NewSafeMap[sttypes.StreamID, *stream]()
 
 	for _, index := range indexes {
 		st := &testStream{

--- a/p2p/stream/common/requestmanager/requestmanager.go
+++ b/p2p/stream/common/requestmanager/requestmanager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/ethereum/go-ethereum/event"
+	types "github.com/harmony-one/harmony/common/types"
 	"github.com/harmony-one/harmony/internal/utils"
 	"github.com/harmony-one/harmony/p2p/stream/common/streammanager"
 	sttypes "github.com/harmony-one/harmony/p2p/stream/types"
@@ -22,10 +23,10 @@ import (
 // TODO: each peer is able to have a queue of requests instead of one request at a time.
 // TODO: add QoS evaluation for each stream
 type requestManager struct {
-	streams   *sttypes.SafeMap[sttypes.StreamID, *stream]  // All streams
-	available *sttypes.SafeMap[sttypes.StreamID, struct{}] // Streams that are available for request
-	pendings  *sttypes.SafeMap[uint64, *request]           // requests that are sent but not received response
-	waitings  requestQueues                                // double linked list of requests that are on the waiting list
+	streams   *types.SafeMap[sttypes.StreamID, *stream]  // All streams
+	available *types.SafeMap[sttypes.StreamID, struct{}] // Streams that are available for request
+	pendings  *types.SafeMap[uint64, *request]           // requests that are sent but not received response
+	waitings  requestQueues                              // double linked list of requests that are on the waiting list
 
 	myProtoID sttypes.ProtoID
 
@@ -71,9 +72,9 @@ func newRequestManager(sm streammanager.ReaderSubscriber, pid sttypes.ProtoID) *
 	logger := utils.Logger().With().Str("module", "request manager").Logger()
 
 	return &requestManager{
-		streams:   sttypes.NewSafeMap[sttypes.StreamID, *stream](),
-		available: sttypes.NewSafeMap[sttypes.StreamID, struct{}](),
-		pendings:  sttypes.NewSafeMap[uint64, *request](),
+		streams:   types.NewSafeMap[sttypes.StreamID, *stream](),
+		available: types.NewSafeMap[sttypes.StreamID, struct{}](),
+		pendings:  types.NewSafeMap[uint64, *request](),
 		waitings:  newRequestQueues(),
 
 		myProtoID: pid,
@@ -598,7 +599,7 @@ func (rm *requestManager) refreshStreams() {
 	}
 }
 
-func checkStreamUpdates(exists *sttypes.SafeMap[sttypes.StreamID, *stream], targets []sttypes.Stream) (added []sttypes.Stream, removed []*stream) {
+func checkStreamUpdates(exists *types.SafeMap[sttypes.StreamID, *stream], targets []sttypes.Stream) (added []sttypes.Stream, removed []*stream) {
 	targetM := make(map[sttypes.StreamID]sttypes.Stream)
 
 	for _, target := range targets {

--- a/p2p/stream/common/requestmanager/requestmanager_test.go
+++ b/p2p/stream/common/requestmanager/requestmanager_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	types "github.com/harmony-one/harmony/common/types"
 	sttypes "github.com/harmony-one/harmony/p2p/stream/types"
 	"github.com/pkg/errors"
 )
@@ -418,7 +419,7 @@ func TestRequestManager_Concurrency(t *testing.T) {
 func TestGenReqID(t *testing.T) {
 	retry := 100000
 	rm := &requestManager{
-		pendings: sttypes.NewSafeMap[uint64, *request](),
+		pendings: types.NewSafeMap[uint64, *request](),
 	}
 
 	for i := 0; i != retry; i++ {
@@ -432,7 +433,7 @@ func TestGenReqID(t *testing.T) {
 
 func TestCheckStreamUpdates(t *testing.T) {
 	tests := []struct {
-		exists            *sttypes.SafeMap[sttypes.StreamID, *stream]
+		exists            *types.SafeMap[sttypes.StreamID, *stream]
 		targets           []sttypes.Stream
 		expAddedIndexes   []int
 		expRemovedIndexes []int

--- a/p2p/stream/common/requestmanager/types.go
+++ b/p2p/stream/common/requestmanager/types.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	types "github.com/harmony-one/harmony/common/types"
 	sttypes "github.com/harmony-one/harmony/p2p/stream/types"
 	"github.com/pkg/errors"
 )
@@ -100,8 +101,8 @@ type request struct {
 	raw  *interface{}
 	// options
 	priority  reqPriority
-	whitelist *sttypes.SafeMap[sttypes.StreamID, struct{}] // allowed streams
-	blacklist *sttypes.SafeMap[sttypes.StreamID, struct{}] // banned streams}
+	whitelist *types.SafeMap[sttypes.StreamID, struct{}] // allowed streams
+	blacklist *types.SafeMap[sttypes.StreamID, struct{}] // banned streams}
 }
 
 func (req *request) ReqID() uint64 {
@@ -140,7 +141,7 @@ func (req *request) isStreamAllowed(stid sttypes.StreamID) bool {
 
 func (req *request) addBlacklistedStream(stid sttypes.StreamID) {
 	if req.blacklist == nil {
-		req.blacklist = sttypes.NewSafeMap[sttypes.StreamID, struct{}]()
+		req.blacklist = types.NewSafeMap[sttypes.StreamID, struct{}]()
 	}
 	req.blacklist.Set(stid, struct{}{})
 }
@@ -177,7 +178,7 @@ func (req *request) blacklistIDs() []sttypes.StreamID {
 
 func (req *request) addWhiteListStream(stid sttypes.StreamID) {
 	if req.whitelist == nil {
-		req.whitelist = sttypes.NewSafeMap[sttypes.StreamID, struct{}]()
+		req.whitelist = types.NewSafeMap[sttypes.StreamID, struct{}]()
 	}
 	req.whitelist.Set(stid, struct{}{})
 }

--- a/p2p/stream/common/streammanager/streammanager.go
+++ b/p2p/stream/common/streammanager/streammanager.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/harmony-one/abool"
+	types "github.com/harmony-one/harmony/common/types"
 	"github.com/harmony-one/harmony/internal/utils"
 	sttypes "github.com/harmony-one/harmony/p2p/stream/types"
 	"github.com/libp2p/go-libp2p/core/network"
@@ -48,7 +49,7 @@ type streamManager struct {
 	// protocol ID (e.g. different version)
 	streams *streamSet
 	// tracks removed streams with cooldown
-	removedStreams *sttypes.SafeMap[sttypes.StreamID, *RemovalInfo]
+	removedStreams *types.SafeMap[sttypes.StreamID, *RemovalInfo]
 	// reserved streams
 	reservedStreams *streamSet
 	isTrustedPeer   func(libp2p_peer.ID) bool
@@ -83,7 +84,7 @@ type streamManager struct {
 	// trustedStreams tracks stream IDs of successfully established trusted peer streams
 	// and their location (main or reserved list) for efficient counting
 	// Value: true = main list, false = reserved list
-	trustedStreams *sttypes.SafeMap[sttypes.StreamID, bool]
+	trustedStreams *types.SafeMap[sttypes.StreamID, bool]
 	// Atomic counters for trusted streams - optimized for O(1) counting
 	numTrustedStreamsMain     int64 // Count of trusted streams in main list
 	numTrustedStreamsReserved int64 // Count of trusted streams in reserved list
@@ -187,7 +188,7 @@ func newStreamManager(pid sttypes.ProtoID, host host, pf peerFinder, handleStrea
 		config:                c,
 		streams:               newStreamSet(),
 		reservedStreams:       newStreamSet(),
-		removedStreams:        sttypes.NewSafeMap[sttypes.StreamID, *RemovalInfo](),
+		removedStreams:        types.NewSafeMap[sttypes.StreamID, *RemovalInfo](),
 		isTrustedPeer:         c.IsTrustedPeer,
 		getTrustedPeers:       c.GetTrustedPeers,
 		host:                  host,
@@ -206,7 +207,7 @@ func newStreamManager(pid sttypes.ProtoID, host host, pf peerFinder, handleStrea
 		setupSem:              make(chan struct{}, setupConcurrency),
 		trustedPeersInitiated: c.TrustedPeersInitiated,
 		trustedPeersProcessed: abool.New(),
-		trustedStreams:        sttypes.NewSafeMap[sttypes.StreamID, bool](),
+		trustedStreams:        types.NewSafeMap[sttypes.StreamID, bool](),
 	}
 
 	// Initialize all stream metrics with this protocol ID


### PR DESCRIPTION
This PR moves the generic thread-safe `SafeMap` from `p2p/stream/types` to `common/types` so it can be reused outside the stream package, and updates all callers (host, stream manager, request manager, and staged sync) to use the new import path.